### PR TITLE
Update comment in flopy3boundaries.ipynb

### DIFF
--- a/examples/Notebooks/flopy3boundaries.ipynb
+++ b/examples/Notebooks/flopy3boundaries.ipynb
@@ -67,9 +67,9 @@
    "outputs": [],
    "source": [
     "stress_period_data = [\n",
-    "                      [2, 3, 4, 10.7, 5000., -5.7],   #layer, row, column, stage conductance, river bottom\n",
-    "                      [2, 3, 5, 10.7, 5000., -5.7],   #layer, row, column, stage conductance, river bottom\n",
-    "                      [2, 3, 6, 10.7, 5000., -5.7],   #layer, row, column, stage conductance, river bottom\n",
+    "                      [2, 3, 4, 10.7, 5000., -5.7],   #layer, row, column, stage, conductance, river bottom\n",
+    "                      [2, 3, 5, 10.7, 5000., -5.7],   #layer, row, column, stage, conductance, river bottom\n",
+    "                      [2, 3, 6, 10.7, 5000., -5.7],   #layer, row, column, stage, conductance, river bottom\n",
     "                     ]\n",
     "m = flopy.modflow.Modflow(modelname='test', model_ws=workspace)\n",
     "riv = flopy.modflow.ModflowRiv(m, stress_period_data=stress_period_data)\n",


### PR DESCRIPTION
There were missing some comma in the comments of stress periods parameters.
Now the number of array elements consists with the documentation.