### PR TITLE
make shapefile import optional

### DIFF
--- a/flopy/utils/gridgen.py
+++ b/flopy/utils/gridgen.py
@@ -7,13 +7,6 @@ from flopy.modflow.mfdisu import ModflowDisU
 from flopy.utils.util_array import read1d, Util2d
 from flopy.mbase import which
 
-try:
-    import shapefile
-except:
-    raise Exception('Error importing shapefile: ' +
-                    'try pip install pyshp')
-
-
 # todo
 # creation of line and polygon shapefiles from features (holes!)
 # program layer functionality for plot method
@@ -39,6 +32,13 @@ def features_to_shapefile(features, featuretype, filename):
     None
 
     """
+    
+    try:
+        import shapefile
+    except:
+        raise Exception('Error importing shapefile: ' +
+                        'try pip install pyshp')
+    
     if featuretype.lower() not in ['point', 'line', 'polygon']:
         raise Exception('Unrecognized feature type: {}'.format(featuretype))
 


### PR DESCRIPTION
The `shapefile` module isn't listed as required in setup.py, but trying to import this module fails if it isn't present.

Since only one function uses it, I propose the `try/except` block that imports the module be placed inside that function so that the rest of this submodule can be used without it.