### PR TITLE
minor (hopfully) fairly inconsequential mods

### DIFF
--- a/flopy/modflow/mfsfr2.py
+++ b/flopy/modflow/mfsfr2.py
@@ -1343,7 +1343,11 @@ class ModflowSfr2(Package):
         increases in the downstream direction. This may speed convergence of
         the NWT solver in some situations.
 
+        Returns
+        -------
+        r : dictionary mapping old segment numbers to new
         """
+
         segments = self.all_segments
         segments.sort(order="nseg")
         # get renumbering info from per=0
@@ -1418,6 +1422,7 @@ class ModflowSfr2(Package):
         self.channel_geometry_data = renumber_channel_data(
             self.channel_geometry_data)
         self.channel_flow_data = renumber_channel_data(self.channel_flow_data)
+        return r
 
     def plot_path(self, start_seg=None, end_seg=0, plot_segment_lines=True):
         """

--- a/flopy/utils/mflistfile.py
+++ b/flopy/utils/mflistfile.py
@@ -575,7 +575,7 @@ class ListBudget(object):
         # sp = int(line[self.sp_idxs[0]:self.sp_idxs[1]])
 
         # Get rid of nasty things
-        line = line.replace(',', '')
+        line = line.replace(',', '').replace('*', '')
 
         searchstring = 'TIME STEP'
         idx = line.index(searchstring) + len(searchstring)


### PR DESCRIPTION
adding a return to `m.sfr.renumber_segments()` to return segment mapping dict

deal with \'*\' abutting strings in mflist