### PR TITLE
Resolve several numpy warnings

### DIFF
--- a/autotest/t031_test.py
+++ b/autotest/t031_test.py
@@ -114,7 +114,7 @@ def test_get_destination_data():
     # check that all starting locations are included in the pathline data
     # (pathline data slice not just endpoints)
     starting_locs = ra_slice(well_epd, ['k0', 'i0', 'j0'])
-    pathline_locs = np.array(well_pthld[['k', 'i', 'j']].tolist(),
+    pathline_locs = np.array(np.array(well_pthld)[['k', 'i', 'j']].tolist(),
                              dtype=starting_locs.dtype)
     assert np.all(np.in1d(starting_locs, pathline_locs))
 

--- a/flopy/modflow/mfsfr2.py
+++ b/flopy/modflow/mfsfr2.py
@@ -352,9 +352,7 @@ class ModflowSfr2(Package):
         # assign node numbers if there are none (structured grid)
         if np.diff(self.reach_data.node).max() == 0 and self.parent.has_package('DIS'):
             # first make kij list
-            lrc = self.reach_data[['k', 'i', 'j']].copy()
-            #lrc = (lrc.view((int, len(lrc.dtype.names)))).tolist()
-            lrc = lrc.tolist()
+            lrc = np.array(self.reach_data)[['k', 'i', 'j']].tolist()
             self.reach_data['node'] = self.parent.dis.get_node(lrc)
         # assign unique ID and outreach columns to each reach
         self.reach_data.sort(order=['iseg', 'ireach'])
@@ -1147,7 +1145,7 @@ class ModflowSfr2(Package):
         segs = self.segment_data[0].nseg[isvar]
         isseg = np.array([True if s in segs else False for s in self.reach_data.iseg])
         isinlet = isseg & (self.reach_data.ireach == 1)
-        rd = self.reach_data[isinlet][['k', 'i', 'j', 'iseg', 'ireach']].copy()
+        rd = np.array(self.reach_data[isinlet])[['k', 'i', 'j', 'iseg', 'ireach']]
         ra = rfn.merge_arrays([rd, ra], flatten=True, usemask=False)
         return ra.view(np.recarray)
 
@@ -1426,10 +1424,11 @@ class ModflowSfr2(Package):
         # lnames = []
         # [lnames.append(name.lower()) for name in names]
         # --make copy of data for multiple calls
-        d = np.recarray.copy(self.reach_data[columns])
+        d = np.array(self.reach_data)
         for idx in ['k', 'i', 'j', 'node']:
             if (idx in columns):
                 d[idx] += 1
+        d = d[columns]
         formats = _fmt_string(d)[:-1] + '\n'
         for i in range(len(d)):
             f_sfr.write(formats.format(*d[i]))
@@ -1439,12 +1438,12 @@ class ModflowSfr2(Package):
                 'flow', 'runoff',
                 'etsw', 'pptsw', 'roughch', 'roughbk', 'cdpth', 'fdpth',
                 'awdth', 'bwdth']
-        fmts = _fmt_string_list(self.segment_data[i][cols].copy()[j])
+        seg_dat = np.array(self.segment_data[i])[cols][j]
+        fmts = _fmt_string_list(seg_dat)
 
         nseg, icalc, outseg, iupseg, iprior, nstrpts, flow, runoff, etsw, \
-        pptsw, roughch, roughbk, cdpth, fdpth, awdth, bwdth = \
-            [0 if v == self.default_value else v for v in
-             self.segment_data[i][cols].copy()[j]]
+            pptsw, roughch, roughbk, cdpth, fdpth, awdth, bwdth = \
+            [0 if v == self.default_value else v for v in seg_dat]
 
         f_sfr.write(
             ' '.join(fmts[0:4]).format(nseg, icalc, outseg, iupseg) + ' ')
@@ -1479,10 +1478,10 @@ class ModflowSfr2(Package):
     def _write_6bc(self, i, j, f_sfr, cols=[]):
 
         icalc = self.segment_data[i][j][1]
-        fmts = _fmt_string_list(self.segment_data[i][cols].copy()[j])
+        seg_dat = np.array(self.segment_data[i])[cols][j]
+        fmts = _fmt_string_list(seg_dat)
         hcond, thickm, elevupdn, width, depth, thts, thti, eps, uhc = \
