### PR TITLE
Updates mflmt.py documentation

### DIFF
--- a/flopy/modflow/mflmt.py
+++ b/flopy/modflow/mflmt.py
@@ -4,7 +4,7 @@ the ModflowLmt class as `flopy.modflow.ModflowLmt`.
 
 Additional information for this MODFLOW package can be found at the `Online
 MODFLOW Guide
-<http://water.usgs.gov/ogw/modflow/MODFLOW-2005-Guide/index.html?lmt.htm>`_.
+<http://water.usgs.gov/ogw/modflow/MODFLOW-2005-Guide/index.html?lmt6.htm>`_.
 
 """
 import os


### PR DESCRIPTION
The link to the Modflow-Guide returned an 404-Error.
This PR fixes the URL.