### PR TITLE
Forgive loading models with an incomplete BAS6 package

### DIFF
--- a/autotest/t007_test.py
+++ b/autotest/t007_test.py
@@ -916,7 +916,7 @@ def test_shapefile_ibound():
     model_ws = os.path.join('..', 'examples', 'data',
                             'freyberg_multilayer_transient')
     ml = flopy.modflow.Modflow.load(nam_file, model_ws=model_ws, check=False,
-                                    verbose=True, load_only=[])
+                                    verbose=True, load_only=['bas6'])
     ml.export(shape_name)
     shp = shapefile.Reader(shape_name)
     field_names = [item[0] for item in shp.fields][1:]

--- a/flopy/modflow/mf.py
+++ b/flopy/modflow/mf.py
@@ -504,7 +504,7 @@ class Modflow(BaseModel):
             One package can also be specified, e.g. "rch". Default is None,
             which attempts to load all files. An empty list [] will not load
             any additional packages than is necessary. At a minimum, "dis" or
-            "disu" is always loaded, and "bas6" (if available) is also loaded.
+            "disu" is always loaded.
         forgive : bool, optional
             Option to raise exceptions on package load failure, which can be
             useful for debugging. Default False.
@@ -636,18 +636,6 @@ class Modflow(BaseModel):
         dis.sr = sr
         dis.tr = TemporalReference(itmuni=itmuni, start_datetime=start_datetime)
         dis.start_datetime = start_datetime
-
-        # load bas after dis if it is available. Note that the free format
-        # option was already determined earlier in this method.
-        if bas_key is not None:
-            pck = bas.package.load(bas.filename, ml,
-                                   ext_unit_dict=ext_unit_dict, check=False)
-            files_successfully_loaded.append(bas.filename)
-            if ml.verbose:
-                print('   {:4s} package load...success'
-                      .format(pck.name[0]))
-            assert bas_key == ml.pop_key_list.pop()
-            ext_unit_dict.pop(bas_key)
 
         if load_only is None:
             # load all packages/files

--- a/flopy/utils/util_array.py
+++ b/flopy/utils/util_array.py
@@ -2672,18 +2672,20 @@ class Util2d(object):
                          array_free_format=array_free_format)
 
         elif cr_dict['type'] == 'external':
-            if str('binary') not in str(cr_dict['fmtin'].lower()):
+            ext_unit = ext_unit_dict[cr_dict['nunit']]
+            if ext_unit.filehandle is None:
+                raise IOError('cannot read unit {0}, filename: {1}'
+                              .format(cr_dict['nunit'], ext_unit.filename))
+            elif 'binary' not in str(cr_dict['fmtin'].lower()):
                 assert cr_dict['nunit'] in list(ext_unit_dict.keys())
-                data = Util2d.load_txt(shape,
-                                       ext_unit_dict[
-                                           cr_dict['nunit']].filehandle,
+                data = Util2d.load_txt(shape, ext_unit.filehandle,
                                        dtype, cr_dict['fmtin'])
             else:
                 if cr_dict['nunit'] not in list(ext_unit_dict.keys()):
                     cr_dict["nunit"] *= -1
                 assert cr_dict['nunit'] in list(ext_unit_dict.keys())
                 header_data, data = Util2d.load_bin(
-                    shape, ext_unit_dict[cr_dict['nunit']].filehandle, dtype,
+                    shape, ext_unit.filehandle, dtype,
                     bintype='Head')
             u2d = Util2d(model, shape, dtype, data, name=name,
                          iprn=cr_dict['iprn'], fmtin="(FREE)",


### PR DESCRIPTION
This PR allows loading a MODFLOW model with an incomplete BAS6 package, e.g. where STRT is an EXTERNAL reference to a file that does not exist. Previously, a vague error would be raised in this instance:
> TypeError: coercing to Unicode: need string or buffer, NoneType found
as loading BAS6 in full was required.

Changes in this PR first show a better exception when attempting to load an array from an EXTERNAL file that does not exist, e.g.:
> IOError: cannot read unit 630, filename: ./starting.hds

And secondly, BAS6 is loaded under the same `forgive` / `load_only` options as the other packages, as it doesn't require any special treatment beyond finding the "FREE" option, as is already done if the file is present. This allows loading of MODFLOW models with incomplete BAS6 packages.