### PR TITLE
Develop

### DIFF
--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -782,7 +782,7 @@ class Package(object):
                                            fmtin=old_value.fmtin,
                                            locat=old_value.locat)
             elif isinstance(old_value, utils.mflist):
-                value = utils.mflist(self.parent, old_value.dtype, data=value)
+                value = utils.mflist(self.parent, dtype=old_value.dtype, data=value)
             elif isinstance(old_value, list):
                 if isinstance(old_value[0], utils.util_3d):
                     new_list = []
@@ -1010,7 +1010,7 @@ class Package(object):
                 ifig = fignum[-1] + 1
                 caxs.append(value.plot(key, names, kper,
                                        filename_base=fileb, file_extension=fext, mflay=mflay,
-                                       fignum=fignum, colorbar=colorbar))
+                                       fignum=fignum, colorbar=colorbar, **kwargs))
 
             elif isinstance(value, utils.util_3d):
                 if self.parent.verbose:

--- a/flopy/modflow/mfsfr2.py
+++ b/flopy/modflow/mfsfr2.py
@@ -932,7 +932,7 @@ class ModflowSfr2(Package):
         #def plot(self,  **kwargs):
         #return super(ModflowSfr2, self).plot(**kwargs)
 
-    def write(self, filename=None):
+    def write_file(self, filename=None):
 
         # tabfiles = False
         # tabfiles_dict = {}

--- a/flopy/utils/util_list.py
+++ b/flopy/utils/util_list.py
@@ -691,7 +691,7 @@ class mflist(object):
                     array_dict[aname] = array[k]
         fio.write_grid_shapefile(filename, self.sr, array_dict)
 
-    def to_array(self, kper=0,mask=False):
+    def to_array(self, kper=0, mask=False):
         """
         Convert stress period boundary condition (mflist) data for a
         specified stress period to a 3-D numpy array

--- a/py.test/t009_test.py
+++ b/py.test/t009_test.py
@@ -1,7 +1,7 @@
 __author__ = 'aleaf'
 
-import sys
-sys.path.append('/Users/aleaf/Documents/GitHub/flopy3')
+#import sys
+#sys.path.append('/Users/aleaf/Documents/GitHub/flopy3')
 import os
 import numpy as np
 import matplotlib

--- a/py.test/t009_test.py
+++ b/py.test/t009_test.py
@@ -41,7 +41,7 @@ def sfr_process(mfnam, sfrfile, model_ws, outfolder=outpath):
     if not os.path.exists(outfolder):
         os.makedirs(outfolder)
     outpath = os.path.join(outfolder, sfrfile)
-    sfr.write(outpath)
+    sfr.write_file(outpath)
 
     m.remove_package('SFR2')
     sfr2 = flopy.modflow.ModflowSfr2.load(outpath, m)

--- a/py.test/t009_test.py
+++ b/py.test/t009_test.py
@@ -1,7 +1,7 @@
 __author__ = 'aleaf'
 
-#import sys
-#sys.path.append('/Users/aleaf/Documents/GitHub/flopy3')
+import sys
+sys.path.append('/Users/aleaf/Documents/GitHub/flopy3')
 import os
 import numpy as np
 import matplotlib as mpl
@@ -10,9 +10,11 @@ import flopy
 if os.path.split(os.getcwd())[-1] == 'flopy3':
     path = os.path.join('examples', 'data', 'mf2005_test')
     path2 = os.path.join('examples', 'data', 'sfr_test')
+    outpath = os.path.join('py.test/temp')
 else:
     path = os.path.join('..', 'examples', 'data', 'mf2005_test')
     path2 = os.path.join('..', 'examples', 'data', 'sfr_test')
+    outpath = 'temp'
 
 sfr_items = {0: {'mfnam': 'test1ss.nam',
                      'sfrfile': 'test1ss.sfr'},
@@ -30,7 +32,7 @@ sfr_items = {0: {'mfnam': 'test1ss.nam',
                      'sfrfile': 'TL2009.sfr'}
                  }
 
-def sfr_process(mfnam, sfrfile, model_ws, outfolder='temp'):
+def sfr_process(mfnam, sfrfile, model_ws, outfolder=outpath):
 
     m = flopy.modflow.Modflow.load(mfnam, model_ws=model_ws, verbose=False)
     sfr = m.get_package('SFR2')
@@ -104,7 +106,9 @@ def test_sfr():
     
     m, sfr = sfr_process('UZFtest2.nam', 'UZFtest2.sfr', path)
 
-    assert isinstance(sfr.plot()[0], mpl.axes.Axes) # test the plot() method
+    #assert isinstance(sfr.plot()[0], mpl.axes.Axes) # test the plot() method
+    sfr.reach_data = interpolate_to_reaches(sfr)
+    sfr.plot(key='strtop', vmin=sfr.reach_data.strtop.min(), vmax=sfr.reach_data.strtop.max())
 
     # trout lake example (only sfr file is included)
     # can add tests for sfr connection with lak package

--- a/py.test/t010_test.py
+++ b/py.test/t010_test.py
@@ -3,8 +3,8 @@ Some basic tests for SFR checker (not super rigorous)
 need to add a test case that has elevation input by reach
 """
 
-import sys
-sys.path.append('/Users/aleaf/Documents/GitHub/flopy3')
+#import sys
+#sys.path.append('/Users/aleaf/Documents/GitHub/flopy3')
 import os
 import flopy
 from flopy.modflow.mfsfr2 import check
@@ -22,8 +22,12 @@ def load_check_sfr(mfnam, model_ws, checker_output_path):
 
 def test_sfrcheck():
 
-    path = os.path.join('..', 'examples', 'data', 'mf2005_test')
-    cpth = os.path.join('temp')
+    if os.path.split(os.getcwd())[-1] == 'flopy3':
+        path = os.path.join('examples', 'data', 'mf2005_test')
+        cpth = os.path.join('py.test/temp')
+    else:
+        path = os.path.join('..', 'examples', 'data', 'mf2005_test')
+        cpth = os.path.join('temp')
 
     m = flopy.modflow.Modflow.load('test1tr.nam', model_ws=path, verbose=False)
 

--- a/py.test/t010_test.py
+++ b/py.test/t010_test.py
@@ -3,8 +3,8 @@ Some basic tests for SFR checker (not super rigorous)
 need to add a test case that has elevation input by reach
 """
 
-#import sys
-#sys.path.append('/Users/aleaf/Documents/GitHub/flopy3')
+import sys
+sys.path.append('/Users/aleaf/Documents/GitHub/flopy3')
 import os
 import flopy
 from flopy.modflow.mfsfr2 import check


### PR DESCRIPTION
Renamed krch, irch, jrch to k,i,j for consistency with stress_period_data. stress_period_data attribute now a view on reach_data, instead of a copy. This seems to be a good way to go, as changes made to reach_data ripple to stress_period_data, so that if one edits reach_data, they can use the plot method to visualize the changes.

I would like to flag the addition of **kwargs to the plot call for mflist in the base package class in case it causes problems. It would be nice for every plotting method to allow the user access to the full functionality of the underlying matplotlib method(s) via kwargs, but I could see this potentially being problematic if the kwargs go to unintended places. If we don't want to go this route, another option would be to have a kwarg dictionary (e.g. ```matplotlib_kwargs={}```) that would get passed to the underlying plotting method. Thoughts?