### PR TITLE
Revise SpatialReference properties, add geotransform

### DIFF
--- a/autotest/t007_test.py
+++ b/autotest/t007_test.py
@@ -238,7 +238,7 @@ def test_export_array():
 
     try:
         from scipy.ndimage import rotate
-    except:
+    except ImportError:
         rotate = False
         pass
 
@@ -284,7 +284,7 @@ def test_export_array():
     try:
         # test GeoTIFF export
         import rasterio
-    except:
+    except ImportError:
         pass
     if rasterio is not None:
         m.sr.export_array(os.path.join(tpth, 'fb.tif'), m.dis.top.array,
@@ -294,6 +294,11 @@ def test_export_array():
         assert src.shape == (m.nrow, m.ncol)
         assert np.abs(src.bounds[0] - m.sr.bounds[0]) < 1e-6
         assert np.abs(src.bounds[1] - m.sr.bounds[1]) < 1e-6
+        np.testing.assert_almost_equal(
+            src.affine,
+            [176.7766952966369, 176.77669529663686, 619653.0,
+             176.77669529663686, -176.7766952966369, 3353277.0, 0.0, 0.0, 1.0])
+
 
 def test_mbase_sr():
     import numpy as np

--- a/autotest/t007_test.py
+++ b/autotest/t007_test.py
@@ -611,14 +611,14 @@ def test_dynamic_xll_yll():
                                        xll=xll, yll=yll, rotation=30)
     assert sr1.xlength == 1250.0
     assert sr1.ylength == 5000.0
-    assert sr1.dx == 500.0
-    assert sr1.dy == 250.0
+    assert sr1.dx == 250.0
+    assert sr1.dy == 500.0
     np.testing.assert_almost_equal(
-        sr1.get_extent(), [-2213.2, 1369.3317547, 29.03, 4984.1570189])
+        sr1.get_extent(), (-2213.2, 1369.3317547, 29.03, 4984.1570189))
     np.testing.assert_almost_equal(
         sr1.geotransform,
-        (-2213.2, 433.01270189221935, 125.0,
-         4359.157018922193, 250.0, -216.50635094610968))
+        (-2213.2, 216.50635094610968, 250.0,
+         4359.157018922193, 125.0, -433.01270189221935))
 
     xul, yul = sr1.xul, sr1.yul
     sr1.length_multiplier = 1.0 / 3.281
@@ -626,14 +626,14 @@ def test_dynamic_xll_yll():
     assert sr1.yll == yll
     assert sr1.xlength == 1250.0
     assert sr1.ylength == 5000.0
