### PR TITLE
Ensure external 1-D arrays are written like 2-D arrays

### DIFF
--- a/flopy/utils/gridgen.py
+++ b/flopy/utils/gridgen.py
@@ -1593,7 +1593,7 @@ class Gridgen(object):
         else:
             s += '  DELR = OPEN/CLOSE delr.dat\n'
             fname = os.path.join(self.model_ws, 'delr.dat')
-            np.savetxt(fname, delr)
+            np.savetxt(fname, np.atleast_2d(delr))
 
         # delc
         delc = self.dis.delc.array
@@ -1602,7 +1602,7 @@ class Gridgen(object):
         else:
             s += '  DELC = OPEN/CLOSE delc.dat\n'
             fname = os.path.join(self.model_ws, 'delc.dat')
-            np.savetxt(fname, delc)
+            np.savetxt(fname, np.atleast_2d(delc))
 
         # top
         top = self.dis.top.array

--- a/flopy/utils/util_array.py
+++ b/flopy/utils/util_array.py
@@ -2398,7 +2398,7 @@ class Util2d(object):
     def write_txt(shape, file_out, data, fortran_format="(FREE)",
                   python_format=None):
         if fortran_format.upper() == '(FREE)' and python_format is None:
-            np.savetxt(file_out, data,
+            np.savetxt(file_out, np.atleast_2d(data),
                        ArrayFormat.get_default_numpy_fmt(data.dtype),
                        delimiter='')
             return


### PR DESCRIPTION
This change ensures that external files of 1-D arrays written by `Util2d.write_txt` and `Gridgen.to_disu6` are written on one line (i.e. row output). For example, previously an open/close file for delr would have been written on one line in delr.ref, but some subtle changes from #386 changed this behavior to write this external file with column output, i.e. one line per number. This is because [numpy.savetxt](https://docs.scipy.org/doc/numpy-1.15.0/reference/generated/numpy.savetxt.html) writes 1-D arrays as column output.

(It is also because the array's fortran_format changed from a default `(nplE15.6)` format from a numpy array constructor to a `(FREE)` fortran_format from a Util2d array constructor. Specifically [here](https://github.com/modflowpy/flopy/pull/386/files#diff-5a7ded6d95d1111d69d9a5f7df39907e) delr is first a Util2d object from Util2d.load, but then overwritten as a numpy array with the former `delr.array.reshape` call, which is a subtle thing to catch in a dynamically-typed language like Python.)