### PR TITLE
feat(vtk): Added new htop argument to vtk writer

### DIFF
--- a/docs/version_changes.md
+++ b/docs/version_changes.md
@@ -4,6 +4,7 @@ FloPy Changes
 * Added support for pyshp version 2.x, which contains a different call signature for the writer than earlier versions.
 * Added a new flopy3_MT3DMS_examples notebook, which uses Flopy to reproduce the example problems described in the MT3DMS documentation report by Zheng and Wang (1999).
 * Pylint is now used on Travis for the Python 3.5 distribution to check for coding errors.
+* Added a new htop argument to the vtk writer, which allows cell tops to be defined by the simulated head.
 
 * Bug fixes:
     * Removed variable MXUZCON from `mtuzt.py` that was present during the development of MT3D-USGS, but was not included in the release version of MT3D-USGS. 

--- a/flopy/utils/reference.py
+++ b/flopy/utils/reference.py
@@ -1416,9 +1416,38 @@ class SpatialReference(object):
                                    iv1 + nrvncv, iv2 + nrvncv,
                                    iv4, iv3, iv1, iv2])
 
+        # renumber and reduce the vertices if ibound_filter
+        if ibound is not None:
+
+            # go through the vertex list and mark vertices that are used
+            ivertrenum = np.zeros(npoints, dtype=np.int)
+            for vlist in iverts:
+                for iv in vlist:
+                    # mark vertices that are actually used
+                    ivertrenum[iv] = 1
+
+            # renumber vertices that are used, skip those that are not
+            inum = 0
+            for i in range(npoints):
+                if ivertrenum[i] > 0:
+                    inum += 1
+                    ivertrenum[i] = inum
+            ivertrenum -= 1
+
+            # reassign the vertex list using the new vertex numbers
+            iverts2 = []
+            for vlist in iverts:
+                vlist2 = []
+                for iv in vlist:
+                    vlist2.append(ivertrenum[iv])
+                iverts2.append(vlist2)
+            iverts = iverts2
+            idx = np.where(ivertrenum >= 0)
+            verts = verts[idx]
+
         return verts, iverts
 
-    def get_3d_vertex_connectivity(self, nlay, botm, ibound=None):
+    def get_3d_vertex_connectivity(self, nlay, top, bot, ibound=None):
         if ibound is None:
             ncells = nlay * self.nrow * self.ncol
             ibound = np.ones((nlay, self.nrow, self.ncol), dtype=np.int)
@@ -1438,7 +1467,7 @@ class SpatialReference(object):
                     pts = self.get_vertices(i, j)
                     pt0, pt1, pt2, pt3, pt0 = pts
 
-                    z = botm[k + 1, i, j]
+                    z = bot[k, i, j]
 
                     verts[ipoint, 0:2] = np.array(pt1)
                     verts[ipoint, 2] = z
@@ -1460,7 +1489,7 @@ class SpatialReference(object):
                     ivert.append(ipoint)
                     ipoint += 1
 
-                    z = botm[k, i, j]
+                    z = top[k, i, j]
 
                     verts[ipoint, 0:2] = np.array(pt1)
                     verts[ipoint, 2] = z


### PR DESCRIPTION
htop can now be passed into the vtk writer. htop should be the top of the cell or the head, whichever is lower. Also refactored the shared_vertex option so that when the ibound filter is used, only the points for the active cells are included in the vtk point list. Prior to this change, all of the vertex points for the grid were included in the vtk file, which resulted in very large vtk files.