### PR TITLE
Fixes

### DIFF
--- a/flopy/modflow/mfsfr2.py
+++ b/flopy/modflow/mfsfr2.py
@@ -748,13 +748,13 @@ class ModflowSfr2(Package):
 
 
         # Add one to the kij indices
-        names = self.reach_data.dtype.names
-        lnames = []
-        [lnames.append(name.lower()) for name in names]
+        #names = self.reach_data.dtype.names
+        #lnames = []
+        #[lnames.append(name.lower()) for name in names]
         # --make copy of data for multiple calls
         d = np.recarray.copy(self.reach_data[columns])
         for idx in ['krch', 'irch', 'jrch', 'node']:
-            if (idx in lnames):
+            if (idx in columns):
                 d[idx] += 1
         formats = _fmt_string(d)[:-1] + '\n'
         for i in range(len(d)):
@@ -918,18 +918,18 @@ class ModflowSfr2(Package):
                     # write datasets 6a, 6b and 6c
                     self._write_segment_data(i, j, f_sfr)
 
-                    icalc = self.segment_data[i][j][1]
+                    icalc = self.segment_data[i].icalc[j]
                     if icalc == 2:
                         if i == 0 or self.nstrm > 0 and not self.reachinput:  # or isfropt <= 1:
                             for k in range(2):
-                                for d in self.channel_geometry_data[i][j][k]:
+                                for d in self.channel_geometry_data[i][j+1][k]:
                                     f_sfr.write('{:.2f} '.format(d))
                                 f_sfr.write('\n')
 
                     if icalc == 4:
                         #nstrpts = self.segment_data[i][j][5]
                         for k in range(3):
-                            for d in self.channel_flow_data[i][j][k]:
+                            for d in self.channel_flow_data[i][j+1][k]:
                                 f_sfr.write('{:.2f} '.format(d))
                             f_sfr.write('\n')
             if self.tabfiles and i == 0:

--- a/py.test/SFR_test.py
+++ b/py.test/SFR_test.py
@@ -43,7 +43,7 @@ def test_sfr():
     
     m, sfr = sfr_process('testsfr2_tab.nam', 'testsfr2_tab_ICALC2.sfr', path)
     
-    assert sfr.channel_geometry_data[0][0] == [[0.0, 2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0],
+    assert sfr.channel_geometry_data[0][1] == [[0.0, 2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0],
                                                [6.0, 4.5, 3.5, 0.0, 0.3, 3.5, 4.5, 6.0]]
     
     m, sfr = sfr_process('testsfr2.nam', 'testsfr2.sfr', path)

--- a/py.test/SFR_test.py
+++ b/py.test/SFR_test.py
@@ -4,8 +4,12 @@ import os
 import numpy as np
 import flopy
 
-
-path = os.path.join('..', 'examples', 'data', 'mf2005_test')
+# pytest changes the directory to flopy3
+path = ''
+if os.path.split(os.getcwd())[-1] == 'py.test':
+    path += '../'
+path += 'examples/data/mf2005_test/'
+#path = os.path.join('..', 'examples', 'data', 'mf2005_test')
 
 def sfr_process(mfnam, sfrfile, model_ws, outfolder='data'):
 

--- a/py.test/SFRchecker_test.py
+++ b/py.test/SFRchecker_test.py
@@ -9,7 +9,6 @@ import os
 import flopy
 from flopy.modflow.mfsfr2 import check
 
-path = '../examples/data/mf2005_test/'
 # pytest changes the directory to flopy3
 path = ''
 if os.path.split(os.getcwd())[-1] == 'py.test':


### PR DESCRIPTION
Joe-
I think I fixed the problems you found (at least the testing works for python 2 and 3 on my computer). One error was with column name indexing for the reach data. The column names to write are determined by a function _get_item2_names(), based on the values of nstrm, reachinput and isfropt, and whether the grid is structured. That way the information in the reach_data array isn't constrained by how that array was created. This also allows for additional information that is not part of the SFR package input to be stored there, such as outreach and a unique reachID number for each reach. Both of these things facilitate not only the checker, but also construction of the SFR input dataset (this is why I made the methods get_outlets(), get_outreaches(), and _interpolate_to_reaches() part of the package class instead of the checker class.

The other issue appeared to be an indexing issue with the channel_geometry_data and channel_flow_data dictionaries. Right now I have the SFR module set up so that node, layer, row and column are zero-based, and segment and reach are 1-based. I originally was going to have segment and reach be zero-based, but this quickly gets confusing, because then it means that outseg and upsegs must be zero-based, and at least for outsegs, a value of 0 signifies an outlet. And we are also storing some segment data in dictionaries, which have non-consecutive indexing, so the zero-based convention seemed to make less sense there. Anyways, I added one to resolve this issue, but let me know what you and Chris (or whoever else wants to weigh in) think of this.