### PR TITLE
Modified util_2d to use the OPEN/CLOSE control record when external_path is not specified

### DIFF
--- a/flopy/utils/util_array.py
+++ b/flopy/utils/util_array.py
@@ -1290,9 +1290,8 @@ class util_2d(object):
                     self.model.add_external(self.ext_filename, self.locat)
 
                 return ''
-            # JCB: Added a new condition for the case in which a filename is passed, but
-            # external_path (and ext_filename) are None.
-            elif os.path.exists(self.__value) and self.ext_filename is None:
+            # Handles the case where a filename is passed, but exernal_path and ext_filename are None.
+            elif os.path.exists(os.path.join(self.model.model_ws, self.__value)) and self.ext_filename is None:
                 if self.model.free_format:
                     self.fmtin = '(FREE)'
                     self.py_desc = self.fort_2_py(self.fmtin)
@@ -1493,11 +1492,10 @@ class util_2d(object):
                         cr = 'CONSTANT ' + self.py_desc[1].format(self.__value)
                     cr = '{0:s}{1:s}#{2:<30s}\n'.format(cr, lay_space,
                                                         self.name)
-                # JCB: Added a new condition for the case in which a filename is passed, but
-                # external_path (and ext_filename) are None. Writes out relative path with
-                # respect to model_ws.
-                elif self.vtype == str and os.path.exists(self.__value):
-                    fr = os.path.relpath(self.__value, self.model.model_ws)
+                # Handles the case where a filename is passed, but exernal_path and ext_filename are None.
+                # Writes out relative path with respect to model_ws.
+                elif self.vtype == str and os.path.exists(os.path.join(self.model.model_ws, self.__value)):
+                    fr = os.path.relpath(os.path.join(self.model.model_ws, self.__value), self.model.model_ws)
                     cr = 'OPEN/CLOSE  {0:>30s} {1:15.6G} {2:>10s} {3:2.0f} {4:<30s}\n'.format(fr, self.cnstnt,
                          self.fmtin.strip(), self.iprn, self.name)
                 else:
@@ -1590,7 +1588,7 @@ class util_2d(object):
                 try:
                     value = int(value)
                 except:
-                    # print value
+                    # print(value)
                     # print os.path.join(self.model.model_ws,value)
                     # JDH Note: value should be the filename with
                     #            the relative path. Trace through code to

--- a/flopy/utils/util_array.py
+++ b/flopy/utils/util_array.py
@@ -1290,6 +1290,19 @@ class util_2d(object):
                     self.model.add_external(self.ext_filename, self.locat)
 
                 return ''
+            # JCB: Added a new condition for the case in which a filename is passed, but
+            # external_path (and ext_filename) are None.
+            elif os.path.exists(self.__value) and self.ext_filename is None:
+                if self.model.free_format:
+                    self.fmtin = '(FREE)'
+                    self.py_desc = self.fort_2_py(self.fmtin)
+                else:
+                    shutil.copy2(self.__value, self.ext_filename)
+                    # if fixed format, we need to get a new unit number
+                    #  and reset locat
+                    self.locat = self.model.next_ext_unit()
+                    self.model.add_external(self.ext_filename, self.locat)
+                return ''
                 # otherwise, we need to load the the value filename
             #  and return as a string
             else:
@@ -1480,6 +1493,13 @@ class util_2d(object):
                         cr = 'CONSTANT ' + self.py_desc[1].format(self.__value)
                     cr = '{0:s}{1:s}#{2:<30s}\n'.format(cr, lay_space,
                                                         self.name)
+                # JCB: Added a new condition for the case in which a filename is passed, but
+                # external_path (and ext_filename) are None. Writes out relative path with
+                # respect to model_ws.
+                elif self.vtype == str and os.path.exists(self.__value):
+                    fr = os.path.relpath(self.__value, self.model.model_ws)
+                    cr = 'OPEN/CLOSE  {0:>30s} {1:15.6G} {2:>10s} {3:2.0f} {4:<30s}\n'.format(fr, self.cnstnt,
+                         self.fmtin.strip(), self.iprn, self.name)
                 else:
                     cr = 'INTERNAL {0:15.6G} {1:>10s} {2:2.0f} #{3:<30s}\n' \
                         .format(self.cnstnt, self.fmtin, self.iprn, self.name)


### PR DESCRIPTION
Modified `get_control_record()` and `get_file_array()` methods by creating
an additional condition to include cases where `external_path` (and
therefore `ext_filename`) has not been set and we have passed a file name
which we want opened and closed (not written to the destination package
file).