### PR TITLE
fix(import): mf6 absolute path imports changed to relative path imports

### DIFF
--- a/flopy/mf6/modflow/mfsimulation.py
+++ b/flopy/mf6/modflow/mfsimulation.py
@@ -6,18 +6,17 @@ mfsimulation module.  contains the MFSimulation class
 import errno, sys, inspect
 import collections
 import os.path
-import numpy as np
-from flopy.mbase import run_model
-from flopy.mf6.mfbase import PackageContainer, MFFileMgmt, ExtFileAction, \
-                             PackageContainerType, MFDataException, \
-                             FlopyException, VerbosityLevel
-from flopy.mf6.mfmodel import MFModel
-from flopy.mf6.mfpackage import MFPackage
-from flopy.mf6.data.mfstructure import DatumType
-from flopy.mf6.data import mfstructure, mfdata
-from flopy.mf6.utils import binaryfile_utils
-from flopy.mf6.utils import mfobservation
-from flopy.mf6.modflow import mfnam, mfims, mftdis, mfgwfgnc, mfgwfmvr
+from ...mbase import run_model
+from ..mfbase import PackageContainer, MFFileMgmt, ExtFileAction, \
+                     PackageContainerType, MFDataException, FlopyException, \
+                     VerbosityLevel
+from ..mfmodel import MFModel
+from ..mfpackage import MFPackage
+from ..data.mfstructure import DatumType
+from ..data import mfstructure, mfdata
+from ..utils import binaryfile_utils
+from ..utils import mfobservation
+from ..modflow import mfnam, mfims, mftdis, mfgwfgnc, mfgwfmvr
 
 
 class SimulationDict(collections.OrderedDict):


### PR DESCRIPTION
Absolute path imports of flopy in the mf6 part of flopy have all been changed to relative path imports.  However, there still are a few places in the original flopy code that use absolute path imports of flopy (in export/utils.py, plot/plotutil.py, utils/datafile.py, utils/util_array.py, and utils/util_list.py).  In these cases I am not sure if this was intentional or not, so I did not change it.