### PR TITLE
bug(mt3d): ensure namefile_ext is str type

### DIFF
--- a/autotest/t003_test.py
+++ b/autotest/t003_test.py
@@ -97,9 +97,21 @@ def test_loadoc_nstpfail():
     return
 
 
+@raises(IOError)
+def test_load_nam_mf_nonexistant_file():
+    ml = flopy.modflow.Modflow.load('nonexistant.nam')
+
+
+@raises(IOError)
+def test_load_nam_mt_nonexistant_file():
+    ml = flopy.mt3d.Mt3dms.load('nonexistant.nam')
+
+
 if __name__ == '__main__':
     test_loadoc()
     test_loadoc_nstpfail()
+    test_load_nam_mf_nonexistant_file()
+    test_load_nam_mt_nonexistant_file()
     # test_loadoc_lenfail()
     # test_loadfreyberg()
     # test_loadoahu()

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -189,7 +189,7 @@ class BaseModel(ModelInterface):
         """
         ModelInterface.__init__(self)
         self.__name = modelname
-        self.namefile_ext = namefile_ext
+        self.namefile_ext = namefile_ext or ''
         self._namefile = self.__name + '.' + self.namefile_ext
         self._packagelist = []
         self.heading = ''

--- a/flopy/mt3d/mt.py
+++ b/flopy/mt3d/mt.py
@@ -544,13 +544,8 @@ class Mt3dms(BaseModel):
         >>> mt.ftlfilename = 'example.ftl'
 
         """
-        # test if name file is passed with extension (i.e., is a valid file)
-        modelname_extension = None
-        if os.path.isfile(os.path.join(model_ws, f)):
-            modelname = f.rpartition('.')[0]
-            modelname_extension = f.rpartition('.')[2]
-        else:
-            modelname = f
+        modelname, ext = os.path.splitext(f)
+        modelname_extension = ext[1:]  # without '.'
 
         if verbose:
             sys.stdout.write('\nCreating new model with name: {}\n{}\n\n'.

--- a/flopy/mt3d/mt.py
+++ b/flopy/mt3d/mt.py
@@ -559,13 +559,12 @@ class Mt3dms(BaseModel):
         files_not_loaded = []
 
         # read name file
+        namefile_path = os.path.join(mt.model_ws, f)
+        if not os.path.isfile(namefile_path):
+            raise IOError('cannot find name file: ' + str(namefile_path))
         try:
-            # namefile_path = os.path.join(mt.model_ws, mt.namefile)
-            # namefile_path = f
-            namefile_path = os.path.join(mt.model_ws, f)
-            ext_unit_dict = mfreadnam.parsenamefile(namefile_path,
-                                                    mt.mfnam_packages,
-                                                    verbose=verbose)
+            ext_unit_dict = mfreadnam.parsenamefile(
+                namefile_path, mt.mfnam_packages, verbose=verbose)
         except Exception as e:
             # print("error loading name file entries from file")
             # print(str(e))


### PR DESCRIPTION
Attempting to load a mt3d model that does not exist (e.g. `foo.nam`) raises a confusing message:
> TypeError: can only concatenate str (not "NoneType") to str

This PR changes the behavior to split the extension a bit cleaner to make a `str` type, regardless if the file exists or not, and allow a more useful message to be shown:
>Exception: error loading name file entries from file:
> Could not find .\foo.nam in directory . 