### PR TITLE
Minor cleanup in sfr.write_input() for the case when ISFROPT==0

### DIFF
--- a/flopy/modflow/mfsfr2.py
+++ b/flopy/modflow/mfsfr2.py
@@ -977,9 +977,15 @@ class ModflowSfr2(Package):
 
             if i == 0:
                 f_sfr.write(' '.join(fmts[1:4]).format(thickm, elevupdn, width) + ' ')
-                f_sfr.write(' '.join(fmts[5:8]).format(thts, thti, eps) + ' ')
+                if self.isfropt in [4, 5]:
+                    f_sfr.write(' '.join(fmts[5:8]).format(thts, thti, eps) + ' ')
+
                 if self.isfropt == 5:
                     f_sfr.write(fmts[8].format(uhc) + ' ')
+                    
+            elif i > 0 and self.isfropt == 0:
+                f_sfr.write(' '.join(fmts[1:4]).format(thickm, elevupdn, width) + ' ')
+
         elif self.isfropt in [0, 4, 5] and icalc >= 2:
             f_sfr.write(fmts[0].format(hcond) + ' ')
 


### PR DESCRIPTION
When ISFROPT==0, sfr.write_input() writing uninitialized values when stress period = 1; and not enough terms are written when stress period > 1.  The problem is shown in the attached screen shot...the three variables highlighted by the red box were not being written when stress period > 1.  ISFROPT gets set equal to zero by default when the keyword Reachinput is not used.

![isfropt 0](https://cloud.githubusercontent.com/assets/3236576/18520693/c8d118b0-7a5d-11e6-8027-551bcd9f95d3.png)
