### PR TITLE
Update mtbtn.py

### DIFF
--- a/flopy/mt3d/mtbtn.py
+++ b/flopy/mt3d/mtbtn.py
@@ -606,9 +606,9 @@ class Mt3dBtn(Package):
         f_btn.write('{0:>10s}\n'.format(ss))
 
         # A16, A17
-        if self.timprs is None:
-            f_btn.write('{0:10d}\n'.format(self.nprs))
-        else:
+        f_btn.write('{0:10d}\n'.format(self.nprs))
+        
+        if self.nprs > 0:
             f_btn.write('{0:10d}\n'.format(len(self.timprs)))
             timprs = Util2d(self.parent, (len(self.timprs),),
                              np.float32, self.timprs, name='timprs',
@@ -617,11 +617,10 @@ class Mt3dBtn(Package):
             f_btn.write(timprs.string)
 
         # A18, A19
-        if self.obs is None:
-            f_btn.write('{0:10d}{1:10d}\n'.format(0, self.nprobs))
-        else:
-            nobs = self.obs.shape[0]
-            f_btn.write('{0:10d}{1:10d}\n'.format(nobs, self.nprobs))
+        f_btn.write('{0:10d}{1:10d}\n'.format(0, self.nprobs))
+        
+        nobs = self.obs.shape[0]
+        if nobs > 0:
             for i in range(nobs):
                 f_btn.write('{0:10d}{1:10d}{2:10d}\n' \
                             .format(self.obs[i, 0] + 1, self.obs[i, 1] + 1,

--- a/flopy/mt3d/mtbtn.py
+++ b/flopy/mt3d/mtbtn.py
@@ -619,9 +619,8 @@ class Mt3dBtn(Package):
         # A18, A19
         f_btn.write('{0:10d}{1:10d}\n'.format(0, self.nprobs))
         
-        nobs = self.obs.shape[0]
-        if nobs > 0:
-            for i in range(nobs):
+        if self.nprobs > 0:
+            for i in range(self.nprobs):
                 f_btn.write('{0:10d}{1:10d}{2:10d}\n' \
                             .format(self.obs[i, 0] + 1, self.obs[i, 1] + 1,
                                     self.obs[i, 2] + 1))

--- a/flopy/mt3d/mtbtn.py
+++ b/flopy/mt3d/mtbtn.py
@@ -619,7 +619,7 @@ class Mt3dBtn(Package):
         # A18, A19
         if self.obs is None:
             f_btn.write('{0:10d}{1:10d}\n'.format(0, self.nprobs))
-        elif self.obs > 0:
+        else:
             nobs = self.obs.shape[0]
             f_btn.write('{0:10d}{1:10d}\n'.format(nobs, self.nprobs))
             for i in range(nobs):

--- a/flopy/mt3d/mtbtn.py
+++ b/flopy/mt3d/mtbtn.py
@@ -617,10 +617,12 @@ class Mt3dBtn(Package):
             f_btn.write(timprs.string)
 
         # A18, A19
-        f_btn.write('{0:10d}{1:10d}\n'.format(0, self.nprobs))
-        
-        if self.nprobs > 0:
-            for i in range(self.nprobs):
+        if self.obs is None:
+            f_btn.write('{0:10d}{1:10d}\n'.format(0, self.nprobs))
+        elif self.obs > 0:
+            nobs = self.obs.shape[0]
+            f_btn.write('{0:10d}{1:10d}\n'.format(nobs, self.nprobs))
+            for i in range(nobs):
                 f_btn.write('{0:10d}{1:10d}{2:10d}\n' \
                             .format(self.obs[i, 0] + 1, self.obs[i, 1] + 1,
                                     self.obs[i, 2] + 1))


### PR DESCRIPTION
If the nprs value is negative, the BTN package should write that negative value no matter what was set for timprs. Before there was some logic included that if the user would assign any value to timprs, the nprs was not honoured. For me this was like hidden magic, that I was not expecting from reading the documentation.

An alternative solution would be to state in the documentation that timprs should be None.

Same goes for the observation item.