### PR TITLE
fix creep of btn obs locations when reading and writing mt3d model

### DIFF
--- a/autotest/t023_test.py
+++ b/autotest/t023_test.py
@@ -30,6 +30,8 @@ def test_mt3d_multispecies():
     sconc3 = np.random.random((nrow, ncol))
     btn = flopy.mt3d.Mt3dBtn(mt, ncomp=ncomp, sconc=1., sconc2=2.,
                              sconc3=sconc3, sconc5=5.)
+    # check obs I/O
+    mt.btn.obs = np.array([[0, 2, 300], [0, 1, 250]])
     crch32 = np.random.random((nrow, ncol))
     cevt33 = np.random.random((nrow, ncol))
     ssm = flopy.mt3d.Mt3dSsm(mt, crch=1., crch2=2., crch3={2:crch32}, crch5=5.,
@@ -49,6 +51,8 @@ def test_mt3d_multispecies():
     # Load the MT3D model into mt2 and then write it out
     fname = modelname + '.nam'
     mt2 = flopy.mt3d.Mt3dms.load(fname, model_ws=testpth, verbose=True)
+    # check obs I/O
+    assert np.all(mt.btn.obs == mt2.btn.obs)
     mt2.name = modelname2
     mt2.write_input()
 

--- a/flopy/mt3d/mtbtn.py
+++ b/flopy/mt3d/mtbtn.py
@@ -882,7 +882,7 @@ class Mt3dBtn(Package):
                 i = int(line[10:20])
                 j = int(line[20:30])
                 obs.append([k, i, j])
-            obs = np.array(obs)
+            obs = np.array(obs) - 1
             if model.verbose:
                 print('   OBS {}'.format(obs))
 


### PR DESCRIPTION
This is a tiny one: 
When writing btn obs, flopy adds 1 to the k,i,j values bringing us nicely from a python world to a mt3d world; this makes sense. However, when loading a mt3d model we weren't subtracting 1. The result was a systematic migration of observation locations in 3D space when loading and writing. Quick fix, subtract 1 when loading.