### PR TITLE
Auxiliary variable fix (#533)

### DIFF
--- a/autotest/t504_test.py
+++ b/autotest/t504_test.py
@@ -783,7 +783,7 @@ def test036_twrihfb():
 
     rch = sim.simulation_data.mfdata[(model_name, 'rcha', 'period', 'recharge')]
     rch_data = rch.get_data()
-    assert(rch_data[0][5][1] == 0.00000003)
+    assert(rch_data[0][5, 1] == 0.00000003)
 
     # write simulation again
     sim.simulation_data.mfpath.set_sim_path(save_folder)

--- a/autotest/t505_test.py
+++ b/autotest/t505_test.py
@@ -442,6 +442,9 @@ def test021_twri():
                                 stress_period_data=stress_period_data)
 
     # build stress_period_data for drn package
+    conc = np.ones((15, 15), dtype=np.float) * 35.
+    auxdata = {0: [6, conc]}
+
     stress_period_data = []
     drn_heads = [0.0, 0.0, 10.0, 20.0, 30.0, 50.0, 70.0, 90.0, 100.0]
     for col, head in zip(range(1, 10), drn_heads):
@@ -450,7 +453,11 @@ def test021_twri():
                                 save_flows=True, maxbound=9,
                                 stress_period_data=stress_period_data)
     rch_package = ModflowGwfrcha(model, readasarrays=True, fixed_cell=True,
-                                 recharge={0: 0.00000003})
+                                 recharge={0: 0.00000003},
+                                 auxiliary=[('iface', 'conc')], aux=auxdata)
+
+    aux = rch_package.aux.get_data()
+
 
     stress_period_data = []
     layers = [2, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
@@ -906,11 +913,18 @@ def test004_bcfss():
                                                 'DIGITS', 2, 'GENERAL')],
                               saverecord=[('HEAD', 'ALL'), ('BUDGET', 'ALL')],
                               printrecord=[('HEAD', 'ALL'), ('BUDGET', 'ALL')])
-
+    aux = {0: [[50.0], [1.3]], 1: [[200.0], [1.5]]}
+    # aux = {0: [[100.0], [2.3]]}
     rch_package = ModflowGwfrcha(model, readasarrays=True, save_flows=True,
                                  auxiliary=[('var1', 'var2')],
-                                 recharge={0: 0.004}, aux={
-            0: [[100.0], [2.3]]})  # *** test if aux works ***
+                                 recharge={0: 0.004}, aux=aux)  # *** test if aux works ***
+
+    # aux tests
+    aux_out = rch_package.aux.get_data()
+    assert(aux_out[0][0][0,0] == 50.)
+    assert(aux_out[0][1][0,0] == 1.3)
+    assert(aux_out[1][0][0,0] == 200.0)
+    assert(aux_out[1][1][0,0] == 1.5)
 
     riv_period = {}
     riv_period_array = []

--- a/flopy/mf6/data/mfdataarray.py
+++ b/flopy/mf6/data/mfdataarray.py
@@ -520,6 +520,14 @@ class MFArray(MFMultiDimVar):
             self._keyword, pre_data_comments=None)
         return return_val
 
+    def _is_layered_aux(self):
+        # determine if this is the special aux variable case
+        if self.structure.name.lower() == 'aux' and \
+                self._get_storage_obj().layered:
+            return True
+        else:
+            return False
+
     def get_file_entry(self, layer=None,
                        ext_file_action=ExtFileAction.copy_relative_paths):
         if isinstance(layer, int):
@@ -530,11 +538,8 @@ class MFArray(MFMultiDimVar):
                 or not data_storage.has_data():
             return ''
 
-        # determine if this is the special aux variable case
-        if self.structure.name.lower() == 'aux' and data_storage.layered:
-            layered_aux = True
-        else:
-            layered_aux = False
+        layered_aux = self._is_layered_aux()
+
         # prepare indent
         indent = self._simulation_data.indent_string
         shape_ml = MultiList(shape=self._layer_shape)
@@ -962,28 +967,16 @@ class MFTransientArray(MFArray, MFTransient):
                 sim_time = self._data_dimensions.package_dim.model_dim[
                     0].simulation_time
                 num_sp = sim_time.get_num_stress_periods()
-                data = None
                 for sp in range(0, num_sp):