-            [0 if v == self.default_value else v for v in
-             self.segment_data[i][cols].copy()[j]]
+            [0 if v == self.default_value else v for v in seg_dat]
 
         if self.isfropt in [0, 4, 5] and icalc <= 0:
             f_sfr.write(
@@ -1863,7 +1862,7 @@ class check:
 
         failed = array[col1] > array[col2]
         if np.any(failed):
-            failed_info = array[failed].copy()
+            failed_info = np.array(array)[failed]
             txt += level0txt.format(len(failed_info)) + '\n'
             if self.level == 1:
                 diff = failed_info[col2] - failed_info[col1]
@@ -1871,13 +1870,9 @@ class check:
                         failed_info[c].sum() != 0
                         and c != 'diff'
                         and 'tmp' not in c]
-                # currently failed_info[cols] results in a warning. Not sure
-                # how to do this properly with a recarray.
                 failed_info = recfunctions.append_fields(
-                    failed_info[cols].view(np.recarray).copy(),
-                    names='diff',
-                    data=diff,
-                    asrecarray=True)
+                    failed_info[cols].copy(), names='diff', data=diff,
+                    usemask=False, asrecarray=False)
                 failed_info.sort(order='diff', axis=0)
                 if not sort_ascending:
                     failed_info = failed_info[::-1]
@@ -1968,15 +1963,15 @@ class check:
         inds = (sd.outseg < sd.nseg) & (sd.outseg != 0)
 
         if len(txt) == 0 and np.any(inds):
-            decreases = sd[['nseg', 'outseg']][inds].copy()
+            decreases = np.array(sd[inds])[['nseg', 'outseg']]
             txt += 'Found segment numbers decreasing in the downstream direction.\n'.format(
                 len(decreases))
             txt += 'MODFLOW will run but convergence may be slowed:\n'
             if self.level == 1:
                 txt += 'nseg outseg\n'
                 t = ''
-                for ns, os in decreases:
-                    t += '{} {}\n'.format(ns, os)
+                for nseg, outseg in decreases:
+                    t += '{} {}\n'.format(nseg, outseg)
                 txt += t  # '\n'.join(textwrap.wrap(t, width=10))
         if len(t) == 0:
             passed = True
@@ -2072,25 +2067,25 @@ class check:
             print(headertxt.strip())
 
         # make nreach vectors of each conductance parameter
-        reach_data = self.reach_data.copy()
+        reach_data = np.array(self.reach_data)
         # if no dis file was supplied, can't compute node numbers
         # make nodes based on unique row, col pairs
         # if np.diff(reach_data.node).max() == 0:
         # always use unique rc, since flopy assigns nodes by k, i, j
         uniquerc = {}
-        for i, (r, c) in enumerate(reach_data[['i', 'j']].copy()):
+        for i, (r, c) in enumerate(reach_data[['i', 'j']]):
             if (r, c) not in uniquerc:
                 uniquerc[(r, c)] = i + 1
         reach_data['node'] = [uniquerc[(r, c)] for r, c in
-                              reach_data[['i', 'j']].copy()]
+                              reach_data[['i', 'j']]]
 
-        K = reach_data.strhc1
+        K = reach_data['strhc1']
         if K.max() == 0:
             K = self.sfr._interpolate_to_reaches('hcond1', 'hcond2')
-        b = reach_data.strthick
+        b = reach_data['strthick']
         if b.max() == 0:
             b = self.sfr._interpolate_to_reaches('thickm1', 'thickm2')
-        L = reach_data.rchlen
+        L = reach_data['rchlen']
         w = self.sfr._interpolate_to_reaches('width1', 'width2')
 
         # Calculate SFR conductance for each reach
@@ -2099,13 +2094,13 @@ class check:
         binv[idx] = 1. / b[idx]
         Cond = K * w * L * binv
 
-        shared_cells = _get_duplicates(reach_data.node)
+        shared_cells = _get_duplicates(reach_data['node'])
 
         nodes_with_multiple_conductance = set()
         for node in shared_cells:
 
             # select the collocated reaches for this cell
-            conductances = Cond[reach_data.node == node].copy()
+            conductances = Cond[reach_data['node'] == node].copy()
             conductances.sort()
 
             # list nodes with multiple non-zero SFR reach conductances
