### PR TITLE
Replace "which" with built-ins / distutils.spawn

### DIFF
--- a/autotest/t009_test.py
+++ b/autotest/t009_test.py
@@ -305,7 +305,7 @@ def test_export():
 
 def test_example():
     m = flopy.modflow.Modflow.load('test1ss.nam', version='mf2005',
-                                   exe_name='mf2005.exe',
+                                   exe_name='mf2005',
                                    model_ws=path,
                                    load_only=['ghb', 'evt', 'rch', 'dis',
                                               'bas6', 'oc', 'sip', 'lpf'])

--- a/autotest/t020_test.py
+++ b/autotest/t020_test.py
@@ -18,11 +18,8 @@ def analyticalWaterTableSolution(h1, h2, z, R, K, L, x):
 
 def test_mfnwt_run():
     import os
-    import platform
     import flopy
     exe_name = 'mfnwt'
-    if platform.system() == 'Windows':
-        exe_name = '{}.exe'.format(exe_name)
     exe = flopy.which(exe_name)
 
     if exe is None:

--- a/autotest/t502_test.py
+++ b/autotest/t502_test.py
@@ -1,5 +1,4 @@
 import os
-import platform
 import shutil
 
 import flopy
@@ -19,8 +18,6 @@ def test_create_and_run_model():
     sim_name = 'testsim'
     model_name = 'testmodel'
     exe_name = 'mf6'
-    if platform.system() == 'Windows':
-        exe_name += '.exe'
 
     # set up simulation
     tdis_name = '{}.tdis'.format(sim_name)

--- a/autotest/t503_test.py
+++ b/autotest/t503_test.py
@@ -2,7 +2,6 @@ import os
 import shutil
 import flopy
 import pymake
-import platform
 
 
 def download_mf6_distribution():
@@ -52,8 +51,6 @@ for f in folders:
     shutil.copytree(src, dst)
 
 exe_name = 'mf6'
-if platform.system() == 'Windows':
-    exe_name += '.exe'
 v = flopy.which(exe_name)
 run = True
 if v is None:

--- a/autotest/t504_test.py
+++ b/autotest/t504_test.py
@@ -1,5 +1,4 @@
 import os
-import platform
 
 import numpy as np
 
@@ -15,9 +14,6 @@ except:
     print('could not import pymake')
 
 exe_name = 'mf6'
-#exe_name = 'C:\\WrdApp\\mf6.0.1\\bin\\mf6'
-if platform.system() == 'Windows':
-    exe_name += '.exe'
 v = flopy.which(exe_name)
 
 run = True

--- a/autotest/t505_test.py
+++ b/autotest/t505_test.py
@@ -1,5 +1,4 @@
 import os
-import platform
 
 import numpy as np
 
@@ -41,9 +40,6 @@ except:
     print('could not import pymake')
 
 exe_name = 'mf6'
-# exe_name = 'C:\\WrdApp\\mf6.0.1\\bin\\mf6'
-if platform.system() == 'Windows':
-    exe_name += '.exe'
 v = flopy.which(exe_name)
 
 run = True

--- a/flopy/__init__.py
+++ b/flopy/__init__.py
@@ -35,4 +35,4 @@ from . import plot
 from . import export
 from . import pest
 from . import mf6
-from .mbase import run_model, which, is_exe
+from .mbase import run_model, which

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -22,31 +22,15 @@ import numpy as np
 from flopy import utils
 from .version import __version__
 
+if sys.version_info >= (3, 3):
+    from shutil import which
+else:
+    from distutils.spawn import find_executable as which
+
 # Global variables
 iconst = 1  # Multiplier for individual array elements in integer and real arrays read by MODFLOW's U2DREL, U1DREL and U2DINT.
 iprn = -1  # Printout flag. If >= 0 then array values read are printed in listing file.
 
-
-def is_exe(fpath):
-    return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
-
-
-def which(program):
-    fpath, fname = os.path.split(program)
-    if fpath:
-        if is_exe(program):
-            return program
-    else:
-        # test for exe in current working directory
-        if is_exe(program):
-            return program
-        # test for exe in path statement
-        for path in os.environ["PATH"].split(os.pathsep):
-            path = path.strip('"')
-            exe_file = os.path.join(path, program)
-            if is_exe(exe_file):
-                return exe_file
-    return None
 
 
 class FileData(object):


### PR DESCRIPTION
Flopy's "which" doesn't always work as good as other implementations of similar utilities. For instance, it does not find "mf2005.exe" on Windows computers with an input of "mf2005". This means that most of `t012_test.py` is effectively skipped on Windows computers. While other tests (e.g. `t020_test.py`) adjusted the executable before testing with "which".

This PR replaces "which" with the Python 3.3 built-in [shutil.which](https://docs.python.org/3/library/shutil.html#shutil.which), which is agnostic to Windows executable file extensions (i.e. `.exe`). Older Python versions can use [distutils.spawn](https://docs.python.org/2/distutils/apiref.html#module-distutils.spawn) for the same functionality. Also, `flopy.is_exe` is removed, as it wasn't used anywhere else. I've also removed portions of the autotests that add `.exe` to some tests, since these are no longer needed. In fact, this PR is mostly about code reduction!