### PR TITLE
fix writing output unit and format to LMT package

### DIFF
--- a/flopy/modflow/mflmt.py
+++ b/flopy/modflow/mflmt.py
@@ -152,9 +152,9 @@ class ModflowLmt(Package):
             elif t[0].lower() == 'output_file_header':
                 output_file_header = t[1]
             elif t[0].lower() == 'output_file_format':
-                output_file_unit = t[1]
+                output_file_format = t[1]
 
         lmt = ModflowLmt(model, output_file_name, output_file_unit,
-                         output_file_header, output_file_unit)
+                         output_file_header, output_file_format)
         return lmt
 


### PR DESCRIPTION
Because of this mix-up the output unit was actually the format, which crashed when it had to be written to the file as an integer.