### PR TITLE
Cleaned-up PR for util_list.get_dataframe() method

### DIFF
--- a/autotest/t004_test_utilarray.py
+++ b/autotest/t004_test_utilarray.py
@@ -716,7 +716,8 @@ def test_mflist():
     # test get_dataframe() on mflist obj
     sp_data3 = {0: [1, 1, 1, 1.0],
                 1: [[1, 1, 3, 3.0], [1, 1, 2, 6.0]],
-                2: [[1, 2, 4, 8.0], [1, 2, 3, 4.0], [1, 2, 2, 4.0], [1, 1, 3, 3.0], [1, 1, 2, 6.0]]}
+                2: [[1, 2, 4, 8.0], [1, 2, 3, 4.0], [1, 2, 2, 4.0], 
+                    [1, 1, 3, 3.0], [1, 1, 2, 6.0]]}
     wel4 = flopy.modflow.ModflowWel(ml, stress_period_data=sp_data3)
     df = wel4.stress_period_data.get_dataframe()
     assert df['flux0'].sum() == 1.
@@ -724,13 +725,18 @@ def test_mflist():
     assert df['flux2'].sum() == 25.
     sp_data4 = {0: [1, 1, 1, 1.0],
                 1: [[1, 1, 3, 3.0], [1, 1, 3, 6.0]],
-                2: [[1, 2, 4, 8.0], [1, 2, 4, 4.0], [1, 2, 4, 4.0], [1, 1, 3, 3.0], [1, 1, 3, 6.0]]}
+                2: [[1, 2, 4, 8.0], [1, 2, 4, 4.0], [1, 2, 4, 4.0], 
+                    [1, 1, 3, 3.0], [1, 1, 3, 6.0]]}
     wel5 = flopy.modflow.ModflowWel(ml, stress_period_data=sp_data4)
     df = wel5.stress_period_data.get_dataframe()
     assert df['flux0'].sum() == 1.
     assert df['flux1'].sum() == 9.
-    assert df.loc[df.apply(lambda x: x.k == 1 and x.i == 1 and x.j == 3, axis=1), 'flux2'].values == 9.0
-    assert df.loc[df.apply(lambda x: x.k == 1 and x.i == 2 and x.j == 4, axis=1), 'flux2'].values == 16.0
+    assert df.loc[
+               df.apply(lambda x: x.k == 1 and x.i == 1 and x.j == 3, axis=1),
+               'flux2'].values == 9.0
+    assert df.loc[
+               df.apply(lambda x: x.k == 1 and x.i == 2 and x.j == 4, axis=1), 
+               'flux2'].values == 16.0
 
 
 

--- a/autotest/t004_test_utilarray.py
+++ b/autotest/t004_test_utilarray.py
@@ -676,7 +676,6 @@ def test_append_mflist():
     wel3 = flopy.modflow.ModflowWel(ml, stress_period_data= \
         wel2.stress_period_data.append(
             wel1.stress_period_data))
-
     ml.write_input()
 
 
@@ -714,6 +713,26 @@ def test_mflist():
 
     assert flx1.sum() == flx2.sum()
 
+    # test get_dataframe() on mflist obj
+    sp_data3 = {0: [1, 1, 1, 1.0],
+                1: [[1, 1, 3, 3.0], [1, 1, 2, 6.0]],
+                2: [[1, 2, 4, 8.0], [1, 2, 3, 4.0], [1, 2, 2, 4.0], [1, 1, 3, 3.0], [1, 1, 2, 6.0]]}
+    wel4 = flopy.modflow.ModflowWel(ml, stress_period_data=sp_data3)
+    df = wel4.stress_period_data.get_dataframe()
+    assert df['flux0'].sum() == 1.
+    assert df['flux1'].sum() == 9.
+    assert df['flux2'].sum() == 25.
+    sp_data4 = {0: [1, 1, 1, 1.0],
+                1: [[1, 1, 3, 3.0], [1, 1, 3, 6.0]],
+                2: [[1, 2, 4, 8.0], [1, 2, 4, 4.0], [1, 2, 4, 4.0], [1, 1, 3, 3.0], [1, 1, 3, 6.0]]}
+    wel5 = flopy.modflow.ModflowWel(ml, stress_period_data=sp_data4)
+    df = wel5.stress_period_data.get_dataframe()
+    assert df['flux0'].sum() == 1.
+    assert df['flux1'].sum() == 9.
+    assert df.loc[df.apply(lambda x: x.k == 1 and x.i == 1 and x.j == 3, axis=1), 'flux2'].values == 9.0
+    assert df.loc[df.apply(lambda x: x.k == 1 and x.i == 2 and x.j == 4, axis=1), 'flux2'].values == 16.0
+
+
 
 def test_how():
     import numpy as np