-    assert sr1.dx == 500.0
-    assert sr1.dy == 250.0
+    assert sr1.dx == 250.0
+    assert sr1.dy == 500.0
     np.testing.assert_almost_equal(
-        sr1.get_extent(), [-475.1628162, 616.7395778, 29.03, 1539.2790152])
+        sr1.get_extent(), (-475.1628162, 616.7395778, 29.03, 1539.2790152))
     np.testing.assert_almost_equal(
         sr1.geotransform,
-        (-475.1628162145685, 131.97583111618997, 38.098140810728424,
-         1348.7883111618996, 76.19628162145685, -65.98791555809498))
+        (-475.1628162145685, 65.987915558094983, 76.196281621456848,
+         1348.7883111618996, 38.098140810728424, -131.97583111618997))
 
     sr2 = flopy.utils.SpatialReference(delr=ms2.dis.delr.array,
                                        delc=ms2.dis.delc.array, lenuni=2,

--- a/autotest/t007_test.py
+++ b/autotest/t007_test.py
@@ -553,10 +553,20 @@ def test_dynamic_xll_yll():
     sr1 = flopy.utils.SpatialReference(delr=ms2.dis.delr.array,
                                        delc=ms2.dis.delc.array, lenuni=2,
                                        xll=xll, yll=yll, rotation=30)
+    assert sr1.xlength == 1250.0
+    assert sr1.ylength == 5000.0
+    np.testing.assert_almost_equal(
+        sr1.get_extent(), [-2213.2, 1369.3317547, 29.03, 4984.1570189])
+
     xul, yul = sr1.xul, sr1.yul
     sr1.length_multiplier = 1.0 / 3.281
     assert sr1.xll == xll
     assert sr1.yll == yll
+    assert sr1.xlength == 1250.0
+    assert sr1.ylength == 5000.0
+    np.testing.assert_almost_equal(
+        sr1.get_extent(), [-475.1628162, 616.7395778, 29.03, 1539.2790152])
+
     sr2 = flopy.utils.SpatialReference(delr=ms2.dis.delr.array,
                                        delc=ms2.dis.delc.array, lenuni=2,
                                        xul=xul, yul=yul, rotation=30)
@@ -585,12 +595,12 @@ def test_dynamic_xll_yll():
     assert np.abs(sr4.xul - (xul + 10.)) < 1e-6 # these shouldn't move because ul has priority
     assert np.abs(sr4.yul - (yul + 21.)) < 1e-6
     assert np.abs(sr4.xll - sr4.xul) < 1e-6
-    assert np.abs(sr4.yll - (sr4.yul - sr4.yedge[0])) < 1e-6
+    assert np.abs(sr4.yll - (sr4.yul - sr4.ylength)) < 1e-6
     sr4.xll = 0.
     sr4.yll = 10.
     assert sr4.origin_loc == 'll'
     assert sr4.xul == 0.
-    assert sr4.yul == sr4.yedge[0] + 10.
+    assert sr4.yul == sr4.ylength + 10.
     sr4.xul = xul
     sr4.yul = yul
     assert sr4.origin_loc == 'ul'
@@ -604,10 +614,10 @@ def test_dynamic_xll_yll():
                                        rotation=0, epsg=26915)
     sr5.lenuni = 1
     assert sr5.length_multiplier == .3048
-    assert sr5.yul == sr5.yll + sr5.yedge[0] * sr5.length_multiplier
+    assert sr5.yul == sr5.yll + sr5.ylength * sr5.length_multiplier
     sr5.lenuni = 2
     assert sr5.length_multiplier == 1.
-    assert sr5.yul == sr5.yll + sr5.yedge[0]
+    assert sr5.yul == sr5.yll + sr5.ylength
     sr5.proj4_str = '+proj=utm +zone=16 +datum=NAD83 +units=us-ft +no_defs'
     assert sr5.units == 'feet'
     assert sr5.length_multiplier == 1/.3048

--- a/flopy/utils/reference.py
+++ b/flopy/utils/reference.py
@@ -1058,6 +1058,7 @@ class SpatialReference(object):
             txt += 'NODATA_value  {}\n'.format(fmt) % (nodata)
             with open(filename, 'w') as output:
                 output.write(txt)
+            with open(filename, 'ab') as output:  # for Python 3
                 np.savetxt(output, a, **kwargs)
             print('wrote {}'.format(filename))
 


### PR DESCRIPTION
The commit messages have more details, but the aim of this PR is to revise a few properties in the SpatialReference class. Here are the main changes:
 * Add `dx`, `dy`, `xlength`, `ylength` and `geotransform` properties to SpatialReference, which are used for array exports.
 * Remove `set_origin` and `theta`, as they don't appear to be needed (anymore?) and have no tests. They can be re-added, but some of the trigonometry will need to be revised, and tests added. `theta` was removed as it was using -ve angles for clockwise rotations. The correct rotation direction is counter clockwise (i.e. positive angles).
 * Exporting rasters with different resolutions in x- and y-directions should be supported by `export_array`, as it is supported by Surfer and GDAL (and hence QGIS). However, not all software support dx/dy in Arc Ascii grid formats. A warning is added if either delr and/or delc are not uniform.
 * Currently, rotated grids exported to Arc Ascii grids with `export_array` will do a spline interpolation. This modifies the grid dimensions and values, which are often extrapolated beyond the grid's min/max values. I've added a warning to be shown, as it's not typical that an export method would do this processing. Consider removing this feature, and moving the recipe to the Notes section or other place.

In case anyone is wondering where this is all going, I'd like to eventually revise `export_netcdf` to write netCDF files that are more compliant with the GDAL family of GIS software, which is best done with a `geotransform`.

Happy to discuss any of the changes, as there is a lot going on.