### PR TITLE
Write Simulation Silent Option (#552) + Retrieving Data Optimization (#553)

### DIFF
--- a/autotest/t504_test.py
+++ b/autotest/t504_test.py
@@ -52,15 +52,15 @@ def test001a_tharmonic():
                             verbosity_level=0)
     sim.simulation_data.mfpath.set_sim_path(run_folder)
 
+    # write simulation to new location
+    sim.write_simulation()
+
     model = sim.get_model(model_name)
     model.export('{}/tharmonic.nc'.format(model.model_ws))
     model.export('{}/tharmonic.shp'.format(model.model_ws))
     model.dis.botm.export('{}/botm.shp'.format(model.model_ws))
 
     mg = model.modelgrid
-
-    # write simulation to new location
-    sim.write_simulation()
 
     if run:
         # run simulation

--- a/autotest/t504_test.py
+++ b/autotest/t504_test.py
@@ -53,7 +53,7 @@ def test001a_tharmonic():
     sim.simulation_data.mfpath.set_sim_path(run_folder)
 
     # write simulation to new location
-    sim.write_simulation()
+    sim.write_simulation(silent=True)
 
     model = sim.get_model(model_name)
     model.export('{}/tharmonic.nc'.format(model.model_ws))

--- a/flopy/mf6/data/mfdataarray.py
+++ b/flopy/mf6/data/mfdataarray.py
@@ -782,7 +782,9 @@ class MFArray(MFMultiDimVar):
         storage = self._get_storage_obj()
         if storage.layered:
             if layer is None:
-                if allow_multiple_layers:
+                if storage.layer_storage.get_total_size() == 1:
+                    layer_index = [0]
+                elif allow_multiple_layers:
                     layer_index = storage.get_active_layer_indices()
                 else:
                     comment = 'Data "{}" is layered but no ' \

--- a/flopy/mf6/data/mfdataarray.py
+++ b/flopy/mf6/data/mfdataarray.py
@@ -609,7 +609,11 @@ class MFArray(MFMultiDimVar):
         else:
             # data is not layered
             if not self.structure.data_item_structures[0].just_data:
