### PR TITLE
Fix a few "[NbConvertApp] ERROR" from Python 3.6

### DIFF
--- a/examples/Notebooks/flopy3_WatertableRecharge_example.ipynb
+++ b/examples/Notebooks/flopy3_WatertableRecharge_example.ipynb
@@ -35,8 +35,8 @@
     }
    ],
    "source": [
-    "%matplotlib inline\n",
     "from __future__ import print_function\n",
+    "%matplotlib inline\n",
     "import os\n",
     "import sys\n",
     "import platform\n",

--- a/examples/Notebooks/flopy3_sfrpackage_example.ipynb
+++ b/examples/Notebooks/flopy3_sfrpackage_example.ipynb
@@ -37,7 +37,7 @@
     }
    ],
    "source": [
-    "% matplotlib inline\n",
+    "%matplotlib inline\n",
     "import sys\n",
     "import platform\n",
     "import os\n",

--- a/examples/Notebooks/flopy3_shapefile_export.ipynb
+++ b/examples/Notebooks/flopy3_shapefile_export.ipynb
@@ -18,7 +18,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "% matplotlib inline\n",
+    "%matplotlib inline\n",
     "import sys\n",
     "import os\n",
     "import numpy as np\n",

--- a/examples/Notebooks/flopy3_working_stack_demo.ipynb
+++ b/examples/Notebooks/flopy3_working_stack_demo.ipynb
@@ -30,9 +30,9 @@
     }
    ],
    "source": [
+    "from __future__ import print_function\n",
     "%matplotlib inline\n",
     "from IPython.display import clear_output, display\n",
-    "from __future__ import print_function\n",
     "import time\n",
     "import os\n",
     "import sys\n",


### PR DESCRIPTION
I noticed that Travis CI's Python 3.6 builds were failing due to a few errors in the example notebooks. This attempts to fix them.

Errors were either using `% matplotlib inline` instead of `%matplotlib inline`, or not having `from __future__` at the top.