### PR TITLE
refactor whitespace in NAM file and MFList output files

### DIFF
--- a/flopy/discretization/grid.py
+++ b/flopy/discretization/grid.py
@@ -162,12 +162,11 @@ class Grid(object):
     # access to basic grid properties
     ###################################
     def __repr__(self):
-        s = "xll:{0:<.10G}; yll:{1:<.10G}; rotation:{2:<G}; ". \
-            format(self.xoffset, self.yoffset, self.angrot)
-        s += "proj4_str:{0}; ".format(self.proj4)
-        s += "units:{0}; ".format(self.units)
-        s += "lenuni:{0}; ".format(self.lenuni)
-        return s
+        return (
+            "xll:{0:<.10G}; yll:{1:<.10G}; rotation:{2:<G}; proj4_str:{3}; "
+            "units:{4}; lenuni:{5}"
+            .format(self.xoffset, self.yoffset, self.angrot, self.proj4,
+                    self.units, self.lenuni))
 
     @property
     def grid_type(self):

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -915,14 +915,17 @@ class BaseModel(ModelInterface):
         ----------
 
         """
-        s = ''
+        lines = []
         for p in self.packagelist:
             for i in range(len(p.name)):
                 if p.unit_number[i] == 0:
                     continue
-                s += '{:14s} {:5d}  '.format(p.name[i], p.unit_number[i]) + \
-                     '{:s} {:s}\n'.format(p.file_name[i], p.extra[i])
-        return s
+                s = '{:14s} {:5d}  {}'.format(
+                        p.name[i], p.unit_number[i], p.file_name[i])
+                if p.extra[i]:
+                    s += ' ' + p.extra[i]
+                lines.append(s)
+        return '\n'.join(lines) + '\n'
 
     def has_package(self, name):
         """

--- a/flopy/modflow/mf.py
+++ b/flopy/modflow/mf.py
@@ -414,7 +414,7 @@ class Modflow(BaseModel):
         f_nam.write('{}\n'.format(self.heading))
         if self.structured:
             f_nam.write('#' + str(self.modelgrid))
-        f_nam.write(" ;start_datetime:{0}\n".format(self.start_datetime))
+        f_nam.write("; start_datetime:{0}\n".format(self.start_datetime))
         if self.version == 'mf2k':
             if self.glo.unit_number[0] > 0:
                 f_nam.write('{:14s} {:5d}  {}\n'.format(self.glo.name[0],

--- a/flopy/utils/util_list.py
+++ b/flopy/utils/util_list.py
@@ -695,13 +695,15 @@ class MfList(DataInterface, DataListInterface):
 
             if kper_vtype == np.recarray:
                 name = f.name
-                f.close()
-                f = open(name, 'ab+')
-                # print(f)
-                self.__tofile(f, kper_data)
-                f.close()
-                f = open(name, 'a')
-                # print(f)
+                if self.__binary:
+                    f.close()
+                    # switch file append mode to binary
+                    with open(name, 'ab+') as f:
+                        self.__tofile(f, kper_data)
+                    # continue back to non-binary
+                    f = open(name, 'a')
+                else:
+                    self.__tofile(f, kper_data)
             elif kper_vtype == str:
                 f.write('         open/close ' + kper_data)
                 if self.__binary:


### PR DESCRIPTION
These are a few changes that relate only to the output whitespace, and should not change any behavior:
* The discretization line in the NAM file had an awkward `..lenuni:2;  ;start_datetime...` (with a gap), which is tidied up to a more common delimited style
* Also with the NAM file, there was trailing whitespace after package source file, i.e. `freyberg.dis `.
* On Windows (only), the MFList outputs (e.g. WEL, etc.) had a mixture of CRLF and LF endings, as this file used a mixture of binary and non-binary open modes while appending output. This is now changed so that the write mode only changes to binary if the data is binary.