### PR TITLE
MNW2 load: KeyError raised if no pumpage specified for stress period 0

### DIFF
--- a/flopy/modflow/mfmnw2.py
+++ b/flopy/modflow/mfmnw2.py
@@ -870,7 +870,7 @@ class ModflowMnw2(Package):
             self.make_stress_period_data(self.mnw)
 
         if stress_period_data is not None:
-            if 'k' not in stress_period_data[0].dtype.names:
+            if 'k' not in stress_period_data[list(stress_period_data.keys())[0]].dtype.names:
                 self._add_kij_to_stress_period_data()
 
         self.parent.add_package(self)


### PR DESCRIPTION
If no pumping specified in MNW2 package for stress period 0, a `KeyError` will be thrown. Instead can use first available dictionary key to check if "k" in `dtype.names`.