### PR TITLE
Tidy up more warnings/errors with recent numpy versions

### DIFF
--- a/autotest/t011_test.py
+++ b/autotest/t011_test.py
@@ -27,7 +27,8 @@ def test_mflistfile():
 
     times = mflist.get_times()
     bud = mflist.get_data(totim=times[0])
-    assert isinstance(bud, np.ndarray)
+    # TODO: there are two return types, but only one is documented
+    assert isinstance(bud, np.ndarray) or bud is None
 
     # plt.bar(bud['index'], bud['value'])
     # plt.xticks(bud['index'], bud['name'], rotation=45, size=6)

--- a/flopy/utils/mflistfile.py
+++ b/flopy/utils/mflistfile.py
@@ -250,7 +250,7 @@ class ListBudget(object):
             names.insert(0, 'stress_period')
             names.insert(0, 'time_step')
             names.insert(0, 'totim')
-            return self.cum[names].view(np.recarray)
+            return np.array(self.cum)[names].view(np.recarray)
 
     def get_model_runtime(self, units='seconds'):
         """
@@ -417,6 +417,7 @@ class ListBudget(object):
             print('Could not find specified condition.')
             print('  kstpkper = {}'.format(kstpkper))
             print('  totim = {}'.format(totim))
+            # TODO: return zero-length array, or update docstring return type
             return None
 
         if incremental:
@@ -764,26 +765,26 @@ class ListBudget(object):
                 print(
                         'end of file found while seeking time information for ts,sp',
                         ts, sp)
-                return np.NaN, np.NaN, np.Nan
+                return np.NaN, np.NaN, np.NaN
             elif ihead == 2 and 'SECONDS     MINUTES      HOURS       DAYS        YEARS' not in line:
                 break
             elif '-----------------------------------------------------------' in line:
                 line = self.f.readline()
                 break
         tslen = self._parse_time_line(line)
-        if tslen == None:
+        if tslen is None:
             print('error parsing tslen for ts,sp', ts, sp)
-            return np.NaN, np.NaN, np.Nan
+            return np.NaN, np.NaN, np.NaN
 
         sptim = self._parse_time_line(self.f.readline())
-        if sptim == None:
+        if sptim is None:
             print('error parsing sptim for ts,sp', ts, sp)
-            return np.NaN, np.NaN, np.Nan
+            return np.NaN, np.NaN, np.NaN
 
         totim = self._parse_time_line(self.f.readline())
-        if totim == None:
+        if totim is None:
             print('error parsing totim for ts,sp', ts, sp)
-            return np.NaN, np.NaN, np.Nan
+            return np.NaN, np.NaN, np.NaN
         return tslen, sptim, totim
 
     def _parse_time_line(self, line):


### PR DESCRIPTION
Similar to #317, clean up a few warnings/errors with recent numpy releases, such as `FutureWarning`s (mostly on recarrays), and a few `AttributeError`s on numpy's nan.