### PR TITLE
ci(.travis.yml): Drop Python 3.4, add Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,21 @@
 language: python
 os: linux
-dist: trusty
-sudo: required
+dist: xenial
 compiler: gcc
+
+services:
+  - xvfb
 
 matrix:
   include:
     - python: 2.7
-    - python: 3.4
     - python: 3.5
     - python: 3.6
-    - python: "3.6-dev"
-    - python: "nightly"
+    - python: 3.7
+    - python: "3.7-dev"
 
   allow_failures:
-    - python: "3.6-dev"
     - python: "3.7-dev"
-    - python: "nightly"
 
 cache:
   pip: true
@@ -42,11 +41,6 @@ env:
   global:
     - NO_NET=1
 
-# start Virtual X, so default matplotlib backend works
-before_install:
-    - "export DISPLAY=:99.0"
-    - "sh -e /etc/init.d/xvfb start"
-
 # command to install dependencies
 install:
     - if [[ ! -d "$HOME/.local/bin" ]]; then
@@ -61,15 +55,10 @@ install:
     - ls -l /usr/bin/g++-6
     - export CXX="g++"
     - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then
-      pip install -r requirements2-34.travis.txt;
-      pip install requests;
-      echo requests version1; python -c "import requests; print(requests.__version__)";
-      fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 3.4 ]];
-      then pip install -r requirements2-34.travis.txt;
-      fi
-    - if [[ $TRAVIS_PYTHON_VERSION > 3.4 ]];
-      then pip install -r requirements.travis.txt;
+        pip install -r requirements27.travis.txt;
+        echo requests version1; python -c "import requests; print(requests.__version__)";
+      else
+        pip install -r requirements.travis.txt;
       fi
     - pip install https://github.com/modflowpy/pymake/zipball/master
     - pip install --upgrade jupyter
@@ -94,8 +83,9 @@ script:
     - echo pylint version; pylint --version
     - nosetests -v build_exes.py --with-id --with-timer -w ./autotest
     - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then
-      nosetests -v autotest_notebooks.py --with-id --with-timer -w ./autotest --with-coverage --cover-package=flopy;
-      nosetests -v autotest_scripts.py --with-id --with-timer -w ./autotest --with-coverage --cover-package=flopy;
+        nosetests -v autotest_scripts.py --with-id --with-timer -w ./autotest --with-coverage --cover-package=flopy;
+      elif [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then
+        nosetests -v autotest_notebooks.py --with-id --with-timer -w ./autotest --with-coverage --cover-package=flopy;
       fi
     - nosetests -v --with-id --with-timer -w ./autotest --with-coverage --cover-package=flopy
 

--- a/autotest/autotest_notebooks.py
+++ b/autotest/autotest_notebooks.py
@@ -1,6 +1,5 @@
 # Remove the temp directory and then create a fresh one
 import os
-import platform
 import shutil
 import subprocess
 
@@ -29,12 +28,6 @@ def get_Notebooks(dpth):
 
 
 def run_notebook(dpth, fn):
-    # only run notebook autotests on released versions of python 3.6
-    pvstr = platform.python_version()
-    if '3.6.' not in pvstr and '+' not in pvstr:
-        print('skipping...{} on python {}'.format(fn, pvstr))
-        return
-    
     # run autotest on each notebook
     pth = os.path.join(dpth, fn)
     cmd = 'jupyter ' + 'nbconvert ' + \

--- a/autotest/autotest_scripts.py
+++ b/autotest/autotest_scripts.py
@@ -2,7 +2,6 @@
 from __future__ import print_function
 import os
 import sys
-import platform
 import shutil
 
 exclude = ['flopy_swi2_ex2.py', 'flopy_swi2_ex5.py']
@@ -54,12 +53,6 @@ def import_from(mod, name):
 
 
 def run_scripts(fn):
-    # only run script autotests on released versions of python 3.6
-    pvstr = platform.python_version()
-    if '3.6.' not in pvstr and '+' not in pvstr:
-        print('skipping...{} on python {}'.format(fn, pvstr))
-        return
-
     # import run function from scripts
     s = os.path.splitext(fn)[0]
     run = import_from(s, 'run')

--- a/requirements27.travis.txt
+++ b/requirements27.travis.txt
@@ -7,3 +7,4 @@ pyproj
 pyshp
 enum34
 pandas
+requests


### PR DESCRIPTION
Python 3.4 is a few weeks from it's end-of-life https://devguide.python.org/#branchstatus

Python 3.7 was released half a year ago, so it makes sense add this to the Travis CI mix.

I've also dropped 3.6-dev, as 3.7-dev was already there.

Note that some of these changes were in place from a3822baa79bacbf326fd651c93a9bdd7d106ebfd but reverted.