### PR TITLE
Improper uses of sys.exit

### DIFF
--- a/examples/scripts/flopy_swi2_ex1.py
+++ b/examples/scripts/flopy_swi2_ex1.py
@@ -48,7 +48,7 @@ def run():
             if '.py' != os.path.splitext(f)[1].lower():
                 print('  removing...{}'.format(os.path.basename(f)))
                 os.remove(os.path.join(workspace, f))
-        sys.exit(1)
+        return 1
 
     modelname = 'swiex1'
     exe_name = 'mf2005'
@@ -204,3 +204,4 @@ def run():
 
 if __name__ == "__main__":
     success = run()
+    sys.exit(success)

--- a/examples/scripts/flopy_swi2_ex2.py
+++ b/examples/scripts/flopy_swi2_ex2.py
@@ -69,7 +69,7 @@ def run():
         for d in dirs:
             if os.path.exists(d):
                 os.rmdir(d)
-        sys.exit(1)
+        return 1
 
     # make working directories
     for d in dirs:
@@ -371,3 +371,4 @@ def run():
 
 if __name__ == '__main__':
     success = run()
+    sys.exit(success)

--- a/flopy/mt3d/mtcts.py
+++ b/flopy/mt3d/mtcts.py
@@ -1,9 +1,8 @@
+from ..pakbase import Package
+
 __author__ = 'emorway'
 
-import sys
-import numpy as np
-from ..pakbase import Package
-from ..utils import Util2d, Util3d, read1d, MfList
+
 class Mt3dCts(Package):
     """
     MT3D-USGS Contaminant Treatment System package class
@@ -215,13 +214,10 @@ class Mt3dCts(Package):
         # 
         # # Item 1 (MXCTS, ICTSOUT, MXEXT, MXINJ, MXWEL, IFORCE)
         # line = f.readline()
+        # if line[0] == '#':
+        #     raise ValueError('CTS package does not support comment lines')
         # if model.verbose:
         #     print('   loading MXCTS, ICTSOUT, MXEXT, MXINJ, MXWEL, IFORCE...')
-        #     if line[0] == '#':
-        #         print('   "#" found in the first position.  CTS package does ',
-        #               'not support comment lines\n')
-        #         print('   Stopping.')
-        #         sys.exit()
         # 
         # m_arr = line.strip().split()
         # mxcts = int(m_arr[0])

--- a/flopy/mt3d/mtlkt.py
+++ b/flopy/mt3d/mtlkt.py
@@ -1,10 +1,10 @@
-__author__ = 'emorway'
-
 import sys
 import numpy as np
 
 from ..pakbase import Package
-from ..utils import Util2d, read1d, MfList
+from ..utils import Util2d, MfList
+
+__author__ = 'emorway'
 
 
 class Mt3dLkt(Package):
@@ -313,10 +313,7 @@ class Mt3dLkt(Package):
         # Item 1 (NLKINIT,MXLKBC,ICBCLK,IETLAK)
         line = f.readline()
         if line[0] == '#':
-            if model.verbose:
-                print(
-                    '   LKT package currently does not support comment lines...')
-                sys.exit()
+            raise ValueError('LKT package does not support comment lines')
 
         if model.verbose:
             print('   loading nlkinit,mxlkbc,icbclk,ietlak   ')

--- a/flopy/mt3d/mtsft.py
+++ b/flopy/mt3d/mtsft.py
@@ -1,10 +1,10 @@
-__author__ = 'emorway'
-
 import sys
 import numpy as np
 
 from ..pakbase import Package
 from ..utils import Util2d, MfList
+
+__author__ = 'emorway'
 
 
 class Mt3dSft(Package):
@@ -485,10 +485,7 @@ class Mt3dSft(Package):
         # Item 1 (NSFINIT, MXSFBC, ICBCSF, IOUTOBS, IETSFR)
         line = f.readline()
         if line[0] == '#':
-            if model.verbose:
-                print('   SFT package currently does not support comment ' \
-                      'lines...')
-                sys.exit()
+            raise ValueError('SFT package does not support comment lines')
 
         if model.verbose:
             print('   loading nsfinit, mxsfbc, icbcsf, ioutobs, ietsfr...')
@@ -521,10 +518,8 @@ class Mt3dSft(Package):
 
         vals = line.strip().split()
 
-        if len(vals) < 7 and model.verbose:
-            print('   not enough values specified in item 2 of SFT input \
-                      file, exiting...')
-            sys.exit()
+        if len(vals) < 7:
+            raise ValueError('expected 7 values for item 2 of SFT input file')
         else:
             isfsolv = int(vals[0])
             wimp = float(vals[1])


### PR DESCRIPTION
Found a few instances where a module calls `sys.exit` while in verbose mode. This is a Python no-no, and I've rewritten these instances to raise a ValueError.

However, `sys.exit` should be used in scripts where `__name__ == '__main__'` so the success code is returned to the shell.