### PR TITLE
LAK: Explicit cast to np.array isn't preserved

### DIFF
--- a/flopy/modflow/mflak.py
+++ b/flopy/modflow/mflak.py
@@ -322,7 +322,7 @@ class ModflowLak(Package):
         self.sscncr = sscncr
         self.surfdep = surfdep
         if isinstance(stages, float):
-            stages = np.array(self.nlakes, dtype=np.float) * stages
+            stages = np.array(self.nlakes * stages, dtype=np.float)
         elif isinstance(stages, list):
             stages = np.array(stages)
         if stages.shape[0] != nlakes:


### PR DESCRIPTION
I ran into a small snag while trying to set up a test model that uses a single lake.  Running the following bit of script shows what I think is an error.  'stages' is explicitly cast to type np.array.  However, it works out to be np.float64 after the multiplication by a float ('stages').  By putting the multiplication inside the explicit cast, the result is an array. I'm using python 3.5.3.  Suggested fix is for line 325 of mflak.py

    >>> nlakes
    1
    >>> stages
    268.0
    >>> stages = np.array(nlakes, dtype=np.float) * stages
    >>> stages
    268.0
    >>> type(stages)
    <class 'numpy.float64'>
    >>> stages = np.array(nlakes * stages, dtype=np.float)
    >>> stages
    array(268.0)
    >>> type(stages)
    <class 'numpy.ndarray'>