### PR TITLE
Resolve UnboundLocalError with crs property

### DIFF
--- a/autotest/t007_test.py
+++ b/autotest/t007_test.py
@@ -1081,19 +1081,20 @@ def test_wkt_parse():
     """Test parsing of Coordinate Reference System parameters
     from well-known-text in .prj files."""
 
-    from flopy.utils.reference import crs
+    from flopy.export.shapefile_utils import CRS
+
+    geocs_params = [
+        'wktstr', 'geogcs', 'datum', 'spheroid_name', 'semi_major_axis',
+        'inverse_flattening', 'primem', 'gcs_unit']
 
     prjs = glob.glob('../examples/data/prj_test/*')
-
     for prj in prjs:
         with open(prj) as src:
             wkttxt = src.read()
             wkttxt = wkttxt.replace("'", '"')
         if len(wkttxt) > 0 and 'projcs' in wkttxt.lower():
-            crsobj = crs(esri_wkt=wkttxt)
-            geocs_params = ['wktstr', 'geogcs', 'datum', 'spheroid_name',
-                            'semi_major_axis', 'inverse_flattening',
-                            'primem', 'gcs_unit']
+            crsobj = CRS(esri_wkt=wkttxt)
+            assert isinstance(crsobj.crs, dict)
             for k in geocs_params:
                 assert crsobj.__dict__[k] is not None
             projcs_params = [k for k in crsobj.__dict__

--- a/flopy/export/shapefile_utils.py
+++ b/flopy/export/shapefile_utils.py
@@ -685,7 +685,7 @@ class CRS(object):
     @property
     def crs(self):
         """
-        Dict mapping crs attibutes to proj4 parameters
+        Dict mapping crs attributes to proj4 parameters
         """
         proj = None
         if self.projcs is not None:
@@ -709,6 +709,7 @@ class CRS(object):
             proj = 'longlat'
 
         # datum
+        datum = None
         if 'NAD' in self.datum.lower() or \
                 'north' in self.datum.lower() and \
                 'america' in self.datum.lower():
@@ -721,11 +722,12 @@ class CRS(object):
             datum = 'wgs84'
 
         # ellipse
-        if '1866' in self.spheriod_name:
+        ellps = None
+        if '1866' in self.spheroid_name:
             ellps = 'clrk66'
-        elif 'grs' in self.spheriod_name.lower():
+        elif 'grs' in self.spheroid_name.lower():
             ellps = 'grs80'
-        elif 'wgs' in self.spheriod_name.lower():
+        elif 'wgs' in self.spheroid_name.lower():
             ellps = 'wgs84'
 
         return {'proj': proj,
@@ -792,7 +794,7 @@ class CRS(object):
         self.geogcs = self._gettxt('GEOGCS["', '"')
         self.datum = self._gettxt('DATUM["', '"')
         tmp = self._getgcsparam('SPHEROID')
-        self.spheriod_name = tmp.pop(0)
+        self.spheroid_name = tmp.pop(0)
         self.semi_major_axis = tmp.pop(0)
         self.inverse_flattening = tmp.pop(0)
         self.primem = self._getgcsparam('PRIMEM')

--- a/flopy/utils/reference.py
+++ b/flopy/utils/reference.py
@@ -1933,6 +1933,9 @@ class crs(object):
     """
 
     def __init__(self, prj=None, esri_wkt=None, epsg=None):
+        warnings.warn(
+            "crs has been deprecated. Use CRS in shapefile_utils instead.",
+            category=DeprecationWarning)
         self.wktstr = None
         if prj is not None:
             with open(prj) as fprj:
@@ -1973,6 +1976,7 @@ class crs(object):
             proj = 'longlat'
 
         # datum
+        datum = None
         if 'NAD' in self.datum.lower() or \
                 'north' in self.datum.lower() and \
                 'america' in self.datum.lower():
@@ -1985,6 +1989,7 @@ class crs(object):
             datum = 'wgs84'
 
         # ellipse
+        ellps = None
         if '1866' in self.spheroid_name:
             ellps = 'clrk66'
         elif 'grs' in self.spheroid_name.lower():


### PR DESCRIPTION
Identified a bug while exporting a netCDF file where a `UnboundLocalError` was raised for `datum` and/or `ellps`.