### PR TITLE
Changed header separator character from "," to ";" when writing spati…

### DIFF
--- a/flopy/modflow/mf.py
+++ b/flopy/modflow/mf.py
@@ -283,7 +283,7 @@ class Modflow(BaseModel):
         f_nam = open(fn_path, 'w')
         f_nam.write('{}\n'.format(self.heading))
         f_nam.write('#'+str(self.sr))
-        f_nam.write(" ,start_datetime:{0}\n".format(self.start_datetime))
+        f_nam.write(" ;start_datetime:{0}\n".format(self.start_datetime))
         if self.version == 'mf2k':
             f_nam.write('{:12s} {:3d} {}\n'.format(self.glo.name[0], self.glo.unit_number[0], self.glo.file_name[0]))
         f_nam.write('{:12s} {:3d} {}\n'.format(self.lst.name[0], self.lst.unit_number[0], self.lst.file_name[0]))

--- a/flopy/utils/reference.py
+++ b/flopy/utils/reference.py
@@ -124,7 +124,7 @@ class SpatialReference(object):
             for line in f:
                 if not line.startswith('#'):
                     break
-                header.extend(line.strip().replace('#','').split(','))
+                header.extend(line.strip().replace('#','').split(';'))
 
         xul, yul = None, None
         rotation = 0.0
@@ -294,9 +294,9 @@ class SpatialReference(object):
         self._reset()
 
     def __repr__(self):
-        s = "xul:{0:<G}, yul:{1:<G}, rotation:{2:<G}, ".\
+        s = "xul:{0:<G}; yul:{1:<G}; rotation:{2:<G}; ".\
             format(self.xul,self.yul,self.rotation)
-        s += "proj4_str:{0}, ".format(self.proj4_str)
+        s += "proj4_str:{0}; ".format(self.proj4_str)
         s += "units:{0}".format(self.units)
         return s
 


### PR DESCRIPTION
…al reference to nam file. This enables the proper parsing of the string when a proj4_str is used that has comma's embedded as part of the +towgs84 clause (e.g. +towgs84=0,0,0,0,0,0,0).