### PR TITLE
Fix(Numpy array .aslist() calls)

### DIFF
--- a/flopy/modflow/mfgage.py
+++ b/flopy/modflow/mfgage.py
@@ -108,7 +108,7 @@ class ModflowGage(Package):
                     for idx in range(numgage):
                         files.append('{}.gage{}.go'.format(model.name, idx+1))
                 if isinstance(files, np.ndarray):
-                    files = files.flatten().aslist()
+                    files = files.flatten().tolist()
                 elif isinstance(files, str):
                     files = [files]
                 elif isinstance(files, int) or isinstance(files, float):

--- a/flopy/modflow/mflak.py
+++ b/flopy/modflow/mflak.py
@@ -385,7 +385,7 @@ class ModflowLak(Package):
                 if isinstance(value, np.ndarray):
                     td = {}
                     for k in range(value.shape[0]):
-                        td[k] = value[k, :].aslist()
+                        td[k] = value[k, :].tolist()
                     flux_data[key] = td
                     if len(list(flux_data.keys())) != nlakes:
                         err = 'flux_data dictionary must ' + \
@@ -395,7 +395,7 @@ class ModflowLak(Package):
                         isinstance(value, int):
                     td = {}
                     for k in range(self.nlakes):
-                        td[k] = (np.ones(6, dtype=np.float) * value).aslist()
+                        td[k] = (np.ones(6, dtype=np.float) * value).tolist()
                     flux_data[key] = td
                 elif isinstance(value, dict):
                     try:

--- a/flopy/utils/flopy_io.py
+++ b/flopy/utils/flopy_io.py
@@ -83,7 +83,7 @@ def write_fixed_var(v, length=10, ipos=None, free=False, comment=None):
 
     """
     if isinstance(v, np.ndarray):
-        v = v.aslist()
+        v = v.tolist()
     elif isinstance(v, int) or isinstance(v, float) or isinstance(v, bool):
         v = [v]
     ncol = len(v)
@@ -94,7 +94,7 @@ def write_fixed_var(v, length=10, ipos=None, free=False, comment=None):
             ipos.append(length)
     else:
         if isinstance(ipos, np.ndarray):
-            ipos = ipos.flatten().aslist()
+            ipos = ipos.flatten().tolist()
         elif isinstance(ipos, int):
             ipos = [ipos]
         if len(ipos) < ncol:
@@ -148,7 +148,7 @@ def read_fixed_var(line, ncol=1, length=10, ipos=None, free=False):
                 ipos.append(length)
         else:
             if isinstance(ipos, np.ndarray):
-                ipos = ipos.flatten().aslist()
+                ipos = ipos.flatten().tolist()
             elif isinstance(ipos, int):
                 ipos = [ipos]
             ncol = len(ipos)


### PR DESCRIPTION
I found when creating or modifying a LAK package with flux_data input as
a numpy array that ModflowLak would die on td[k] = value[k, :].aslist().
I could find no reference to this numpy array method, so not sure where
it comes from. I changed .aslist() to .tolist() (https://docs.scipy.org/
doc/numpy/reference/generated/numpy.ndarray.tolist.html), which works.
I subsequently encountered the same error in other files (flopy_io and
mfgage), and hence altered the .aslist() calls in those too.