@@ -745,12 +764,12 @@ def test_util3d_reset():
 
 if __name__ == '__main__':
     # test_util3d_reset()
-    # test_mflist()
+    test_mflist()
     # test_new_get_file_entry()
     # test_arrayformat()
     # test_util2d_external_free_nomodelws()
     # test_util2d_external_free_path_nomodelws()
-    test_util2d_external_free()
+    # test_util2d_external_free()
     # test_util2d_external_free_path()
     # test_util2d_external_fixed()
     # test_util2d_external_fixed_path()

--- a/flopy/utils/util_list.py
+++ b/flopy/utils/util_list.py
@@ -193,12 +193,14 @@ class MfList(DataInterface, DataListInterface):
         if not isinstance(fields, list):
             fields = [fields]
         names = [n for n in self.dtype.names if n not in fields]
-        dtype = np.dtype([(k, d) for k, d in self.dtype.descr if k not in fields])
+        dtype = np.dtype(
+            [(k, d) for k, d in self.dtype.descr if k not in fields])
         spd = {}
         for k, v in self.data.items():
             # because np 1.9 doesn't support indexing by list of columns
             newarr = np.array([self.data[k][n] for n in names]).transpose()
-            newarr = np.array(list(map(tuple, newarr)), dtype=dtype).view(np.recarray)
+            newarr = np.array(list(map(tuple, newarr)), dtype=dtype).view(
+                np.recarray)
             for n in dtype.names:
                 newarr[n] = self.data[k][n]
             spd[k] = newarr
@@ -465,7 +467,8 @@ class MfList(DataInterface, DataListInterface):
                 dfg = dfi.groupby(names)
                 count = dfg[varnames[0]].count().rename('n')
                 if (count > 1).values.any():
-                    print("Duplicated list entry locations aggregated for kper {}".format(per))
+                    print("Duplicated list entry locations aggregated "
+                          "for kper {}".format(per))
                     for kij in count[count > 1].index.values:
                         print("    (k,i,j) {}".format(kij))
                 dfi = dfg.sum()  # aggregate
@@ -477,7 +480,8 @@ class MfList(DataInterface, DataListInterface):
             for var in varnames:
                 diffcols = list([n for n in df.columns if var in n])
                 diff = df[diffcols].fillna(0).diff(axis=1)
-                diff['{}0'.format(var)] = 1  # always return the first stress period
+                diff['{}0'.format(
+                    var)] = 1  # always return the first stress period
                 changed = diff.sum(axis=0) != 0
                 keep.append(df.loc[:, changed.index[changed]])
             df = pd.concat(keep, axis=1)
@@ -602,7 +606,8 @@ class MfList(DataInterface, DataListInterface):
             elif (kper in kpers):
                 kper_vtype = self.__vtype[kper]
 
-            if self._model.array_free_format and self._model.external_path is not None:
+            if self._model.array_free_format and self._model.external_path is\
+                    not None:
                 # py_filepath = ''
                 # py_filepath = os.path.join(py_filepath,
                 #                            self._model.external_path)
@@ -759,11 +764,8 @@ class MfList(DataInterface, DataListInterface):
                                str(kper) + ':\n'
                     for idx in out_idx:
                         d = data[idx]
-                        warn_str += " {0:9d} {1:9d} {2:9d}\n".format(d['k']
-                                                                     + 1, d[
-                                                                         'i'] + 1,
-                                                                     d[
-                                                                         'j'] + 1)
+                        warn_str += " {0:9d} {1:9d} {2:9d}\n".format(
+                            d['k'] + 1, d['i'] + 1, d['j'] + 1)
                     warnings.warn(warn_str)
 
     def __find_last_kper(self, kper):
