### PR TITLE
Only add .nam extension if needed

### DIFF
--- a/flopy/modflow/mf.py
+++ b/flopy/modflow/mf.py
@@ -523,9 +523,13 @@ class Modflow(BaseModel):
 
         """
 
-        # try to tack on '.nam' if missing from the filename
-        if not f.lower().endswith('.nam'):
-            f += '.nam'
+        # similar to modflow command: if file does not exist , try file.nam
+        namefile_path = os.path.join(model_ws, f)
+        if (not os.path.isfile(namefile_path) and
+                os.path.isfile(namefile_path + '.nam')):
+            namefile_path += '.nam'
+        if not os.path.isfile(namefile_path):
+            raise IOError('cannot find name file: ' + str(namefile_path))
 
         # Determine model name from 'f', without any extension or path
         modelname = os.path.splitext(os.path.basename(f))[0]
@@ -540,8 +544,6 @@ class Modflow(BaseModel):
 
         files_successfully_loaded = []
         files_not_loaded = []
-
-        namefile_path = os.path.join(ml.model_ws, f)
 
         # set the reference information
         ref_attributes = SpatialReference.load(namefile_path)


### PR DESCRIPTION
The load function should be able to import exotic/classic MODFLOW models that don't use a `.nam` extensions for the NAM file (Visual MODFLOW Classic, GMS, probably others). These changes in this PR mimic the behavior of the MODFLOW command, where a `.nam` extension is added only if the file does not exist.

And if neither of these files exist, a `IOError` is raised.