### PR TITLE
BUG: BAS6 free reading, fixed writing

### DIFF
--- a/autotest/t044_test.py
+++ b/autotest/t044_test.py
@@ -49,6 +49,10 @@ def load_and_write_pcgn(mfnam, pth):
     m = flopy.modflow.Modflow.load(mfnam, model_ws=lpth, verbose=True,
                                    exe_name=exe_name)
     assert m.load_fail is False
+    if mfnam in ['twri.nam']:  # update this list for fixed models
+        assert m.free_format_input is False
+    else:
+        assert m.free_format_input is True
 
     if run:
         try:

--- a/flopy/modflow/mfbas.py
+++ b/flopy/modflow/mfbas.py
@@ -214,20 +214,26 @@ class ModflowBas(Package):
         #f_bas.write('%s\n' % self.heading)
         f_bas.write('{0:s}\n'.format(self.heading))
         # Second line: format specifier
-        self.options = ''
+        opts = []
         if self.ixsec:
-            self.options += 'XSECTION'
+            opts.append('XSECTION')
         if self.ichflg:
-            self.options += ' CHTOCH'
+            opts.append('CHTOCH')
         if self.ifrefm:
-            self.options += ' FREE'
+            opts.append('FREE')
         if self.stoper is not None:
-            self.options += ' STOPERROR {0}'.format(self.stoper)
-        f_bas.write('{0:s}\n'.format(self.options))
+            opts.append('STOPERROR {0}'.format(self.stoper))
+        self.options = ' '.join(opts)
+        f_bas.write(self.options + '\n')
         # IBOUND array
         f_bas.write(self.ibound.get_file_entry())
         # Head in inactive cells
-        f_bas.write('{0:15.6G}\n'.format(self.hnoflo))
+        str_hnoflo = str(self.hnoflo).rjust(10)
+        if not self.ifrefm and len(str_hnoflo) > 10:
+            # write fixed-width no more than 10 characters
+            str_hnoflo = '{0:10.4G}'.format(self.hnoflo)
+            assert len(str_hnoflo) <= 10, str_hnoflo
+        f_bas.write(str_hnoflo + '\n')
         # Starting heads array
         f_bas.write(self.strt.get_file_entry())
         # Close file

--- a/flopy/modflow/mfbas.py
+++ b/flopy/modflow/mfbas.py
@@ -8,6 +8,7 @@ MODFLOW Guide
 
 """
 
+import re
 import sys
 import numpy as np
 from ..pakbase import Package
@@ -282,29 +283,19 @@ class ModflowBas(Package):
             if line[0] != '#':
                 break
         #dataset 1 -- options
-        line = line.upper()
+        # only accept alphanumeric characters, as well as '+', '-' and '.'
+        line = re.sub(r'[^A-Z0-9\.\-\+]', ' ', line.upper())
         opts = line.strip().split()
-        ixsec = False
-        ichflg = False
-        ifrefm = False
-        iprinttime = False
-        ishowp = False
-        istoperror = False
-        stoper = None
-        if 'XSECTION' in opts:
-            ixsec = True
-        if 'CHTOCH' in opts:
-            ichflg = True
-        if 'FREE' in opts:
-            ifrefm = True
-        if 'PRINTTIME' in opts:
-            iprinttime = True
-        if 'SHOWPROGRESS' in opts:
-            ishowp = True
+        ixsec = 'XSECTION' in opts
+        ichflg = 'CHTOCH' in opts
+        ifrefm = 'FREE' in opts
+        iprinttime = 'PRINTTIME' in opts
+        ishowp = 'SHOWPROGRESS' in opts
         if 'STOPERROR' in opts:
-            istoperror = True
             i = opts.index('STOPERROR')
             stoper = np.float32(opts[i+1])
+        else:
+            stoper = None
         #get nlay,nrow,ncol if not passed
         if nlay is None and nrow is None and ncol is None:
             nrow, ncol, nlay, nper = model.get_nrow_ncol_nlay_nper()


### PR DESCRIPTION
There are actually two related bugs addressed in this PR (one for each commit):
1. Loading: option lines like `FREE, SHOWPROGRESS` (see examples/data/pcgn_test/MNW2.bas) were not correctly parsed, since `split()` would get `FREE,`, rather than `FREE` (see the comma?). The fix is to replace most non alphanumeric characters with a space before `split()`
2. Writing: the hnoflow was not correctly written for fixed-formats, making MODFLOW think -999.0 was 0.0