### PR TITLE
fix ncol set to nrow in BTN setmodflowvars

### DIFF
--- a/flopy/mt3d/mtbtn.py
+++ b/flopy/mt3d/mtbtn.py
@@ -262,7 +262,7 @@ class Mt3dBtn(Package):
             self.nrow = self.parent.mf.dis.nrow
 
         if ncol is not None:
-            self.ncol = nrow
+            self.ncol = ncol
         else:
             self.ncol = self.parent.mf.dis.ncol
 


### PR DESCRIPTION
Small fix which I noted after seeing the same number for nrow and ncol in line 3 of the btn written by flopy.