### PR TITLE
Zero-based integers for select ModflowFlwob variables

### DIFF
--- a/autotest/t041_test.py
+++ b/autotest/t041_test.py
@@ -205,16 +205,19 @@ def test_obs_create_and_write():
             raise ValueError('could not load new HOB output file')
 
 
-def test_hob_options():
+def test_filenames():
     """
-    test041 load and run a simple MODFLOW-2005 OBS example with specified filenames
+    test041 load and run a simple MODFLOW-2005 OBS example with specified
+    filenames
     """
-    print('test041 load and run a simple MODFLOW-2005 OBS example with specified filenames')
+    print('test041 load and run a simple MODFLOW-2005 OBS example with'
+          ' specified filenames')
     pth = os.path.join(cpth, 'simple')
     modelname = 'hob_simple'
     pkglst = ['dis', 'bas6', 'pcg', 'lpf']
-    m = flopy.modflow.Modflow.load(modelname + '.nam', model_ws=pth, check=False,
-                                   load_only=pkglst, verbose=False, exe_name=exe_name)
+    m = flopy.modflow.Modflow.load(modelname + '.nam', model_ws=pth,
+                                   check=False, load_only=pkglst,
+                                   verbose=False, exe_name=exe_name)
 
     obs = flopy.modflow.HeadObservation(m, layer=0, row=5, column=5,
                                         time_series_data=[[1., 54.4],
@@ -240,14 +243,14 @@ def test_hob_options():
 
     # Lists of length nqtfb
     obsnam = ['drob_1', 'drob_2']
-    irefsp = [1, 1]
+    irefsp = [0, 0]
     toffset = [0, 0]
     flwobs = [0., 0.]
 
     # Lists of length (nqfb, nqclfb)
-    layer = [[1], [1]]
-    row = [[6], [9]]
-    column = [[6], [9]]
+    layer = [[0], [0]]
+    row = [[5], [8]]
+    column = [[5], [8]]
     factor = [[1.], [1.]]
 
     drob = flopy.modflow.ModflowFlwob(m,
@@ -271,10 +274,11 @@ def test_hob_options():
     # Write the model input files
     m.write_input()
 
-    assert m.get_output(unit=51) == f_out, 'output filename ({}) does \
-                                                not match specified name'.format(m.get_output(unit=51))
-
-    assert os.path.isfile(os.path.join(pth, f_in)), 'specified HOB input file not found'
+    s = 'output filename ({}) does ' \
+        'not match specified name'.format(m.get_output(unit=51))
+    assert m.get_output(unit=51) == f_out, s
+    s = 'specified HOB input file not found'
+    assert os.path.isfile(os.path.join(pth, f_in)), s
 
     # run the modflow-2005 model
     if run:
@@ -315,4 +319,4 @@ if __name__ == '__main__':
     test_hob_simple()
     test_obs_create_and_write()
     test_obs_load_and_write()
-    test_hob_options()
+    test_filenames()

--- a/flopy/modflow/mfflwob.py
+++ b/flopy/modflow/mfflwob.py
@@ -34,7 +34,7 @@ class ModflowFlwob(Package):
     obsnam : string list of length nqtfb
         Observation name
     irefsp : int of length nqtfb
-        Stress period to which the observation time is referenced.
+        The zero-based stress period to which the observation time is referenced.
         The reference point is the beginning of the specified stress period.
     toffset : float list of length nqtfb
         Is the time from the beginning of the stress period irefsp to the time
@@ -49,11 +49,11 @@ class ModflowFlwob(Package):
         Observed flow value from the head-dependent flow boundary into the
         aquifer (+) or the flow from the aquifer into the boundary (-)
     layer : int list of length(nqfb, nqclfb)
-        layer index for the cell included in the cell group
+        The zero-based layer index for the cell included in the cell group.
     row : int list of length(nqfb, nqclfb)
-        row index for the cell included in the cell group
+        The zero-based row index for the cell included in the cell group.
     column : int list of length(nqfb, nqclfb)
-        column index of the cell included in the cell group
+        The zero-based column index of the cell included in the cell group.
     factor : float list of length(nqfb, nqclfb)
         Is the portion of the simulated gain or loss in the cell that is
         included in the total gain or loss for this cell group (fn of eq. 5).
@@ -275,7 +275,7 @@ class ModflowFlwob(Package):
             for j in range(self.nqobfb[i]):
                 # write section 4
                 line = '{}{:10d}{:10.4g} {:10.4g}\n'.format(self.obsnam[c],
-                                                            self.irefsp[c],
+                                                            self.irefsp[c] + 1,
                                                             self.toffset[c],
                                                             self.flwobs[c])
                 f_fbob.write(line)
@@ -287,9 +287,9 @@ class ModflowFlwob(Package):
                 # set factor to 1.0 for all cells in group
                 if self.nqclfb[i] < 0:
                     self.factor[i, :] = 1.0
-                line = '{:10d}'.format(self.layer[i, j])
-                line += '{:10d}'.format(self.row[i, j])
-                line += '{:10d}'.format(self.column[i, j])
+                line = '{:10d}'.format(self.layer[i, j] + 1)
+                line += '{:10d}'.format(self.row[i, j] + 1)
+                line += '{:10d}'.format(self.column[i, j] + 1)
                 line += ' '.format(self.factor[i, j])
                 # note is 10f good enough here?
                 line += '{:10f}\n'.format(self.factor[i, j])

--- a/flopy/modflow/mfflwob.py
+++ b/flopy/modflow/mfflwob.py
@@ -34,7 +34,8 @@ class ModflowFlwob(Package):
     obsnam : string list of length nqtfb
         Observation name
     irefsp : int of length nqtfb
-        The zero-based stress period to which the observation time is referenced.
+        The zero-based stress period to which the observation time is
+        referenced.
         The reference point is the beginning of the specified stress period.
     toffset : float list of length nqtfb
         Is the time from the beginning of the stress period irefsp to the time

--- a/flopy/modflow/mfhob.py
+++ b/flopy/modflow/mfhob.py
@@ -456,20 +456,20 @@ class HeadObservation(object):
     Parameters
     ----------
     tomulth : float
-        time-offset multiplier for head observations. Default is 1.
+        Time-offset multiplier for head observations. Default is 1.
     obsnam : string
         Observation name. Default is 'HOBS'
     layer : int
-        is the zero-based layer index of the cell in which the head observation
+        The zero-based layer index of the cell in which the head observation
         is located. If layer is less than zero, hydraulic heads from multiple
         layers are combined to calculate a simulated value. The number of
         layers equals the absolute value of layer, or abs(layer). Default is 0.
     row : int
-        zero-based row index for the observation. Default is 0.
+        The zero-based row index for the observation. Default is 0.
     column : int
-        zero-based column index of the observation. Default is 0.
+        The zero-based column index of the observation. Default is 0.
     irefsp : int
-        the stress period to which the observation time is referenced.
+        The zero-based stress period to which the observation time is referenced.
     roff : float
         Fractional offset from center of cell in Y direction (between rows).
         Default is 0.
@@ -482,17 +482,17 @@ class HeadObservation(object):
         if initial value is head and subsequent changes in head. Only
         specified if irefsp is < 0. Default is 1.
     mlay : dictionary of length (abs(irefsp))
-        key represents zero-based layer numbers for multilayer observations an
+        Key represents zero-based layer numbers for multilayer observations and
         value represents the fractional value for each layer of multilayer
         observations. If mlay is None, a default mlay of {0: 1.} will be
         used (default is None).
     time_series_data : list or numpy array
-        two-dimensional list or numpy array containing the simulation time of
+        Two-dimensional list or numpy array containing the simulation time of
         the observation and the observed head [[totim, hob]]. If
         time_series_dataDefault is None, a default observation of 0. at
         totim 0. will be created (default is None).
     names : list
-        list of specified observation names. If names is None, observation
+        List of specified observation names. If names is None, observation
         names will be automatically generated from obsname and the order
         of the timeseries data (default is None).
 

--- a/flopy/modflow/mfhob.py
+++ b/flopy/modflow/mfhob.py
@@ -469,7 +469,8 @@ class HeadObservation(object):
     column : int
         The zero-based column index of the observation. Default is 0.
     irefsp : int
-        The zero-based stress period to which the observation time is referenced.
+        The zero-based stress period to which the observation time is
+        referenced.
     roff : float
         Fractional offset from center of cell in Y direction (between rows).
         Default is 0.


### PR DESCRIPTION
Changes to `ModflowHob` and `ModflowFlwob` to treat variables `irefsp`, `layer`, `row`, and `column` uniformly as zero-based integers. Addresses issue #586.