+                    data = None
                     if sp in self._data_storage:
                         self.get_data_prep(sp)
                         data = super(MFTransientArray, self).get_data(
                             apply_mult=apply_mult, **kwargs)
-                        data = np.expand_dims(data, 0)
-                    else:
-                        if data is None:
-                            # get any data
-                            self.get_data_prep(self._data_storage.key()[0])
-                            data = super(MFTransientArray, self).get_data(
-                                apply_mult=apply_mult, **kwargs)
-                            data = np.expand_dims(data, 0)
-                        if self.structure.type == DatumType.integer:
-                            data = np.full_like(data, 0)
-                        else:
-                            data = np.full_like(data, 0.0)
                     if output is None:
-                        output = data
+                        output = {sp: data}
                     else:
-                        output = np.concatenate((output, data))
+                        output[sp] = data
                 return output
             else:
                 self.get_data_prep(layer)

--- a/flopy/mf6/data/mfdatalist.py
+++ b/flopy/mf6/data/mfdatalist.py
@@ -934,17 +934,17 @@ class MFTransientList(MFList, mfdata.MFTransient, DataListInterface):
         if self._data_storage is not None and len(self._data_storage) > 0:
             if key is None:
                 if 'array' in kwargs:
-                    output = {}
+                    output = []
                     sim_time = self._data_dimensions.package_dim.model_dim[
                         0].simulation_time
                     num_sp = sim_time.get_num_stress_periods()
                     for sp in range(0, num_sp):
                         if sp in self._data_storage:
                             self.get_data_prep(sp)
-                            output[sp] = super(MFTransientList, self).get_data(
-                                apply_mult=apply_mult)
+                            output.append(super(MFTransientList, self).get_data(
+                                apply_mult=apply_mult))
                         else:
-                            output[sp] = None
+                            output.append(None)
                     return output
                 else:
                     output = {}

--- a/flopy/mf6/data/mfdatalist.py
+++ b/flopy/mf6/data/mfdatalist.py
@@ -934,24 +934,24 @@ class MFTransientList(MFList, mfdata.MFTransient, DataListInterface):
         if self._data_storage is not None and len(self._data_storage) > 0:
             if key is None:
                 if 'array' in kwargs:
-                    output = []
+                    output = {}
                     sim_time = self._data_dimensions.package_dim.model_dim[
                         0].simulation_time
                     num_sp = sim_time.get_num_stress_periods()
                     for sp in range(0, num_sp):
                         if sp in self._data_storage:
                             self.get_data_prep(sp)
-                            output.append(super(MFTransientList, self).get_data(
-                                apply_mult=apply_mult))
+                            output[sp] = super(MFTransientList, self).get_data(
+                                apply_mult=apply_mult)
                         else:
-                            output.append(None)
+                            output[sp] = None
                     return output
                 else:
-                    output = []
+                    output = {}
                     for key in self._data_storage.keys():
                         self.get_data_prep(key)
-                        output.append(super(MFTransientList, self).get_data(
-                            apply_mult=apply_mult))
+                        output[key] = super(MFTransientList, self).get_data(
+                            apply_mult=apply_mult)
                     return output
             self.get_data_prep(key)
             return super(MFTransientList, self).get_data(apply_mult=apply_mult)

--- a/flopy/mf6/modflow/mfsimulation.py
+++ b/flopy/mf6/modflow/mfsimulation.py
@@ -583,7 +583,7 @@ class MFSimulation(PackageContainer):
                                                              )]
 
         try:
-            solution_group_list = solution_recarray.get_data()
+            solution_group_dict = solution_recarray.get_data()
         except MFDataException as mfde:
             message = 'Error occurred while loading solution groups from ' \
                       'the simulation name file.'
@@ -591,7 +591,7 @@ class MFSimulation(PackageContainer):
                                   model=instance.name,
                                   package='nam',
                                   message=message)
-        for solution_group in solution_group_list:
+        for solution_group in solution_group_dict.values():
             for solution_info in solution_group:
                 ims_file = mfims.ModflowIms(instance, filename=solution_info[1],
                                             pname=solution_info[2])


### PR DESCRIPTION
Auxiliary variables now accept any data formats in any order. Integrated better better test coverage of aux variables into our current tests. get_data() now returns transient data as a dictionary.