@@ -2229,8 +2224,8 @@ class check:
                                                           data=d_elev,
                                                           asrecarray=True)
                 txt += self._boolean_compare(
-                    segment_data[['nseg', 'outseg', 'elevup', 'elevdn',
-                                  'd_elev']].copy(),
+                    np.array(segment_data)[['nseg', 'outseg', 'elevup',
+                                            'elevdn', 'd_elev']],
                     col1='d_elev', col2=np.zeros(len(segment_data)),
                     level0txt='Stress Period {}: '.format(per + 1) + \
                               '{} segments encountered with elevdn > elevup.',
@@ -2249,11 +2244,11 @@ class check:
                     non_outlets_seg_data,
                     names=['outseg_elevup', 'd_elev2'],
                     data=[outseg_elevup, d_elev2],
-                    asrecarray=True)
+                    usemask=False, asrecarray=False)
 
                 txt += self._boolean_compare(
                     non_outlets_seg_data[['nseg', 'outseg', 'elevdn',
-                                          'outseg_elevup', 'd_elev2']].copy(),
+                                          'outseg_elevup', 'd_elev2']],
                     col1='d_elev2', col2=np.zeros(len(non_outlets_seg_data)),
                     level0txt='Stress Period {}: '.format(per + 1) + \
                               '{} segments encountered with segments encountered ' \
@@ -2299,18 +2294,17 @@ class check:
             # non_outlets = reach_data[reach_data.outreach != 0]
             # outreach_elevdn = np.array([reach_data.strtop[o - 1] for o in reach_data.outreach])
             # d_strtop = outreach_elevdn[reach_data.outreach != 0] - non_outlets.strtop
-            rd = recfunctions.append_fields(rd, names=['strtopdn', 'd_strtop'],
-                                            data=[strtopdn, diffs],
-                                            asrecarray=True)
+            rd = recfunctions.append_fields(
+                rd, names=['strtopdn', 'd_strtop'], data=[strtopdn, diffs],
+                usemask=False, asrecarray=False)
 
-            txt += self._boolean_compare(rd[['k', 'i', 'j', 'iseg', 'ireach',
-                                             'strtop', 'strtopdn', 'd_strtop',
-                                             'reachID']].copy(),
-                                         col1='d_strtop',
-                                         col2=np.zeros(len(rd)),
-                                         level0txt='{} reaches encountered with strtop < strtop of downstream reach.',
-                                         level1txt='Elevation rises:',
-                                         )
+            txt += self._boolean_compare(
+                rd[['k', 'i', 'j', 'iseg', 'ireach', 'strtop', 'strtopdn',
+                    'd_strtop', 'reachID']],
+                col1='d_strtop', col2=np.zeros(len(rd)),
+                level0txt='{} reaches encountered with strtop < strtop of downstream reach.',
+                level1txt='Elevation rises:',
+            )
             if len(txt) == 0:
                 passed = True
         else:
@@ -2329,25 +2323,21 @@ class check:
             return
         passed = False
         warning = True
-        if self.sfr.nstrm < 0 or self.sfr.reachinput and self.sfr.isfropt in [
-            1, 2, 3]:  # see SFR input instructions
-            reach_data = self.reach_data
-            i, j, k = reach_data.i, reach_data.j, reach_data.k
+        if (self.sfr.nstrm < 0 or self.sfr.reachinput and
+                self.sfr.isfropt in [1, 2, 3]):  # see SFR input instructions
+            reach_data = np.array(self.reach_data)
+            i, j, k = reach_data['i', 'j', 'k']
 
             # check streambed bottoms in relation to respective cell bottoms
             bots = self.sfr.parent.dis.botm.array[k, i, j]
             streambed_bots = reach_data.strtop - reach_data.strthick
-            reach_data = recfunctions.append_fields(reach_data,
-                                                    names=['layerbot',
-                                                           'strbot'],
-                                                    data=[bots,
-                                                          streambed_bots],
-                                                    asrecarray=True)
+            reach_data = recfunctions.append_fields(
+                reach_data, names=['layerbot', 'strbot'],
+                data=[bots, streambed_bots], usemask=False, asrecarray=False)
 
             txt += self._boolean_compare(
-                reach_data[['k', 'i', 'j', 'iseg', 'ireach',
-                            'strtop', 'strthick', 'strbot', 'layerbot',
-                            'reachID']].copy(),
+                reach_data[['k', 'i', 'j', 'iseg', 'ireach', 'strtop',
+                            'strthick', 'strbot', 'layerbot', 'reachID']],
                 col1='layerbot', col2='strbot',
                 level0txt='{} reaches encountered with streambed bottom below layer bottom.',
                 level1txt='Layer bottom violations:',
@@ -2362,7 +2352,7 @@ class check:
 
             txt += self._boolean_compare(
                 reach_data[['k', 'i', 'j', 'iseg', 'ireach',
-                            'strtop', 'modeltop', 'strhc1', 'reachID']].copy(),
+                            'strtop', 'modeltop', 'strhc1', 'reachID']],
                 col1='strtop', col2='modeltop',
                 level0txt='{} reaches encountered with streambed above model top.',
                 level1txt='Model top violations:',
