### PR TITLE
Allow for use of 2-D zone array for all layers

### DIFF
--- a/flopy/utils/zonbud.py
+++ b/flopy/utils/zonbud.py
@@ -1646,6 +1646,7 @@ def read_zbarray(fname):
 
     # Initialize data counter
     totlen = 0
+    i = 0
 
     # First line contains array dimensions
     dimstring = lines.pop(0).strip().split()
@@ -1663,6 +1664,7 @@ def read_zbarray(fname):
     for line in lines:
         rowitems = line.strip().split()
 
+        # Skip blank lines
         if len(rowitems) == 0:
             continue
 
@@ -1714,12 +1716,9 @@ def read_zbarray(fname):
                 # place values for the previous layer into the zone array
                 vals = np.array(vals, dtype=np.int32).reshape((nrow, ncol))
                 zones[lay, :, :] = vals[:, :]
-
-                if lay == nlay - 1:
-                    break
-                else:
-                    lay += 1
+                lay += 1
             totlen += len(rowitems)
+        i += 1
     s = 'The number of values read ({:,.0f})' \
         ' does not match the number expected' \
         ' ({:,.0f})'.format(totlen,

--- a/flopy/utils/zonbud.py
+++ b/flopy/utils/zonbud.py
@@ -57,10 +57,10 @@ class ZoneBudget(object):
             raise Exception(
                 'Cannot load cell budget file: {}.'.format(cbc_file))
 
-        if isinstance(z, list):
-            for zi in z:
-                assert isinstance(zi, int), 'Zones must be provided as integers: {}'.format(zi)
-            z = np.array(z)
+        # if isinstance(z, list):
+        #     for zi in z:
+        #         assert isinstance(zi, int), 'Zones must be provided as integers: {}'.format(zi)
+        #     z = np.array(z)
         elif isinstance(z, np.ndarray):
             assert z.dtype in [int, np.int32, np.int64], 'Zones dtype must be integer'
 

--- a/flopy/utils/zonbud.py
+++ b/flopy/utils/zonbud.py
@@ -1556,8 +1556,10 @@ def write_zbarray(fname, X, fmtin=None, iprn=None):
         The array of zones to be written.
     fname :  str
         The path and name of the file to be written.
-    width : int
+    fmtin : int
         The number of values to write to each line.
+    iprn : int
+        Padding space to add between each value.
 
     Returns
     -------

--- a/flopy/utils/zonbud.py
+++ b/flopy/utils/zonbud.py
@@ -61,8 +61,8 @@ class ZoneBudget(object):
         #     for zi in z:
         #         assert isinstance(zi, int), 'Zones must be provided as integers: {}'.format(zi)
         #     z = np.array(z)
-        elif isinstance(z, np.ndarray):
-            assert z.dtype in [int, np.int32, np.int64], 'Zones dtype must be integer'
+        if isinstance(z, np.ndarray):
+            assert np.issubdtype(z, np.integer), 'Zones dtype must be integer'
 
         # Check for negative zone values
         for zi in np.unique(z):

--- a/flopy/utils/zonbud.py
+++ b/flopy/utils/zonbud.py
@@ -1687,6 +1687,8 @@ def read_zbarray(fname):
             elif locat == 'INTERNAL':
                 # READ ZONES
                 rowvals = [int(v) for v in rowitems]
+                s = 'Too many values encountered on this line.'
+                assert len(rowvals) <= fmtin, s
                 vals.extend(rowvals)
 
             elif locat == 'EXTERNAL':


### PR DESCRIPTION
I updated the logic which compares the shape of the input zone array against the model. If the input array is 2-D (or single layer 3-D) and has matching row/column dimensions, the zones are now applied to all layers. An exception is raised in the case where other odd shaped arrays are encountered (i.e. not a single-layer 3-D array and number of layers does not match number of layers in the model).