### PR TITLE
Use tuple index for multidimensional indexing

### DIFF
--- a/flopy/modpath/mp.py
+++ b/flopy/modpath/mp.py
@@ -246,7 +246,7 @@ class Modpath(BaseModel):
                         'Error: no well package in the passed model')
                 for kper in range(nper):
                     mflist = self.__mf.wel.stress_period_data[kper]
-                    idx = [mflist['k'], mflist['i'], mflist['j']]
+                    idx = (mflist['k'], mflist['i'], mflist['j'])
                     arr[idx] = 1
                 ngrp = arr.sum()
                 icnt = 0

--- a/flopy/plot/crosssection.py
+++ b/flopy/plot/crosssection.py
@@ -582,7 +582,7 @@ class ModelCrossSection(object):
 
         # Plot the list locations
         plotarray = np.zeros(self.dis.botm.shape, dtype=np.int)
-        idx = [mflist['k'], mflist['i'], mflist['j']]
+        idx = (mflist['k'], mflist['i'], mflist['j'])
         plotarray[idx] = 1
         plotarray = np.ma.masked_equal(plotarray, 0)
         if color is None:

--- a/flopy/plot/map.py
+++ b/flopy/plot/map.py
@@ -376,14 +376,14 @@ class ModelMap(object):
         # Plot the list locations
         plotarray = np.zeros((nlay, self.sr.nrow, self.sr.ncol), dtype=np.int)
         if plotAll:
-            idx = [mflist['i'], mflist['j']]
+            idx = (mflist['i'], mflist['j'])
             # plotarray[:, idx] = 1
             pa = np.zeros((self.sr.nrow, self.sr.ncol), dtype=np.int)
             pa[idx] = 1
             for k in range(nlay):
                 plotarray[k, :, :] = pa.copy()
         else:
-            idx = [mflist['k'], mflist['i'], mflist['j']]
+            idx = (mflist['k'], mflist['i'], mflist['j'])
             plotarray[idx] = 1
 
         # mask the plot array


### PR DESCRIPTION
This is to step around a numpy FutureWarning:

> Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.

Mind you, I'm only seeing this with one combination of Numpy 1.15.0 with Python 3.6, but not other Python versions...