-                file_entry_array.append('{}{}\n'.format(indent,
+                if self._data_name == 'aux':
+                    file_entry_array.append('{}{}\n'.format(
+                        indent, self._get_aux_var_name([0])))
+                else:
+                    file_entry_array.append('{}{}\n'.format(indent,
                                                         self.structure.name))
 
             data_storage_type = data_storage.layer_storage[0].data_storage_type

--- a/flopy/mf6/data/mfdatastorage.py
+++ b/flopy/mf6/data/mfdatastorage.py
@@ -9,7 +9,7 @@ from ..mfbase import MFDataException, VerbosityLevel
 from ..data.mfstructure import DatumType, MFDataItemStructure
 from ..data import mfdatautil
 from ...utils.datautil import DatumUtil, FileIter, MultiListIter, PyListUtil, \
-                              ConstIter, ArrayIndexIter, MultiList
+                              ArrayIndexIter, MultiList
 from .mfdatautil import convert_data, MFComment
 from .mffileaccess import MFFileAccessArray, MFFileAccess
 
@@ -750,10 +750,7 @@ class DataStorage(object):
         if not success:
             # try to store as a single layer
             success = self._set_array_layer(data, layer, multiplier, key)
-        if self.layer_storage.get_total_size() > 1:
-            self.layered = True
-        else:
-            self.layered = False
+        self.layered = bool(self.layer_storage.get_total_size() > 1)
         if not success:
             message = 'Unable to set data "{}" layer {}.  Data is not ' \
                       'in a valid format' \

--- a/flopy/mf6/data/mfdatastorage.py
+++ b/flopy/mf6/data/mfdatastorage.py
@@ -825,13 +825,11 @@ class DataStorage(object):
             resolved_path = \
                     self._simulation_data.mfpath.resolve_path(new_data[1],
                                                               model_name)
-            if self._simulation_data.verify_external_data == False or \
-                    self._verify_data(FileIter(resolved_path), layer):
-                # store location to file
-                self.store_external(new_data[1], layer, [multiplier],
-                                    print_format=iprn, binary=binary,
-                                    do_not_verify=True)
-                return True
+            # store location to file
+            self.store_external(new_data[1], layer, [multiplier],
+                                print_format=iprn, binary=binary,
+                                do_not_verify=True)
+            return True
         # try to resolve as internal array
         layer_storage = self.layer_storage[self._resolve_layer(layer)]
         if not (layer_storage.data_storage_type ==
@@ -1643,51 +1641,6 @@ class DataStorage(object):
             return self.layer_storage.first_index()
         else:
             return layer
-
-    def _verify_data(self, data_iter, layer):
-        # get expected size
-        data_dimensions = self.get_data_dimensions(layer)
-        # get expected data types
-        if self.data_dimensions.structure.type == DatumType.recarray or \
-                self.data_dimensions.structure.type == DatumType.record:
-            data_types = self.data_dimensions.structure.\
-                get_data_item_types(return_enum_type=True)
-            # check to see if data contains the correct types and is a possibly
-            # correct size
-            record_loc = 0
-            actual_data_size = 0
-            if isinstance(data_iter.multi_list, np.recarray):
-                rows_of_data = len(data_iter.multi_list.shape)
-            else:
-                rows_of_data = 0
-                for data_item in data_iter:
-                    if self._is_type(data_item, data_types[2][record_loc]):
-                        actual_data_size += 1
-                    if record_loc == len(data_types[0]) - 1:
-                        record_loc = 0
-                        rows_of_data += 1
-                    else:
-                        record_loc += 1
-            return rows_of_data > 0 and (rows_of_data < data_dimensions[0] or
-                                         data_dimensions[0] == -1)
-        else:
-            expected_data_size = 1
-            for dimension in data_dimensions:
-                if dimension > 0:
-                    expected_data_size = expected_data_size * dimension
-            data_type = self.data_dimensions.structure.\
-                get_datum_type(return_enum_type=True)
-            # check to see if data can fit dimensions
-            if isinstance(data_iter.multi_list, np.ndarray):
-                # use more efficient method to check ndarrays
-                return data_iter.multi_list.size >= expected_data_size
-            actual_data_size = 0
-            for data_item in data_iter:
-                if self._is_type(data_item, data_type):
-                    actual_data_size += 1
-                if actual_data_size >= expected_data_size:
-                    return True
-            return False
 
     def _to_ndarray(self, data, layer):
         data_dimensions = self.get_data_dimensions(layer)

--- a/flopy/mf6/data/mfdatastorage.py
+++ b/flopy/mf6/data/mfdatastorage.py
@@ -728,43 +728,45 @@ class DataStorage(object):
         if isinstance(data, int) or isinstance(data, float) or isinstance(data, str):
             data = [data]
 
-        # try to set as a single layer
-        if not self._set_array_layer(data, layer, multiplier, key):
-            # check for possibility of multi-layered data
-            success = False
-            layer_num = 0
-            if layer is None and self.data_structure_type == \
-                    DataStructureType.ndarray and len(data) ==\
-                    self.layer_storage.get_total_size():
-                self.layered = True
-                # loop through list and try to store each list entry as a layer
-                success = True
-                for layer_num, layer_data in enumerate(data):
-                    if not isinstance(layer_data, list) and \
-                            not isinstance(layer_data, dict) and \
-                            not isinstance(layer_data, np.ndarray):
-                        layer_data = [layer_data]
-                    layer_index = self.layer_storage.nth_index(layer_num)
-                    success = success and self._set_array_layer(layer_data,
-                                                                layer_index,
-                                                                multiplier,
-                                                                key)
-            if not success:
-                message = 'Unable to set data "{}" layer {}.  Data is not ' \
-                          'in a valid format' \
-                          '.'.format(self.data_dimensions.structure.name,
-                                     layer_num)
-                type_, value_, traceback_ = sys.exc_info()
-                raise MFDataException(
-                    self.data_dimensions.structure.get_model(),
-                    self.data_dimensions.structure.get_package(),
-                    self.data_dimensions.structure.path, 'setting array data',
-                    self.data_dimensions.structure.name, inspect.stack()[0][3],
-                    type_, value_, traceback_, message,
-                    self._simulation_data.debug)
-        elif layer is None:
+        # check for possibility of multi-layered data
+        success = False
+        layer_num = 0
+        if layer is None and self.data_structure_type == \
+                DataStructureType.ndarray and len(data) ==\
+                self.layer_storage.get_total_size() and not \
+                isinstance(data, dict):
+            # loop through list and try to store each list entry as a layer
+            success = True
+            for layer_num, layer_data in enumerate(data):
+                if not isinstance(layer_data, list) and \
+                        not isinstance(layer_data, dict) and \
+                        not isinstance(layer_data, np.ndarray):
+                    layer_data = [layer_data]
+                layer_index = self.layer_storage.nth_index(layer_num)
+                success = success and self._set_array_layer(layer_data,
+                                                            layer_index,
+                                                            multiplier,
+                                                            key)
+        if not success:
+            # try to store as a single layer
+            success = self._set_array_layer(data, layer, multiplier, key)
+        if self.layer_storage.get_total_size() > 1:
+            self.layered = True
+        else:
             self.layered = False
-            self.layer_storage.list_shape = (1,)
+        if not success:
+            message = 'Unable to set data "{}" layer {}.  Data is not ' \
+                      'in a valid format' \
+                      '.'.format(self.data_dimensions.structure.name,
+                                 layer_num)
+            type_, value_, traceback_ = sys.exc_info()
+            raise MFDataException(
+                self.data_dimensions.structure.get_model(),
+                self.data_dimensions.structure.get_package(),
+                self.data_dimensions.structure.path, 'setting array data',
+                self.data_dimensions.structure.name, inspect.stack()[0][3],
+                type_, value_, traceback_, message,
+                        self._simulation_data.debug)
 
     def _set_array_layer(self, data, layer, multiplier, key):
         # look for a single constant value
@@ -826,7 +828,8 @@ class DataStorage(object):
             resolved_path = \
                     self._simulation_data.mfpath.resolve_path(new_data[1],
                                                               model_name)
-            if self._verify_data(FileIter(resolved_path), layer):
+            if self._simulation_data.verify_external_data == False or \
+                    self._verify_data(FileIter(resolved_path), layer):
                 # store location to file
                 self.store_external(new_data[1], layer, [multiplier],
                                     print_format=iprn, binary=binary,
@@ -836,10 +839,12 @@ class DataStorage(object):
         layer_storage = self.layer_storage[self._resolve_layer(layer)]
         if not (layer_storage.data_storage_type ==
                 DataStorageType.internal_constant and
-                    PyListUtil.has_one_item(data)) and \
-                self._verify_data(MultiListIter(data), layer):
+                    PyListUtil.has_one_item(data)):
             # store data as is
-            self.store_internal(data, layer, False, multiplier, key=key)
+            try:
+                self.store_internal(data, layer, False, multiplier, key=key)
+            except MFDataException:
+                return False
             return True
         return False
 
@@ -1554,6 +1559,7 @@ class DataStorage(object):
         if dimensions[0] < 0:
             return None
         all_none = True
+        np_data_type =  self.data_dimensions.structure.get_datum_type()
         full_data = np.full(dimensions, np.nan,
                             self.data_dimensions.structure.get_datum_type(True))
         is_aux = self.data_dimensions.structure.name == 'aux'
@@ -1612,7 +1618,7 @@ class DataStorage(object):
                         not self.layered)[0] * mult
                 else:
                     data_out = file_access.read_text_data_from_file(
-                        self.get_data_size(layer), self._data_type,
+                        self.get_data_size(layer), np_data_type,
                         self.get_data_dimensions(layer), layer,
                         read_file)[0] * mult
                 if self.layer_storage.get_total_size() == 1 or \
@@ -1624,9 +1630,9 @@ class DataStorage(object):
                 if full_data is not None:
                     all_none = False
                 aux_data.append(full_data)
-                full_data = np.full(dimensions, np.nan,
-                                    self.data_dimensions.structure.get_datum_type(
-                                        True))
+                full_data = np.full(
+                    dimensions, np.nan,
+                    self.data_dimensions.structure.get_datum_type(True))
         if is_aux:
             if all_none:
                 return None
@@ -1653,15 +1659,18 @@ class DataStorage(object):
             # correct size
             record_loc = 0
             actual_data_size = 0
-            rows_of_data = 0
-            for data_item in data_iter:
-                if self._is_type(data_item, data_types[2][record_loc]):
-                    actual_data_size += 1
-                if record_loc == len(data_types[0]) - 1:
-                    record_loc = 0
-                    rows_of_data += 1
-                else:
-                    record_loc += 1
+            if isinstance(data_iter.multi_list, np.recarray):
+                rows_of_data = len(data_iter.multi_list.shape)
+            else:
+                rows_of_data = 0
+                for data_item in data_iter:
+                    if self._is_type(data_item, data_types[2][record_loc]):
+                        actual_data_size += 1
+                    if record_loc == len(data_types[0]) - 1:
+                        record_loc = 0
+                        rows_of_data += 1
+                    else:
+                        record_loc += 1
             return rows_of_data > 0 and (rows_of_data < data_dimensions[0] or
                                          data_dimensions[0] == -1)
         else:
@@ -1672,6 +1681,9 @@ class DataStorage(object):
             data_type = self.data_dimensions.structure.\
                 get_datum_type(return_enum_type=True)
             # check to see if data can fit dimensions
+            if isinstance(data_iter.multi_list, np.ndarray):
+                # use more efficient method to check ndarrays
+                return data_iter.multi_list.size >= expected_data_size
             actual_data_size = 0
             for data_item in data_iter:
                 if self._is_type(data_item, data_type):
@@ -1694,8 +1706,7 @@ class DataStorage(object):
         if data_dimensions[0] < 0:
             return ls.data_const_value
         else:
-            data_iter = ConstIter(ls.data_const_value[0])
-            return self._fill_dimensions(data_iter, data_dimensions)
+            return np.full(data_dimensions, ls.data_const_value[0])
 
     def _is_type(self, data_item, data_type):
         if data_type == DatumType.string or data_type == DatumType.keyword:

--- a/flopy/mf6/modflow/mfsimulation.py
+++ b/flopy/mf6/modflow/mfsimulation.py
@@ -168,7 +168,7 @@ class MFSimulationData(object):
         self._sci_note_upper_thres = 100000
         self._sci_note_lower_thres = 0.001
         self.fast_write = True
-        self.verify_external_data = True
+        self.verify_external_data = False
         self.comments_on = False
         self.auto_set_sizes = True
         self.debug = False
@@ -792,7 +792,8 @@ class MFSimulation(PackageContainer):
                                           message=message)
 
     def write_simulation(self,
-                         ext_file_action=ExtFileAction.copy_relative_paths):
+                         ext_file_action=ExtFileAction.copy_relative_paths,
+                         silent=False):
         """
         writes the simulation to files
 
@@ -803,10 +804,15 @@ class MFSimulation(PackageContainer):
             has changed.  defaults to copy_relative_paths which copies only
             files with relative paths, leaving files defined by absolute
             paths fixed.
-
+        silent : bool
+            writes out the simulation in silent mode (verbosity_level = 0)
         Examples
         --------
         """
