### PR TITLE
FormattedHeadFile get_ts bug

### DIFF
--- a/flopy/utils/formattedfile.py
+++ b/flopy/utils/formattedfile.py
@@ -196,7 +196,7 @@ class FormattedLayerFile(LayerFile):
         current_col = 0
         result = None
         # Loop until data retreived or eof
-        while (current_col < self.ncol - 1 or self.file.tell() == self.totalbytes) and current_col < i:
+        while (current_col < self.ncol - 1 or self.file.tell() == self.totalbytes) and current_col <= i:
             line = self.file.readline()
             arrline = line.split()
             for val in arrline:


### PR DESCRIPTION
Fixed bug reading formatted files with get_ts.  The reader was stopping one column early when the column being read was immediately after a line wrap.  In the code the outer while loop was checking for the column incorrectly but the inner for loop check is/was correct.  The conditional in the while loop has been updated to agree with the for loop.