### PR TITLE
Fixed string formatting in mfnwt line 253. Added colons and changed format …

### DIFF
--- a/flopy/modflow/mfnwt.py
+++ b/flopy/modflow/mfnwt.py
@@ -250,7 +250,7 @@ class ModflowNwt(Package):
         # Open file for writing
         f = open(self.fn_path, 'w')
         f.write('%s\n' % self.heading)
-        f.write('{10.1e}{10.1e}{10i}{10.1e}{10i}{10i}{10i} '.format(
+        f.write('{:10.1e}{:10.1e}{:10d}{:10.1e}{:10d}{:10d}{:10d} '.format(
             self.headtol, self.fluxtol, self.maxiterout, self.thickfact, self.linmeth, self.iprnwt, self.ibotav))
         isspecified = False
         for option in self.options:


### PR DESCRIPTION
…from "i" to "d" for integers.