@@ -900,8 +902,10 @@ class MfList(DataInterface, DataListInterface):
 
         from flopy.plot import PlotUtilities
         axes = PlotUtilities._plot_mflist_helper(self, key=key, names=names,
-                                                 kper=kper, filename_base=filename_base,
-                                                 file_extension=file_extension, mflay=mflay,
+                                                 kper=kper,
+                                                 filename_base=filename_base,
+                                                 file_extension=file_extension,
+                                                 mflay=mflay,
                                                  **kwargs)
 
         return axes
@@ -1039,9 +1043,12 @@ class MfList(DataInterface, DataListInterface):
 
         for name, arr in arrays.items():
             if unstructured:
-                cnt = np.zeros((self._model.nlay * self._model.ncpl,), dtype=np.float)
+                cnt = np.zeros((self._model.nlay * self._model.ncpl,),
+                               dtype=np.float)
             else:
-                cnt = np.zeros((self._model.nlay, self._model.nrow, self._model.ncol), dtype=np.float)
+                cnt = np.zeros(
+                    (self._model.nlay, self._model.nrow, self._model.ncol),
+                    dtype=np.float)
             #print(name,kper)
             for rec in sarr:
                 if unstructured:

--- a/flopy/utils/util_list.py
+++ b/flopy/utils/util_list.py
@@ -16,7 +16,6 @@ from ..datbase import DataInterface, DataListInterface, DataType
 
 try:
     from numpy.lib import NumpyVersion
-
     numpy114 = NumpyVersion(np.__version__) >= '1.14.0'
 except ImportError:
     numpy114 = False
@@ -163,8 +162,8 @@ class MfList(DataInterface, DataListInterface):
             other_len = other_data.shape[0]
             self_len = self_data.shape[0]
 
-            if (other_len == 0 and self_len == 0) or \
-                    (kper not in self_kpers and kper not in other_kpers):
+            if (other_len == 0 and self_len == 0) or\
+               (kper not in self_kpers and kper not in other_kpers):
                 continue
             elif self_len == 0:
                 new_dict[kper] = other_data
@@ -174,8 +173,9 @@ class MfList(DataInterface, DataListInterface):
                 new_len = other_data.shape[0] + self_data.shape[0]
                 new_data = np.recarray(new_len, dtype=self.dtype)
                 new_data[:self_len] = self_data
-                new_data[self_len:self_len + other_len] = other_data
+                new_data[self_len:self_len+other_len] = other_data
                 new_dict[kper] = new_data
+
 
         return new_dict
 
@@ -193,14 +193,12 @@ class MfList(DataInterface, DataListInterface):
         if not isinstance(fields, list):
             fields = [fields]
         names = [n for n in self.dtype.names if n not in fields]
-        dtype = np.dtype(
-            [(k, d) for k, d in self.dtype.descr if k not in fields])
+        dtype = np.dtype([(k, d) for k, d in self.dtype.descr if k not in fields])
         spd = {}
         for k, v in self.data.items():
             # because np 1.9 doesn't support indexing by list of columns
             newarr = np.array([self.data[k][n] for n in names]).transpose()
-            newarr = np.array(list(map(tuple, newarr)), dtype=dtype).view(
-                np.recarray)
+            newarr = np.array(list(map(tuple, newarr)), dtype=dtype).view(np.recarray)
             for n in dtype.names:
                 newarr[n] = self.data[k][n]
             spd[k] = newarr
@@ -326,8 +324,8 @@ class MfList(DataInterface, DataListInterface):
                         raise Exception("MfList error: casting list " + \
                                         "to ndarray: " + str(e))
 
-                # super hack - sick of recarrays already
-                # if (isinstance(d,np.ndarray) and len(d.dtype.fields) > 1):
+                #super hack - sick of recarrays already
+                #if (isinstance(d,np.ndarray) and len(d.dtype.fields) > 1):
                 #    d = d.view(np.recarray)
 
                 if isinstance(d, np.recarray):
@@ -463,7 +461,14 @@ class MfList(DataInterface, DataListInterface):
                 dfi = dfi.set_index(names)
             else:
                 dfi = pd.DataFrame.from_records(recs)
