### PR TITLE
Improve flopy.pakbase.Package.add_to_dtype

### DIFF
--- a/flopy/pakbase.py
+++ b/flopy/pakbase.py
@@ -164,17 +164,27 @@ class Package(object):
 
     @staticmethod
     def add_to_dtype(dtype, field_names, field_types):
+        """
+        Add one or more fields to a structured array data type
+
+        Parameters
+        ----------
+        dtype : numpy.dtype
+            Input structured array datatype to add to.
+        field_names : str or list
+            One or more field names.
+        field_types : numpy.dtype or list
+            One or more data types. If one data type is supplied, it is
+            repeated for each field name.
+        """
         if not isinstance(field_names, list):
             field_names = [field_names]
         if not isinstance(field_types, list):
             field_types = [field_types] * len(field_names)
-        newdtypes = [dtype]
+        newdtypes = dtype.descr
         for field_name, field_type in zip(field_names, field_types):
-            tempdtype = np.dtype([(field_name, field_type)])
-            newdtypes.append(tempdtype)
-        newdtype = sum((dtype.descr for dtype in newdtypes), [])
-        newdtype = np.dtype(newdtype)
-        return newdtype
+            newdtypes.append((str(field_name), field_type))
+        return np.dtype(newdtypes)
 
     def check(self, f=None, verbose=True, level=1):
         """


### PR DESCRIPTION
Specifically, force `field_name` to be a string, and simpler append of new data types. Also add missing docstring for this method.

This fixes an issue reading some package files with Python 2.7, where this method was raising "TypeError: data type not understood".  This was introduced in 3964672 for #248, which uses `io.open` to read text files, which returns Unicode objects instead of string objects (like `open` does). While this may seem harmless, it causes issues with Numpy's structured arrays, basically trying to do `np.dtype([(u'iface', np.float32)])`, which is a no no.