### PR TITLE
When ISFROPT==0 and stress period > 1 in SFR.write_input(), not all o…

### DIFF
--- a/flopy/modflow/mfsfr2.py
+++ b/flopy/modflow/mfsfr2.py
@@ -980,6 +980,9 @@ class ModflowSfr2(Package):
                 f_sfr.write(' '.join(fmts[5:8]).format(thts, thti, eps) + ' ')
                 if self.isfropt == 5:
                     f_sfr.write(fmts[8].format(uhc) + ' ')
+            elif i > 0 and self.isfropt == 0:
+                f_sfr.write(' '.join(fmts[1:4]).format(thickm, elevupdn, width) + ' ')
+
         elif self.isfropt in [0, 4, 5] and icalc >= 2:
             f_sfr.write(fmts[0].format(hcond) + ' ')
 

--- a/flopy/modflow/mfsfr2.py
+++ b/flopy/modflow/mfsfr2.py
@@ -977,7 +977,9 @@ class ModflowSfr2(Package):
 
             if i == 0:
                 f_sfr.write(' '.join(fmts[1:4]).format(thickm, elevupdn, width) + ' ')
-                f_sfr.write(' '.join(fmts[5:8]).format(thts, thti, eps) + ' ')
+                if self.isfropt in [4,5]:
+                    f_sfr.write(' '.join(fmts[5:8]).format(thts, thti, eps) + ' ')
+                
                 if self.isfropt == 5:
                     f_sfr.write(fmts[8].format(uhc) + ' ')
             elif i > 0 and self.isfropt == 0:


### PR DESCRIPTION
Andy is still working on SFR.write_input(), but I'm not sure if this bug was on his radar?  The problem is shown in the attached screen shot...the three variables highlighted by the red box were not being written when stress period > 1.
 
![isfropt 0](https://cloud.githubusercontent.com/assets/3236576/18232078/2e36f00a-727d-11e6-8338-8fb232fe1f06.png)