-                dfi = dfi.set_index(names)
+                # dfi = dfi.set_index(names)
+                dfg = dfi.groupby(names)
+                count = dfg[varnames[0]].count().rename('n')
+                if (count > 1).values.any():
+                    print("Duplicated list entry locations aggregated for kper {}".format(per))
+                    for kij in count[count > 1].index.values:
+                        print("    (k,i,j) {}".format(kij))
+                dfi = dfg.sum()  # aggregate
                 dfi.columns = list(['{}{}'.format(c, per) for c in varnames])
             dfs.append(dfi)
         df = pd.concat(dfs, axis=1)
@@ -471,9 +476,8 @@ class MfList(DataInterface, DataListInterface):
             keep = []
             for var in varnames:
                 diffcols = list([n for n in df.columns if var in n])
-                diff = df[diffcols].diff(axis=1)
-                diff['{}0'.format(
-                    var)] = 1  # always return the first stress period
+                diff = df[diffcols].fillna(0).diff(axis=1)
+                diff['{}0'.format(var)] = 1  # always return the first stress period
                 changed = diff.sum(axis=0) != 0
                 keep.append(df.loc[:, changed.index[changed]])
             df = pd.concat(keep, axis=1)
@@ -598,13 +602,14 @@ class MfList(DataInterface, DataListInterface):
             elif (kper in kpers):
                 kper_vtype = self.__vtype[kper]
 
-            if self._model.array_free_format and self._model.external_path is \
+            if self._model.array_free_format and self._model.external_path is\
                     not None:
+
                 # py_filepath = ''
                 # py_filepath = os.path.join(py_filepath,
                 #                            self._model.external_path)
                 filename = self.package.name[0] + \
-                           "_{0:04d}.dat".format(kper)
+                            "_{0:04d}.dat".format(kper)
                 filenames.append(filename)
         return filenames
 
@@ -658,12 +663,12 @@ class MfList(DataInterface, DataListInterface):
                 kper_vtype = int
 
             f.write(" {0:9d} {1:9d} # stress period {2:d}\n"
-                    .format(itmp, 0, kper + 1))
+                    .format(itmp, 0, kper+1))
 
             isExternal = False
             if self._model.array_free_format and \
-                    self._model.external_path is not None and \
-                    forceInternal is False:
+                            self._model.external_path is not None and \
+                            forceInternal is False:
                 isExternal = True
             if self.__binary:
                 isExternal = True
@@ -681,7 +686,7 @@ class MfList(DataInterface, DataListInterface):
                     if self._model.external_path is not None:
                         model_filepath = os.path.join(
                             self._model.external_path,
-                            filename)
+                                                      filename)
                     self.__tofile(py_filepath, kper_data)
                     kper_vtype = str
                     kper_data = model_filepath
