### PR TITLE
Add drawdown to available headertypes

### DIFF
--- a/flopy/utils/datafile.py
+++ b/flopy/utils/datafile.py
@@ -18,7 +18,7 @@ class Header(object):
         floattype = 'f4'
         if precision == 'double':
             floattype = 'f8'
-        self.header_types = ['head', 'ucn']
+        self.header_types = ['drawdown', 'head', 'ucn']
         if filetype is None:
             self.header_type = None
         else:
@@ -26,7 +26,7 @@ class Header(object):
                 filetype = filetype.decode()
             self.header_type = filetype.lower()
         if self.header_type in self.header_types:
-            if self.header_type == 'head':
+            if self.header_type == 'head' or self.header_type == 'drawdown':
                 self.dtype = np.dtype([('kstp', 'i4'), ('kper', 'i4'),
                                        ('pertim', floattype),
                                        ('totim', floattype),


### PR DESCRIPTION
The fdn-drawdown file specifies the following header:

1    1   1.000000E+00   1.000000E+00         DRAWDOWN   165   175     1 (10(1X1PE13.5))

The headertype in this case is drawdown which results in an error reading the file.

Specified drawdown type is not available. Available types are:
  1 head
  2 ucn

So I have added this type to the datafile-header types.
The dtype should be the same as from header_type head.