### PR TITLE
Allow negative unit number to be written to Gage package input

### DIFF
--- a/flopy/modflow/mfgage.py
+++ b/flopy/modflow/mfgage.py
@@ -164,7 +164,6 @@ class ModflowGage(Package):
             # add gage output files to model
             for n in range(numgage):
                 iu = abs(gage_data['unit'][n])
-                # gage_data['unit'][n] = iu
                 fname = files[n]
                 model.add_output_file(iu, fname=fname, binflag=False,
                                       package=ModflowGage.ftype())

--- a/flopy/modflow/mfgage.py
+++ b/flopy/modflow/mfgage.py
@@ -164,7 +164,7 @@ class ModflowGage(Package):
             # add gage output files to model
             for n in range(numgage):
                 iu = abs(gage_data['unit'][n])
-                gage_data['unit'][n] = iu
+                # gage_data['unit'][n] = iu
                 fname = files[n]
                 model.add_output_file(iu, fname=fname, binflag=False,
                                       package=ModflowGage.ftype())


### PR DESCRIPTION
FloPy was previously resetting negative gage output unit numbers (UNIT) to absolute values before writing package file. 

From MODFLOW-NWT docs:

> UNIT 
Unit number for output file. Specify negative value of unit number to invoke reading of optional parameter OUTTYPE for listing additional information for lakes.

Previously:
autotest t047_test.py wasn't catching this but was writing the gage package incorrectly as:

> 2
-1 26
-2 27


This fix(?) removes line that sets gage_data['unit'] [n] to the absolute value. 
After this change FloPy in writes:

> 2
-1 -26 1
-2 -27 1

Unit numbers in the .nam file are still positive and correct.