### PR TITLE
Implement intersect method for VertexGrid

### DIFF
--- a/autotest/t062_test_intersect.py
+++ b/autotest/t062_test_intersect.py
@@ -59,7 +59,7 @@ def disv_model():
         cellxy[icpl, 1] = (yv[iv[1]] + yv[iv[2]]) / 2.
 
     # need to create cell2d, which is [[icpl, xc, yc, nv, iv1, iv2, iv3, iv4]]
-    cell2d = [[icpl, cellxy[icpl, 0], cellxy[icpl, 1], 4, *iverts[icpl]] for
+    cell2d = [[icpl, cellxy[icpl, 0], cellxy[icpl, 1], 4]  + iverts[icpl] for
               icpl in range(ncpl)]
     vertices = [[ivert, verts[ivert, 0], verts[ivert, 1]] for ivert in
                 range(nvert)]

--- a/autotest/t062_test_intersect.py
+++ b/autotest/t062_test_intersect.py
@@ -1,0 +1,117 @@
+import flopy
+import numpy as np
+import matplotlib.pyplot as plt
+
+# grid properties
+nlay = 3
+nrow = 21
+ncol = 20
+delr = 500.
+delc = 500.
+top = 400.
+botm = [220., 200., 0.]
+xorigin=3000
+yorigin=1000
+angrot=10
+
+
+def dis_model():
+    sim = flopy.mf6.MFSimulation()
+    gwf = flopy.mf6.ModflowGwf(sim)
+
+    # dis
+    flopy.mf6.ModflowGwfdis(gwf, nlay=nlay, nrow=nrow, ncol=ncol,
+                            delr=delr, delc=delc,
+                            top=top, botm=botm,
+                            xorigin=xorigin,yorigin=yorigin,angrot=angrot)
+    return gwf
+
+def disv_model():
+    sim = flopy.mf6.MFSimulation()
+    gwf = flopy.mf6.ModflowGwf(sim)
+
+    ncpl = nrow * ncol
+    xv = np.linspace(0, delr * ncol, ncol + 1)
+    yv = np.linspace(delc * nrow, 0, nrow + 1)
+    xv, yv = np.meshgrid(xv, yv)
+    xv = xv.ravel()
+    yv = yv.ravel()
+
+    def get_vlist(i, j, nrow, ncol):
+        v1 = i * (ncol + 1) + j
+        v2 = v1 + 1
+        v3 = v2 + ncol + 1
+        v4 = v3 - 1
+        return [v1, v2, v3, v4]
+
+    iverts = []
+    for i in range(nrow):
+        for j in range(ncol):
+            iverts.append(get_vlist(i, j, nrow, ncol))
+
+    nvert = xv.shape[0]
+    verts = np.hstack((xv.reshape(nvert, 1), yv.reshape(nvert, 1)))
+
+    cellxy = np.empty((nvert, 2))
+    for icpl in range(ncpl):
+        iv = iverts[icpl]
+        cellxy[icpl, 0] = (xv[iv[0]] + xv[iv[1]]) / 2.
+        cellxy[icpl, 1] = (yv[iv[1]] + yv[iv[2]]) / 2.
+
+    # need to create cell2d, which is [[icpl, xc, yc, nv, iv1, iv2, iv3, iv4]]
+    cell2d = [[icpl, cellxy[icpl, 0], cellxy[icpl, 1], 4, *iverts[icpl]] for
+              icpl in range(ncpl)]
+    vertices = [[ivert, verts[ivert, 0], verts[ivert, 1]] for ivert in
+                range(nvert)]
+    # disv
+    flopy.mf6.ModflowGwfdisv(gwf, nlay=nlay, ncpl=ncpl,
+                             top=top, botm=botm,
+                             nvert=nvert, vertices=vertices,
+                             cell2d=cell2d,
+                             xorigin=xorigin,yorigin=yorigin,angrot=angrot)
+    gwf.modelgrid.set_coord_info(xoff=xorigin,yoff=yorigin,angrot=angrot)
+    return gwf
+
+def test_intersection():
+    ml_dis = dis_model()
+    ml_disv = disv_model()
+
+    if False:
+        plt.subplots()
+        ml_dis.modelgrid.plot()
+        plt.subplots()
+        ml_disv.modelgrid.plot()
+
+    for i in range(3):
+        if i==0:
+            # inside a cell, in real-world coordinates
+            x = 4000
+            y = 4000
+            local = False
+        elif i==1:
+            # on the cell-edge, in local coordinates
+            x = 4000
+            y = 4000
+            local = True
+        elif i==2:
+            # inside a cell, in local coordinates
+            x = 4001
+            y = 4001
+            local = True
+        if local:
+            print('In local coordinates:')
+        else:
+            print('In real_world coordinates:')
+        row,col = ml_dis.modelgrid.intersect(x,y,local)
+        print('x={},y={} in dis  is in row {} and col {}, so...'.format(x,y,row,
+                                                                        col))
+        cell2d_dis = row * ml_dis.modelgrid.ncol + col
+        print('x={},y={} in dis  is in cell2d-number {}'.format(x,y,cell2d_dis))
+
+        cell2d_disv = ml_disv.modelgrid.intersect(x, y,local)
+        print('x={},y={} in disv is in cell2d-number {}'.format(x,y,cell2d_disv))
+
+        assert cell2d_dis == cell2d_disv
+
+if __name__ == '__main__':
+    test_intersection()

--- a/examples/Notebooks/flopy3_mf6_vertex_plotting.ipynb
+++ b/examples/Notebooks/flopy3_mf6_vertex_plotting.ipynb
@@ -452,6 +452,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Print the head at specific coordinates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "icell2d = vmg.intersect(8.,-1.)\n",
+    "print('The head in layer 1 at x = 8, y = -1 is {}'.format(hdata[0,icell2d]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Plotting specific discharge\n",
     "\n",
     "In modflow 6 SAVE_SPECIFIC_DISCHARGE can be specified in the NPF package option block. \n",
@@ -926,7 +943,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,

--- a/flopy/discretization/grid.py
+++ b/flopy/discretization/grid.py
@@ -313,7 +313,7 @@ class Grid(object):
     def get_local_coords(self, x, y):
         """
         Given x and y array-like values, apply rotation, scale and offset,
-        to convert them from model coordinates to real-world coordinates.
+        to convert them from real-world coordinates to model coordinates.
         """
         if isinstance(x, list):
             x = np.array(x)
@@ -328,7 +328,7 @@ class Grid(object):
 
         return x, y
 
-    def intersect(self, x, y, local=True):
+    def intersect(self, x, y, local=False):
         if not local:
             return self.get_local_coords(x, y)
         else:

--- a/flopy/discretization/structuredgrid.py
+++ b/flopy/discretization/structuredgrid.py
@@ -202,28 +202,47 @@ class StructuredGrid(Grid):
     ###############
     ### Methods ###
     ###############
-    def intersect(self, x, y, local=True):
+    def intersect(self, x, y, local=False):
+        """
+        Get the row and column of a point with coordinates x and y
+
+        When the point is on the edge of two cells, the cell with the lowest
+        row or column is returned.
+
+        Parameters
+        ----------
+        x : float
+            The x-coordinate of the requested point
+        y : float
+            The y-coordinate of the requested point
+        local: bool (optional)
+            If True, x and y are in local coordinates (defaults to False)
+
+
+        Returns
+        -------
+        row : int
+            The row number
+        col : int
+            The column number
+
+        """
+        # transform x and y to local coordinates
         x, y = super(StructuredGrid, self).intersect(x, y, local)
 
-        if x < 0 or y < 0:
+        # get the cell edges in local coordinates
+        xe, ye = self.xyedges
+
+        xcomp = x > xe
+        if np.all(xcomp) or not np.any(xcomp):
             raise Exception('x, y point given is outside of the model area')
-        # find row
-        y_bound = 0
-        row = None
-        for index, row_width in enumerate(self.__delc):
-            y_bound += row_width
-            if y <= y_bound:
-                row = index
-        # find column
-        x_bound = 0
-        col = None
-        for index, col_width in enumerate(self.__delr):
-            x_bound += col_width
-            if x <= x_bound:
-                col = index
-        # determine success
-        if col is None or row is None:
+        col = np.where(xcomp)[0][-1]
+
+        ycomp = y < ye
+        if np.all(ycomp) or not np.any(ycomp):
             raise Exception('x, y point given is outside of the model area')
+        row = np.where(ycomp)[0][-1]
+
         return row, col
 
     def _cell_vert_list(self, i, j):
@@ -266,7 +285,7 @@ class StructuredGrid(Grid):
         Returns
         -------
         lc : matplotlib.collections.LineCollection
-p
+
         """
         from flopy.plot import PlotMapView
 

--- a/flopy/discretization/unstructuredgrid.py
+++ b/flopy/discretization/unstructuredgrid.py
@@ -140,7 +140,7 @@ class UnstructuredGrid(Grid):
 
         return self._cache_dict[cache_index].data
 
-    def intersect(self, x, y, local=True):
+    def intersect(self, x, y, local=False):
         x, y = super(UnstructuredGrid, self).intersect(x, y, local)
         raise Exception('Not implemented yet')
 

--- a/flopy/discretization/vertexgrid.py
+++ b/flopy/discretization/vertexgrid.py
@@ -107,7 +107,7 @@ class VertexGrid(Grid):
 
         return self._cache_dict[cache_index].data
 
-    def intersect(self, x, y, local=True):
+    def intersect(self, x, y, local=False):
         """
         Get the CELL2D number of a point with coordinates x and y
         
@@ -120,8 +120,8 @@ class VertexGrid(Grid):
             The x-coordinate of the requested point
         y : float
             The y-coordinate of the requested point
-        local: bool
-            If True, x and y are in real-world coordinates
+        local: bool (optional)
+            If True, x and y are in local coordinates (defaults to False)
 
     
         Returns
@@ -130,7 +130,9 @@ class VertexGrid(Grid):
             The CELL2D number
         
         """
-        x, y = super(VertexGrid, self).intersect(x, y, local)
+        if local:
+            # transform x and y to real-world coordinates
+            x, y = super(VertexGrid, self).get_coords(x,y)
         xv, yv, zv = self.xyzvertices
         for icell2d in range(self.ncpl):
             xa = np.array(xv[icell2d])
@@ -157,6 +159,25 @@ class VertexGrid(Grid):
         """
         return list(zip(self.xvertices[cellid],
                         self.yvertices[cellid]))
+
+    def plot(self, **kwargs):
+        """
+        Plot the grid lines.
+
+        Parameters
+        ----------
+        kwargs : ax, colors.  The remaining kwargs are passed into the
+            the LineCollection constructor.
+
+        Returns
+        -------
+        lc : matplotlib.collections.LineCollection
+
+        """
+        from flopy.plot import PlotMapView
+
+        mm = PlotMapView(modelgrid=self)
+        return mm.plot_grid(**kwargs)
 
     def _build_grid_geometry_info(self):
         cache_index_cc = 'cellcenters'

--- a/flopy/utils/geometry.py
+++ b/flopy/utils/geometry.py
@@ -436,3 +436,27 @@ def get_polygon_centroid(verts):
     cx = cx * 1./ 6. / a
     cy = cy * 1./ 6. / a
     return cx, cy
+
+
+def is_clockwise(x, y):
+    """
+    Determine if a ring is defined clockwise
+    
+    Parameters
+    ----------
+    x : numpy ndarray
+        The x-coordinates of the ring
+    y : numpy ndarray
+        The y-coordinate of the ring
+
+    Returns
+    -------
+    clockwise : bool
+        True when the ring is defined clockwise, False otherwise
+    
+    """
+    if not (x[0] == x[-1]) and (y[0] == y[-1]):
+        # close the ring if needed
+        x = np.append(x, x[-1])
+        y = np.append(y, y[-1])
+    return np.sum((np.diff(x)) * (y[1:] + y[:-1])) > 0


### PR DESCRIPTION
I have implemented the intersect-method for a VertexGrid (disv). This intersect method is set up in the same way as in a StructuredGrid, where you pass floats `x` and `y` and optionally a variable called `local`, and you get a cell2d-number in return (instead of row,col).

This method first checks which cells are likely to intersect with the point (x,y), to speed things up. Then it uses the Path.contains_point method from matplotlib. It should work for any type of geometry (rectangles, triangles, etc.). When the point is on the edge between two cells, the lowest cell2d-number is returned.

I have added some lines in flopy3_mf6_vertex_plotting.ipynb, so that the code is tested. Please let me know it this is not the way to go.