@@ -2677,10 +2667,11 @@ def _print_rec_array(array, cols=None, delimiter=' ', float_format='{:.6f}'):
     if np.shape(array)[0] > 1:
         cols = [c for c in cols if array[c].min() > -999999]
     # add _fmt_string call here
-    fmts = _fmt_string_list(array[cols], float_format=float_format)
+    array = np.array(array)[cols]
+    fmts = _fmt_string_list(array, float_format=float_format)
     txt += delimiter.join(cols) + '\n'
     txt += '\n'.join(
-        [delimiter.join(fmts).format(*r) for r in array[cols].copy().tolist()])
+        [delimiter.join(fmts).format(*r) for r in array.tolist()])
     return txt
 
 

--- a/flopy/modflow/mfsfr2.py
+++ b/flopy/modflow/mfsfr2.py
@@ -2109,7 +2109,8 @@ class check:
             conductances.sort()
 
             # list nodes with multiple non-zero SFR reach conductances
-            if conductances[0] / conductances[-1] > tol:
+            if (conductances[-1] != 0.0 and
+                    (conductances[0] / conductances[-1] > tol)):
                 nodes_with_multiple_conductance.update({node})
 
         if len(nodes_with_multiple_conductance) > 0:

--- a/flopy/modflow/mfsfr2.py
+++ b/flopy/modflow/mfsfr2.py
@@ -2122,17 +2122,15 @@ class check:
                         ['k', 'i', 'j', 'iseg', 'ireach', 'rchlen', 'strthick',
                          'strhc1', 'width', 'conductance']]
 
-                reach_data = recfunctions.append_fields(reach_data,
-                                                        names=['width',
-                                                               'conductance'],
-                                                        data=[w, Cond],
-                                                        usemask=False,
-                                                        asrecarray=True)
+                reach_data = recfunctions.append_fields(
+                    reach_data,
+                    names=['width', 'conductance'], data=[w, Cond],
+                    usemask=False, asrecarray=False)
                 has_multiple = np.array(
                     [True if n in nodes_with_multiple_conductance
-                     else False for n in reach_data.node])
-                reach_data = reach_data[has_multiple].copy()
-                reach_data = reach_data[cols].copy()
+                     else False for n in reach_data['node']])
+                reach_data = reach_data[has_multiple]
+                reach_data = reach_data[cols]
                 txt += _print_rec_array(reach_data, delimiter='\t')
 
         self._txt_footer(headertxt, txt, 'overlapping conductance')
@@ -2326,11 +2324,11 @@ class check:
         if (self.sfr.nstrm < 0 or self.sfr.reachinput and
                 self.sfr.isfropt in [1, 2, 3]):  # see SFR input instructions
             reach_data = np.array(self.reach_data)
-            i, j, k = reach_data['i', 'j', 'k']
+            i, j, k = reach_data['i'], reach_data['j'], reach_data['k']
 
             # check streambed bottoms in relation to respective cell bottoms
             bots = self.sfr.parent.dis.botm.array[k, i, j]
-            streambed_bots = reach_data.strtop - reach_data.strthick
+            streambed_bots = reach_data['strtop'] - reach_data['strthick']
             reach_data = recfunctions.append_fields(
                 reach_data, names=['layerbot', 'strbot'],
                 data=[bots, streambed_bots], usemask=False, asrecarray=False)
@@ -2346,9 +2344,9 @@ class check:
                 warning = False  # this constitutes an error (MODFLOW won't run)
             # check streambed elevations in relation to model top
             tops = self.sfr.parent.dis.top.array[i, j]
