### PR TITLE
 Reading and Writing of MF6 Binary Lists

### DIFF
--- a/examples/Notebooks/flopy3_mf6_tutorial.ipynb
+++ b/examples/Notebooks/flopy3_mf6_tutorial.ipynb
@@ -443,7 +443,7 @@
    "source": [
     "### Specifying MFList Data in an External File \n",
     "\n",
-    "MFList data can be specified in an external file using a dictionary with the 'filename' key.  If the 'data' key is also included in the dictionary and is not None, flopy will create the file with the data contained in the 'data' key.  The code below creates a chd package which creates and references an external file containing data for stress period 1 and stores the data internally in the chd package file for stress period 2. "
+    "MFList data can be specified in an external file using a dictionary with the 'filename' key.  If the 'data' key is also included in the dictionary and is not None, flopy will create the file with the data contained in the 'data' key.  The 'binary' key can be used to save data to a binary file ('binary': True).  The code below creates a chd package which creates and references an external file containing data for stress period 1 and stores the data internally in the chd package file for stress period 2. "
    ]
   },
   {

--- a/flopy/discretization/structuredgrid.py
+++ b/flopy/discretization/structuredgrid.py
@@ -34,23 +34,29 @@ class StructuredGrid(Grid):
     get_cell_vertices(i, j)
         returns vertices for a single cell at row, column i, j.
     """
-    def __init__(self, delc, delr, top=None, botm=None, idomain=None,
+    def __init__(self, delc=None, delr=None, top=None, botm=None, idomain=None,
                  lenuni=None, epsg=None, proj4=None, prj=None, xoff=0.0,
-                 yoff=0.0, angrot=0.0):
+                 yoff=0.0, angrot=0.0, nlay=None, nrow=None, ncol=None):
         super(StructuredGrid, self).__init__('structured', top, botm, idomain,
                                              lenuni, epsg, proj4, prj, xoff,
                                              yoff, angrot)
         self.__delc = delc
         self.__delr = delr
-        self.__nrow = len(delc)
-        self.__ncol = len(delr)
+        if delc is not None:
+            self.__nrow = len(delc)
+        else:
+            self.__nrow = nrow
+        if delr is not None:
+            self.__ncol = len(delr)
+        else:
+            self.__ncol = ncol
         if top is not None:
             assert self.__nrow * self.__ncol == len(np.ravel(top))
         if botm is not None:
             assert self.__nrow * self.__ncol == len(np.ravel(botm[0]))
             self.__nlay = len(botm)
         else:
-            self.__nlay = None
+            self.__nlay = nlay
 
     ####################
     # Properties

--- a/flopy/discretization/unstructuredgrid.py
+++ b/flopy/discretization/unstructuredgrid.py
@@ -25,10 +25,10 @@ class UnstructuredGrid(Grid):
     get_cell_vertices(cellid)
         returns vertices for a single cell at cellid.
     """
-    def __init__(self, vertices, iverts, xcenters, ycenters,
+    def __init__(self, vertices=None, iverts=None, xcenters=None, ycenters=None,
                  top=None, botm=None, idomain=None, lenuni=None,
                  ncpl=None, epsg=None, proj4=None, prj=None,
-                 xoff=0., yoff=0., angrot=0., layered=True):
+                 xoff=0., yoff=0., angrot=0., layered=True, nodes=None):
         super(UnstructuredGrid, self).__init__(self.grid_type, top, botm, idomain,
                                                lenuni, epsg, proj4, prj,
                                                xoff, yoff, angrot)
@@ -41,6 +41,7 @@ class UnstructuredGrid(Grid):
         self._layered = layered
         self._xc = xcenters
         self._yc = ycenters
+        self._nodes = nodes
 
         if iverts is not None:
             if self.layered:
@@ -72,6 +73,13 @@ class UnstructuredGrid(Grid):
     @property
     def layered(self):
         return self._layered
+
+    @property
+    def nnodes(self):
+        if self._nodes is not None:
+            return self._nodes
+        else:
+            return self.nlay * self.ncpl
 
     @property
     def ncpl(self):

--- a/flopy/discretization/vertexgrid.py
+++ b/flopy/discretization/vertexgrid.py
@@ -32,9 +32,10 @@ class VertexGrid(Grid):
         returns vertices for a single cell at cellid.
     """
 
-    def __init__(self, vertices, cell2d, top=None, botm=None, idomain=None,
+    def __init__(self, vertices=None, cell2d=None, top=None, botm=None, idomain=None,
                  lenuni=None, epsg=None, proj4=None, prj=None, xoff=0.0,
-                 yoff=0.0, angrot=0.0, grid_type='vertex'):
+                 yoff=0.0, angrot=0.0, grid_type='vertex',
+                 nlay=None, ncpl=None):
         super(VertexGrid, self).__init__(grid_type, top, botm, idomain, lenuni,
                                          epsg, proj4, prj, xoff, yoff, angrot)
         self._vertices = vertices
@@ -42,15 +43,26 @@ class VertexGrid(Grid):
         self._top = top
         self._botm = botm
         self._idomain = idomain
+        if botm is None:
+            self._nlay = nlay
+            self._ncpl = ncpl
+        else:
+            self._nlay = None
+            self._ncpl = None
 
     @property
     def nlay(self):
         if self._botm is not None:
             return len(self._botm)
+        else:
+            return self._nlay
 
     @property
     def ncpl(self):
-        return len(self._botm[0])
+        if self._botm is not None:
+            return len(self._botm[0])
+        else:
+            return self._ncpl
 
     @property
     def shape(self):

--- a/flopy/mf6/coordinates/modeldimensions.py
+++ b/flopy/mf6/coordinates/modeldimensions.py
@@ -11,6 +11,7 @@ from ..data.mfstructure import DatumType
 from ..utils.mfenums import DiscretizationType
 from ...utils.datautil import DatumUtil, NameIter
 
+
 class DataDimensions(object):
     """
     Resolves dimension information for model data using information contained

--- a/flopy/mf6/data/mfdata.py
+++ b/flopy/mf6/data/mfdata.py
@@ -474,15 +474,9 @@ class MFMultiDimVar(MFData):
         layer_storage.fname = ext_file_path
         ext_format = ['OPEN/CLOSE', "'{}'".format(ext_file_path)]
         if storage.data_structure_type != DataStructureType.recarray:
-            ext_format.append('FACTOR')
             if layer_storage.factor is not None:
+                ext_format.append('FACTOR')
                 ext_format.append(str(layer_storage.factor))
-            else:
-                if self.structure.get_datum_type(return_enum_type=True) == \
-                        DatumType.double_precision:
-                    ext_format.append('1.0')
-                else:
-                    ext_format.append('1')
         if layer_storage.binary:
             ext_format.append('(BINARY)')
         if layer_storage.iprn is not None:

--- a/flopy/mf6/data/mffileaccess.py
+++ b/flopy/mf6/data/mffileaccess.py
@@ -851,7 +851,7 @@ class MFFileAccessList(MFFileAccess):
         while line != '':
             line = file_handle.readline()
             arr_line = PyListUtil.split_data_line(line)
-            if arr_line and (len(arr_line[0]) >= 2 and
+            if not arr_line or(len(arr_line[0]) >= 2 and
                     arr_line[0][:3].upper() == 'END'):
                 # end of block
                 if store_data:
@@ -859,11 +859,13 @@ class MFFileAccessList(MFFileAccess):
                         # store as rec array
                         storage.store_internal(data_loaded, None, False,
                                                current_key)
+                        storage.data_dimensions.unlock()
+                        return [False, line, data_line]
                     else:
                         data_rec = storage._build_recarray(data_loaded,
                                                            current_key, True)
-                storage.data_dimensions.unlock()
-                return [False, line, data_line]
+                        storage.data_dimensions.unlock()
+                        return data_rec
             if recarray_len != 1 and \
                     not MFComment.is_comment(arr_line, True):
                 key = find_keyword(arr_line, struct.get_keywords())
@@ -873,12 +875,14 @@ class MFFileAccessList(MFFileAccess):
                         if store_internal:
                             storage.store_internal(data_loaded, None, False,
                                                    current_key)
+                            storage.data_dimensions.unlock()
+                            return [True, line, data_line]
                         else:
                             data_rec = storage._build_recarray(data_loaded,
                                                                current_key,
                                                                True)
-                    storage.data_dimensions.unlock()
-                    return [True, line, data_line]
+                            storage.data_dimensions.unlock()
+                            return data_rec
             if simple_line and struct.num_optional == 0:
                 if MFComment.is_comment(arr_line,
                                         True):

--- a/flopy/mf6/data/mffileaccess.py
+++ b/flopy/mf6/data/mffileaccess.py
@@ -851,7 +851,7 @@ class MFFileAccessList(MFFileAccess):
         while line != '':
             line = file_handle.readline()
             arr_line = PyListUtil.split_data_line(line)
-            if not arr_line or(len(arr_line[0]) >= 2 and
+            if not line or (arr_line and len(arr_line[0]) >= 2 and
                     arr_line[0][:3].upper() == 'END'):
                 # end of block
                 if store_data:

--- a/flopy/mf6/mfmodel.py
+++ b/flopy/mf6/mfmodel.py
@@ -253,6 +253,21 @@ class MFModel(PackageContainer, ModelInterface):
         return self._model_time
 
     @property
+    def modeldiscrit(self):
+        if self.get_grid_type() == DiscretizationType.DIS:
+            dis = self.get_package('dis')
+            return StructuredGrid(nlay=dis.nlay.get_data(),
+                                  nrow=dis.nrow.get_data(),
+                                  ncol=dis.ncol.get_data())
+        elif self.get_grid_type() == DiscretizationType.DISV:
+            dis = self.get_package('disv')
+            return VertexGrid(ncpl=dis.ncpl.get_data(),
+                              nlay=dis.nlay.get_data())
+        elif self.get_grid_type() == DiscretizationType.DISU:
+            dis = self.get_package('disu')
+            return UnstructuredGrid(nodes=dis.nodes.get_data())
+
+    @property
     def modelgrid(self):
         if not self._mg_resync:
             return self._modelgrid


### PR DESCRIPTION
Feature allows for the reading and writing of MF6 external binary files. Interface allows user to create a binary file from existing data, specify an existing binary file to use, and access binary data from an existing MF6 simulation.