### PR TITLE
Fix(grid.py): lenuni stored as integer in Grid

### DIFF
--- a/flopy/discretization/grid.py
+++ b/flopy/discretization/grid.py
@@ -62,6 +62,10 @@ class Grid(object):
         spatial reference locates the grid in a coordinate system
     epsg : epsg SpatialReference
         spatial reference locates the grid in a coordinate system
+    lenuni : int
+        modflow lenuni parameter
+    units : str
+        string representation of the lenuni parameter
     origin_x : float
         x coordinate of the origin point in the spatial reference coordinate
         system
@@ -126,12 +130,21 @@ class Grid(object):
     def __init__(self, grid_type=None, top=None, botm=None, idomain=None,
                  lenuni=None, epsg=None, proj4=None, prj=None, xoff=0.0, yoff=0.0,
                  angrot=0.0):
+        lenunits = {0: "undefined", 1: "feet", 2: "meters", 3: "centimeters"}
+        LENUNI = {"u": 0, "f": 1, "m": 2, "c": 3}
         self.use_ref_coords = True
         self._grid_type = grid_type
         self._top = top
         self._botm = botm
         self._idomain = idomain
+
+        if lenuni is None:
+            lenuni = 0
+        elif isinstance(lenuni, str):
+            lenuni = LENUNI[lenuni.lower()[0]]
         self._lenuni = lenuni
+
+        self._units = lenunits[self._lenuni]
         self._epsg = epsg
         self._proj4 = proj4
         self._prj = prj
@@ -149,7 +162,7 @@ class Grid(object):
         s = "xll:{0:<.10G}; yll:{1:<.10G}; rotation:{2:<G}; ". \
             format(self.xoffset, self.yoffset, self.angrot)
         s += "proj4_str:{0}; ".format(self.proj4)
-        s += "units:{0}; ".format("")
+        s += "units:{0}; ".format(self.units)
         s += "lenuni:{0}; ".format(self.lenuni)
         s += "length_multiplier:{}".format(1)
         return s
@@ -210,6 +223,10 @@ class Grid(object):
     def top_botm(self):
         new_top = np.expand_dims(self._top, 0)
         return np.concatenate((new_top, self._botm), axis=0)
+
+    @property
+    def units(self):
+        return self._units
 
     @property
     def lenuni(self):

--- a/flopy/discretization/grid.py
+++ b/flopy/discretization/grid.py
@@ -64,8 +64,6 @@ class Grid(object):
         spatial reference locates the grid in a coordinate system
     lenuni : int
         modflow lenuni parameter
-    units : str
-        string representation of the lenuni parameter
     origin_x : float
         x coordinate of the origin point in the spatial reference coordinate
         system

--- a/flopy/export/netcdf.py
+++ b/flopy/export/netcdf.py
@@ -190,7 +190,7 @@ class NetCdf(object):
                 'Warning: model has no coordinate reference system specified. '
                 'Using default proj4 string: {}'.format(proj4_str))
         self.proj4_str = proj4_str
-        self.grid_units = self.model_grid.lenuni
+        self.grid_units = self.model_grid.units
         self.z_positive = z_positive
         if self.grid_units is None:
             self.grid_units = "unspecified"
@@ -764,7 +764,7 @@ class NetCdf(object):
         time[:] = np.asarray(time_values)
 
         # Elevation
-        attribs = {"units": self.model_grid.lenuni,
+        attribs = {"units": self.model_grid.units,
                    "standard_name": "elevation",
                    "long_name": NC_LONG_NAMES.get("elevation", "elevation"),
                    "axis": "Z",
@@ -796,7 +796,7 @@ class NetCdf(object):
 
         # x
         self.log("creating x var")
-        attribs = {"units": self.model_grid.lenuni,
+        attribs = {"units": self.model_grid.units,
                    "standard_name": "projection_x_coordinate",
                    "long_name": NC_LONG_NAMES.get("x",
                                                   "x coordinate of projection"),
@@ -807,7 +807,7 @@ class NetCdf(object):
 
         # y
         self.log("creating y var")
-        attribs = {"units": self.model_grid.lenuni,
+        attribs = {"units": self.model_grid.units,
                    "standard_name": "projection_y_coordinate",
                    "long_name": NC_LONG_NAMES.get("y",
                                                   "y coordinate of projection"),
@@ -836,7 +836,7 @@ class NetCdf(object):
 
         if self.model_grid.grid_type == 'structured':
             # delc
-            attribs = {"units": self.model_grid.lenuni.strip('s'),
+            attribs = {"units": self.model_grid.units.strip('s'),
                        "long_name": NC_LONG_NAMES.get("delc",
                                                       "Model grid cell spacing along a column"),
                        }
@@ -848,7 +848,7 @@ class NetCdf(object):
                                 "To compute the unrotated grid, use the origin point and this array."
 
             # delr
-            attribs = {"units":self.model_grid.lenuni.strip('s'),
+            attribs = {"units":self.model_grid.units.strip('s'),
                        "long_name": NC_LONG_NAMES.get("delr",
                                                       "Model grid cell spacing along a row"),
                        }

--- a/flopy/modflow/mf.py
+++ b/flopy/modflow/mf.py
@@ -252,7 +252,7 @@ class Modflow(BaseModel):
         else:
             ibound = None
 
-        lenuni = {0: "undefined", 1: "feet", 2: "meters", 3: "centimeters"}
+
         if self.get_package('disu') is not None:
             raise NotImplementedError("Unstructured grid <model.modelgrid> generation"
                                       " not yet implemented for modflow-usg. Please create"
@@ -263,7 +263,7 @@ class Modflow(BaseModel):
                                          self.dis.delr.array,
                                          self.dis.top.array,
                                          self.dis.botm.array, ibound,
-                                         lenuni[self.dis.lenuni],
+                                         self.dis.lenuni,
                                          proj4=self._modelgrid.proj4,
                                          epsg=self._modelgrid.epsg,
                                          xoff=self._modelgrid.xoffset,

--- a/flopy/seawat/swt.py
+++ b/flopy/seawat/swt.py
@@ -163,12 +163,11 @@ class Seawat(BaseModel):
         else:
             ibound = None
         # build grid
-        lenuni = {0: "undefined", 1: "feet", 2: "meters", 3: "centimeters"}
         self._modelgrid = StructuredGrid(self.dis.delc.array,
                                          self.dis.delr.array,
                                          self.dis.top.array,
                                          self.dis.botm.array, ibound,
-                                         lenuni=lenuni[self.dis.lenuni],
+                                         lenuni=self.dis.lenuni,
                                          proj4=self._modelgrid.proj4,
                                          epsg=self._modelgrid.epsg,
                                          xoff=self._modelgrid.xoffset,


### PR DESCRIPTION
* added units property to Grid base class

* added support for either string or int lenuni parameter input for Grid class

* updated mf.Modflow.modelgrid property to pass integer lenuni to modelgrid

* updated swt.Seawat.modelgrid property to pass integer lenuni to modelgrid

issue #489 