### PR TITLE
Relax HOBs mlay Sum Criteria

### DIFF
--- a/autotest/t041_test.py
+++ b/autotest/t041_test.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import numpy as np
 import flopy
+from nose.tools import raises
 
 try:
     import pymake
@@ -280,6 +281,33 @@ def test_hob_options():
         success, buff = m.run_model(silent=False)
         assert success, 'could not run simple MODFLOW-2005 model'
 
+    return
+
+
+def test_multilayerhob_pr():
+    """
+    test041 test multilayer obs PR == 1 criteria with problematic PRs
+    """
+    ml = flopy.modflow.Modflow()
+    dis = flopy.modflow.ModflowDis(ml, nlay=3, nrow=1, ncol=1, nper=1,
+                                   perlen=[1])
+    flopy.modflow.HeadObservation(ml,layer=-3,row=0,column=0,
+                                  time_series_data=[[1.0, 0]],
+                                  mlay={0:0.19, 1:0.69, 2:0.12})
+    return
+
+
+@raises(ValueError)
+def test_multilayerhob_prfail():
+    """
+    test041 failure of multilayer obs PR == 1 criteria
+    """
+    ml = flopy.modflow.Modflow()
+    dis = flopy.modflow.ModflowDis(ml, nlay=3, nrow=1, ncol=1, nper=1,
+                                   perlen=[1])
+    flopy.modflow.HeadObservation(ml,layer=-3,row=0,column=0,
+                                  time_series_data=[[1.0, 0]],
+                                  mlay={0:0.50, 1:0.50, 2:0.01})
     return
 
 

--- a/flopy/modflow/mfhob.py
+++ b/flopy/modflow/mfhob.py
@@ -552,10 +552,9 @@ class HeadObservation(object):
             tot = 0.
             for key, value in self.mlay.items():
                 tot += value
-            if not(tot > 0.99999 and tot < 1.00001).:
-                msg = ('sum of dataset 4 proportions must equal 1.0 - ' + \
-                       'sum of dataset 4 proportions = {tot} for ' + \
-                       'observation name {obsname}.').format(tot=tot, obsname=self.obsname)
+            if tot != 1.:
+                msg = 'sum of dataset 4 proportions must equal 1.0 - ' + \
+                      'sum of dataset 4 proportions = {}'.format(tot)
                 raise ValueError(msg)
 
         # convert passed time_series_data to a numpy array

--- a/flopy/modflow/mfhob.py
+++ b/flopy/modflow/mfhob.py
@@ -552,7 +552,7 @@ class HeadObservation(object):
             tot = 0.
             for key, value in self.mlay.items():
                 tot += value
-            if not(tot > 0.99999 and tot < 1.00001).:
+            if not(np.isclose(tot, 1.0, rtol=0)):
                 msg = ('sum of dataset 4 proportions must equal 1.0 - ' + \
                        'sum of dataset 4 proportions = {tot} for ' + \
                        'observation name {obsname}.').format(tot=tot, obsname=self.obsname)

--- a/flopy/modflow/mfhob.py
+++ b/flopy/modflow/mfhob.py
@@ -552,9 +552,10 @@ class HeadObservation(object):
             tot = 0.
             for key, value in self.mlay.items():
                 tot += value
-            if tot != 1.:
-                msg = 'sum of dataset 4 proportions must equal 1.0 - ' + \
-                      'sum of dataset 4 proportions = {}'.format(tot)
+            if not(tot > 0.99999 and tot < 1.00001).:
+                msg = ('sum of dataset 4 proportions must equal 1.0 - ' + \
+                       'sum of dataset 4 proportions = {tot} for ' + \
+                       'observation name {obsname}.').format(tot=tot, obsname=self.obsname)
                 raise ValueError(msg)
 
         # convert passed time_series_data to a numpy array


### PR DESCRIPTION
Due to binary representation of base-10 floats in Python, floats read from text can have high decimal place values added to them. This can cause an error when reading in an HOB with multilayer observations. The sum of the mlay must equal 1; however, the sum could be calculated as 0.9999999 and raise an error. This relaxes the criteria for the sum of mlay to 0.99999 < sum < 1.00001. It also changes the error message to include the observation name where the error occurred.

Resolves #528. Didn't cause any additional failures or errors during the autotest. I called Travis to pass it by him, but he didn't answer.