### PR TITLE
Fix(plotutil.py): saturated_thickness() method.

### DIFF
--- a/flopy/plot/plotutil.py
+++ b/flopy/plot/plotutil.py
@@ -1544,7 +1544,7 @@ class PlotUtilities(object):
             nlay, nrow, ncol = head.shape
             ncpl = nrow * ncol
             head.shape = (nlay, ncpl)
-            top.shape = (nlay, ncpl)
+            top.shape = (ncpl,)
             botm.shape = (nlay, ncpl)
             if laytyp.ndim == 3:
                 laytyp.shape = (nlay, ncpl)


### PR DESCRIPTION
changed top.shape from (nlay, ncpl) to (ncpl,) to fix multi-layered model support

issue #486 