### PR TITLE
Maintain order of items in code.json

### DIFF
--- a/code.json
+++ b/code.json
@@ -1,10 +1,34 @@
 [
     {
-        "status": "Release Candidate", 
-        "downloadURL": "https://code.usgs.gov/usgs/modflow/flopy/archive/master.zip", 
-        "repositoryURL": "https://code.usgs.gov/usgs/modflow/flopy.git", 
-        "disclaimerURL": "https://code.usgs.gov/usgs/modflow/flopy/blob/master/DISCLAIMER.md", 
+        "name": "flopy", 
         "description": "FloPy is a python package to create, run, and post-process MODFLOW-based models.", 
+        "organization": "U.S. Geological Survey", 
+        "contact": {
+            "name": "Joseph D. Hughes", 
+            "email": "jdhughes@usgs.gov"
+        }, 
+        "version": "3.2.9.199", 
+        "status": "Release Candidate", 
+        "date": {
+            "metadataLastUpdated": "2018-09-17"
+        }, 
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://code.usgs.gov/usgs/modflow/flopy/blob/master/LICENSE.md", 
+                    "name": "Public Domain, CC0-1.0"
+                }
+            ], 
+            "usageType": "openSource"
+        }, 
+        "homepageURL": "https://code.usgs.gov/usgs/modflow/flopy/", 
+        "repositoryURL": "https://code.usgs.gov/usgs/modflow/flopy.git", 
+        "downloadURL": "https://code.usgs.gov/usgs/modflow/flopy/archive/master.zip", 
+        "disclaimerURL": "https://code.usgs.gov/usgs/modflow/flopy/blob/master/DISCLAIMER.md", 
+        "vcs": "git", 
+        "languages": [
+            "python"
+        ], 
         "tags": [
             "MODFLOW", 
             "MODFLOW 6", 
@@ -20,30 +44,6 @@
             "transport model", 
             "python"
         ], 
-        "vcs": "git", 
-        "languages": [
-            "python"
-        ], 
-        "contact": {
-            "name": "Joseph D. Hughes", 
-            "email": "jdhughes@usgs.gov"
-        }, 
-        "laborHours": -1, 
-        "version": "3.2.9.199", 
-        "date": {
-            "metadataLastUpdated": "2018-09-17"
-        }, 
-        "organization": "U.S. Geological Survey", 
-        "permissions": {
-            "licenses": [
-                {
-                    "URL": "https://code.usgs.gov/usgs/modflow/flopy/blob/master/LICENSE.md", 
-                    "name": "Public Domain, CC0-1.0"
-                }
-            ], 
-            "usageType": "openSource"
-        }, 
-        "homepageURL": "https://code.usgs.gov/usgs/modflow/flopy/", 
-        "name": "flopy"
+        "laborHours": -1
     }
 ]

--- a/pre-commit.py
+++ b/pre-commit.py
@@ -6,7 +6,7 @@ import os
 import sys
 import datetime
 import json
-
+from collections import OrderedDict
 
 # update files and paths so that there are the same number of
 # path and file entries in the paths and files list. Enter '.'
@@ -193,20 +193,21 @@ def add_updated_files():
 
 def update_codejson(vmajor, vminor, vmicro, vbuild):
 
+    json_fname = files[4]
     # get branch
     branch = get_branch()
     if branch is None:
-        print('Cannot update code.json - could not determine current branch')
+        print('Cannot update {0} - could not determine current branch'
+              .format(json_fname))
         return
 
     # create version
     version = get_tag(vmajor, vminor, vmicro)
-    
+
     # load and modify json file
-    jsonFile = open('code.json', 'r') # Open the JSON file for reading
-    data = json.load(jsonFile) # Read the JSON into the buffer
-    jsonFile.close() # Close the JSON file
-    
+    with open(json_fname, 'r') as f:
+        data = json.load(f, object_pairs_hook=OrderedDict)
+
     # modify the json file data
     now = datetime.datetime.now()
     sdate = now.strftime('%Y-%m-%d')
@@ -217,13 +218,14 @@ def update_codejson(vmajor, vminor, vmicro, vbuild):
     else:
         data[0]['version'] = version + '.{}'.format(vbuild)
         data[0]['status'] = 'Release Candidate'
-    
+
     # rewrite the json file
-    with open(files[4], 'w') as f:
-        json.dump(data, f, indent=4)  
-    
+    with open(json_fname, 'w') as f:
+        json.dump(data, f, indent=4)
+        f.write('\n')
+
     return
-    
+
 
 def update_readme_markdown(vmajor, vminor, vmicro, vbuild):
     


### PR DESCRIPTION
This helps minimize numbers of lines changed after pre-commit.py, as dictionaries are inherently not ordered. This change uses an OrderedDict to maintain the order in code.json. Note that content of code.json has not changed, and has non-working URLs. It is only ordered more naturally:
```
['name',
 'description',
 'organization',
 'contact',
 'version',
 'status',
 'date',
 'permissions',
 'homepageURL',
 'repositoryURL',
 'downloadURL',
 'disclaimerURL',
 'vcs',
 'languages',
 'tags',
 'laborHours']
```