### PR TITLE
feat(CellBudgetFile): method to return file position

### DIFF
--- a/autotest/t017_test.py
+++ b/autotest/t017_test.py
@@ -128,7 +128,7 @@ def test_cellbudgetfile_position():
     except:
         assert False, 'could not list records on {}'.format(opth)
 
-    names = v2.get_unique_record_names()
+    names = v2.get_unique_record_names(decode=True)
 
     cbcd2 = []
     for i in range(0, v2.get_nrecords()):

--- a/flopy/utils/binaryfile.py
+++ b/flopy/utils/binaryfile.py
@@ -854,9 +854,14 @@ class CellBudgetFile(object):
             print(rec)
         return
 
-    def get_unique_record_names(self):
+    def get_unique_record_names(self, decode=False):
         """
         Get a list of unique record names in the file
+
+        Parameters
+        ----------
+        decode : bool
+            Optional boolean used to decode byte strings (default is False).
 
         Returns
         ----------
@@ -864,16 +869,24 @@ class CellBudgetFile(object):
             List of unique text names in the binary file.
 
         """
-        names = []
-        for text in self.textlist:
-            if isinstance(text, bytes):
-                text = text.decode()
-            names.append(text)
+        if decode:
+            names = []
+            for text in self.textlist:
+                if isinstance(text, bytes):
+                    text = text.decode()
+                names.append(text)
+        else:
+            names = self.textlist
         return names
 
-    def get_unique_package_names(self):
+    def get_unique_package_names(self, decode=False):
         """
         Get a list of unique package names in the file
+
+        Parameters
+        ----------
+        decode : bool
+            Optional boolean used to decode byte strings (default is False).
 
         Returns
         ----------
@@ -881,11 +894,14 @@ class CellBudgetFile(object):
             List of unique package names in the binary file.
 
         """
-        names = []
-        for text in self.paknamlist:
-            if isinstance(text, bytes):
-                text = text.decode()
-            names.append(text)
+        if decode:
+            names = []
+            for text in self.paknamlist:
+                if isinstance(text, bytes):
+                    text = text.decode()
+                names.append(text)
+        else:
+            names = self.paknamlist
         return names
 
     def _unique_package_names(self):

--- a/flopy/utils/zonbud.py
+++ b/flopy/utils/zonbud.py
@@ -161,7 +161,7 @@ class ZoneBudget(object):
 
         # All record names in the cell-by-cell budget binary file
         self.record_names = [n.strip() for n in
-                             self.cbc.get_unique_record_names()]
+                             self.cbc.get_unique_record_names(decode=True)]
 
         # Get imeth for each record in the CellBudgetFile record list
         self.imeth = {}


### PR DESCRIPTION
Add method `.get_position()` to `CellBudgetFile` to return position of the
start of the data for a record in binary budget files. Optionally,
return the position of the start of the header for a record in binary
budget files. This method can be used to extract a slice from a binary
budget file. Update t017 autotest to test `.get_position()` method.

Modify `.list_unique_records()` and `.list_unique_package_names()` methods
to convert byte strings to standard strings (using `.decode()`). Update
t017 and t039 autotests to accommodate this modification.