### PR TITLE
Older numpy needs opened file in binary mode for writetxt

### DIFF
--- a/flopy/utils/util_list.py
+++ b/flopy/utils/util_list.py
@@ -695,7 +695,7 @@ class MfList(DataInterface, DataListInterface):
 
             if kper_vtype == np.recarray:
                 name = f.name
-                if self.__binary:
+                if self.__binary or not numpy114:
                     f.close()
                     # switch file append mode to binary
                     with open(name, 'ab+') as f:


### PR DESCRIPTION
A modification from #622 broke writing MFList outputs (WEL, etc.) for users with numpy < 1.14.0

With these older numpy versions, `np.writetxt` needed to be opened with `b` mode.

Note that I've carefully checked this behaviour change between these two numpy releases.