### PR TITLE
Fix zones in simulation file

### DIFF
--- a/flopy/modpath/mpsim.py
+++ b/flopy/modpath/mpsim.py
@@ -108,7 +108,8 @@ class ModpathSim(Package):
         self.trace_file = '{}.{}'.format(model.name, 'trace_file.txt')
         self.trace_id = trace_id
         self.stop_zone = stop_zone
-        self.zone = zone
+        self.zone = Util3d(model, (nlay,nrow,ncol), np.int, \
+                    zone, name='zone', locat=self.unit_number[0]) 
         self.retard_fac = retard_fac
         self.retard_fcCB = retard_fcCB
 
@@ -268,9 +269,9 @@ class ModpathSim(Package):
 
         if self.options_dict['ZoneArrayOption'] != 1:
             # item 30
-            f_sim.write('{0:s}\n'.format(self.stop_zone))
+            f_sim.write('{0:d}\n'.format(self.stop_zone))
             # item 31
-            f_sim.write(self.stop_zone.get_file_entry())
+            f_sim.write(self.zone.get_file_entry())
 
         if self.options_dict['RetardationOption'] != 1:
             # item 32


### PR DESCRIPTION
This fixes the writing of zone information to the .mpsim file.