### PR TITLE
Change default proj4 from EPSG:4326 to None

### DIFF
--- a/autotest/t007_test.py
+++ b/autotest/t007_test.py
@@ -343,12 +343,14 @@ def test_mbase_modelgrid():
 
     assert ml.modelgrid.xoffset == 500
     assert ml.modelgrid.yoffset == 0.0
+    assert ml.modelgrid.proj4 is None
     ml.model_ws = tpth
 
     ml.write_input()
     ml1 = flopy.modflow.Modflow.load("test.nam", model_ws=ml.model_ws)
     assert str(ml1.modelgrid) == str(ml.modelgrid)
     assert ml1.start_datetime == ml.start_datetime
+    assert ml1.modelgrid.proj4 is None
 
 def test_free_format_flag():
     import flopy
@@ -425,8 +427,7 @@ def test_mg():
                                                        delr=ms.dis.delr.array,
                                                        xoff=xll, yoff=xll,
                                                        angrot=angrot,
-                                                       lenuni=2,
-                                                       proj4='EPSG:4326')
+                                                       lenuni=2)
 
     # test that transform for arbitrary coordinates
     # is working in same as transform for model grid

--- a/autotest/t032_test.py
+++ b/autotest/t032_test.py
@@ -76,9 +76,9 @@ def test_epsgref():
     ep = epsgRef()
     ep.reset()
 
-    getprj(4326)
+    getprj(32614)  # WGS 84 / UTM zone 14N
     prj = ep.to_dict()
-    assert 4326 in prj
+    assert 32614 in prj
 
     ep.add(9999, 'junk')
     prj = ep.to_dict()

--- a/flopy/discretization/unstructuredgrid.py
+++ b/flopy/discretization/unstructuredgrid.py
@@ -28,7 +28,7 @@ class UnstructuredGrid(Grid):
     """
     def __init__(self, vertices, iverts, xcenters, ycenters,
                  top=None, botm=None, idomain=None, lenuni=None,
-                 ncpl=None, epsg=None, proj4="EPSG:4326", prj=None,
+                 ncpl=None, epsg=None, proj4=None, prj=None,
                  xoff=0., yoff=0., angrot=0., layered=True):
         super(UnstructuredGrid, self).__init__(self.grid_type, top, botm, idomain,
                                                lenuni, epsg, proj4, prj,

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -225,7 +225,7 @@ class BaseModel(ModelInterface):
                           DeprecationWarning)
 
         rotation = kwargs.pop("rotation", 0.0)
-        proj4_str = kwargs.pop("proj4_str", "EPSG:4326")
+        proj4_str = kwargs.pop("proj4_str", None)
         self._start_datetime = kwargs.pop("start_datetime", "1-1-1970")
 
         # build model discretization objects

--- a/flopy/mf6/utils/reference.py
+++ b/flopy/mf6/utils/reference.py
@@ -70,7 +70,7 @@ class StructuredSpatialReference(object):
     """
 
     def __init__(self, delr=1.0, delc=1.0, lenuni=1, nlay=1, xul=None,
-                 yul=None, rotation=0.0, proj4_str="EPSG:4326", **kwargs):
+                 yul=None, rotation=0.0, proj4_str=None, **kwargs):
         self.delc = np.atleast_1d(np.array(delc))
         self.delr = np.atleast_1d(np.array(delr))
         self.nlay = nlay
@@ -91,7 +91,7 @@ class StructuredSpatialReference(object):
 
         xul, yul = None, None
         rotation = 0.0
-        proj4_str = "EPSG:4326"
+        proj4_str = None
         start_datetime = "1/1/1970"
 
         for item in header:
@@ -565,7 +565,7 @@ class VertexSpatialReference(object):
 
     """
     def __init__(self, xvdict=None, yvdict=None, nlay=1, xadj=0, yadj=0,
-                 rotation=0., lenuni=1., proj4_str='EPSG:4326', **kwargs):
+                 rotation=0., lenuni=1., proj4_str=None, **kwargs):
 
         assert len(xvdict) == len(yvdict), \
             'len(xvdict): {} != len(yvdict): {}'.format(len(xvdict),
@@ -600,7 +600,7 @@ class VertexSpatialReference(object):
                 header.extend(line.strip().replace('#', '').split(','))
 
         xadj, yadj = None, None
-        proj4_str = "EPSG:4326"
+        proj4_str = None
         start_datetime = "1/1/1970"
 
         for item in header:
@@ -844,7 +844,7 @@ class SpatialReference(object):
     """
     def __new__(cls, delr=1.0, delc=1.0, xvdict=None, yvdict=None, lenuni=1,
                 nlay=1, xul=None, yul=None, xadj=0., yadj=0., rotation=0.0,
-                proj4_str="EPSG:4326", distype='structured'):
+                proj4_str=None, distype='structured'):
 
         if distype == 'structured':
             new = object.__new__(StructuredSpatialReference)

--- a/flopy/modflow/mfdis.py
+++ b/flopy/modflow/mfdis.py
@@ -86,9 +86,9 @@ class ModflowDis(Package):
         clockwise rotation (in degrees) of the grid about the upper left
         corner. default is 0.0
     proj4_str : str
-        PROJ4 string that defines the xul-yul coordinate system
-        (.e.g. '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs ').
-        Can be an EPSG code (e.g. 'EPSG:4326'). Default is 'EPSG:4326'
+        PROJ4 string that defines the projected coordinate system
+        (e.g. '+proj=utm +zone=14 +datum=WGS84 +units=m +no_defs ').
+        Can be an EPSG code (e.g. 'EPSG:32614'). Default is None.
     start_datetime : str
         starting datetime of the simulation. default is '1/1/1970'
 
@@ -868,7 +868,7 @@ class ModflowDis(Package):
         header = header.replace('#', '')
         xul, yul = None, None
         rotation = None
-        proj4_str = "EPSG:4326"
+        proj4_str = None
         start_datetime = "1/1/1970"
         dep = False
         for item in header.split(','):

--- a/flopy/utils/reference.py
+++ b/flopy/utils/reference.py
@@ -1559,7 +1559,7 @@ class SpatialReferenceUnstructured(SpatialReference):
     """
 
     def __init__(self, xc, yc, verts, iverts, ncpl, layered=True, lenuni=1,
-                 proj4_str="EPSG:4326", epsg=None, units=None,
+                 proj4_str=None, epsg=None, units=None,
                  length_multiplier=1.):
         warnings.warn("SpatialReferenceUnstructured has been deprecated. "
                       "Use VertexGrid instead.",


### PR DESCRIPTION
In some flopy modules the default projection for model grids is [EPSG:4326](http://epsg.io/4326) (a.k.a. WGS 84 or World Geodetic System 1984), which is a geodetic coordinate system with units of degrees of latitude and longitude.

MODFLOW grids do not support length units in degrees. Generally, it should only support projected coordinate reference systems with units in meters, feet, etc. as defined in various UTM zones, State grids, national grids, locally-defined grids for a site, etc.

This PR changes the default projection to None (i.e. undefined). The NAM file would show just `proj4_str:` with an empty value. This is more-or-less already done with `discretization/grid.py`, but there were a few other modules that needed attention.