### PR TITLE
Fix 'tuple not callable' error in SFR

### DIFF
--- a/flopy/modflow/mfsfr2.py
+++ b/flopy/modflow/mfsfr2.py
@@ -561,7 +561,7 @@ class ModflowSfr2(Package):
                              ('reachID', np.int),
                              ('outreach', np.int)])
         else:
-            return np.dtype([('node', np.int)
+            return np.dtype([('node', np.int),
                              ('iseg', np.int),
                              ('ireach', np.int),
                              ('rchlen', np.float32),


### PR DESCRIPTION
Missing comma in mfsfr2.py get_default_reach_dtype for unstructured option.