### PR TITLE
Fix "Cannot allocate memory" error for Python 2.7 on non-Windows

### DIFF
--- a/autotest/t032_test.py
+++ b/autotest/t032_test.py
@@ -27,11 +27,15 @@ def test_polygon_from_ij():
                                    nlay=2, delr=100, delc=100,
                                    top=3, botm=botm, model=m)
 
-    ncdf = NetCdf('toy.model.nc', m)
+    fname = os.path.join(mpth, 'toy.model.nc')
+    ncdf = NetCdf(fname, m)
     ncdf.write()
 
-    m.export('toy_model_two.nc')
-    dis.export('toy_model_dis.nc')
+    fname = os.path.join(mpth, 'toy_model_two.nc')
+    m.export(fname)
+
+    fname = os.path.join(mpth, 'toy_model_dis.nc')
+    dis.export(fname)
 
     mg = m.modelgrid
     mg.set_coord_info(xoff=mg._xul_to_xll(600000.0, -45.0),


### PR DESCRIPTION
Supersedes #621

I don't fully understand the issue, except that there are various issues issues (e.g. [here](https://bugs.python.org/issue7213)) related to Popen's `close_fds` parameter for Python 2.7 on non-Windows. My guess is the file descriptors get too full and no more memory can be allocated to hold the buffers. Setting `close_fds=True` fixes the issue for this scenario. I'm not sure if it should be a general default for Popen.

And also, Python 2.7 is [nearly dead](https://pythonclock.org/) and I'd suggest dropping support for this soon, as most other Python projects have already done, e.g., numpy's release from last week is Python 3.5+ only.

Other improvements to `normal_msg` docstring and handling.