### PR TITLE
BUG: UPW's data sets 2 to 6 can span several lines

### DIFF
--- a/flopy/modflow/mflpf.py
+++ b/flopy/modflow/mflpf.py
@@ -63,14 +63,14 @@ class ModflowLpf(Package):
         of the hydraulic conductivity along columns (the Y direction) to the
         hydraulic conductivity along rows (the X direction).
         (default is 1).
-    layvka : float or array of floats (nlay)
+    layvka : int or array of ints (nlay)
         a flag for each layer that indicates whether variable VKA is vertical
         hydraulic conductivity or the ratio of horizontal to vertical
         hydraulic conductivity.
         0: VKA is vertical hydraulic conductivity
         not 0: VKA is the ratio of horizontal to vertical hydraulic conductivity
         (default is 0).
-    laywet : float or array of floats (nlay)
+    laywet : int or array of ints (nlay)
         contains a flag for each layer that indicates if wetting is active.
         0 wetting is inactive
         not 0 wetting is active
@@ -446,7 +446,7 @@ class ModflowLpf(Package):
         # LAYVKA array
         if model.verbose:
             print('   loading LAYVKA...')
-        layvka = np.empty((nlay), dtype=np.float32)
+        layvka = np.empty((nlay,), dtype=np.int32)
         layvka = read1d(f, layvka)
 
         # LAYWET array

--- a/flopy/modflow/mfupw.py
+++ b/flopy/modflow/mfupw.py
@@ -69,11 +69,11 @@ class ModflowUpw(Package):
         value of CHANI for each layer. The horizontal anisotropy is the ratio
         of the hydraulic conductivity along columns (the Y direction) to the
         hydraulic conductivity along rows (the X direction).
-    layvka : float or array of floats (nlay)
+    layvka : int or array of ints (nlay)
         a flag for each layer that indicates whether variable VKA is vertical
         hydraulic conductivity or the ratio of horizontal to vertical
         hydraulic conductivity.
-    laywet : float or array of floats (nlay)
+    laywet : int or array of ints (nlay)
         contains a flag for each layer that indicates if wetting is active.
         laywet should always be zero for the UPW Package because all cells
         initially active are wettable.
@@ -197,7 +197,7 @@ class ModflowUpw(Package):
         self.iphdry = iphdry
         self.laytyp = Util2d(model, (nlay,), np.int32, laytyp, name='laytyp')
         self.layavg = Util2d(model, (nlay,), np.int32, layavg, name='layavg')
-        self.chani = Util2d(model, (nlay,), np.int32, chani, name='chani')
+        self.chani = Util2d(model, (nlay,), np.float32, chani, name='chani')
         self.layvka = Util2d(model, (nlay,), np.int32, layvka, name='vka')
         self.laywet = Util2d(model, (nlay,), np.int32, laywet, name='laywet')
 
@@ -378,7 +378,7 @@ class ModflowUpw(Package):
         # LAYVKA array
         if model.verbose:
             print('   loading LAYVKA...')
-        layvka = np.empty((nlay,), dtype=np.float32)
+        layvka = np.empty((nlay,), dtype=np.int32)
         layvka = read1d(f, layvka)
 
         # LAYWET array

--- a/flopy/modflow/mfupw.py
+++ b/flopy/modflow/mfupw.py
@@ -12,7 +12,7 @@ import sys
 import numpy as np
 from .mfpar import ModflowPar as mfpar
 from ..pakbase import Package
-from ..utils import Util2d, Util3d
+from ..utils import Util2d, Util3d, read1d
 from ..utils.flopy_io import line_parse
 
 
@@ -356,36 +356,37 @@ class ModflowUpw(Package):
             for k in range(3, len(t)):
                 if 'NOPARCHECK' in t[k].upper():
                     noparcheck = True
+
         # LAYTYP array
         if model.verbose:
             print('   loading LAYTYP...')
-        line = f.readline()
-        t = line.strip().split()
-        laytyp = np.array((t[0:nlay]), dtype=np.int32)
+        laytyp = np.empty((nlay,), dtype=np.int32)
+        laytyp = read1d(f, laytyp)
+
         # LAYAVG array
         if model.verbose:
             print('   loading LAYAVG...')
-        line = f.readline()
-        t = line.strip().split()
-        layavg = np.array((t[0:nlay]), dtype=np.int32)
+        layavg = np.empty((nlay,), dtype=np.int32)
+        layavg = read1d(f, layavg)
+
         # CHANI array
         if model.verbose:
             print('   loading CHANI...')
-        line = f.readline()
-        t = line.strip().split()
-        chani = np.array((t[0:nlay]), dtype=np.float32)
+        chani = np.empty((nlay,), dtype=np.float32)
+        chani = read1d(f, chani)
+
         # LAYVKA array
         if model.verbose:
             print('   loading LAYVKA...')
-        line = f.readline()
-        t = line.strip().split()
-        layvka = np.array((t[0:nlay]), dtype=np.int32)
+        layvka = np.empty((nlay,), dtype=np.float32)
+        layvka = read1d(f, layvka)
+
         # LAYWET array
         if model.verbose:
             print('   loading LAYWET...')
-        line = f.readline()
-        t = line.strip().split()
-        laywet = np.array((t[0:nlay]), dtype=np.int32)
+        laywet = np.empty((nlay,), dtype=np.int32)
+        laywet = read1d(f, laywet)
+
         # Item 7: WETFCT, IWETIT, IHDWET
         wetfct, iwetit, ihdwet = None, None, None
         iwetdry = laywet.sum()


### PR DESCRIPTION
Use `read1d` to read LAYTYP, LAYAVG, CHANI, LAYVKA, and LAYWET, which can span more than one line.
This was essentially lifted from mflpf.py