### PR TITLE
feat(mf6 rename all packages method + copy support)

### DIFF
--- a/autotest/t505_test.py
+++ b/autotest/t505_test.py
@@ -881,6 +881,38 @@ def test005_advgw_tidal():
     assert pymake.compare_heads(None, None, files1=head_file, files2=head_new,
                                 outfile=outfile)
 
+    # test rename all
+    model.rename_all_packages('new_name')
+    assert model.name_file.filename == 'new_name.nam'
+    package_type_dict = {}
+    for package in model.packagelist:
+        if not package.package_type in package_type_dict:
+            assert package.filename == 'new_name.{}'.format(package.package_type)
+            package_type_dict[package.package_type] = 1
+    sim.write_simulation()
+    name_file = os.path.join(run_folder, 'new_name.nam')
+    assert os.path.exists(name_file)
+    dis_file = os.path.join(run_folder, 'new_name.dis')
+    assert os.path.exists(dis_file)
+
+    sim.rename_all_packages('all_files_same_name')
+    package_type_dict = {}
+    for package in model.packagelist:
+        if not package.package_type in package_type_dict:
+            assert package.filename == \
+                   'all_files_same_name.{}'.format(package.package_type)
+            package_type_dict[package.package_type] = 1
+    assert sim._tdis_file.filename == 'all_files_same_name.tdis'
+    for ims_file in sim._ims_files.values():
+        assert ims_file.filename == 'all_files_same_name.ims'
+    sim.write_simulation()
+    name_file = os.path.join(run_folder, 'all_files_same_name.nam')
+    assert os.path.exists(name_file)
+    dis_file = os.path.join(run_folder, 'all_files_same_name.dis')
+    assert os.path.exists(dis_file)
+    tdis_file = os.path.join(run_folder, 'all_files_same_name.tdis')
+    assert os.path.exists(tdis_file)
+
     # clean up
     sim.delete_output_files()
 

--- a/flopy/discretization/grid.py
+++ b/flopy/discretization/grid.py
@@ -162,11 +162,19 @@ class Grid(object):
     # access to basic grid properties
     ###################################
     def __repr__(self):
-        return (
-            "xll:{0:<.10G}; yll:{1:<.10G}; rotation:{2:<G}; proj4_str:{3}; "
-            "units:{4}; lenuni:{5}"
-            .format(self.xoffset, self.yoffset, self.angrot, self.proj4,
-                    self.units, self.lenuni))
+        if self.xoffset is not None and self.yoffset is not None \
+                and self.angrot is not None:
+            s = "xll:{0:<.10G}; yll:{1:<.10G}; rotation:{2:<G}; ". \
+                format(self.xoffset, self.yoffset, self.angrot)
+        else:
+            s = ''
+        if self.proj4 is not None:
+            s += "proj4_str:{0}; ".format(self.proj4)
+        if self.units is not None:
+            s += "units:{0}; ".format(self.units)
+        if self.lenuni is not None:
+            s += "lenuni:{0}; ".format(self.lenuni)
+        return s
 
     @property
     def grid_type(self):

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -485,6 +485,9 @@ class BaseModel(ModelInterface):
         using self.dis.delr, self.dis.delc, and self.dis.lenuni before being
         returned
         """
+        if item == 'output_packages' or not hasattr(self, 'output_packages'):
+            raise AttributeError(item)
+
         if item == 'sr':
             if self.dis is not None:
                 return self.dis.sr

--- a/flopy/mf6/data/dfn/gwf-disu.dfn
+++ b/flopy/mf6/data/dfn/gwf-disu.dfn
@@ -64,7 +64,7 @@ type integer
 reader urword
 optional true
 longname number of vertices
-description is the total number of (x, y) vertex pairs used to define the plan-view shape of each cell in the model grid.  If NVERT is not specified or is specified as zero, then the VERTICES and CELL2D blocks below are not read.  NVERT and the accompanying VERTICES and CELL2D blocks should be specified for most simulations.  If the XT3D or SAVE\_SPECIFIC\_DISCHARGE options are specified in the NPF Package, these this information is required.
+description is the total number of (x, y) vertex pairs used to define the plan-view shape of each cell in the model grid.  If NVERT is not specified or is specified as zero, then the VERTICES and CELL2D blocks below are not read.  NVERT and the accompanying VERTICES and CELL2D blocks should be specified for most simulations.  If the XT3D or SAVE\_SPECIFIC\_DISCHARGE options are specified in the NPF Package, then this information is required.
 
 # --------------------- gwf disu griddata ---------------------
 

--- a/flopy/mf6/data/mfdatastorage.py
+++ b/flopy/mf6/data/mfdatastorage.py
@@ -120,6 +120,9 @@ class LayerStorage(object):
             return str(self.get_data())
 
     def __getattr__(self, attr):
+        if attr == 'binary' or not hasattr(self, 'binary'):
+            raise AttributeError(attr)
+
         if attr == 'array':
             return self._data_storage_parent.get_data(self._lay_indexes, True)
         elif attr == '__getstate__':

--- a/flopy/mf6/mfmodel.py
+++ b/flopy/mf6/mfmodel.py
@@ -74,6 +74,8 @@ class MFModel(PackageContainer, ModelInterface):
         sets the file path to the model folder and updates all model file paths
     is_valid : () : boolean
         checks the validity of the model and all of its packages
+    rename_all_packages : (name : string)
+        renames all packages in the model
 
     See Also
     --------
@@ -833,6 +835,19 @@ class MFModel(PackageContainer, ModelInterface):
             # remove child packages
             for child_package in child_package_list:
                 self._remove_package_from_dictionaries(child_package)
+
+    def rename_all_packages(self, name):
+        package_type_count = {}
+        self.name_file.filename = '{}.nam'.format(name)
+        for package in self.packagelist:
+            if package.package_type not in package_type_count:
+                package.filename = '{}.{}'.format(name, package.package_type)
+                package_type_count[package.package_type] = 1
+            else:
+                package_type_count[package.package_type] += 1
+                package.filename = '{}_{}.{}'.format(
+                    name, package_type_count[package.package_type],
+                    package.package_type)
 
     def register_package(self, package, add_to_package_list=True,
                          set_package_name=True, set_package_filename=True):

--- a/flopy/mf6/mfmodel.py
+++ b/flopy/mf6/mfmodel.py
@@ -174,7 +174,13 @@ class MFModel(PackageContainer, ModelInterface):
             Package object of type :class:`flopy.pakbase.Package`
 
         """
-        return self.get_package(item)
+        if item == 'name_file' or not hasattr(self, 'name_file'):
+            raise AttributeError(item)
+
+        package = self.get_package(item)
+        if package is not None:
+            return package
+        raise AttributeError(item)
 
     def __repr__(self):
         return self._get_data_str(True)

--- a/flopy/utils/datafile.py
+++ b/flopy/utils/datafile.py
@@ -292,7 +292,7 @@ class LayerFile(object):
 
         masked_values = kwargs.pop("masked_values", [])
         if self.model is not None:
-            if self.model.bas6 is not None:
+            if hasattr(self.model, 'bas6') and self.model.bas6 is not None:
                 masked_values.append(self.model.bas6.hnoflo)
         kwargs["masked_values"] = masked_values
 


### PR DESCRIPTION
Added a rename_all_packages method to the mf6 model and simulation classes which renames all the packages to a single name with a unique extension. If extensions are not unique, a suffix is added to the name to make the full file name unique.

Also added support for copy of mf6 simulation/model/package/data objects. Copy works for all objects but deepcopy sometimes does not always copy subpackages correctly. This problem may be a bug with how deepcopy handles multiple references being kept around to a single object.