### PR TITLE
Change MfList.fmt_string for floats to use numpy's string formatter

### DIFF
--- a/flopy/utils/util_list.py
+++ b/flopy/utils/util_list.py
@@ -13,6 +13,12 @@ import os
 import warnings
 import numpy as np
 
+try:
+    from numpy.lib import NumpyVersion
+    numpy114 = NumpyVersion(np.__version__) >= '1.14.0'
+except ImportError:
+    numpy114 = False
+
 
 class MfList(object):
     """
@@ -213,9 +219,10 @@ class MfList(object):
             mxact = max(mxact, self.get_itmp(kper))
         return mxact
 
-    # Get the numpy savetxt-style fmt string that corresponds to the dtype
     @property
     def fmt_string(self):
+        """Returns a C-style fmt string for numpy savetxt that corresponds to
+        the dtype"""
         if self.list_free_format is not None:
             use_free = self.list_free_format
         else:
@@ -225,32 +232,40 @@ class MfList(object):
             # mt3d list data is fixed format
             if 'mt3d' in self.package.parent.version.lower():
                 use_free = False
-        fmt_string = ''
+        fmts = []
         for field in self.dtype.descr:
             vtype = field[1][1].lower()
             if vtype == 'i':
                 if use_free:
-                    fmt_string += ' %9d'
+                    fmts.append('%9d')
                 else:
-                    fmt_string += '%10d'
+                    fmts.append('%10d')
             elif vtype == 'f':
                 if use_free:
-                    fmt_string += ' %15.7E'
+                    if numpy114:
+                        # Use numpy's floating-point formatter (Dragon4)
+                        fmts.append('%15s')
+                    else:
+                        fmts.append('%15.7E')
                 else:
-                    fmt_string += '%10G'
-
+                    fmts.append('%10G')
             elif vtype == 'o':
                 if use_free:
-                    fmt_string += ' %9s'
+                    fmts.append('%9s')
                 else:
-                    fmt_string += '%10s'
+                    fmts.append('%10s')
             elif vtype == 's':
-                raise Exception("MfList error: '\str\' type found it dtype." + \
-                                " This gives unpredictable results when " + \
-                                "recarray to file - change to \'object\' type")
+                raise TypeError(
+                        "MfList.fmt_string error: 'str' type found in dtype. "
+                        "This gives unpredictable results when "
+                        "recarray to file - change to 'object' type")
             else:
-                raise Exception("MfList.fmt_string error: unknown vtype " + \
-                                "in dtype:" + vtype)
+                raise TypeError("MfList.fmt_string error: unknown vtype in "
+                                "field: {}".format(field))
+        if use_free:
+            fmt_string = ' ' + ' '.join(fmts)
+        else:
+            fmt_string = ''.join(fmts)
         return fmt_string
 
     # Private method to cast the data argument


### PR DESCRIPTION
Stress data written by flopy inflates floating point precision, rather than preserving the native precision of the data type. This is due to a C-formatter tucked deep within flopy/utils/util_list.py. For example, a flux rate from a well package that is originally -8773.9 is effectively written by flopy as -8773.9004, introducing a difference of 0.0004. The good news is that these differences do not matter to single-precision floats (i.e. REAL or float32), but they are visually different when formatted, or used in double precision (or float64).

```python
import numpy as np
x = np.float32(-8773.9)
print(str(x))  # -8773.9

# Here is what MfList.fmt_string currently does
print(' %15.7E' % (x,))  # '  -8.7739004E+03'

# Suggested fix, keep 1-space + 15-character string, but get numpy to format the float type to a string
print(' %15s' % (x,))  # '         -8773.9'
```
As shown above (and in this PR), the suggested fix is to just format a string for fixed-width floats. Numpy supports a wide range of different float types with different precisions, and they generally get formatted to string in a way that honors their precision.

There are possible consequences to this PR. For instance, files written by flopy will look different. E.g., a well package file that previously looks like this:
```
...
         1       135       158  -6.9352997E+01
         1       140       147  -9.3911003E+01
         1       140       150  -8.0982002E+01
         1       142       158  -1.6040001E+01
         1       143       158  -6.4769997E+01
         1       147       150  -2.0000000E-02
         1       151       157  -2.6480000E+03
         1       155       163  -9.4968002E+01
         1       166       167  -2.5591899E+03
```
would then look like this:
```
...
         1       135       158         -69.353
         1       140       147         -93.911
         1       140       150         -80.982
         1       142       158          -16.04
         1       143       158          -64.77
         1       147       150           -0.02
         1       151       157         -2648.0
         1       155       163         -94.968
         1       166       167        -2559.19
```