### PR TITLE
refactor: silence a few DeprecationWarning messages

### DIFF
--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -215,11 +215,8 @@ class BaseModel(ModelInterface):
         xll = kwargs.pop("xll", None)
         yll = kwargs.pop("yll", None)
         self._xul = kwargs.pop("xul", None)
-        if self._xul is not None:
-            warnings.warn('xul/yul have been deprecated. Use xll/yll instead.',
-                          DeprecationWarning)
         self._yul = kwargs.pop("yul", None)
-        if self._yul is not None:
+        if self._xul is not None or self._yul is not None:
             warnings.warn('xul/yul have been deprecated. Use xll/yll instead.',
                           DeprecationWarning)
 

--- a/flopy/modflow/mf.py
+++ b/flopy/modflow/mf.py
@@ -5,8 +5,12 @@ mf module.  Contains the ModflowGlobal, ModflowList, and Modflow classes.
 """
 
 import os
-import inspect
 import flopy
+import sys
+if sys.version_info[0] == 2:
+    from inspect import getargspec as getfullargspec
+else:
+    from inspect import getfullargspec
 from ..mbase import BaseModel
 from ..pakbase import Package
 from ..utils import mfreadnam
@@ -760,10 +764,9 @@ class Modflow(BaseModel):
         for key, item in ext_unit_dict.items():
             if item.package is not None:
                 if item.filetype in load_only:
+                    package_load_args = getfullargspec(item.package.load)[0]
                     if forgive:
                         try:
-                            package_load_args = \
-                                list(inspect.getargspec(item.package.load))[0]
                             if "check" in package_load_args:
                                 item.package.load(item.filename, ml,
                                                   ext_unit_dict=ext_unit_dict,
@@ -785,8 +788,6 @@ class Modflow(BaseModel):
                                 print(msg)
                             files_not_loaded.append(item.filename)
                     else:
-                        package_load_args = \
-                            list(inspect.getargspec(item.package.load))[0]
                         if "check" in package_load_args:
                             item.package.load(item.filename, ml,
                                               ext_unit_dict=ext_unit_dict,

--- a/flopy/modflow/mfdis.py
+++ b/flopy/modflow/mfdis.py
@@ -213,12 +213,12 @@ class ModflowDis(Package):
             yll = mg._yul_to_yll(yul)
         mg.set_coord_info(xoff=xll, yoff=yll, angrot=rotation, proj4=proj4_str)
 
-        if rotation is None:
-            rotation = 0.0
-        self._sr = SpatialReference(self.delr, self.delc, self.lenuni,
-                                    xul=xul, yul=yul,
-                                    rotation=rotation,
-                                    proj4_str=proj4_str)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            self._sr = SpatialReference(self.delr, self.delc, self.lenuni,
+                                        xul=xul, yul=yul,
+                                        rotation=rotation or 0.0,
+                                        proj4_str=proj4_str)
 
         self.tr = TemporalReference(itmuni=self.itmuni,
                                     start_datetime=start_datetime)


### PR DESCRIPTION
 - Show one "xul/yul have been deprecated" warning message if both were provided (e.g. in older .nam files)
 - [inspect.getargspec()](https://docs.python.org/library/inspect.html#inspect.getargspec) is deprecated since Python 3.0; use inspect.getfullargspec()
 - Ignore DeprecationWarning when creating `dis._sr`

There are pile of other warnings that I haven't touched yet, but anyone interested can see them by setting the environment variable `PYTHONWARNINGS=always::DeprecationWarning` from a shell, or in a script:
```python
import warnings
warnings.simplefilter('always', category=DeprecationWarning)
```