+        saved_verb_lvl = self.simulation_data.verbosity_level
+        if silent:
+            self.simulation_data.verbosity_level = VerbosityLevel.quiet
+
         # write simulation name file
         if self.simulation_data.verbosity_level.value >= \
                 VerbosityLevel.normal.value:
@@ -911,6 +917,9 @@ class MFSimulation(PackageContainer):
             print('INFORMATION: {} external files copied'.format(
                 num_files_copied))
         self.simulation_data.mfpath.set_last_accessed_path()
+
+        if silent:
+            self.simulation_data.verbosity_level = saved_verb_lvl
 
     def set_sim_path(self, path):
         self.simulation_data.mfpath.set_sim_path(path)

--- a/flopy/mf6/modflow/mfsimulation.py
+++ b/flopy/mf6/modflow/mfsimulation.py
@@ -168,7 +168,6 @@ class MFSimulationData(object):
         self._sci_note_upper_thres = 100000
         self._sci_note_lower_thres = 0.001
         self.fast_write = True
-        self.verify_external_data = False
         self.comments_on = False
         self.auto_set_sizes = True
         self.debug = False

--- a/flopy/utils/datautil.py
+++ b/flopy/utils/datautil.py
@@ -230,7 +230,8 @@ class PyListUtil(object):
             # consistent delimiter has been found.  continue using that
             # delimiter without doing further checks
             if PyListUtil.delimiter_used is None:
-                clean_line = line.strip().split()
+                comment_split = line.strip().split('#', 1)
+                clean_line = comment_split[0].strip().split()
             else:
                 comment_split = line.strip().split('#', 1)
                 clean_line = comment_split[0].strip().split(


### PR DESCRIPTION
The write_simulation method now has a silent parameter to write simulations silently:

sim.write_simulation(silent=True)

This behaves the same as setting the verbosity level to quiet before calling write_simulation and then setting it back to its previous value after the write_simulation call.

Retrieving mf6 data has also been optimized to run faster.