### PR TITLE
feat(datafile): Raise IOError when attempting to read empty files

### DIFF
--- a/autotest/t017_test.py
+++ b/autotest/t017_test.py
@@ -3,12 +3,14 @@ import os
 import shutil
 import numpy as np
 import flopy
+from nose.tools import assert_raises
 
 cpth = os.path.join('temp', 't017')
 # delete the directory if it exists
 if os.path.isdir(cpth):
     shutil.rmtree(cpth)
 os.makedirs(cpth)
+
 
 def test_formattedfile_read():
 
@@ -34,6 +36,14 @@ def test_formattedfile_read():
     ts = h.get_ts((0, 7, 5))
     assert np.isclose(ts[0, 1], 944.487, 1e-6), \
         'time series value ({}) != {}'.format(ts[0, 1], 944.487)
+
+    # Check error when reading empty file
+    fname = os.path.join(cpth, 'empty.githds')
+    with open(fname, 'w'):
+        pass
+    with assert_raises(IOError):
+        flopy.utils.FormattedHeadFile(fname)
+
     return
 
 
@@ -60,6 +70,16 @@ def test_binaryfile_read():
     ts = h.get_ts((0, 7, 5))
     assert np.isclose(ts[0, 1], 26.00697135925293), \
         'time series value ({}) != {}'.format(ts[0, 1], - 26.00697135925293)
+
+    # Check error when reading empty file
+    fname = os.path.join(cpth, 'empty.githds')
+    with open(fname, 'w'):
+        pass
+    with assert_raises(IOError):
+        flopy.utils.HeadFile(fname)
+    with assert_raises(IOError):
+        flopy.utils.HeadFile(fname, 'head', 'single')
+
     return
 
 
@@ -137,6 +157,13 @@ def test_cellbudgetfile_position():
     for i, (d1, d2) in enumerate(zip(cbcd, cbcd2)):
         msg = '{} data from slice is not identical'.format(names[i].rstrip())
         assert np.array_equal(d1, d2), msg
+
+    # Check error when reading empty file
+    fname = os.path.join(cpth, 'empty.gitcbc')
+    with open(fname, 'w'):
+        pass
+    with assert_raises(IOError):
+        flopy.utils.CellBudgetFile(fname)
 
     return
 

--- a/flopy/utils/binaryfile.py
+++ b/flopy/utils/binaryfile.py
@@ -199,8 +199,16 @@ def get_headfile_precision(filename):
     for i in range(33, 127):
         asciiset += chr(i)
 
-    # first try single
+    # Open file, and check filesize to ensure this is not an empty file
     f = open(filename, 'rb')
+    f.seek(0, 2)
+    totalbytes = f.tell()
+    f.seek(0, 0)  # reset to beginning
+    assert f.tell() == 0
+    if totalbytes == 0:
+        raise IOError('datafile error: file is empty: ' + str(filename))
+
+    # first try single
     vartype = [('kstp', '<i4'), ('kper', '<i4'), ('pertim', '<f4'),
                ('totim', '<f4'), ('text', 'S16')]
     hdr = binaryread(f, vartype)
@@ -548,6 +556,13 @@ class CellBudgetFile(object):
         self.precision = precision
         self.verbose = verbose
         self.file = open(self.filename, 'rb')
+        # Get filesize to ensure this is not an empty file
+        self.file.seek(0, 2)
+        totalbytes = self.file.tell()
+        self.file.seek(0, 0)  # reset to beginning
+        assert self.file.tell() == 0
+        if totalbytes == 0:
+            raise IOError('datafile error: file is empty: ' + str(filename))
         self.nrow = 0
         self.ncol = 0
         self.nlay = 0

--- a/flopy/utils/datafile.py
+++ b/flopy/utils/datafile.py
@@ -87,12 +87,17 @@ class LayerFile(object):
     """
 
     def __init__(self, filename, precision, verbose, kwargs):
-        assert os.path.exists(
-            filename), "datafile error: datafile not found:" + str(filename)
         self.filename = filename
         self.precision = precision
         self.verbose = verbose
         self.file = open(self.filename, 'rb')
+        # Get filesize to ensure this is not an empty file
+        self.file.seek(0, 2)
+        totalbytes = self.file.tell()
+        self.file.seek(0, 0)  # reset to beginning
+        assert self.file.tell() == 0
+        if totalbytes == 0:
+            raise IOError('datafile error: file is empty: ' + str(filename))
         self.nrow = 0
         self.ncol = 0
         self.nlay = 0


### PR DESCRIPTION
This feature provides a more useful error message when attempting to read an empty file. For example, if a mt3dms simulations crashes (e.g. #466), it leaves an empty `file.ucn` file and this is the error:
```
ucnobj = flopy.utils.UcnFile('file.ucn')
```
> IndexError: index 0 is out of bounds for axis 0 with size 0

The new message should now be:
> OSError: datafile error: file is empty: file.ucn

which is intended to help the user sort out their issue. This message is used for:
 - `flopy.utils.UcnFile`
 - `flopy.utils.FormattedHeadFile`
 - `flopy.utils.HeadFile` (with/without auto-precision detection)
 - `flopy.utils.CellBudgetFile`