### PR TITLE
suppressing error when proj4_str is None

### DIFF
--- a/flopy/utils/reference.py
+++ b/flopy/utils/reference.py
@@ -283,7 +283,8 @@ class SpatialReference(object):
             return units
         except:
             if self.proj4_str is not None:
-                print('   could not parse units from {}'.format(self.proj4_str))
+                print('   could not parse units from {}'.format(
+                    self.proj4_str))
 
     @property
     def units(self):

--- a/flopy/utils/reference.py
+++ b/flopy/utils/reference.py
@@ -282,7 +282,8 @@ class SpatialReference(object):
                 units = "feet"
             return units
         except:
-            print('   could not parse units from {}'.format(self.proj4_str))
+            if self.proj4_str is not None:
+                print('   could not parse units from {}'.format(self.proj4_str))
 
     @property
     def units(self):


### PR DESCRIPTION
When `proj4_str` is `None`, `SpatialReference` throws errors about not being able to parse units. Seems a meaningless error for instructive cases that are not projected.