### PR TITLE
Update comments in flopy3boundaries.ipynb

### DIFF
--- a/examples/Notebooks/flopy3boundaries.ipynb
+++ b/examples/Notebooks/flopy3boundaries.ipynb
@@ -67,9 +67,9 @@
    "outputs": [],
    "source": [
     "stress_period_data = [\n",
-    "                      [2, 3, 4, 10.7, 5000., -5.7],   #layer, row, column, stage conductance, river bottom\n",
-    "                      [2, 3, 5, 10.7, 5000., -5.7],   #layer, row, column, stage conductance, river bottom\n",
-    "                      [2, 3, 6, 10.7, 5000., -5.7],   #layer, row, column, stage conductance, river bottom\n",
+    "                      [2, 3, 4, 10.7, 5000., -5.7],   #layer, row, column, stage, conductance, river bottom\n",
+    "                      [2, 3, 5, 10.7, 5000., -5.7],   #layer, row, column, stage, conductance, river bottom\n",
+    "                      [2, 3, 6, 10.7, 5000., -5.7],   #layer, row, column, stage, conductance, river bottom\n",
     "                     ]\n",
     "m = flopy.modflow.Modflow(modelname='test', model_ws=workspace)\n",
     "riv = flopy.modflow.ModflowRiv(m, stress_period_data=stress_period_data)\n",
@@ -345,9 +345,9 @@
    ],
    "source": [
     "sp1 = [\n",
-    "       [2, 3, 4, 10.7, 5000., -5.7],   #layer, row, column, stage conductance, river bottom\n",
-    "       [2, 3, 5, 10.7, 5000., -5.7],   #layer, row, column, stage conductance, river bottom\n",
-    "       [2, 3, 6, 10.7, 5000., -5.7],   #layer, row, column, stage conductance, river bottom\n",
+    "       [2, 3, 4, 10.7, 5000., -5.7],   #layer, row, column, stage, conductance, river bottom\n",
+    "       [2, 3, 5, 10.7, 5000., -5.7],   #layer, row, column, stage, conductance, river bottom\n",
+    "       [2, 3, 6, 10.7, 5000., -5.7],   #layer, row, column, stage, conductance, river bottom\n",
     "      ]\n",
     "print(sp1)"
    ]


### PR DESCRIPTION
There were missing some commas in the comments of stress periods parameters.
Now the number of array elements consists with the documentation.