-            reach_data = recfunctions.append_fields(reach_data,
-                                                    names='modeltop',
-                                                    data=tops, asrecarray=True)
+            reach_data = recfunctions.append_fields(
+                reach_data, names='modeltop', data=tops,
+                usemask=False, asrecarray=False)
 
             txt += self._boolean_compare(
                 reach_data[['k', 'i', 'j', 'iseg', 'ireach',
@@ -2397,16 +2395,15 @@ class check:
             segment_ends = recfunctions.stack_arrays(
                 [first_reaches, last_reaches],
                 asrecarray=True, usemask=False)
-            segment_ends['strtop'] = np.append(segment_data.elevup,
-                                               segment_data.elevdn)
+            segment_ends['strtop'] = np.append(segment_data['elevup'],
+                                               segment_data['elevdn'])
             i, j = segment_ends.i, segment_ends.j
             tops = self.sfr.parent.dis.top.array[i, j]
             diff = tops - segment_ends.strtop
-            segment_ends = recfunctions.append_fields(segment_ends,
-                                                      names=['modeltop',
-                                                             'diff'],
-                                                      data=[tops, diff],
-                                                      asrecarray=True)
+            segment_ends = recfunctions.append_fields(
+                segment_ends,
+                names=['modeltop', 'diff'], data=[tops, diff],
+                usemask=False, asrecarray=False)
 
             txt += self._boolean_compare(segment_ends[['k', 'i', 'j', 'iseg',
                                                        'strtop', 'modeltop',

--- a/flopy/utils/modpathfile.py
+++ b/flopy/utils/modpathfile.py
@@ -229,7 +229,7 @@ class PathlineFile():
             Slice of pathline data array (e.g. PathlineFile._data)
             containing only pathlines with final k,i,j in dest_cells.
         """
-        ra = self._data.view(np.recarray)
+        ra = np.array(self._data)
         # find the intersection of endpoints and dest_cells
         # convert dest_cells to same dtype for comparison
         raslice = ra[['k', 'i', 'j']]
@@ -238,10 +238,10 @@ class PathlineFile():
         epdest = ra[inds].copy().view(np.recarray)
 
         # use particle ids to get the rest of the paths
-        inds = np.in1d(ra.particleid, epdest.particleid)
+        inds = np.in1d(ra['particleid'], epdest.particleid)
         pthldes = ra[inds].copy()
         pthldes.sort(order=['particleid', 'time'])
-        return pthldes
+        return pthldes.view(np.recarray)
 
     def write_shapefile(self, pathline_data=None,
                         one_per_particle=True,

--- a/flopy/utils/recarray_utils.py
+++ b/flopy/utils/recarray_utils.py
@@ -5,7 +5,7 @@ def create_empty_recarray(length, dtype, default_value=0):
     assert isinstance(dtype, np.dtype), "dtype argument must be an instance of np.dtype, not list."
     for name in dtype.names:
         dt = dtype.fields[name][0]
-        if 'float' in str(dt):
+        if np.issubdtype(dt, np.float_):
             r[name] = default_value
     return r.view(np.recarray)
 

--- a/flopy/utils/util_array.py
+++ b/flopy/utils/util_array.py
@@ -2430,7 +2430,7 @@ class Util2d(object):
     def load_bin(shape, file_in, dtype, bintype=None):
         import flopy.utils.binaryfile as bf
         nrow, ncol = shape
-        if bintype is not None and not np.issubdtype(dtype, np.int):
+        if bintype is not None and not np.issubdtype(dtype, np.integer):
             header_dtype = bf.BinaryHeader.set_dtype(bintype=bintype)
             header_data = np.fromfile(file_in, dtype=header_dtype, count=1)
         else:


### PR DESCRIPTION
Recent builds pass autotests ([e.g.](https://travis-ci.org/modflowpy/flopy/jobs/363188376)), but their logs reveal many warnings from numpy (RuntimeWarning and FutureWarning). While some of these are annoying, they do indicate some functionality will break in not-too-distant numpy versions.

I've made several modifications to resolve some of these issues, and generally there are two kinds of fixes:
 * Use masked arrays to handle invalid values. Masked arrays are essentially what MODFLOW does with an IBOUND array, so I find it surprising to not see them used in flopy. To me it seems wrong to use `np.nan` values in arrays for this purpose, as it may cause invalid value issues.
 * Use structured arrays rather than recarrays. Recarrays are essentially structured arrays, but with [extra overhead](https://jakevdp.github.io/PythonDataScienceHandbook/02.09-structured-data-numpy.html) and limitations. If you have seen a numpy warning with the words "this will return a view instead of a copy" it's from selecting multiple fields from recarrays. These warnings don't happen with structured arrays.

Note that these modifications are to internal data types, i.e. I haven't modified the return types. Please review carefully and comment if I have modified anything that I shouldn't have!

Also, I think I may have found a bug with `thin_cell_threshold` (in `mfdis.py`), which I've fixed. It may need a unit test...