@@ -897,11 +902,9 @@ class MfList(DataInterface, DataListInterface):
         """
 
         from flopy.plot import PlotUtilities
-        axes = PlotUtilities._plot_mflist_helper(self, key=key, names=names,
-                                                 kper=kper,
-                                                 filename_base=filename_base,
-                                                 file_extension=file_extension,
-                                                 mflay=mflay,
+        axes = PlotUtilities._plot_mflist_helper(self, key=key,names=names,
+                                                 kper=kper, filename_base=filename_base,
+                                                 file_extension=file_extension, mflay=mflay,
                                                  **kwargs)
 
         return axes
@@ -995,7 +998,7 @@ class MfList(DataInterface, DataListInterface):
             raise NotImplementedError()
 
         if 'node' in self.dtype.names:
-            if 'i' not in self.dtype.names and \
+            if 'i' not in self.dtype.names and\
                     "j" not in self.dtype.names:
                 i0 = 1
                 unstructured = True
@@ -1044,8 +1047,8 @@ class MfList(DataInterface, DataListInterface):
             else:
                 cnt = np.zeros((self._model.nlay, self._model.nrow,
                                 self._model.ncol),
-                               dtype=np.float)
-            # print(name,kper)
+                                dtype=np.float)
+            #print(name,kper)
             for rec in sarr:
                 if unstructured:
                     arr[rec['node']] += rec[name]

--- a/flopy/utils/util_list.py
+++ b/flopy/utils/util_list.py
@@ -162,8 +162,8 @@ class MfList(DataInterface, DataListInterface):
             other_len = other_data.shape[0]
             self_len = self_data.shape[0]
 
-            if (other_len == 0 and self_len == 0) or\
-               (kper not in self_kpers and kper not in other_kpers):
+            if (other_len == 0 and self_len == 0) or \
+                    (kper not in self_kpers and kper not in other_kpers):
                 continue
             elif self_len == 0:
                 new_dict[kper] = other_data
@@ -173,7 +173,7 @@ class MfList(DataInterface, DataListInterface):
                 new_len = other_data.shape[0] + self_data.shape[0]
                 new_data = np.recarray(new_len, dtype=self.dtype)
                 new_data[:self_len] = self_data
-                new_data[self_len:self_len+other_len] = other_data
+                new_data[self_len:self_len + other_len] = other_data
                 new_dict[kper] = new_data
 
 
@@ -324,8 +324,8 @@ class MfList(DataInterface, DataListInterface):
                         raise Exception("MfList error: casting list " + \
                                         "to ndarray: " + str(e))
 
-                #super hack - sick of recarrays already
-                #if (isinstance(d,np.ndarray) and len(d.dtype.fields) > 1):
+                # super hack - sick of recarrays already
+                # if (isinstance(d,np.ndarray) and len(d.dtype.fields) > 1):
                 #    d = d.view(np.recarray)
 
                 if isinstance(d, np.recarray):
@@ -602,14 +602,11 @@ class MfList(DataInterface, DataListInterface):
             elif (kper in kpers):
                 kper_vtype = self.__vtype[kper]
 
-            if self._model.array_free_format and self._model.external_path is\
-                    not None:
-
+            if self._model.array_free_format and self._model.external_path is not None:
                 # py_filepath = ''
                 # py_filepath = os.path.join(py_filepath,
                 #                            self._model.external_path)
-                filename = self.package.name[0] + \
-                            "_{0:04d}.dat".format(kper)
+                filename = self.package.name[0] + "_{0:04d}.dat".format(kper)
                 filenames.append(filename)
         return filenames
 
@@ -663,12 +660,12 @@ class MfList(DataInterface, DataListInterface):
                 kper_vtype = int
 
             f.write(" {0:9d} {1:9d} # stress period {2:d}\n"
-                    .format(itmp, 0, kper+1))
+                    .format(itmp, 0, kper + 1))
 
             isExternal = False
             if self._model.array_free_format and \
-                            self._model.external_path is not None and \
-                            forceInternal is False:
+                    self._model.external_path is not None and \
+                    forceInternal is False:
                 isExternal = True
             if self.__binary:
                 isExternal = True
@@ -686,7 +683,7 @@ class MfList(DataInterface, DataListInterface):
                     if self._model.external_path is not None:
                         model_filepath = os.path.join(
                             self._model.external_path,
-                                                      filename)
+                            filename)
                     self.__tofile(py_filepath, kper_data)
                     kper_vtype = str
                     kper_data = model_filepath
@@ -902,7 +899,7 @@ class MfList(DataInterface, DataListInterface):
         """
 
         from flopy.plot import PlotUtilities
-        axes = PlotUtilities._plot_mflist_helper(self, key=key,names=names,
+        axes = PlotUtilities._plot_mflist_helper(self, key=key, names=names,
                                                  kper=kper, filename_base=filename_base,
                                                  file_extension=file_extension, mflay=mflay,
                                                  **kwargs)
@@ -1042,12 +1039,9 @@ class MfList(DataInterface, DataListInterface):
 
         for name, arr in arrays.items():
             if unstructured:
-                cnt = np.zeros((self._model.nlay * self._model.ncpl,),
-                               dtype=np.float)
+                cnt = np.zeros((self._model.nlay * self._model.ncpl,), dtype=np.float)
             else:
-                cnt = np.zeros((self._model.nlay, self._model.nrow,
-                                self._model.ncol),
-                                dtype=np.float)
+                cnt = np.zeros((self._model.nlay, self._model.nrow, self._model.ncol), dtype=np.float)
             #print(name,kper)
             for rec in sarr:
                 if unstructured:


### PR DESCRIPTION
 Modification of `util_list.get_dataframe()` method to deal with multiple

Deal with multiple wells (or list entries) in model nodes when constructing the pandas DataFrame.
Method is now to aggregate such wells in the dataframe.

Added some tests for this method too - couldn't find elsewhere.
Also think `squeeze` option is safer with a fillna or diff from NaN
picks up no changes.

