### PR TITLE
Read WEL Reductions from List File

### DIFF
--- a/autotest/t011_test.py
+++ b/autotest/t011_test.py
@@ -6,6 +6,7 @@ Some basic tests for mflistfile.py module (not super rigorous)
 import os
 import flopy
 import numpy as np
+from nose.tools import raises
 
 
 def test_mflistfile():
@@ -55,6 +56,36 @@ def test_mflistfile():
 
     return
 
+def test_mflist_reducedpumping():
+    '''
+    test reading reduced pumping data from list file
+    '''
+    pth = os.path.join('..', 'examples', 'data', 'mfusg_test',
+                       '03B_conduit_unconfined', 'output')
+    list_file = os.path.join(pth, 'ex3B.lst')
+    mflist = flopy.utils.MfusgListBudget(list_file)
+    assert isinstance(mflist.get_reduced_pumping(), np.recarray)
+    
+    return
+
+@raises(AssertionError) 
+def test_mflist_reducedpumping_fail():
+    '''
+    test failure for reading reduced pumping data from list file
+    '''
+    pth = os.path.join('..', 'examples', 'data', 'mfusg_test',
+                       '03A_conduit_unconfined', 'output')
+    list_file = os.path.join(pth, 'ex3A.lst')
+    # Catch before flopy to avoid masking file not found assert
+    if not os.path.isfile(list_file):
+        msg = '{} {}'.format(list_file, 'not found')
+        raise FileNotFoundError(msg)
+    mflist = flopy.utils.MfusgListBudget(list_file)
+    mflist.get_reduced_pumping()
+    
+    return
 
 if __name__ == '__main__':
     test_mflistfile()
+    test_mflist_reducedpumping()
+    test_mflist_reducedpumping_fail()

--- a/examples/data/mfusg_test/03B_conduit_unconfined/ex3B.nam
+++ b/examples/data/mfusg_test/03B_conduit_unconfined/ex3B.nam
@@ -11,4 +11,3 @@ DATA(BINARY) 30 ex3B.hds
 DATA(BINARY) 31 ex3B.ddn
 DATA(BINARY) 35 ex3B.cln.cbb
 DATA(BINARY) 36 ex3B.cln.hds
-DATA         55 ex3B.cln.afr

--- a/examples/data/mfusg_test/03B_conduit_unconfined/ex3B.wel
+++ b/examples/data/mfusg_test/03B_conduit_unconfined/ex3B.wel
@@ -1,3 +1,3 @@
-         1        50 autoflowreduce iunitafr 55
+         1        50 autoflowreduce iunitafr 7
          0         0         1      Stress Period 1
          1   -62840.

--- a/examples/data/mfusg_test/03B_conduit_unconfined/output/ex3B.lst
+++ b/examples/data/mfusg_test/03B_conduit_unconfined/output/ex3B.lst
@@ -1,6 +1,6 @@
                                   MODFLOW-USG      
       U.S. GEOLOGICAL SURVEY MODULAR FINITE-DIFFERENCE GROUNDWATER FLOW MODEL
-                            VERSION 1.2.00 03/21/2014
+                            VERSION 1.5.00 02/27/2019
 
  LIST FILE: ex3B.lst
                          UNIT    7
@@ -57,7 +57,7 @@
  FILE TYPE:DATA   UNIT   55   STATUS:UNKNOWN
  FORMAT:FORMATTED              ACCESS:SEQUENTIAL          
 
- BAS -- BASIC PACKAGE-USG      1.2.00 03/21/2014                        INPUT READ FROM UNIT    1
+ BAS -- BASIC PACKAGE-USG      1.5.00 02/27/2019                        INPUT READ FROM UNIT    1
  
  # MODFLOW2005 Basic Package                                                     
  #                                                                               
@@ -88,7 +88,7 @@
                     ----------------------------------------
      CLN-NODE NO. CLNTYP ORIENTATION  CLN LENGTH    BOT ELEVATION         FANGLE         IFLIN           ICCWADI
      -----------  ------ ----------- -----------    -------------    -----------        ------    -------
-              1      1          0    0.300000E+02   -0.200000E+02    0.157000E+01          0          0
+              1      1          0    0.300000E+02   -0.200000E+02    0.157000E+01         -1          0
 
                      CLN TO 3-D GRID CONNECTION INFORMATION
                     ----------------------------------------
@@ -102,6 +102,7 @@
      CONDUIT NODE        RADIUS   CONDUIT SAT K
      ------------        ------   -------------
               1    0.500000E+00    0.323000E+11
+ 
 
  DIS -- UNSTRUCTURED GRID DISCRETIZATION PACKAGE, VERSION 1 : 5/17/2010 - INPUT READ FROM UNIT   12
 
@@ -109,11 +110,11 @@
 
                      DELC =   470.000    
 
- TOP ELEVATION OF LAYER 1 =  10.00000    
+ TOP ELEVATION OF LAYER 1 =   10.0000    
 
    MODEL LAYER BOTTOM EL. =   0.00000     FOR LAYER   1
 
- BOT. EL. OF QUASI-3D BED = -10.00000     FOR LAYER   1
+ BOT. EL. OF QUASI-3D BED =  -10.0000     FOR LAYER   1
 
    MODEL LAYER BOTTOM EL. =  -20.0000     FOR LAYER   2
 
@@ -133,7 +134,7 @@
 
  AQUIFER HEAD WILL BE SET TO   999.00     AT ALL NO-FLOW NODES (IBOUND=0).
 
-             INITIAL HEAD =  10.00000     FOR LAYER   1
+             INITIAL HEAD =   10.0000     FOR LAYER   1
 
              INITIAL HEAD =   30.0000     FOR LAYER   2
 
@@ -146,7 +147,7 @@
          INPUT READ FROM UNIT 11
  TRANSIENT SIMULATION
  CELL-BY-CELL FLOWS WILL BE SAVED ON UNIT 50
- HEAD AT CELLS THAT CONVERT TO DRY= -1000.00    
+ HEAD AT CELLS THAT CONVERT TO DRY=  -1000.0    
  WETTING CAPABILITY IS NOT ACTIVE
  IKVFLAG=0, NODAL INPUT OF CV
       LAYER  LAYER-TYPE CODE     INTERBLOCK T
@@ -154,11 +155,11 @@
          1            4          0 -- HARMONIC    
          2            4          0 -- HARMONIC    
 
- COLUMN TO ROW ANISOTROPY =  1.000000    
+ COLUMN TO ROW ANISOTROPY =   1.00000    
 
      PRIMARY STORAGE COEF =  1.000000E-04 FOR LAYER   1
 
-    HYD. COND. ALONG ROWS =  100.0000     FOR LAYER   1
+    HYD. COND. ALONG ROWS =   100.000     FOR LAYER   1
 
  VERT HYD COND /THICKNESS =   0.00000     FOR LAYER   1
 
@@ -186,7 +187,7 @@
  MAXIMUM NUMBER OF ACTIVE WELLS (MXACTW) =      1
  C-B-C FLUX FLAG OR UNIT NUMBER (IWELCB) = 50
  WELL FLUX WILL BE REDUCED WHEN SATURATED THICKNESS IS LESS THAN 1 PERCENT OF CELL THICKNESS
- WELL REDUCTION INFO WILL BE WRITTEN TO UNIT:    55
+ WELL REDUCTION INFO WILL BE WRITTEN TO UNIT:     7
 
 
      0 Well parameters
@@ -210,7 +211,7 @@ FROM THE SOLVER INPUT FILE.
  MAXIMUM NUMBER OF BACKTRACKS    (NUMTRACK)      =       200
  BACKTRACKING TOLERANCE FACTOR       (BTOL)      =    0.110000E+26
  BACKTRACKING REDUCTION FACTOR     (BREDUC)      =    0.200000E+00
- BACKTRACKING REIDUAL LIMIT       (RES_LIM)      =    0.100000E+01
+ BACKTRACKING RESIDUAL LIMIT      (RES_LIM)      =    0.100000E+01
  ***Newton Linearization will be used***
  
  ***XMD linear solver will be used***
@@ -234,7 +235,7 @@ FROM THE SOLVER INPUT FILE.
 
                                MULTIPLIER FOR DELT =     1.000
 
-                            INITIAL TIME STEP SIZE =  1.0000000    
+                            INITIAL TIME STEP SIZE =   1.000000    
 
  WEL -- WELL PACKAGE, VERSION 7, 5/2/2005 INPUT READ FROM UNIT   14
 
@@ -246,26 +247,41 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0          0.289505E+10     0.289505E+10
-        1               17                                                                        -10.0485               2    50    50  lay row col
-        1               17                                                                        -12.1749                     1           CLN-node number
-        2                             0             0          0.451112E+09     0.451112E+09
-        2               14                                                                         2.52661               1    50    50  lay row col
-        2               14                                                                        -1.30669                     1           CLN-node number
-        3                             0             0          0.149898E+08     0.149898E+08
-        3               14                                                                        0.277472               2    50    50  lay row col
-        3               14                                                                        0.612320                     1           CLN-node number
-        4                             0             0           186396.          186396.    
-        4               11                                                                       -0.299094E-01           1    50    50  lay row col
-        4               11                                                                        0.647046E-01                 1           CLN-node number
-        5                             0             0           1107.07          1107.07    
-        5                5                                                                       -0.362367E-02           1    50    50  lay row col
-        5                5                                                                        0.201316E-02                 1           CLN-node number
-        6                             0             0           2.11259          2.11259    
-        6                2                                                                       -0.181123E-03           1    50    50  lay row col
-        6                2                                                                        0.266826E-05                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0          0.289505E+10     0.289505E+10
+LA         1               17                                                                        -10.0485               2    50    50  lay row col    
+LA         1               17                                                                        -12.1749                     1           CLN-node number
+UR         1                                                                                         -10.0485               2    50    50  lay row col    
+UR         1                                                                                         -12.1749                     1           CLN-node number
+BT         2                             0             0          0.451112E+09     0.451112E+09
+LA         2               14                                                                         2.52661               1    50    50  lay row col    
+LA         2               14                                                                        -1.30669                     1           CLN-node number
+UR         2                                                                                          2.27395               1    50    50  lay row col    
+UR         2                                                                                         -1.30669                     1           CLN-node number
+BT         3                             0             0          0.149898E+08     0.149898E+08
+LA         3               14                                                                        0.277472               2    50    50  lay row col    
+LA         3               14                                                                        0.612320                     1           CLN-node number
+UR         3                                                                                         0.249725               2    50    50  lay row col    
+UR         3                                                                                         0.551088                     1           CLN-node number
+BT         4                             0             0           186396.          186396.    
+LA         4               11                                                                       -0.299094E-01           1    50    50  lay row col    
+LA         4               11                                                                        0.647046E-01                 1           CLN-node number
+UR         4                                                                                         0.284408E-01           2    50    50  lay row col    
+UR         4                                                                                         0.627634E-01                 1           CLN-node number
+BT         5                             0             0           1107.07          1107.07    
+LA         5                5                                                                       -0.362367E-02           1    50    50  lay row col    
+LA         5                5                                                                        0.201316E-02                 1           CLN-node number
+UR         5                                                                                        -0.344249E-02           1    50    50  lay row col    
+UR         5                                                                                         0.201316E-02                 1           CLN-node number
+BT         6                             0             0           2.11259          2.11259    
+LA         6                2                                                                       -0.181123E-03           1    50    50  lay row col    
+LA         6                2                                                                        0.266826E-05                 1           CLN-node number
 
 
      6 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP   1 STRESS PERIOD   1
@@ -274,30 +290,39 @@ FROM THE SOLVER INPUT FILE.
   MAXIMUM CHANGE FOR EACH ITERATION:
   MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL
  ------------------------------------------------------------------------------------------------------------------------------------------
-   -10.05     (    2,   50,   50)   2.527     (    1,   50,   50)  0.2775     (    2,   50,   50) -0.2991E-01 (    1,   50,   50) -0.3624E-02 (    1,   50,   50)
+   -10.05     (    2,   50,   50)   2.274     (    1,   50,   50)  0.2497     (    2,   50,   50)  0.2844E-01 (    2,   50,   50) -0.3442E-02 (    1,   50,   50)
   -0.1811E-03 (    1,   50,   50)
 
   MAXIMUM CHANGE FOR CLN NODE AT EACH ITERATION:
    MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL
  ------------------------------------------------------------------------------------------------------------------------------------
-   -12.175    ,          1  -1.3067    ,          1  0.61232    ,          1  0.64705E-01,          1  0.20132E-02,          1
+   -12.175    ,          1  -1.3067    ,          1  0.55109    ,          1  0.62763E-01,          1  0.20132E-02,          1
    0.26683E-05,          1
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP        1
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0          0.303707E+07     0.303707E+07
-        1               14                                                                        -1.13334               2    49    49  lay row col
-        1               14                                                                       -0.978865                     1           CLN-node number
-        2                             0             0           960.762          960.762    
-        2                7                                                                       -0.296186E-02           2    50    50  lay row col
-        2                7                                                                       -0.654075E-02                 1           CLN-node number
-        3                             0             0           1.75699          1.75699    
-        3                2                                                                        0.144367E-03           1    50    50  lay row col
-        3                2                                                                       -0.325168E-06                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0          0.303707E+07     0.303707E+07
+LA         1               14                                                                        -1.13334               2    49    49  lay row col    
+LA         1               14                                                                       -0.978865                     1           CLN-node number
+UR         1                                                                                         -1.13334               2    49    49  lay row col    
+UR         1                                                                                        -0.978865                     1           CLN-node number
+BT         2                             0             0           960.762          960.762    
+LA         2                7                                                                       -0.296186E-02           2    50    50  lay row col    
+LA         2                7                                                                       -0.654075E-02                 1           CLN-node number
+UR         2                                                                                        -0.296186E-02           2    50    50  lay row col    
+UR         2                                                                                        -0.654075E-02                 1           CLN-node number
+BT         3                             0             0           1.75699          1.75699    
+LA         3                2                                                                        0.144367E-03           1    50    50  lay row col    
+LA         3                2                                                                       -0.325168E-06                 1           CLN-node number
      3 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP   2 STRESS PERIOD   1
 
  TOTAL OF       3OUTER ITERATIONS
@@ -315,17 +340,26 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0          0.152035E+07     0.152035E+07
-        1               13                                                                       -0.589816               2    48    48  lay row col
-        1               13                                                                       -0.522572                     1           CLN-node number
-        2                             0             0           1351.20          1351.20    
-        2                5                                                                       -0.963333E-03           2    50    50  lay row col
-        2                5                                                                       -0.213398E-02                 1           CLN-node number
-        3                             0             0           12.6124          12.6124    
-        3                3                                                                        0.920067E-04           1    37    62  lay row col
-        3                3                                                                       -0.308058E-05                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0          0.152035E+07     0.152035E+07
+LA         1               13                                                                       -0.589816               2    48    48  lay row col    
+LA         1               13                                                                       -0.522572                     1           CLN-node number
+UR         1                                                                                        -0.589816               2    48    48  lay row col    
+UR         1                                                                                        -0.522572                     1           CLN-node number
+BT         2                             0             0           1351.20          1351.20    
+LA         2                5                                                                       -0.963333E-03           2    50    50  lay row col    
+LA         2                5                                                                       -0.213398E-02                 1           CLN-node number
+UR         2                                                                                        -0.963333E-03           2    50    50  lay row col    
+UR         2                                                                                        -0.213398E-02                 1           CLN-node number
+BT         3                             0             0           12.6124          12.6124    
+LA         3                3                                                                        0.920067E-04           1    37    62  lay row col    
+LA         3                3                                                                       -0.308058E-05                 1           CLN-node number
      3 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP   3 STRESS PERIOD   1
 
  TOTAL OF       3OUTER ITERATIONS
@@ -343,24 +377,33 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0          0.102728E+07     0.102728E+07
-        1               11                                                                       -0.419215               2    48    47  lay row col
-        1               11                                                                       -0.373388                     1           CLN-node number
-        2                             0             0           16754.0          16754.0    
-        2                5                                                                        0.186648E-02           1    60    60  lay row col
-        2                5                                                                       -0.111231E-02                 1           CLN-node number
-        3                             0             0           167.065          167.065    
-        3                3                                                                        0.186639E-03           1    60    60  lay row col
-        3                3                                                                       -0.170293E-05                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0          0.102728E+07     0.102728E+07
+LA         1               11                                                                       -0.419215               2    48    47  lay row col    
+LA         1               11                                                                       -0.373388                     1           CLN-node number
+UR         1                                                                                        -0.419215               2    48    47  lay row col    
+UR         1                                                                                        -0.373388                     1           CLN-node number
+BT         2                             0             0           16754.0          16754.0    
+LA         2                5                                                                        0.186648E-02           1    60    60  lay row col    
+LA         2                5                                                                       -0.111231E-02                 1           CLN-node number
+UR         2                                                                                         0.167984E-02           1    60    60  lay row col    
+UR         2                                                                                        -0.111231E-02                 1           CLN-node number
+BT         3                             0             0           167.065          167.065    
+LA         3                3                                                                        0.186639E-03           1    60    60  lay row col    
+LA         3                3                                                                       -0.170293E-05                 1           CLN-node number
      3 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP   4 STRESS PERIOD   1
 
  TOTAL OF       3OUTER ITERATIONS
   MAXIMUM CHANGE FOR EACH ITERATION:
   MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL
  ------------------------------------------------------------------------------------------------------------------------------------------
-  -0.4192     (    2,   48,   47)  0.1866E-02 (    1,   60,   60)  0.1866E-03 (    1,   60,   60)
+  -0.4192     (    2,   48,   47)  0.1680E-02 (    1,   60,   60)  0.1866E-03 (    1,   60,   60)
 
   MAXIMUM CHANGE FOR CLN NODE AT EACH ITERATION:
    MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL
@@ -371,24 +414,33 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           825657.          825657.    
-        1               11                                                                       -0.344008               2    47    46  lay row col
-        1               11                                                                       -0.305226                     1           CLN-node number
-        2                             0             0           39256.8          39256.8    
-        2                4                                                                        0.211738E-02           1    34    30  lay row col
-        2                4                                                                       -0.734386E-03                 1           CLN-node number
-        3                             0             0           392.201          392.201    
-        3                3                                                                        0.211723E-03           1    34    30  lay row col
-        3                3                                                                       -0.350791E-05                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           825657.          825657.    
+LA         1               11                                                                       -0.344008               2    47    46  lay row col    
+LA         1               11                                                                       -0.305226                     1           CLN-node number
+UR         1                                                                                        -0.344008               2    47    46  lay row col    
+UR         1                                                                                        -0.305226                     1           CLN-node number
+BT         2                             0             0           39256.8          39256.8    
+LA         2                4                                                                        0.211738E-02           1    34    30  lay row col    
+LA         2                4                                                                       -0.734386E-03                 1           CLN-node number
+UR         2                                                                                         0.190564E-02           1    34    30  lay row col    
+UR         2                                                                                        -0.734386E-03                 1           CLN-node number
+BT         3                             0             0           392.201          392.201    
+LA         3                3                                                                        0.211723E-03           1    34    30  lay row col    
+LA         3                3                                                                       -0.350791E-05                 1           CLN-node number
      3 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP   5 STRESS PERIOD   1
 
  TOTAL OF       3OUTER ITERATIONS
   MAXIMUM CHANGE FOR EACH ITERATION:
   MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL
  ------------------------------------------------------------------------------------------------------------------------------------------
-  -0.3440     (    2,   47,   46)  0.2117E-02 (    1,   34,   30)  0.2117E-03 (    1,   34,   30)
+  -0.3440     (    2,   47,   46)  0.1906E-02 (    1,   34,   30)  0.2117E-03 (    1,   34,   30)
 
   MAXIMUM CHANGE FOR CLN NODE AT EACH ITERATION:
    MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL
@@ -399,24 +451,33 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           726485.          726485.    
-        1               11                                                                       -0.306550               2    45    45  lay row col
-        1               11                                                                       -0.270098                     1           CLN-node number
-        2                             0             0           92798.8          92798.8    
-        2                4                                                                        0.259973E-02           1    50    11  lay row col
-        2                4                                                                       -0.563736E-03                 1           CLN-node number
-        3                             0             0           927.892          927.892    
-        3                2                                                                        0.259958E-03           1    50    11  lay row col
-        3                2                                                                       -0.372460E-05                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           726485.          726485.    
+LA         1               11                                                                       -0.306550               2    45    45  lay row col    
+LA         1               11                                                                       -0.270098                     1           CLN-node number
+UR         1                                                                                        -0.306550               2    45    45  lay row col    
+UR         1                                                                                        -0.270098                     1           CLN-node number
+BT         2                             0             0           92798.8          92798.8    
+LA         2                4                                                                        0.259973E-02           1    50    11  lay row col    
+LA         2                4                                                                       -0.563736E-03                 1           CLN-node number
+UR         2                                                                                         0.233975E-02           1    50    11  lay row col    
+UR         2                                                                                        -0.563736E-03                 1           CLN-node number
+BT         3                             0             0           927.892          927.892    
+LA         3                2                                                                        0.259958E-03           1    50    11  lay row col    
+LA         3                2                                                                       -0.372460E-05                 1           CLN-node number
      3 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP   6 STRESS PERIOD   1
 
  TOTAL OF       3OUTER ITERATIONS
   MAXIMUM CHANGE FOR EACH ITERATION:
   MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL
  ------------------------------------------------------------------------------------------------------------------------------------------
-  -0.3066     (    2,   45,   45)  0.2600E-02 (    1,   50,   11)  0.2600E-03 (    1,   50,   11)
+  -0.3066     (    2,   45,   45)  0.2340E-02 (    1,   50,   11)  0.2600E-03 (    1,   50,   11)
 
   MAXIMUM CHANGE FOR CLN NODE AT EACH ITERATION:
    MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL
@@ -427,24 +488,33 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           670019.          670019.    
-        1               12                                                                       -0.286904               2    44    43  lay row col
-        1               12                                                                       -0.250871                     1           CLN-node number
-        2                             0             0           106567.          106567.    
-        2                4                                                                        0.365554E-02           1   100    26  lay row col
-        2                4                                                                       -0.477817E-03                 1           CLN-node number
-        3                             0             0           1065.58          1065.58    
-        3                2                                                                        0.365530E-03           1   100    26  lay row col
-        3                2                                                                       -0.344371E-05                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           670019.          670019.    
+LA         1               12                                                                       -0.286904               2    44    43  lay row col    
+LA         1               12                                                                       -0.250871                     1           CLN-node number
+UR         1                                                                                        -0.286904               2    44    43  lay row col    
+UR         1                                                                                        -0.250871                     1           CLN-node number
+BT         2                             0             0           106567.          106567.    
+LA         2                4                                                                        0.365554E-02           1   100    26  lay row col    
+LA         2                4                                                                       -0.477817E-03                 1           CLN-node number
+UR         2                                                                                         0.328999E-02           1   100    26  lay row col    
+UR         2                                                                                        -0.477817E-03                 1           CLN-node number
+BT         3                             0             0           1065.58          1065.58    
+LA         3                2                                                                        0.365530E-03           1   100    26  lay row col    
+LA         3                2                                                                       -0.344371E-05                 1           CLN-node number
      3 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP   7 STRESS PERIOD   1
 
  TOTAL OF       3OUTER ITERATIONS
   MAXIMUM CHANGE FOR EACH ITERATION:
   MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL
  ------------------------------------------------------------------------------------------------------------------------------------------
-  -0.2869     (    2,   44,   43)  0.3656E-02 (    1,  100,   26)  0.3655E-03 (    1,  100,   26)
+  -0.2869     (    2,   44,   43)  0.3290E-02 (    1,  100,   26)  0.3655E-03 (    1,  100,   26)
 
   MAXIMUM CHANGE FOR CLN NODE AT EACH ITERATION:
    MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL
@@ -455,24 +525,33 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           633709.          633709.    
-        1               12                                                                       -0.276435               2    41    41  lay row col
-        1               12                                                                       -0.239970                     1           CLN-node number
-        2                             0             0           5428.60          5428.60    
-        2                4                                                                        0.263996E-02           1   100   100  lay row col
-        2                4                                                                       -0.429445E-03                 1           CLN-node number
-        3                             0             0           54.2526          54.2526    
-        3                2                                                                        0.263904E-03           1   100   100  lay row col
-        3                2                                                                       -0.162171E-05                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           633709.          633709.    
+LA         1               12                                                                       -0.276435               2    41    41  lay row col    
+LA         1               12                                                                       -0.239970                     1           CLN-node number
+UR         1                                                                                        -0.276435               2    41    41  lay row col    
+UR         1                                                                                        -0.239970                     1           CLN-node number
+BT         2                             0             0           5428.59          5428.59    
+LA         2                4                                                                        0.263996E-02           1   100   100  lay row col    
+LA         2                4                                                                       -0.429445E-03                 1           CLN-node number
+UR         2                                                                                         0.237596E-02           1   100   100  lay row col    
+UR         2                                                                                        -0.429445E-03                 1           CLN-node number
+BT         3                             0             0           54.2526          54.2526    
+LA         3                2                                                                        0.263904E-03           1   100   100  lay row col    
+LA         3                2                                                                       -0.162171E-05                 1           CLN-node number
      3 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP   8 STRESS PERIOD   1
 
  TOTAL OF       3OUTER ITERATIONS
   MAXIMUM CHANGE FOR EACH ITERATION:
   MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL
  ------------------------------------------------------------------------------------------------------------------------------------------
-  -0.2764     (    2,   41,   41)  0.2640E-02 (    1,  100,  100)  0.2639E-03 (    1,  100,  100)
+  -0.2764     (    2,   41,   41)  0.2376E-02 (    1,  100,  100)  0.2639E-03 (    1,  100,  100)
 
   MAXIMUM CHANGE FOR CLN NODE AT EACH ITERATION:
    MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL
@@ -483,14 +562,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           607593.          607593.    
-        1               13                                                                       -0.270895               2    38    37  lay row col
-        1               13                                                                       -0.233643                     1           CLN-node number
-        2                             0             0           2.99083          2.99083    
-        2                3                                                                       -0.175539E-03           2    50    50  lay row col
-        2                3                                                                       -0.396364E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           607593.          607593.    
+LA         1               13                                                                       -0.270895               2    38    37  lay row col    
+LA         1               13                                                                       -0.233643                     1           CLN-node number
+UR         1                                                                                        -0.270895               2    38    37  lay row col    
+UR         1                                                                                        -0.233643                     1           CLN-node number
+BT         2                             0             0           2.99083          2.99083    
+LA         2                3                                                                       -0.175539E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.396364E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP   9 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -508,14 +594,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           589408.          589408.    
-        1               12                                                                       -0.268066               2    33    33  lay row col
-        1               12                                                                       -0.229926                     1           CLN-node number
-        2                             0             0           2.78756          2.78756    
-        2                3                                                                       -0.167458E-03           2    50    50  lay row col
-        2                3                                                                       -0.378103E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           589408.          589408.    
+LA         1               12                                                                       -0.268066               2    33    33  lay row col    
+LA         1               12                                                                       -0.229926                     1           CLN-node number
+UR         1                                                                                        -0.268066               2    33    33  lay row col    
+UR         1                                                                                        -0.229926                     1           CLN-node number
+BT         2                             0             0           2.78756          2.78756    
+LA         2                3                                                                       -0.167458E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.378102E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  10 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -533,14 +626,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           575573.          575573.    
-        1               12                                                                       -0.266744               2    36    17  lay row col
-        1               12                                                                       -0.227704                     1           CLN-node number
-        2                             0             0           2.66264          2.66264    
-        2                3                                                                       -0.162122E-03           2    50    50  lay row col
-        2                3                                                                       -0.365996E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           575573.          575573.    
+LA         1               12                                                                       -0.266744               2    36    17  lay row col    
+LA         1               12                                                                       -0.227704                     1           CLN-node number
+UR         1                                                                                        -0.266744               2    36    17  lay row col    
+UR         1                                                                                        -0.227704                     1           CLN-node number
+BT         2                             0             0           2.66264          2.66264    
+LA         2                3                                                                       -0.162122E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.365996E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  11 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -558,14 +658,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           564800.          564800.    
-        1               12                                                                       -0.266212               2    29     1  lay row col
-        1               12                                                                       -0.226381                     1           CLN-node number
-        2                             0             0           2.58249          2.58249    
-        2                3                                                                       -0.158424E-03           2    50    50  lay row col
-        2                3                                                                       -0.357623E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           564800.          564800.    
+LA         1               12                                                                       -0.266212               2    29     1  lay row col    
+LA         1               12                                                                       -0.226381                     1           CLN-node number
+UR         1                                                                                        -0.266212               2    29     1  lay row col    
+UR         1                                                                                        -0.226381                     1           CLN-node number
+BT         2                             0             0           2.58249          2.58249    
+LA         2                3                                                                       -0.158424E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.357623E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  12 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -583,14 +690,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           556194.          556194.    
-        1               12                                                                       -0.265944               2     1     1  lay row col
-        1               12                                                                       -0.225602                     1           CLN-node number
-        2                             0             0           2.52871          2.52871    
-        2                3                                                                       -0.155738E-03           2    50    50  lay row col
-        2                3                                                                       -0.351558E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           556194.          556194.    
+LA         1               12                                                                       -0.265944               2     1     1  lay row col    
+LA         1               12                                                                       -0.225602                     1           CLN-node number
+UR         1                                                                                        -0.265944               2     1     1  lay row col    
+UR         1                                                                                        -0.225602                     1           CLN-node number
+BT         2                             0             0           2.52871          2.52871    
+LA         2                3                                                                       -0.155738E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.351558E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  13 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -608,14 +722,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           549168.          549168.    
-        1               12                                                                       -0.265595               2     1     1  lay row col
-        1               12                                                                       -0.225160                     1           CLN-node number
-        2                             0             0           2.49109          2.49109    
-        2                3                                                                       -0.153705E-03           2    50    50  lay row col
-        2                3                                                                       -0.346975E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           549168.          549168.    
+LA         1               12                                                                       -0.265595               2     1     1  lay row col    
+LA         1               12                                                                       -0.225160                     1           CLN-node number
+UR         1                                                                                        -0.265595               2     1     1  lay row col    
+UR         1                                                                                        -0.225160                     1           CLN-node number
+BT         2                             0             0           2.49109          2.49109    
+LA         2                3                                                                       -0.153705E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.346975E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  14 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -633,14 +754,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           543317.          543317.    
-        1               12                                                                       -0.265131               2     1     1  lay row col
-        1               12                                                                       -0.224931                     1           CLN-node number
-        2                             0             0           2.46374          2.46374    
-        2                3                                                                       -0.152105E-03           2    50    50  lay row col
-        2                3                                                                       -0.343375E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           543317.          543317.    
+LA         1               12                                                                       -0.265131               2     1     1  lay row col    
+LA         1               12                                                                       -0.224931                     1           CLN-node number
+UR         1                                                                                        -0.265131               2     1     1  lay row col    
+UR         1                                                                                        -0.224931                     1           CLN-node number
+BT         2                             0             0           2.46374          2.46374    
+LA         2                3                                                                       -0.152105E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.343375E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  15 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -658,14 +786,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           538358.          538358.    
-        1               12                                                                       -0.264614               2     1     1  lay row col
-        1               12                                                                       -0.224839                     1           CLN-node number
-        2                             0             0           2.44313          2.44313    
-        2                3                                                                       -0.150807E-03           2    50    50  lay row col
-        2                3                                                                       -0.340451E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           538358.          538358.    
+LA         1               12                                                                       -0.264614               2     1     1  lay row col    
+LA         1               12                                                                       -0.224839                     1           CLN-node number
+UR         1                                                                                        -0.264614               2     1     1  lay row col    
+UR         1                                                                                        -0.224839                     1           CLN-node number
+BT         2                             0             0           2.44313          2.44313    
+LA         2                3                                                                       -0.150807E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.340451E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  16 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -683,14 +818,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           534086.          534086.    
-        1               12                                                                       -0.264079               2     1     1  lay row col
-        1               12                                                                       -0.224838                     1           CLN-node number
-        2                             0             0           2.42710          2.42710    
-        2                3                                                                       -0.149721E-03           2    50    50  lay row col
-        2                3                                                                       -0.338004E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           534086.          534086.    
+LA         1               12                                                                       -0.264079               2     1     1  lay row col    
+LA         1               12                                                                       -0.224838                     1           CLN-node number
+UR         1                                                                                        -0.264079               2     1     1  lay row col    
+UR         1                                                                                        -0.224838                     1           CLN-node number
+BT         2                             0             0           2.42710          2.42710    
+LA         2                3                                                                       -0.149721E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.338004E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  17 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -708,14 +850,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           530348.          530348.    
-        1               12                                                                       -0.263544               2     1     1  lay row col
-        1               12                                                                       -0.224900                     1           CLN-node number
-        2                             0             0           2.41423          2.41423    
-        2                3                                                                       -0.148786E-03           2    50    50  lay row col
-        2                3                                                                       -0.335899E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           530348.          530348.    
+LA         1               12                                                                       -0.263544               2     1     1  lay row col    
+LA         1               12                                                                       -0.224900                     1           CLN-node number
+UR         1                                                                                        -0.263544               2     1     1  lay row col    
+UR         1                                                                                        -0.224900                     1           CLN-node number
+BT         2                             0             0           2.41423          2.41423    
+LA         2                3                                                                       -0.148786E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.335899E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  18 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -733,14 +882,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           527032.          527032.    
-        1               12                                                                       -0.263020               2     1     1  lay row col
-        1               12                                                                       -0.225006                     1           CLN-node number
-        2                             0             0           2.40356          2.40356    
-        2                3                                                                       -0.147961E-03           2    50    50  lay row col
-        2                3                                                                       -0.334040E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           527032.          527032.    
+LA         1               12                                                                       -0.263020               2     1     1  lay row col    
+LA         1               12                                                                       -0.225006                     1           CLN-node number
+UR         1                                                                                        -0.263020               2     1     1  lay row col    
+UR         1                                                                                        -0.225006                     1           CLN-node number
+BT         2                             0             0           2.40356          2.40356    
+LA         2                3                                                                       -0.147961E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.334040E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  19 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -758,14 +914,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           524052.          524052.    
-        1               12                                                                       -0.262509               2     1     1  lay row col
-        1               12                                                                       -0.225144                     1           CLN-node number
-        2                             0             0           2.39444          2.39444    
-        2                3                                                                       -0.147215E-03           2    50    50  lay row col
-        2                3                                                                       -0.332360E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           524052.          524052.    
+LA         1               12                                                                       -0.262509               2     1     1  lay row col    
+LA         1               12                                                                       -0.225144                     1           CLN-node number
+UR         1                                                                                        -0.262509               2     1     1  lay row col    
+UR         1                                                                                        -0.225144                     1           CLN-node number
+BT         2                             0             0           2.39444          2.39444    
+LA         2                3                                                                       -0.147215E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.332360E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  20 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -783,14 +946,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           521339.          521339.    
-        1               12                                                                       -0.262016               2     1     1  lay row col
-        1               12                                                                       -0.225305                     1           CLN-node number
-        2                             0             0           2.38641          2.38641    
-        2                3                                                                       -0.146527E-03           2    50    50  lay row col
-        2                3                                                                       -0.330809E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           521339.          521339.    
+LA         1               12                                                                       -0.262016               2     1     1  lay row col    
+LA         1               12                                                                       -0.225305                     1           CLN-node number
+UR         1                                                                                        -0.262016               2     1     1  lay row col    
+UR         1                                                                                        -0.225305                     1           CLN-node number
+BT         2                             0             0           2.38641          2.38641    
+LA         2                3                                                                       -0.146527E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.330809E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  21 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -808,14 +978,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           518842.          518842.    
-        1               12                                                                       -0.261539               2     1     1  lay row col
-        1               12                                                                       -0.225485                     1           CLN-node number
-        2                             0             0           2.37913          2.37913    
-        2                3                                                                       -0.145880E-03           2    50    50  lay row col
-        2                3                                                                       -0.329352E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           518842.          518842.    
+LA         1               12                                                                       -0.261539               2     1     1  lay row col    
+LA         1               12                                                                       -0.225485                     1           CLN-node number
+UR         1                                                                                        -0.261539               2     1     1  lay row col    
+UR         1                                                                                        -0.225485                     1           CLN-node number
+BT         2                             0             0           2.37913          2.37913    
+LA         2                3                                                                       -0.145880E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.329352E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  22 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -833,14 +1010,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           516520.          516520.    
-        1               12                                                                       -0.261078               2     1     1  lay row col
-        1               12                                                                       -0.225679                     1           CLN-node number
-        2                             0             0           2.37235          2.37235    
-        2                3                                                                       -0.145262E-03           2    50    50  lay row col
-        2                3                                                                       -0.327962E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           516520.          516520.    
+LA         1               12                                                                       -0.261078               2     1     1  lay row col    
+LA         1               12                                                                       -0.225679                     1           CLN-node number
+UR         1                                                                                        -0.261078               2     1     1  lay row col    
+UR         1                                                                                        -0.225679                     1           CLN-node number
+BT         2                             0             0           2.37235          2.37235    
+LA         2                3                                                                       -0.145262E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.327962E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  23 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -858,14 +1042,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           514340.          514340.    
-        1               12                                                                       -0.260633               2     1     1  lay row col
-        1               12                                                                       -0.225884                     1           CLN-node number
-        2                             0             0           2.36588          2.36588    
-        2                3                                                                       -0.144663E-03           2    50    50  lay row col
-        2                3                                                                       -0.326615E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           514340.          514340.    
+LA         1               12                                                                       -0.260633               2     1     1  lay row col    
+LA         1               12                                                                       -0.225884                     1           CLN-node number
+UR         1                                                                                        -0.260633               2     1     1  lay row col    
+UR         1                                                                                        -0.225884                     1           CLN-node number
+BT         2                             0             0           2.36587          2.36587    
+LA         2                3                                                                       -0.144663E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.326615E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  24 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -883,14 +1074,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           512274.          512274.    
-        1               12                                                                       -0.260203               2     1     1  lay row col
-        1               12                                                                       -0.226099                     1           CLN-node number
-        2                             0             0           2.35954          2.35954    
-        2                3                                                                       -0.144071E-03           2    50    50  lay row col
-        2                3                                                                       -0.325291E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           512274.          512274.    
+LA         1               12                                                                       -0.260203               2     1     1  lay row col    
+LA         1               12                                                                       -0.226099                     1           CLN-node number
+UR         1                                                                                        -0.260203               2     1     1  lay row col    
+UR         1                                                                                        -0.226099                     1           CLN-node number
+BT         2                             0             0           2.35954          2.35954    
+LA         2                3                                                                       -0.144071E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.325291E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  25 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -908,14 +1106,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           510303.          510303.    
-        1               12                                                                       -0.259786               2     1     1  lay row col
-        1               12                                                                       -0.226321                     1           CLN-node number
-        2                             0             0           2.35318          2.35318    
-        2                3                                                                       -0.143461E-03           2    50    50  lay row col
-        2                3                                                                       -0.323957E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           510303.          510303.    
+LA         1               12                                                                       -0.259786               2     1     1  lay row col    
+LA         1               12                                                                       -0.226321                     1           CLN-node number
+UR         1                                                                                        -0.259786               2     1     1  lay row col    
+UR         1                                                                                        -0.226321                     1           CLN-node number
+BT         2                             0             0           2.35318          2.35318    
+LA         2                3                                                                       -0.143461E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.323957E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  26 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -933,14 +1138,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           508407.          508407.    
-        1               12                                                                       -0.259381               2     1     1  lay row col
-        1               12                                                                       -0.226549                     1           CLN-node number
-        2                             0             0           2.34661          2.34661    
-        2                3                                                                       -0.142783E-03           2    50    50  lay row col
-        2                3                                                                       -0.322554E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           508407.          508407.    
+LA         1               12                                                                       -0.259381               2     1     1  lay row col    
+LA         1               12                                                                       -0.226549                     1           CLN-node number
+UR         1                                                                                        -0.259381               2     1     1  lay row col    
+UR         1                                                                                        -0.226549                     1           CLN-node number
+BT         2                             0             0           2.34661          2.34661    
+LA         2                3                                                                       -0.142783E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.322554E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  27 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -958,14 +1170,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           506572.          506572.    
-        1               12                                                                       -0.258987               2     1     1  lay row col
-        1               12                                                                       -0.226782                     1           CLN-node number
-        2                             0             0           2.33993          2.33993    
-        2                3                                                                       -0.142044E-03           2    50    50  lay row col
-        2                3                                                                       -0.321096E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           506572.          506572.    
+LA         1               12                                                                       -0.258987               2     1     1  lay row col    
+LA         1               12                                                                       -0.226782                     1           CLN-node number
+UR         1                                                                                        -0.258987               2     1     1  lay row col    
+UR         1                                                                                        -0.226782                     1           CLN-node number
+BT         2                             0             0           2.33993          2.33993    
+LA         2                3                                                                       -0.142044E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.321096E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  28 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -983,14 +1202,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           504787.          504787.    
-        1               13                                                                       -0.258604               2     1     1  lay row col
-        1               13                                                                       -0.227020                     1           CLN-node number
-        2                             0             0           2.33354          2.33354    
-        2                3                                                                       -0.141321E-03           2    50    50  lay row col
-        2                3                                                                       -0.319671E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           504787.          504787.    
+LA         1               13                                                                       -0.258604               2     1     1  lay row col    
+LA         1               13                                                                       -0.227020                     1           CLN-node number
+UR         1                                                                                        -0.258604               2     1     1  lay row col    
+UR         1                                                                                        -0.227020                     1           CLN-node number
+BT         2                             0             0           2.33354          2.33354    
+LA         2                3                                                                       -0.141321E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.319671E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  29 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1008,14 +1234,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           503042.          503042.    
-        1               13                                                                       -0.258233               2     1     1  lay row col
-        1               13                                                                       -0.227261                     1           CLN-node number
-        2                             0             0           2.32677          2.32677    
-        2                3                                                                       -0.140752E-03           2    50    50  lay row col
-        2                3                                                                       -0.318370E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           503042.          503042.    
+LA         1               13                                                                       -0.258233               2     1     1  lay row col    
+LA         1               13                                                                       -0.227261                     1           CLN-node number
+UR         1                                                                                        -0.258233               2     1     1  lay row col    
+UR         1                                                                                        -0.227261                     1           CLN-node number
+BT         2                             0             0           2.32677          2.32677    
+LA         2                3                                                                       -0.140752E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.318370E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  30 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1033,14 +1266,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           501329.          501329.    
-        1               13                                                                       -0.257872               2     1     1  lay row col
-        1               13                                                                       -0.227505                     1           CLN-node number
-        2                             0             0           2.31968          2.31968    
-        2                3                                                                       -0.140197E-03           2    50    50  lay row col
-        2                3                                                                       -0.317069E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           501329.          501329.    
+LA         1               13                                                                       -0.257872               2     1     1  lay row col    
+LA         1               13                                                                       -0.227505                     1           CLN-node number
+UR         1                                                                                        -0.257872               2     1     1  lay row col    
+UR         1                                                                                        -0.227505                     1           CLN-node number
+BT         2                             0             0           2.31968          2.31968    
+LA         2                3                                                                       -0.140197E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.317069E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  31 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1058,14 +1298,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           499641.          499641.    
-        1               13                                                                       -0.257521               2   100     1  lay row col
-        1               13                                                                       -0.227751                     1           CLN-node number
-        2                             0             0           2.31226          2.31226    
-        2                3                                                                       -0.139645E-03           2    50    50  lay row col
-        2                3                                                                       -0.315755E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           499641.          499641.    
+LA         1               13                                                                       -0.257521               2   100     1  lay row col    
+LA         1               13                                                                       -0.227751                     1           CLN-node number
+UR         1                                                                                        -0.257521               2   100     1  lay row col    
+UR         1                                                                                        -0.227751                     1           CLN-node number
+BT         2                             0             0           2.31226          2.31226    
+LA         2                3                                                                       -0.139645E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.315755E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  32 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1083,14 +1330,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           497973.          497973.    
-        1               13                                                                       -0.257196               2   100   100  lay row col
-        1               13                                                                       -0.227999                     1           CLN-node number
-        2                             0             0           2.30449          2.30449    
-        2                3                                                                       -0.139092E-03           2    50    50  lay row col
-        2                3                                                                       -0.314425E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           497973.          497973.    
+LA         1               13                                                                       -0.257196               2   100   100  lay row col    
+LA         1               13                                                                       -0.227999                     1           CLN-node number
+UR         1                                                                                        -0.257196               2   100   100  lay row col    
+UR         1                                                                                        -0.227999                     1           CLN-node number
+BT         2                             0             0           2.30449          2.30449    
+LA         2                3                                                                       -0.139092E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.314425E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  33 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1108,14 +1362,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           496319.          496319.    
-        1               10                                                                       -0.256913               2   100   100  lay row col
-        1               10                                                                       -0.228251                     1           CLN-node number
-        2                             0             0           2.29745          2.29745    
-        2                3                                                                       -0.137511E-03           2    50    50  lay row col
-        2                3                                                                       -0.311533E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           496319.          496319.    
+LA         1               10                                                                       -0.256913               2   100   100  lay row col    
+LA         1               10                                                                       -0.228251                     1           CLN-node number
+UR         1                                                                                        -0.256913               2   100   100  lay row col    
+UR         1                                                                                        -0.228251                     1           CLN-node number
+BT         2                             0             0           2.29745          2.29745    
+LA         2                3                                                                       -0.137511E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.311533E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  34 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1133,14 +1394,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           494677.          494677.    
-        1               10                                                                       -0.256597               2   100   100  lay row col
-        1               10                                                                       -0.228500                     1           CLN-node number
-        2                             0             0           2.28942          2.28942    
-        2                3                                                                       -0.137362E-03           2    50    50  lay row col
-        2                3                                                                       -0.310704E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           494677.          494677.    
+LA         1               10                                                                       -0.256597               2   100   100  lay row col    
+LA         1               10                                                                       -0.228500                     1           CLN-node number
+UR         1                                                                                        -0.256597               2   100   100  lay row col    
+UR         1                                                                                        -0.228500                     1           CLN-node number
+BT         2                             0             0           2.28942          2.28942    
+LA         2                3                                                                       -0.137362E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.310704E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  35 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1158,14 +1426,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           493043.          493043.    
-        1               10                                                                       -0.256286               2   100   100  lay row col
-        1               10                                                                       -0.228750                     1           CLN-node number
-        2                             0             0           2.28154          2.28154    
-        2                3                                                                       -0.137103E-03           2    50    50  lay row col
-        2                3                                                                       -0.309764E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           493043.          493043.    
+LA         1               10                                                                       -0.256286               2   100   100  lay row col    
+LA         1               10                                                                       -0.228750                     1           CLN-node number
+UR         1                                                                                        -0.256286               2   100   100  lay row col    
+UR         1                                                                                        -0.228750                     1           CLN-node number
+BT         2                             0             0           2.28154          2.28154    
+LA         2                3                                                                       -0.137103E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.309764E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  36 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1183,14 +1458,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           491414.          491414.    
-        1               10                                                                       -0.255981               2   100   100  lay row col
-        1               10                                                                       -0.229002                     1           CLN-node number
-        2                             0             0           2.27319          2.27319    
-        2                3                                                                       -0.136774E-03           2    50    50  lay row col
-        2                3                                                                       -0.308724E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           491414.          491414.    
+LA         1               10                                                                       -0.255981               2   100   100  lay row col    
+LA         1               10                                                                       -0.229002                     1           CLN-node number
+UR         1                                                                                        -0.255981               2   100   100  lay row col    
+UR         1                                                                                        -0.229002                     1           CLN-node number
+BT         2                             0             0           2.27319          2.27319    
+LA         2                3                                                                       -0.136774E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.308724E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  37 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1208,14 +1490,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           489788.          489788.    
-        1               10                                                                       -0.255683               2   100   100  lay row col
-        1               10                                                                       -0.229253                     1           CLN-node number
-        2                             0             0           2.26405          2.26405    
-        2                3                                                                       -0.136378E-03           2    50    50  lay row col
-        2                3                                                                       -0.307565E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           489788.          489788.    
+LA         1               10                                                                       -0.255683               2   100   100  lay row col    
+LA         1               10                                                                       -0.229253                     1           CLN-node number
+UR         1                                                                                        -0.255683               2   100   100  lay row col    
+UR         1                                                                                        -0.229253                     1           CLN-node number
+BT         2                             0             0           2.26405          2.26405    
+LA         2                3                                                                       -0.136378E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.307565E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  38 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1233,14 +1522,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           488164.          488164.    
-        1               10                                                                       -0.255390               2   100   100  lay row col
-        1               10                                                                       -0.229505                     1           CLN-node number
-        2                             0             0           2.25408          2.25408    
-        2                3                                                                       -0.135924E-03           2    50    50  lay row col
-        2                3                                                                       -0.306293E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           488164.          488164.    
+LA         1               10                                                                       -0.255390               2   100   100  lay row col    
+LA         1               10                                                                       -0.229505                     1           CLN-node number
+UR         1                                                                                        -0.255390               2   100   100  lay row col    
+UR         1                                                                                        -0.229505                     1           CLN-node number
+BT         2                             0             0           2.25408          2.25408    
+LA         2                3                                                                       -0.135924E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.306293E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  39 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1258,14 +1554,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           486541.          486541.    
-        1               10                                                                       -0.255102               2   100   100  lay row col
-        1               10                                                                       -0.229756                     1           CLN-node number
-        2                             0             0           2.24336          2.24336    
-        2                3                                                                       -0.135423E-03           2    50    50  lay row col
-        2                3                                                                       -0.304927E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           486541.          486541.    
+LA         1               10                                                                       -0.255102               2   100   100  lay row col    
+LA         1               10                                                                       -0.229756                     1           CLN-node number
+UR         1                                                                                        -0.255102               2   100   100  lay row col    
+UR         1                                                                                        -0.229756                     1           CLN-node number
+BT         2                             0             0           2.24336          2.24336    
+LA         2                3                                                                       -0.135423E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.304927E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  40 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1283,14 +1586,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           484917.          484917.    
-        1               10                                                                       -0.254821               2   100   100  lay row col
-        1               10                                                                       -0.230007                     1           CLN-node number
-        2                             0             0           2.23202          2.23202    
-        2                3                                                                       -0.134880E-03           2    50    50  lay row col
-        2                3                                                                       -0.303481E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           484917.          484917.    
+LA         1               10                                                                       -0.254821               2   100   100  lay row col    
+LA         1               10                                                                       -0.230007                     1           CLN-node number
+UR         1                                                                                        -0.254821               2   100   100  lay row col    
+UR         1                                                                                        -0.230007                     1           CLN-node number
+BT         2                             0             0           2.23202          2.23202    
+LA         2                3                                                                       -0.134880E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.303481E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  41 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1308,14 +1618,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           483292.          483292.    
-        1               10                                                                       -0.254545               2   100   100  lay row col
-        1               10                                                                       -0.230258                     1           CLN-node number
-        2                             0             0           2.22012          2.22012    
-        2                3                                                                       -0.134295E-03           2    50    50  lay row col
-        2                3                                                                       -0.301965E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           483292.          483292.    
+LA         1               10                                                                       -0.254545               2   100   100  lay row col    
+LA         1               10                                                                       -0.230258                     1           CLN-node number
+UR         1                                                                                        -0.254545               2   100   100  lay row col    
+UR         1                                                                                        -0.230258                     1           CLN-node number
+BT         2                             0             0           2.22012          2.22012    
+LA         2                3                                                                       -0.134295E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.301965E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  42 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1333,14 +1650,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           481665.          481665.    
-        1               10                                                                       -0.254274               2   100   100  lay row col
-        1               10                                                                       -0.230507                     1           CLN-node number
-        2                             0             0           2.20770          2.20770    
-        2                3                                                                       -0.133668E-03           2    50    50  lay row col
-        2                3                                                                       -0.300379E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           481665.          481665.    
+LA         1               10                                                                       -0.254274               2   100   100  lay row col    
+LA         1               10                                                                       -0.230507                     1           CLN-node number
+UR         1                                                                                        -0.254274               2   100   100  lay row col    
+UR         1                                                                                        -0.230507                     1           CLN-node number
+BT         2                             0             0           2.20770          2.20770    
+LA         2                3                                                                       -0.133668E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.300379E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  43 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1358,14 +1682,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           480036.          480036.    
-        1               10                                                                       -0.254010               2   100   100  lay row col
-        1               10                                                                       -0.230756                     1           CLN-node number
-        2                             0             0           2.19475          2.19475    
-        2                3                                                                       -0.132994E-03           2    50    50  lay row col
-        2                3                                                                       -0.298721E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           480036.          480036.    
+LA         1               10                                                                       -0.254010               2   100   100  lay row col    
+LA         1               10                                                                       -0.230756                     1           CLN-node number
+UR         1                                                                                        -0.254010               2   100   100  lay row col    
+UR         1                                                                                        -0.230756                     1           CLN-node number
+BT         2                             0             0           2.19475          2.19475    
+LA         2                3                                                                       -0.132994E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.298721E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  44 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1383,14 +1714,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           478405.          478405.    
-        1               10                                                                       -0.253750               2   100   100  lay row col
-        1               10                                                                       -0.231004                     1           CLN-node number
-        2                             0             0           2.18124          2.18124    
-        2                3                                                                       -0.132273E-03           2    50    50  lay row col
-        2                3                                                                       -0.296987E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           478405.          478405.    
+LA         1               10                                                                       -0.253750               2   100   100  lay row col    
+LA         1               10                                                                       -0.231004                     1           CLN-node number
+UR         1                                                                                        -0.253750               2   100   100  lay row col    
+UR         1                                                                                        -0.231004                     1           CLN-node number
+BT         2                             0             0           2.18124          2.18124    
+LA         2                3                                                                       -0.132273E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.296987E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  45 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1408,14 +1746,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           476771.          476771.    
-        1               10                                                                       -0.253497               2   100   100  lay row col
-        1               10                                                                       -0.231250                     1           CLN-node number
-        2                             0             0           2.16713          2.16713    
-        2                3                                                                       -0.131508E-03           2    50    50  lay row col
-        2                3                                                                       -0.295179E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           476771.          476771.    
+LA         1               10                                                                       -0.253497               2   100   100  lay row col    
+LA         1               10                                                                       -0.231250                     1           CLN-node number
+UR         1                                                                                        -0.253497               2   100   100  lay row col    
+UR         1                                                                                        -0.231250                     1           CLN-node number
+BT         2                             0             0           2.16713          2.16713    
+LA         2                3                                                                       -0.131508E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.295179E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  46 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1433,14 +1778,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           475135.          475135.    
-        1               10                                                                       -0.253249               2   100   100  lay row col
-        1               10                                                                       -0.231495                     1           CLN-node number
-        2                             0             0           2.15245          2.15245    
-        2                3                                                                       -0.130711E-03           2    50    50  lay row col
-        2                3                                                                       -0.293307E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           475135.          475135.    
+LA         1               10                                                                       -0.253249               2   100   100  lay row col    
+LA         1               10                                                                       -0.231495                     1           CLN-node number
+UR         1                                                                                        -0.253249               2   100   100  lay row col    
+UR         1                                                                                        -0.231495                     1           CLN-node number
+BT         2                             0             0           2.15245          2.15245    
+LA         2                3                                                                       -0.130711E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.293307E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  47 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1458,14 +1810,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           473497.          473497.    
-        1               11                                                                       -0.252997               2   100   100  lay row col
-        1               11                                                                       -0.231741                     1           CLN-node number
-        2                             0             0           2.13514          2.13514    
-        2                3                                                                       -0.128641E-03           2    50    50  lay row col
-        2                3                                                                       -0.290122E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           473497.          473497.    
+LA         1               11                                                                       -0.252997               2   100   100  lay row col    
+LA         1               11                                                                       -0.231741                     1           CLN-node number
+UR         1                                                                                        -0.252997               2   100   100  lay row col    
+UR         1                                                                                        -0.231741                     1           CLN-node number
+BT         2                             0             0           2.13514          2.13514    
+LA         2                3                                                                       -0.128641E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.290122E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  48 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1483,14 +1842,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           471857.          471857.    
-        1               11                                                                       -0.252761               2   100   100  lay row col
-        1               11                                                                       -0.231982                     1           CLN-node number
-        2                             0             0           2.12018          2.12018    
-        2                3                                                                       -0.127792E-03           2    50    50  lay row col
-        2                3                                                                       -0.288203E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           471857.          471857.    
+LA         1               11                                                                       -0.252761               2   100   100  lay row col    
+LA         1               11                                                                       -0.231982                     1           CLN-node number
+UR         1                                                                                        -0.252761               2   100   100  lay row col    
+UR         1                                                                                        -0.231982                     1           CLN-node number
+BT         2                             0             0           2.12018          2.12018    
+LA         2                3                                                                       -0.127792E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.288203E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  49 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1508,14 +1874,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           470215.          470215.    
-        1               11                                                                       -0.252529               2   100   100  lay row col
-        1               11                                                                       -0.232222                     1           CLN-node number
-        2                             0             0           2.10480          2.10480    
-        2                3                                                                       -0.126924E-03           2    50    50  lay row col
-        2                3                                                                       -0.286252E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           470215.          470215.    
+LA         1               11                                                                       -0.252529               2   100   100  lay row col    
+LA         1               11                                                                       -0.232222                     1           CLN-node number
+UR         1                                                                                        -0.252529               2   100   100  lay row col    
+UR         1                                                                                        -0.232222                     1           CLN-node number
+BT         2                             0             0           2.10480          2.10480    
+LA         2                3                                                                       -0.126924E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.286252E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  50 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1533,14 +1906,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           468573.          468573.    
-        1               11                                                                       -0.252303               2   100   100  lay row col
-        1               11                                                                       -0.232461                     1           CLN-node number
-        2                             0             0           2.08899          2.08899    
-        2                3                                                                       -0.126037E-03           2    50    50  lay row col
-        2                3                                                                       -0.284268E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           468573.          468573.    
+LA         1               11                                                                       -0.252303               2   100   100  lay row col    
+LA         1               11                                                                       -0.232461                     1           CLN-node number
+UR         1                                                                                        -0.252303               2   100   100  lay row col    
+UR         1                                                                                        -0.232461                     1           CLN-node number
+BT         2                             0             0           2.08899          2.08899    
+LA         2                3                                                                       -0.126037E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.284268E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  51 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1558,14 +1938,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           466929.          466929.    
-        1               11                                                                       -0.252081               2   100   100  lay row col
-        1               11                                                                       -0.232697                     1           CLN-node number
-        2                             0             0           2.07273          2.07273    
-        2                3                                                                       -0.125131E-03           2    50    50  lay row col
-        2                3                                                                       -0.282249E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           466929.          466929.    
+LA         1               11                                                                       -0.252081               2   100   100  lay row col    
+LA         1               11                                                                       -0.232697                     1           CLN-node number
+UR         1                                                                                        -0.252081               2   100   100  lay row col    
+UR         1                                                                                        -0.232697                     1           CLN-node number
+BT         2                             0             0           2.07273          2.07273    
+LA         2                3                                                                       -0.125131E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.282249E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  52 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1583,14 +1970,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           465286.          465286.    
-        1               11                                                                       -0.251865               2   100   100  lay row col
-        1               11                                                                       -0.232931                     1           CLN-node number
-        2                             0             0           2.05598          2.05598    
-        2                3                                                                       -0.124210E-03           2    50    50  lay row col
-        2                3                                                                       -0.280196E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           465286.          465286.    
+LA         1               11                                                                       -0.251865               2   100   100  lay row col    
+LA         1               11                                                                       -0.232931                     1           CLN-node number
+UR         1                                                                                        -0.251865               2   100   100  lay row col    
+UR         1                                                                                        -0.232931                     1           CLN-node number
+BT         2                             0             0           2.05598          2.05598    
+LA         2                3                                                                       -0.124210E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.280196E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  53 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1608,14 +2002,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           463643.          463643.    
-        1               11                                                                       -0.251653               2   100   100  lay row col
-        1               11                                                                       -0.233164                     1           CLN-node number
-        2                             0             0           2.03875          2.03875    
-        2                3                                                                       -0.123275E-03           2    50    50  lay row col
-        2                3                                                                       -0.278108E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           463643.          463643.    
+LA         1               11                                                                       -0.251653               2   100   100  lay row col    
+LA         1               11                                                                       -0.233164                     1           CLN-node number
+UR         1                                                                                        -0.251653               2   100   100  lay row col    
+UR         1                                                                                        -0.233164                     1           CLN-node number
+BT         2                             0             0           2.03875          2.03875    
+LA         2                3                                                                       -0.123275E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.278108E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  54 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1633,14 +2034,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           462000.          462000.    
-        1               11                                                                       -0.251447               2   100   100  lay row col
-        1               11                                                                       -0.233394                     1           CLN-node number
-        2                             0             0           2.02107          2.02107    
-        2                3                                                                       -0.122329E-03           2    50    50  lay row col
-        2                3                                                                       -0.275988E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           462000.          462000.    
+LA         1               11                                                                       -0.251447               2   100   100  lay row col    
+LA         1               11                                                                       -0.233394                     1           CLN-node number
+UR         1                                                                                        -0.251447               2   100   100  lay row col    
+UR         1                                                                                        -0.233394                     1           CLN-node number
+BT         2                             0             0           2.02107          2.02107    
+LA         2                3                                                                       -0.122329E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.275988E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  55 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1658,14 +2066,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           460359.          460359.    
-        1               12                                                                       -0.251245               2   100   100  lay row col
-        1               12                                                                       -0.233621                     1           CLN-node number
-        2                             0             0           2.00243          2.00243    
-        2                3                                                                       -0.121322E-03           2    50    50  lay row col
-        2                3                                                                       -0.273759E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           460359.          460359.    
+LA         1               12                                                                       -0.251245               2   100   100  lay row col    
+LA         1               12                                                                       -0.233621                     1           CLN-node number
+UR         1                                                                                        -0.251245               2   100   100  lay row col    
+UR         1                                                                                        -0.233621                     1           CLN-node number
+BT         2                             0             0           2.00243          2.00243    
+LA         2                3                                                                       -0.121322E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.273759E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  56 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1683,14 +2098,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           458720.          458720.    
-        1               12                                                                       -0.251047               2   100   100  lay row col
-        1               12                                                                       -0.233847                     1           CLN-node number
-        2                             0             0           1.98396          1.98396    
-        2                3                                                                       -0.120354E-03           2    50    50  lay row col
-        2                3                                                                       -0.271581E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           458720.          458720.    
+LA         1               12                                                                       -0.251047               2   100   100  lay row col    
+LA         1               12                                                                       -0.233847                     1           CLN-node number
+UR         1                                                                                        -0.251047               2   100   100  lay row col    
+UR         1                                                                                        -0.233847                     1           CLN-node number
+BT         2                             0             0           1.98396          1.98396    
+LA         2                3                                                                       -0.120354E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.271581E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  57 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1708,14 +2130,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           457084.          457084.    
-        1               12                                                                       -0.250855               2   100   100  lay row col
-        1               12                                                                       -0.234070                     1           CLN-node number
-        2                             0             0           1.96512          1.96512    
-        2                3                                                                       -0.119375E-03           2    50    50  lay row col
-        2                3                                                                       -0.269378E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           457084.          457084.    
+LA         1               12                                                                       -0.250855               2   100   100  lay row col    
+LA         1               12                                                                       -0.234070                     1           CLN-node number
+UR         1                                                                                        -0.250855               2   100   100  lay row col    
+UR         1                                                                                        -0.234070                     1           CLN-node number
+BT         2                             0             0           1.96512          1.96512    
+LA         2                3                                                                       -0.119375E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.269378E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  58 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1733,14 +2162,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           455451.          455451.    
-        1               12                                                                       -0.250667               2   100   100  lay row col
-        1               12                                                                       -0.234291                     1           CLN-node number
-        2                             0             0           1.94593          1.94593    
-        2                3                                                                       -0.118385E-03           2    50    50  lay row col
-        2                3                                                                       -0.267150E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           455451.          455451.    
+LA         1               12                                                                       -0.250667               2   100   100  lay row col    
+LA         1               12                                                                       -0.234291                     1           CLN-node number
+UR         1                                                                                        -0.250667               2   100   100  lay row col    
+UR         1                                                                                        -0.234291                     1           CLN-node number
+BT         2                             0             0           1.94593          1.94593    
+LA         2                3                                                                       -0.118385E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.267150E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  59 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1758,14 +2194,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           453821.          453821.    
-        1               12                                                                       -0.250483               2   100   100  lay row col
-        1               12                                                                       -0.234509                     1           CLN-node number
-        2                             0             0           1.92639          1.92639    
-        2                3                                                                       -0.117385E-03           2    50    50  lay row col
-        2                3                                                                       -0.264899E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           453821.          453821.    
+LA         1               12                                                                       -0.250483               2   100   100  lay row col    
+LA         1               12                                                                       -0.234509                     1           CLN-node number
+UR         1                                                                                        -0.250483               2   100   100  lay row col    
+UR         1                                                                                        -0.234509                     1           CLN-node number
+BT         2                             0             0           1.92639          1.92639    
+LA         2                3                                                                       -0.117385E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.264899E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  60 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1783,14 +2226,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           452196.          452196.    
-        1               12                                                                       -0.250304               2   100   100  lay row col
-        1               12                                                                       -0.234724                     1           CLN-node number
-        2                             0             0           1.90654          1.90654    
-        2                3                                                                       -0.116374E-03           2    50    50  lay row col
-        2                3                                                                       -0.262624E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           452196.          452196.    
+LA         1               12                                                                       -0.250304               2   100   100  lay row col    
+LA         1               12                                                                       -0.234724                     1           CLN-node number
+UR         1                                                                                        -0.250304               2   100   100  lay row col    
+UR         1                                                                                        -0.234724                     1           CLN-node number
+BT         2                             0             0           1.90654          1.90654    
+LA         2                3                                                                       -0.116374E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.262624E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  61 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1808,14 +2258,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           450576.          450576.    
-        1               12                                                                       -0.250129               2   100   100  lay row col
-        1               12                                                                       -0.234937                     1           CLN-node number
-        2                             0             0           1.88638          1.88638    
-        2                3                                                                       -0.115354E-03           2    50    50  lay row col
-        2                3                                                                       -0.260328E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           450576.          450576.    
+LA         1               12                                                                       -0.250129               2   100   100  lay row col    
+LA         1               12                                                                       -0.234937                     1           CLN-node number
+UR         1                                                                                        -0.250129               2   100   100  lay row col    
+UR         1                                                                                        -0.234937                     1           CLN-node number
+BT         2                             0             0           1.88638          1.88638    
+LA         2                3                                                                       -0.115354E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.260328E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  62 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1833,14 +2290,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           448961.          448961.    
-        1               12                                                                       -0.249959               2   100   100  lay row col
-        1               12                                                                       -0.235148                     1           CLN-node number
-        2                             0             0           1.86593          1.86593    
-        2                3                                                                       -0.114325E-03           2    50    50  lay row col
-        2                3                                                                       -0.258013E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           448961.          448961.    
+LA         1               12                                                                       -0.249959               2   100   100  lay row col    
+LA         1               12                                                                       -0.235148                     1           CLN-node number
+UR         1                                                                                        -0.249959               2   100   100  lay row col    
+UR         1                                                                                        -0.235148                     1           CLN-node number
+BT         2                             0             0           1.86593          1.86593    
+LA         2                3                                                                       -0.114325E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.258013E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  63 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1858,14 +2322,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           447352.          447352.    
-        1               12                                                                       -0.249793               2   100   100  lay row col
-        1               12                                                                       -0.235356                     1           CLN-node number
-        2                             0             0           1.84522          1.84522    
-        2                3                                                                       -0.113289E-03           2    50    50  lay row col
-        2                3                                                                       -0.255681E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           447352.          447352.    
+LA         1               12                                                                       -0.249793               2   100   100  lay row col    
+LA         1               12                                                                       -0.235356                     1           CLN-node number
+UR         1                                                                                        -0.249793               2   100   100  lay row col    
+UR         1                                                                                        -0.235356                     1           CLN-node number
+BT         2                             0             0           1.84522          1.84522    
+LA         2                3                                                                       -0.113289E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.255681E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  64 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1883,14 +2354,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           445750.          445750.    
-        1               12                                                                       -0.249631               2   100   100  lay row col
-        1               12                                                                       -0.235561                     1           CLN-node number
-        2                             0             0           1.82426          1.82426    
-        2                3                                                                       -0.112247E-03           2    50    50  lay row col
-        2                3                                                                       -0.253332E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           445750.          445750.    
+LA         1               12                                                                       -0.249631               2   100   100  lay row col    
+LA         1               12                                                                       -0.235561                     1           CLN-node number
+UR         1                                                                                        -0.249631               2   100   100  lay row col    
+UR         1                                                                                        -0.235561                     1           CLN-node number
+BT         2                             0             0           1.82426          1.82426    
+LA         2                3                                                                       -0.112247E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.253332E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  65 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1908,14 +2386,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           444155.          444155.    
-        1               12                                                                       -0.249473               2   100   100  lay row col
-        1               12                                                                       -0.235763                     1           CLN-node number
-        2                             0             0           1.80306          1.80306    
-        2                3                                                                       -0.111201E-03           2    50    50  lay row col
-        2                3                                                                       -0.250971E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           444155.          444155.    
+LA         1               12                                                                       -0.249473               2   100   100  lay row col    
+LA         1               12                                                                       -0.235763                     1           CLN-node number
+UR         1                                                                                        -0.249473               2   100   100  lay row col    
+UR         1                                                                                        -0.235763                     1           CLN-node number
+BT         2                             0             0           1.80306          1.80306    
+LA         2                3                                                                       -0.111201E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.250971E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  66 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1933,14 +2418,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           442567.          442567.    
-        1               12                                                                       -0.249319               2   100   100  lay row col
-        1               12                                                                       -0.235962                     1           CLN-node number
-        2                             0             0           1.78166          1.78166    
-        2                3                                                                       -0.110151E-03           2    50    50  lay row col
-        2                3                                                                       -0.248597E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           442567.          442567.    
+LA         1               12                                                                       -0.249319               2   100   100  lay row col    
+LA         1               12                                                                       -0.235962                     1           CLN-node number
+UR         1                                                                                        -0.249319               2   100   100  lay row col    
+UR         1                                                                                        -0.235962                     1           CLN-node number
+BT         2                             0             0           1.78166          1.78166    
+LA         2                3                                                                       -0.110151E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.248597E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  67 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1958,14 +2450,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           440988.          440988.    
-        1               12                                                                       -0.249169               2   100   100  lay row col
-        1               12                                                                       -0.236159                     1           CLN-node number
-        2                             0             0           1.76006          1.76006    
-        2                3                                                                       -0.109099E-03           2    50    50  lay row col
-        2                3                                                                       -0.246214E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           440988.          440988.    
+LA         1               12                                                                       -0.249169               2   100   100  lay row col    
+LA         1               12                                                                       -0.236159                     1           CLN-node number
+UR         1                                                                                        -0.249169               2   100   100  lay row col    
+UR         1                                                                                        -0.236159                     1           CLN-node number
+BT         2                             0             0           1.76006          1.76006    
+LA         2                3                                                                       -0.109099E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.246214E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  68 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -1983,14 +2482,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           439417.          439417.    
-        1               12                                                                       -0.249023               2   100   100  lay row col
-        1               12                                                                       -0.236353                     1           CLN-node number
-        2                             0             0           1.73828          1.73828    
-        2                3                                                                       -0.108047E-03           2    50    50  lay row col
-        2                3                                                                       -0.243825E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           439417.          439417.    
+LA         1               12                                                                       -0.249023               2   100   100  lay row col    
+LA         1               12                                                                       -0.236353                     1           CLN-node number
+UR         1                                                                                        -0.249023               2   100   100  lay row col    
+UR         1                                                                                        -0.236353                     1           CLN-node number
+BT         2                             0             0           1.73828          1.73828    
+LA         2                3                                                                       -0.108047E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.243825E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  69 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2008,14 +2514,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           437856.          437856.    
-        1               12                                                                       -0.248881               2   100   100  lay row col
-        1               12                                                                       -0.236544                     1           CLN-node number
-        2                             0             0           1.71635          1.71635    
-        2                3                                                                       -0.107000E-03           2    50    50  lay row col
-        2                3                                                                       -0.241433E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           437856.          437856.    
+LA         1               12                                                                       -0.248881               2   100   100  lay row col    
+LA         1               12                                                                       -0.236544                     1           CLN-node number
+UR         1                                                                                        -0.248881               2   100   100  lay row col    
+UR         1                                                                                        -0.236544                     1           CLN-node number
+BT         2                             0             0           1.71635          1.71635    
+LA         2                3                                                                       -0.107000E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.241433E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  70 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2033,14 +2546,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           436304.          436304.    
-        1               12                                                                       -0.248742               2   100   100  lay row col
-        1               12                                                                       -0.236732                     1           CLN-node number
-        2                             0             0           1.69427          1.69427    
-        2                3                                                                       -0.105967E-03           2    50    50  lay row col
-        2                3                                                                       -0.239049E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           436304.          436304.    
+LA         1               12                                                                       -0.248742               2   100   100  lay row col    
+LA         1               12                                                                       -0.236732                     1           CLN-node number
+UR         1                                                                                        -0.248742               2   100   100  lay row col    
+UR         1                                                                                        -0.236732                     1           CLN-node number
+BT         2                             0             0           1.69427          1.69427    
+LA         2                3                                                                       -0.105968E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.239049E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  71 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2058,14 +2578,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           434762.          434762.    
-        1               11                                                                       -0.248607               2   100   100  lay row col
-        1               11                                                                       -0.236918                     1           CLN-node number
-        2                             0             0           1.67219          1.67219    
-        2                3                                                                       -0.104813E-03           2    50    50  lay row col
-        2                3                                                                       -0.236558E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           434762.          434762.    
+LA         1               11                                                                       -0.248607               2   100   100  lay row col    
+LA         1               11                                                                       -0.236918                     1           CLN-node number
+UR         1                                                                                        -0.248607               2   100   100  lay row col    
+UR         1                                                                                        -0.236918                     1           CLN-node number
+BT         2                             0             0           1.67219          1.67219    
+LA         2                3                                                                       -0.104813E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.236558E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  72 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2083,14 +2610,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           433230.          433230.    
-        1               11                                                                       -0.248475               2   100   100  lay row col
-        1               11                                                                       -0.237101                     1           CLN-node number
-        2                             0             0           1.64986          1.64986    
-        2                3                                                                       -0.103740E-03           2    50    50  lay row col
-        2                3                                                                       -0.234127E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           433230.          433230.    
+LA         1               11                                                                       -0.248475               2   100   100  lay row col    
+LA         1               11                                                                       -0.237101                     1           CLN-node number
+UR         1                                                                                        -0.248475               2   100   100  lay row col    
+UR         1                                                                                        -0.237101                     1           CLN-node number
+BT         2                             0             0           1.64986          1.64986    
+LA         2                3                                                                       -0.103740E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.234127E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  73 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2108,14 +2642,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           431710.          431710.    
-        1               11                                                                       -0.248348               2   100   100  lay row col
-        1               11                                                                       -0.237281                     1           CLN-node number
-        2                             0             0           1.62743          1.62743    
-        2                3                                                                       -0.102670E-03           2    50    50  lay row col
-        2                3                                                                       -0.231693E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           431710.          431710.    
+LA         1               11                                                                       -0.248348               2   100   100  lay row col    
+LA         1               11                                                                       -0.237281                     1           CLN-node number
+UR         1                                                                                        -0.248348               2   100   100  lay row col    
+UR         1                                                                                        -0.237281                     1           CLN-node number
+BT         2                             0             0           1.62743          1.62743    
+LA         2                3                                                                       -0.102670E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.231693E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  74 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2133,14 +2674,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           430200.          430200.    
-        1               11                                                                       -0.248223               2   100   100  lay row col
-        1               11                                                                       -0.237457                     1           CLN-node number
-        2                             0             0           1.60493          1.60493    
-        2                3                                                                       -0.101601E-03           2    50    50  lay row col
-        2                3                                                                       -0.229257E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           430200.          430200.    
+LA         1               11                                                                       -0.248223               2   100   100  lay row col    
+LA         1               11                                                                       -0.237457                     1           CLN-node number
+UR         1                                                                                        -0.248223               2   100   100  lay row col    
+UR         1                                                                                        -0.237457                     1           CLN-node number
+BT         2                             0             0           1.60493          1.60493    
+LA         2                3                                                                       -0.101601E-03           2    50    50  lay row col    
+LA         2                3                                                                       -0.229257E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  75 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2158,14 +2706,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           428703.          428703.    
-        1               11                                                                       -0.248102               2   100   100  lay row col
-        1               11                                                                       -0.237632                     1           CLN-node number
-        2                             0             0           1.58236          1.58236    
-        2                3                                                                        0.101026E-03           1    50    50  lay row col
-        2                3                                                                       -0.226822E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           428703.          428703.    
+LA         1               11                                                                       -0.248102               2   100   100  lay row col    
+LA         1               11                                                                       -0.237632                     1           CLN-node number
+UR         1                                                                                        -0.248102               2   100   100  lay row col    
+UR         1                                                                                        -0.237632                     1           CLN-node number
+BT         2                             0             0           1.58236          1.58236    
+LA         2                3                                                                        0.101026E-03           1    50    50  lay row col    
+LA         2                3                                                                       -0.226822E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  76 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2183,14 +2738,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           427217.          427217.    
-        1               11                                                                       -0.247984               2   100   100  lay row col
-        1               11                                                                       -0.237803                     1           CLN-node number
-        2                             0             0           1.55976          1.55976    
-        2                3                                                                        0.100548E-03           1    50    50  lay row col
-        2                3                                                                       -0.224387E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           427217.          427217.    
+LA         1               11                                                                       -0.247984               2   100   100  lay row col    
+LA         1               11                                                                       -0.237803                     1           CLN-node number
+UR         1                                                                                        -0.247984               2   100   100  lay row col    
+UR         1                                                                                        -0.237803                     1           CLN-node number
+BT         2                             0             0           1.55976          1.55976    
+LA         2                3                                                                        0.100548E-03           1    50    50  lay row col    
+LA         2                3                                                                       -0.224387E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  77 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2208,14 +2770,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           425743.          425743.    
-        1               11                                                                       -0.247870               2   100   100  lay row col
-        1               11                                                                       -0.237971                     1           CLN-node number
-        2                             0             0           1.53713          1.53713    
-        2                3                                                                        0.100049E-03           1    50    50  lay row col
-        2                3                                                                       -0.221952E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           425743.          425743.    
+LA         1               11                                                                       -0.247870               2   100   100  lay row col    
+LA         1               11                                                                       -0.237971                     1           CLN-node number
+UR         1                                                                                        -0.247870               2   100   100  lay row col    
+UR         1                                                                                        -0.237971                     1           CLN-node number
+BT         2                             0             0           1.53713          1.53713    
+LA         2                3                                                                        0.100049E-03           1    50    50  lay row col    
+LA         2                3                                                                       -0.221952E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  78 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2233,14 +2802,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           424282.          424282.    
-        1               11                                                                       -0.247759               2   100   100  lay row col
-        1               11                                                                       -0.238137                     1           CLN-node number
-        2                             0             0           1.51450          1.51450    
-        2                3                                                                        0.995308E-04           1    50    50  lay row col
-        2                3                                                                       -0.219518E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           424282.          424282.    
+LA         1               11                                                                       -0.247759               2   100   100  lay row col    
+LA         1               11                                                                       -0.238137                     1           CLN-node number
+UR         1                                                                                        -0.247759               2   100   100  lay row col    
+UR         1                                                                                        -0.238137                     1           CLN-node number
+BT         2                             0             0           1.51450          1.51450    
+LA         2                3                                                                        0.995308E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.219518E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  79 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2258,14 +2834,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           422834.          422834.    
-        1               11                                                                       -0.247650               2   100   100  lay row col
-        1               11                                                                       -0.238300                     1           CLN-node number
-        2                             0             0           1.49188          1.49188    
-        2                3                                                                        0.989935E-04           1    50    50  lay row col
-        2                3                                                                       -0.217084E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           422834.          422834.    
+LA         1               11                                                                       -0.247650               2   100   100  lay row col    
+LA         1               11                                                                       -0.238300                     1           CLN-node number
+UR         1                                                                                        -0.247650               2   100   100  lay row col    
+UR         1                                                                                        -0.238300                     1           CLN-node number
+BT         2                             0             0           1.49188          1.49188    
+LA         2                3                                                                        0.989935E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.217084E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  80 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2283,14 +2866,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           421398.          421398.    
-        1               11                                                                       -0.247545               2   100   100  lay row col
-        1               11                                                                       -0.238460                     1           CLN-node number
-        2                             0             0           1.46929          1.46929    
-        2                3                                                                        0.984384E-04           1    50    50  lay row col
-        2                3                                                                       -0.214650E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           421398.          421398.    
+LA         1               11                                                                       -0.247545               2   100   100  lay row col    
+LA         1               11                                                                       -0.238460                     1           CLN-node number
+UR         1                                                                                        -0.247545               2   100   100  lay row col    
+UR         1                                                                                        -0.238460                     1           CLN-node number
+BT         2                             0             0           1.46929          1.46929    
+LA         2                3                                                                        0.984384E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.214650E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  81 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2308,14 +2898,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           419976.          419976.    
-        1               11                                                                       -0.247443               2   100   100  lay row col
-        1               11                                                                       -0.238617                     1           CLN-node number
-        2                             0             0           1.44674          1.44674    
-        2                3                                                                        0.978662E-04           1    50    50  lay row col
-        2                3                                                                       -0.212218E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           419976.          419976.    
+LA         1               11                                                                       -0.247443               2   100   100  lay row col    
+LA         1               11                                                                       -0.238617                     1           CLN-node number
+UR         1                                                                                        -0.247443               2   100   100  lay row col    
+UR         1                                                                                        -0.238617                     1           CLN-node number
+BT         2                             0             0           1.44674          1.44674    
+LA         2                3                                                                        0.978662E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.212218E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  82 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2333,14 +2930,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           418568.          418568.    
-        1               11                                                                       -0.247344               2   100   100  lay row col
-        1               11                                                                       -0.238772                     1           CLN-node number
-        2                             0             0           1.42424          1.42424    
-        2                3                                                                        0.972776E-04           1    50    50  lay row col
-        2                3                                                                       -0.209787E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           418568.          418568.    
+LA         1               11                                                                       -0.247344               2   100   100  lay row col    
+LA         1               11                                                                       -0.238772                     1           CLN-node number
+UR         1                                                                                        -0.247344               2   100   100  lay row col    
+UR         1                                                                                        -0.238772                     1           CLN-node number
+BT         2                             0             0           1.42424          1.42424    
+LA         2                3                                                                        0.972776E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.209787E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  83 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2358,14 +2962,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           417173.          417173.    
-        1               11                                                                       -0.247247               2   100   100  lay row col
-        1               11                                                                       -0.238924                     1           CLN-node number
-        2                             0             0           1.40181          1.40181    
-        2                3                                                                        0.966735E-04           1    50    50  lay row col
-        2                3                                                                       -0.207359E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           417173.          417173.    
+LA         1               11                                                                       -0.247247               2   100   100  lay row col    
+LA         1               11                                                                       -0.238924                     1           CLN-node number
+UR         1                                                                                        -0.247247               2   100   100  lay row col    
+UR         1                                                                                        -0.238924                     1           CLN-node number
+BT         2                             0             0           1.40181          1.40181    
+LA         2                3                                                                        0.966735E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.207359E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  84 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2383,14 +2994,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           415793.          415793.    
-        1               11                                                                       -0.247154               2   100   100  lay row col
-        1               11                                                                       -0.239073                     1           CLN-node number
-        2                             0             0           1.37946          1.37946    
-        2                3                                                                        0.960547E-04           1    50    50  lay row col
-        2                3                                                                       -0.204935E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           415793.          415793.    
+LA         1               11                                                                       -0.247154               2   100   100  lay row col    
+LA         1               11                                                                       -0.239073                     1           CLN-node number
+UR         1                                                                                        -0.247154               2   100   100  lay row col    
+UR         1                                                                                        -0.239073                     1           CLN-node number
+BT         2                             0             0           1.37946          1.37946    
+LA         2                3                                                                        0.960547E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.204935E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  85 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2408,14 +3026,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           414426.          414426.    
-        1               11                                                                       -0.247063               2   100   100  lay row col
-        1               11                                                                       -0.239219                     1           CLN-node number
-        2                             0             0           1.35721          1.35721    
-        2                3                                                                        0.954218E-04           1    50    50  lay row col
-        2                3                                                                       -0.202514E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           414426.          414426.    
+LA         1               11                                                                       -0.247063               2   100   100  lay row col    
+LA         1               11                                                                       -0.239219                     1           CLN-node number
+UR         1                                                                                        -0.247063               2   100   100  lay row col    
+UR         1                                                                                        -0.239219                     1           CLN-node number
+BT         2                             0             0           1.35721          1.35721    
+LA         2                3                                                                        0.954218E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.202514E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  86 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2433,14 +3058,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           413074.          413074.    
-        1               11                                                                       -0.246975               2   100   100  lay row col
-        1               11                                                                       -0.239363                     1           CLN-node number
-        2                             0             0           1.33506          1.33506    
-        2                3                                                                        0.947755E-04           1    50    50  lay row col
-        2                3                                                                       -0.200100E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           413074.          413074.    
+LA         1               11                                                                       -0.246975               2   100   100  lay row col    
+LA         1               11                                                                       -0.239363                     1           CLN-node number
+UR         1                                                                                        -0.246975               2   100   100  lay row col    
+UR         1                                                                                        -0.239363                     1           CLN-node number
+BT         2                             0             0           1.33506          1.33506    
+LA         2                3                                                                        0.947755E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.200100E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  87 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2458,14 +3090,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           411736.          411736.    
-        1               11                                                                       -0.246889               2   100   100  lay row col
-        1               11                                                                       -0.239504                     1           CLN-node number
-        2                             0             0           1.31302          1.31302    
-        2                3                                                                        0.941165E-04           1    50    50  lay row col
-        2                3                                                                       -0.197692E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           411736.          411736.    
+LA         1               11                                                                       -0.246889               2   100   100  lay row col    
+LA         1               11                                                                       -0.239504                     1           CLN-node number
+UR         1                                                                                        -0.246889               2   100   100  lay row col    
+UR         1                                                                                        -0.239504                     1           CLN-node number
+BT         2                             0             0           1.31302          1.31302    
+LA         2                3                                                                        0.941165E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.197692E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  88 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2483,14 +3122,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           410412.          410412.    
-        1               11                                                                       -0.246806               2   100   100  lay row col
-        1               11                                                                       -0.239642                     1           CLN-node number
-        2                             0             0           1.29112          1.29112    
-        2                3                                                                        0.934454E-04           1    50    50  lay row col
-        2                3                                                                       -0.195294E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           410412.          410412.    
+LA         1               11                                                                       -0.246806               2   100   100  lay row col    
+LA         1               11                                                                       -0.239642                     1           CLN-node number
+UR         1                                                                                        -0.246806               2   100   100  lay row col    
+UR         1                                                                                        -0.239642                     1           CLN-node number
+BT         2                             0             0           1.29112          1.29112    
+LA         2                3                                                                        0.934454E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.195294E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  89 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2508,14 +3154,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           409104.          409104.    
-        1               11                                                                       -0.246725               2   100   100  lay row col
-        1               11                                                                       -0.239778                     1           CLN-node number
-        2                             0             0           1.26936          1.26936    
-        2                3                                                                        0.927627E-04           1    50    50  lay row col
-        2                3                                                                       -0.192908E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           409104.          409104.    
+LA         1               11                                                                       -0.246725               2   100   100  lay row col    
+LA         1               11                                                                       -0.239778                     1           CLN-node number
+UR         1                                                                                        -0.246725               2   100   100  lay row col    
+UR         1                                                                                        -0.239778                     1           CLN-node number
+BT         2                             0             0           1.26936          1.26936    
+LA         2                3                                                                        0.927627E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.192908E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  90 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2533,14 +3186,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           407809.          407809.    
-        1               11                                                                       -0.246647               2   100   100  lay row col
-        1               11                                                                       -0.239911                     1           CLN-node number
-        2                             0             0           1.24776          1.24776    
-        2                3                                                                        0.920691E-04           1    50    50  lay row col
-        2                3                                                                       -0.190538E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           407809.          407809.    
+LA         1               11                                                                       -0.246647               2   100   100  lay row col    
+LA         1               11                                                                       -0.239911                     1           CLN-node number
+UR         1                                                                                        -0.246647               2   100   100  lay row col    
+UR         1                                                                                        -0.239911                     1           CLN-node number
+BT         2                             0             0           1.24776          1.24776    
+LA         2                3                                                                        0.920691E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.190538E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  91 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2558,14 +3218,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           406530.          406530.    
-        1               11                                                                       -0.246572               2   100   100  lay row col
-        1               11                                                                       -0.240042                     1           CLN-node number
-        2                             0             0           1.22635          1.22635    
-        2                3                                                                        0.913652E-04           1    50    50  lay row col
-        2                3                                                                       -0.188184E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           406530.          406530.    
+LA         1               11                                                                       -0.246572               2   100   100  lay row col    
+LA         1               11                                                                       -0.240042                     1           CLN-node number
+UR         1                                                                                        -0.246572               2   100   100  lay row col    
+UR         1                                                                                        -0.240042                     1           CLN-node number
+BT         2                             0             0           1.22635          1.22635    
+LA         2                3                                                                        0.913652E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.188184E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  92 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2583,14 +3250,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           405265.          405265.    
-        1               10                                                                       -0.246506               2   100   100  lay row col
-        1               10                                                                       -0.240168                     1           CLN-node number
-        2                             0             0           1.20751          1.20751    
-        2                3                                                                        0.905537E-04           1    50    50  lay row col
-        2                3                                                                       -0.187474E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           405265.          405265.    
+LA         1               10                                                                       -0.246506               2   100   100  lay row col    
+LA         1               10                                                                       -0.240168                     1           CLN-node number
+UR         1                                                                                        -0.246506               2   100   100  lay row col    
+UR         1                                                                                        -0.240168                     1           CLN-node number
+BT         2                             0             0           1.20751          1.20751    
+LA         2                3                                                                        0.905537E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.187474E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  93 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2608,14 +3282,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           404016.          404016.    
-        1               10                                                                       -0.246435               2   100   100  lay row col
-        1               10                                                                       -0.240294                     1           CLN-node number
-        2                             0             0           1.18643          1.18643    
-        2                3                                                                        0.898355E-04           1    50    50  lay row col
-        2                3                                                                       -0.185122E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           404016.          404016.    
+LA         1               10                                                                       -0.246435               2   100   100  lay row col    
+LA         1               10                                                                       -0.240294                     1           CLN-node number
+UR         1                                                                                        -0.246435               2   100   100  lay row col    
+UR         1                                                                                        -0.240294                     1           CLN-node number
+BT         2                             0             0           1.18643          1.18643    
+LA         2                3                                                                        0.898355E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.185122E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  94 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2633,14 +3314,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           402781.          402781.    
-        1               10                                                                       -0.246366               2   100   100  lay row col
-        1               10                                                                       -0.240418                     1           CLN-node number
-        2                             0             0           1.16554          1.16554    
-        2                3                                                                        0.891091E-04           1    50    50  lay row col
-        2                3                                                                       -0.182789E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           402781.          402781.    
+LA         1               10                                                                       -0.246366               2   100   100  lay row col    
+LA         1               10                                                                       -0.240418                     1           CLN-node number
+UR         1                                                                                        -0.246366               2   100   100  lay row col    
+UR         1                                                                                        -0.240418                     1           CLN-node number
+BT         2                             0             0           1.16554          1.16554    
+LA         2                3                                                                        0.891091E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.182789E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  95 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2658,14 +3346,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           401561.          401561.    
-        1               10                                                                       -0.246299               2   100   100  lay row col
-        1               10                                                                       -0.240539                     1           CLN-node number
-        2                             0             0           1.14485          1.14485    
-        2                3                                                                        0.883749E-04           1    50    50  lay row col
-        2                3                                                                       -0.180475E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           401561.          401561.    
+LA         1               10                                                                       -0.246299               2   100   100  lay row col    
+LA         1               10                                                                       -0.240539                     1           CLN-node number
+UR         1                                                                                        -0.246299               2   100   100  lay row col    
+UR         1                                                                                        -0.240539                     1           CLN-node number
+BT         2                             0             0           1.14485          1.14485    
+LA         2                3                                                                        0.883749E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.180475E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  96 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2683,14 +3378,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           400356.          400356.    
-        1               10                                                                       -0.246234               2   100   100  lay row col
-        1               10                                                                       -0.240658                     1           CLN-node number
-        2                             0             0           1.12438          1.12438    
-        2                3                                                                        0.876334E-04           1    50    50  lay row col
-        2                3                                                                       -0.178183E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           400356.          400356.    
+LA         1               10                                                                       -0.246234               2   100   100  lay row col    
+LA         1               10                                                                       -0.240658                     1           CLN-node number
+UR         1                                                                                        -0.246234               2   100   100  lay row col    
+UR         1                                                                                        -0.240658                     1           CLN-node number
+BT         2                             0             0           1.12438          1.12438    
+LA         2                3                                                                        0.876334E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.178183E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  97 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2708,14 +3410,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           399166.          399166.    
-        1               10                                                                       -0.246171               2   100   100  lay row col
-        1               10                                                                       -0.240774                     1           CLN-node number
-        2                             0             0           1.10413          1.10413    
-        2                3                                                                        0.868854E-04           1    50    50  lay row col
-        2                3                                                                       -0.175912E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           399166.          399166.    
+LA         1               10                                                                       -0.246171               2   100   100  lay row col    
+LA         1               10                                                                       -0.240774                     1           CLN-node number
+UR         1                                                                                        -0.246171               2   100   100  lay row col    
+UR         1                                                                                        -0.240774                     1           CLN-node number
+BT         2                             0             0           1.10413          1.10413    
+LA         2                3                                                                        0.868854E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.175912E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  98 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2733,14 +3442,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           397991.          397991.    
-        1               10                                                                       -0.246111               2   100   100  lay row col
-        1               10                                                                       -0.240888                     1           CLN-node number
-        2                             0             0           1.08411          1.08411    
-        2                3                                                                        0.861315E-04           1    50    50  lay row col
-        2                3                                                                       -0.173663E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           397991.          397991.    
+LA         1               10                                                                       -0.246111               2   100   100  lay row col    
+LA         1               10                                                                       -0.240888                     1           CLN-node number
+UR         1                                                                                        -0.246111               2   100   100  lay row col    
+UR         1                                                                                        -0.240888                     1           CLN-node number
+BT         2                             0             0           1.08411          1.08411    
+LA         2                3                                                                        0.861315E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.173663E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP  99 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2758,14 +3474,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           396831.          396831.    
-        1               10                                                                       -0.246052               2   100   100  lay row col
-        1               10                                                                       -0.241000                     1           CLN-node number
-        2                             0             0           1.06431          1.06431    
-        2                3                                                                        0.853722E-04           1    50    50  lay row col
-        2                3                                                                       -0.171435E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           396831.          396831.    
+LA         1               10                                                                       -0.246052               2   100   100  lay row col    
+LA         1               10                                                                       -0.241000                     1           CLN-node number
+UR         1                                                                                        -0.246052               2   100   100  lay row col    
+UR         1                                                                                        -0.241000                     1           CLN-node number
+BT         2                             0             0           1.06431          1.06431    
+LA         2                3                                                                        0.853722E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.171435E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 100 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2783,14 +3506,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           395685.          395685.    
-        1               10                                                                       -0.245995               2   100   100  lay row col
-        1               10                                                                       -0.241109                     1           CLN-node number
-        2                             0             0           1.04476          1.04476    
-        2                3                                                                        0.846083E-04           1    50    50  lay row col
-        2                3                                                                       -0.169229E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           395685.          395685.    
+LA         1               10                                                                       -0.245995               2   100   100  lay row col    
+LA         1               10                                                                       -0.241109                     1           CLN-node number
+UR         1                                                                                        -0.245995               2   100   100  lay row col    
+UR         1                                                                                        -0.241109                     1           CLN-node number
+BT         2                             0             0           1.04476          1.04476    
+LA         2                3                                                                        0.846083E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.169229E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 101 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2808,14 +3538,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           394554.          394554.    
-        1               10                                                                       -0.245940               2   100   100  lay row col
-        1               10                                                                       -0.241216                     1           CLN-node number
-        2                             0             0           1.02544          1.02544    
-        2                3                                                                        0.838403E-04           1    50    50  lay row col
-        2                3                                                                       -0.167044E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           394554.          394554.    
+LA         1               10                                                                       -0.245940               2   100   100  lay row col    
+LA         1               10                                                                       -0.241216                     1           CLN-node number
+UR         1                                                                                        -0.245940               2   100   100  lay row col    
+UR         1                                                                                        -0.241216                     1           CLN-node number
+BT         2                             0             0           1.02544          1.02544    
+LA         2                3                                                                        0.838403E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.167044E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 102 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2833,14 +3570,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           393439.          393439.    
-        1               10                                                                       -0.245887               2   100   100  lay row col
-        1               10                                                                       -0.241322                     1           CLN-node number
-        2                             0             0           1.00637          1.00637    
-        2                3                                                                        0.830689E-04           1    50    50  lay row col
-        2                3                                                                       -0.164881E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           393439.          393439.    
+LA         1               10                                                                       -0.245887               2   100   100  lay row col    
+LA         1               10                                                                       -0.241322                     1           CLN-node number
+UR         1                                                                                        -0.245887               2   100   100  lay row col    
+UR         1                                                                                        -0.241322                     1           CLN-node number
+BT         2                             0             0           1.00637          1.00637    
+LA         2                3                                                                        0.830689E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.164881E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 103 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2858,14 +3602,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           392337.          392337.    
-        1               10                                                                       -0.245836               2   100   100  lay row col
-        1               10                                                                       -0.241425                     1           CLN-node number
-        2                             0             0          0.987542         0.987542    
-        2                3                                                                        0.822944E-04           1    50    50  lay row col
-        2                3                                                                       -0.162738E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           392337.          392337.    
+LA         1               10                                                                       -0.245836               2   100   100  lay row col    
+LA         1               10                                                                       -0.241425                     1           CLN-node number
+UR         1                                                                                        -0.245836               2   100   100  lay row col    
+UR         1                                                                                        -0.241425                     1           CLN-node number
+BT         2                             0             0          0.987542         0.987542    
+LA         2                3                                                                        0.822944E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.162738E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 104 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2883,14 +3634,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           391251.          391251.    
-        1               10                                                                       -0.245787               2   100   100  lay row col
-        1               10                                                                       -0.241526                     1           CLN-node number
-        2                             0             0          0.968972         0.968972    
-        2                3                                                                        0.815175E-04           1    50    50  lay row col
-        2                3                                                                       -0.160617E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           391251.          391251.    
+LA         1               10                                                                       -0.245787               2   100   100  lay row col    
+LA         1               10                                                                       -0.241526                     1           CLN-node number
+UR         1                                                                                        -0.245787               2   100   100  lay row col    
+UR         1                                                                                        -0.241526                     1           CLN-node number
+BT         2                             0             0          0.968971         0.968971    
+LA         2                3                                                                        0.815175E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.160617E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 105 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2908,14 +3666,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           390179.          390179.    
-        1               10                                                                       -0.245739               2   100   100  lay row col
-        1               10                                                                       -0.241624                     1           CLN-node number
-        2                             0             0          0.950658         0.950658    
-        2                3                                                                        0.807387E-04           1    50    50  lay row col
-        2                3                                                                       -0.158518E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           390179.          390179.    
+LA         1               10                                                                       -0.245739               2   100   100  lay row col    
+LA         1               10                                                                       -0.241624                     1           CLN-node number
+UR         1                                                                                        -0.245739               2   100   100  lay row col    
+UR         1                                                                                        -0.241624                     1           CLN-node number
+BT         2                             0             0          0.950658         0.950658    
+LA         2                3                                                                        0.807387E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.158518E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 106 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2933,14 +3698,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           389121.          389121.    
-        1               10                                                                       -0.245693               2   100   100  lay row col
-        1               10                                                                       -0.241721                     1           CLN-node number
-        2                             0             0          0.932605         0.932605    
-        2                3                                                                        0.799583E-04           1    50    50  lay row col
-        2                3                                                                       -0.156442E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           389121.          389121.    
+LA         1               10                                                                       -0.245693               2   100   100  lay row col    
+LA         1               10                                                                       -0.241721                     1           CLN-node number
+UR         1                                                                                        -0.245693               2   100   100  lay row col    
+UR         1                                                                                        -0.241721                     1           CLN-node number
+BT         2                             0             0          0.932605         0.932605    
+LA         2                3                                                                        0.799583E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.156442E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 107 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2958,14 +3730,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           388078.          388078.    
-        1               10                                                                       -0.245649               2   100   100  lay row col
-        1               10                                                                       -0.241816                     1           CLN-node number
-        2                             0             0          0.914818         0.914818    
-        2                3                                                                        0.791769E-04           1    50    50  lay row col
-        2                3                                                                       -0.154389E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           388078.          388078.    
+LA         1               10                                                                       -0.245649               2   100   100  lay row col    
+LA         1               10                                                                       -0.241816                     1           CLN-node number
+UR         1                                                                                        -0.245649               2   100   100  lay row col    
+UR         1                                                                                        -0.241816                     1           CLN-node number
+BT         2                             0             0          0.914818         0.914818    
+LA         2                3                                                                        0.791769E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.154389E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 108 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -2983,14 +3762,21 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           387048.          387048.    
-        1               10                                                                       -0.245606               2   100   100  lay row col
-        1               10                                                                       -0.241909                     1           CLN-node number
-        2                             0             0          0.897298         0.897298    
-        2                3                                                                        0.783947E-04           1    50    50  lay row col
-        2                3                                                                       -0.152361E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           387048.          387048.    
+LA         1               10                                                                       -0.245606               2   100   100  lay row col    
+LA         1               10                                                                       -0.241909                     1           CLN-node number
+UR         1                                                                                        -0.245606               2   100   100  lay row col    
+UR         1                                                                                        -0.241909                     1           CLN-node number
+BT         2                             0             0          0.897299         0.897299    
+LA         2                3                                                                        0.783947E-04           1    50    50  lay row col    
+LA         2                3                                                                       -0.152361E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 109 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3008,109 +3794,161 @@ FROM THE SOLVER INPUT FILE.
  
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           386034.          386034.    
-        1               10                                                                       -0.245565               2   100   100  lay row col
-        1               10                                                                       -0.242000                     1           CLN-node number
-        2                             0             0           19.7161          19.7161    
-        2                4                                                                        0.456750E-03           2    50    50  lay row col
-        2                4                                                                        0.101942E-02                 1           CLN-node number
-        3                             0             0           4.95801          4.95801    
-        3                4                                                                       -0.307491E-03           2    50    50  lay row col
-        3                4                                                                       -0.691370E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           386034.          386034.    
+LA         1               10                                                                       -0.245565               2   100   100  lay row col    
+LA         1               10                                                                       -0.242000                     1           CLN-node number
+UR         1                                                                                        -0.245565               2   100   100  lay row col    
+UR         1                                                                                        -0.242000                     1           CLN-node number
+BT         2                             0             0           19.7161          19.7161    
+LA         2                4                                                                        0.456750E-03           2    50    50  lay row col    
+LA         2                4                                                                        0.101942E-02                 1           CLN-node number
+UR         2                                                                                         0.411075E-03           2    50    50  lay row col    
+UR         2                                                                                         0.917477E-03                 1           CLN-node number
+BT         3                             0             0           4.95801          4.95801    
+LA         3                4                                                                       -0.307491E-03           2    50    50  lay row col    
+LA         3                4                                                                       -0.691370E-03                 1           CLN-node number
      3 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 110 STRESS PERIOD   1
 
  TOTAL OF       3OUTER ITERATIONS
   MAXIMUM CHANGE FOR EACH ITERATION:
   MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL
  ------------------------------------------------------------------------------------------------------------------------------------------
-  -0.2456     (    2,  100,  100)  0.4567E-03 (    2,   50,   50) -0.3075E-03 (    2,   50,   50)
+  -0.2456     (    2,  100,  100)  0.4111E-03 (    2,   50,   50) -0.3075E-03 (    2,   50,   50)
 
   MAXIMUM CHANGE FOR CLN NODE AT EACH ITERATION:
    MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL
  ------------------------------------------------------------------------------------------------------------------------------------
-  -0.24200    ,          1  0.10194E-02,          1 -0.69137E-03,          1
+  -0.24200    ,          1  0.91748E-03,          1 -0.69137E-03,          1
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      110
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   110
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -62836.3       -19.7013       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           384978.          384978.    
-        1               11                                                                       -0.245432               2   100   100  lay row col
-        1               11                                                                       -0.167850                     1           CLN-node number
-        2                             0             0          0.138405E+10     0.138405E+10
-        2               11                                                                        0.539175E-01           2    50    50  lay row col
-        2               11                                                                        0.118986                     1           CLN-node number
-        3                             0             0          0.415450E+08     0.415450E+08
-        3               10                                                                        0.142183E-01           2    50    50  lay row col
-        3               10                                                                        0.313765E-01                 1           CLN-node number
-        4                             0             0          0.181779E+07     0.181779E+07
-        4                7                                                                        0.524127E-02           2    50    50  lay row col
-        4                7                                                                        0.115729E-01                 1           CLN-node number
-        5                             0             0           29131.5          29131.5    
-        5                5                                                                        0.101824E-02           2    50    50  lay row col
-        5                5                                                                        0.224878E-02                 1           CLN-node number
-        6                             0             0           9.63893          9.63893    
-        6                2                                                                       -0.188677E-04           2    50    50  lay row col
-        6                2                                                                       -0.457824E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           384978.          384978.    
+LA         1               11                                                                       -0.245432               2   100   100  lay row col    
+LA         1               11                                                                       -0.167850                     1           CLN-node number
+UR         1                                                                                        -0.245432               2   100   100  lay row col    
+UR         1                                                                                        -0.167850                     1           CLN-node number
+BT         2                             0             0          0.138405E+10     0.138405E+10
+LA         2               11                                                                        0.539175E-01           2    50    50  lay row col    
+LA         2               11                                                                        0.118986                     1           CLN-node number
+UR         2                                                                                         0.485257E-01           2    50    50  lay row col    
+UR         2                                                                                         0.107087                     1           CLN-node number
+BT         3                             0             0          0.415450E+08     0.415450E+08
+LA         3               10                                                                        0.142183E-01           2    50    50  lay row col    
+LA         3               10                                                                        0.313765E-01                 1           CLN-node number
+UR         3                                                                                         0.137918E-01           2    50    50  lay row col    
+UR         3                                                                                         0.304352E-01                 1           CLN-node number
+BT         4                             0             0          0.181779E+07     0.181779E+07
+LA         4                7                                                                        0.524127E-02           2    50    50  lay row col    
+LA         4                7                                                                        0.115729E-01                 1           CLN-node number
+UR         4                                                                                         0.524127E-02           2    50    50  lay row col    
+UR         4                                                                                         0.115729E-01                 1           CLN-node number
+BT         5                             0             0           29131.5          29131.5    
+LA         5                5                                                                        0.101824E-02           2    50    50  lay row col    
+LA         5                5                                                                        0.224878E-02                 1           CLN-node number
+UR         5                                                                                         0.101824E-02           2    50    50  lay row col    
+UR         5                                                                                         0.224878E-02                 1           CLN-node number
+BT         6                             0             0           9.63893          9.63893    
+LA         6                2                                                                       -0.188677E-04           2    50    50  lay row col    
+LA         6                2                                                                       -0.457824E-04                 1           CLN-node number
      6 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 111 STRESS PERIOD   1
 
  TOTAL OF       6OUTER ITERATIONS
   MAXIMUM CHANGE FOR EACH ITERATION:
   MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL
  ------------------------------------------------------------------------------------------------------------------------------------------
-  -0.2454     (    2,  100,  100)  0.5392E-01 (    2,   50,   50)  0.1422E-01 (    2,   50,   50)  0.5241E-02 (    2,   50,   50)  0.1018E-02 (    2,   50,   50)
+  -0.2454     (    2,  100,  100)  0.4853E-01 (    2,   50,   50)  0.1379E-01 (    2,   50,   50)  0.5241E-02 (    2,   50,   50)  0.1018E-02 (    2,   50,   50)
   -0.1887E-04 (    2,   50,   50)
 
   MAXIMUM CHANGE FOR CLN NODE AT EACH ITERATION:
    MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL
  ------------------------------------------------------------------------------------------------------------------------------------
-  -0.16785    ,          1  0.11899    ,          1  0.31376E-01,          1  0.11573E-01,          1  0.22488E-02,          1
+  -0.16785    ,          1  0.10709    ,          1  0.30435E-01,          1  0.11573E-01,          1  0.22488E-02,          1
   -0.45782E-04,          1
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      111
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   111
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -62196.4       -19.7179       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           374012.          374012.    
-        1               12                                                                       -0.244507               2   100   100  lay row col
-        1               12                                                                       -0.952173E-02                 1           CLN-node number
-        2                             0             0           46804.0          46804.0    
-        2                5                                                                        0.957562E-03           2    50    50  lay row col
-        2                5                                                                        0.212067E-02                 1           CLN-node number
-        3                             0             0           324.778          324.778    
-        3                3                                                                        0.859739E-04           2    50    50  lay row col
-        3                3                                                                        0.189011E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           374012.          374012.    
+LA         1               12                                                                       -0.244507               2   100   100  lay row col    
+LA         1               12                                                                       -0.952173E-02                 1           CLN-node number
+UR         1                                                                                        -0.244507               2   100   100  lay row col    
+UR         1                                                                                        -0.952173E-02                 1           CLN-node number
+BT         2                             0             0           46804.0          46804.0    
+LA         2                5                                                                        0.957562E-03           2    50    50  lay row col    
+LA         2                5                                                                        0.212067E-02                 1           CLN-node number
+UR         2                                                                                         0.861806E-03           2    50    50  lay row col    
+UR         2                                                                                         0.190860E-02                 1           CLN-node number
+BT         3                             0             0           324.778          324.778    
+LA         3                3                                                                        0.859739E-04           2    50    50  lay row col    
+LA         3                3                                                                        0.189011E-03                 1           CLN-node number
      3 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 112 STRESS PERIOD   1
 
  TOTAL OF       3OUTER ITERATIONS
   MAXIMUM CHANGE FOR EACH ITERATION:
   MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL
  ------------------------------------------------------------------------------------------------------------------------------------------
-  -0.2445     (    2,  100,  100)  0.9576E-03 (    2,   50,   50)  0.8597E-04 (    2,   50,   50)
+  -0.2445     (    2,  100,  100)  0.8618E-03 (    2,   50,   50)  0.8597E-04 (    2,   50,   50)
 
   MAXIMUM CHANGE FOR CLN NODE AT EACH ITERATION:
    MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL
  ------------------------------------------------------------------------------------------------------------------------------------
-  -0.95217E-02,          1  0.21207E-02,          1  0.18901E-03,          1
+  -0.95217E-02,          1  0.19086E-02,          1  0.18901E-03,          1
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      112
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   112
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -61573.4       -19.7253       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           364937.          364937.    
-        1               12                                                                       -0.243234               2   100   100  lay row col
-        1               12                                                                       -0.659814E-02                 1           CLN-node number
-        2                             0             0           11927.0          11927.0    
-        2                4                                                                        0.418122E-03           2    50    50  lay row col
-        2                4                                                                        0.930715E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           364937.          364937.    
+LA         1               12                                                                       -0.243234               2   100   100  lay row col    
+LA         1               12                                                                       -0.659814E-02                 1           CLN-node number
+UR         1                                                                                        -0.243234               2   100   100  lay row col    
+UR         1                                                                                        -0.659814E-02                 1           CLN-node number
+BT         2                             0             0           11927.0          11927.0    
+LA         2                4                                                                        0.418122E-03           2    50    50  lay row col    
+LA         2                4                                                                        0.930715E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 113 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3126,16 +3964,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      113
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   113
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -60968.0       -19.7310       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           356567.          356567.    
-        1               12                                                                       -0.241531               2   100   100  lay row col
-        1               12                                                                       -0.537006E-02                 1           CLN-node number
-        2                             0             0           5507.37          5507.37    
-        2                4                                                                        0.252796E-03           2    50    50  lay row col
-        2                4                                                                        0.562676E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           356567.          356567.    
+LA         1               12                                                                       -0.241531               2   100   100  lay row col    
+LA         1               12                                                                       -0.537006E-02                 1           CLN-node number
+UR         1                                                                                        -0.241531               2   100   100  lay row col    
+UR         1                                                                                        -0.537006E-02                 1           CLN-node number
+BT         2                             0             0           5507.37          5507.37    
+LA         2                4                                                                        0.252796E-03           2    50    50  lay row col    
+LA         2                4                                                                        0.562676E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 114 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3151,16 +4000,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      114
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   114
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -60370.6       -19.7358       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           348574.          348574.    
-        1               12                                                                       -0.239520               2   100   100  lay row col
-        1               12                                                                       -0.462672E-02                 1           CLN-node number
-        2                             0             0           3137.58          3137.58    
-        2                3                                                                        0.171842E-03           2    50    50  lay row col
-        2                3                                                                        0.386948E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           348574.          348574.    
+LA         1               12                                                                       -0.239520               2   100   100  lay row col    
+LA         1               12                                                                       -0.462672E-02                 1           CLN-node number
+UR         1                                                                                        -0.239520               2   100   100  lay row col    
+UR         1                                                                                        -0.462672E-02                 1           CLN-node number
+BT         2                             0             0           3137.58          3137.58    
+LA         2                3                                                                        0.171842E-03           2    50    50  lay row col    
+LA         2                3                                                                        0.386948E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 115 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3176,16 +4036,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      115
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   115
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -59782.5       -19.7400       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           340891.          340891.    
-        1               12                                                                       -0.237308               2   100   100  lay row col
-        1               12                                                                       -0.412686E-02                 1           CLN-node number
-        2                             0             0           2026.38          2026.38    
-        2                3                                                                        0.128039E-03           2    50    50  lay row col
-        2                3                                                                        0.288257E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           340891.          340891.    
+LA         1               12                                                                       -0.237308               2   100   100  lay row col    
+LA         1               12                                                                       -0.412686E-02                 1           CLN-node number
+UR         1                                                                                        -0.237308               2   100   100  lay row col    
+UR         1                                                                                        -0.412686E-02                 1           CLN-node number
+BT         2                             0             0           2026.38          2026.38    
+LA         2                3                                                                        0.128039E-03           2    50    50  lay row col    
+LA         2                3                                                                        0.288257E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 116 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3201,16 +4072,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      116
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   116
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -59202.3       -19.7439       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           333469.          333469.    
-        1               12                                                                       -0.234976               2   100   100  lay row col
-        1               12                                                                       -0.376082E-02                 1           CLN-node number
-        2                             0             0           1413.48          1413.48    
-        2                3                                                                        0.100377E-03           2    50    50  lay row col
-        2                3                                                                        0.225933E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           333469.          333469.    
+LA         1               12                                                                       -0.234976               2   100   100  lay row col    
+LA         1               12                                                                       -0.376082E-02                 1           CLN-node number
+UR         1                                                                                        -0.234976               2   100   100  lay row col    
+UR         1                                                                                        -0.376082E-02                 1           CLN-node number
+BT         2                             0             0           1413.48          1413.48    
+LA         2                3                                                                        0.100377E-03           2    50    50  lay row col    
+LA         2                3                                                                        0.225933E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 117 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3226,16 +4108,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      117
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   117
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -58629.4       -19.7474       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           326278.          326278.    
-        1               12                                                                       -0.232577               2   100   100  lay row col
-        1               12                                                                       -0.347724E-02                 1           CLN-node number
-        2                             0             0           1038.21          1038.21    
-        2                3                                                                        0.814993E-04           2    50    50  lay row col
-        2                3                                                                        0.183402E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           326278.          326278.    
+LA         1               12                                                                       -0.232577               2   100   100  lay row col    
+LA         1               12                                                                       -0.347724E-02                 1           CLN-node number
+UR         1                                                                                        -0.232577               2   100   100  lay row col    
+UR         1                                                                                        -0.347724E-02                 1           CLN-node number
+BT         2                             0             0           1038.21          1038.21    
+LA         2                3                                                                        0.814993E-04           2    50    50  lay row col    
+LA         2                3                                                                        0.183402E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 118 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3251,16 +4144,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      118
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   118
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -58063.3       -19.7507       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           319299.          319299.    
-        1               12                                                                       -0.230147               2   100   100  lay row col
-        1               12                                                                       -0.324871E-02                 1           CLN-node number
-        2                             0             0           791.265          791.265    
-        2                2                                                                        0.659425E-04           2    50    50  lay row col
-        2                2                                                                        0.152670E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           319299.          319299.    
+LA         1               12                                                                       -0.230147               2   100   100  lay row col    
+LA         1               12                                                                       -0.324871E-02                 1           CLN-node number
+UR         1                                                                                        -0.230147               2   100   100  lay row col    
+UR         1                                                                                        -0.324871E-02                 1           CLN-node number
+BT         2                             0             0           791.265          791.265    
+LA         2                2                                                                        0.659425E-04           2    50    50  lay row col    
+LA         2                2                                                                        0.152670E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 119 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3276,16 +4180,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      119
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   119
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -57503.7       -19.7538       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           312515.          312515.    
-        1               12                                                                       -0.227707               2   100   100  lay row col
-        1               12                                                                       -0.305905E-02                 1           CLN-node number
-        2                             0             0           619.933          619.933    
-        2                2                                                                        0.560154E-04           2    50    50  lay row col
-        2                2                                                                        0.129647E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           312515.          312515.    
+LA         1               12                                                                       -0.227707               2   100   100  lay row col    
+LA         1               12                                                                       -0.305905E-02                 1           CLN-node number
+UR         1                                                                                        -0.227707               2   100   100  lay row col    
+UR         1                                                                                        -0.305905E-02                 1           CLN-node number
+BT         2                             0             0           619.933          619.933    
+LA         2                2                                                                        0.560154E-04           2    50    50  lay row col    
+LA         2                2                                                                        0.129647E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 120 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3301,16 +4216,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      120
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   120
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -56950.5       -19.7567       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           305917.          305917.    
-        1               12                                                                       -0.225270               2   100   100  lay row col
-        1               12                                                                       -0.289821E-02                 1           CLN-node number
-        2                             0             0           496.250          496.250    
-        2                2                                                                        0.483208E-04           2    50    50  lay row col
-        2                2                                                                        0.111798E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           305917.          305917.    
+LA         1               12                                                                       -0.225270               2   100   100  lay row col    
+LA         1               12                                                                       -0.289821E-02                 1           CLN-node number
+UR         1                                                                                        -0.225270               2   100   100  lay row col    
+UR         1                                                                                        -0.289821E-02                 1           CLN-node number
+BT         2                             0             0           496.250          496.250    
+LA         2                2                                                                        0.483208E-04           2    50    50  lay row col    
+LA         2                2                                                                        0.111798E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 121 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3326,16 +4252,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      121
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   121
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -56403.6       -19.7595       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           299495.          299495.    
-        1               12                                                                       -0.222845               2   100   100  lay row col
-        1               12                                                                       -0.275935E-02                 1           CLN-node number
-        2                             0             0           404.088          404.088    
-        2                2                                                                        0.422031E-04           2    50    50  lay row col
-        2                2                                                                        0.976050E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           299495.          299495.    
+LA         1               12                                                                       -0.222845               2   100   100  lay row col    
+LA         1               12                                                                       -0.275935E-02                 1           CLN-node number
+UR         1                                                                                        -0.222845               2   100   100  lay row col    
+UR         1                                                                                        -0.275935E-02                 1           CLN-node number
+BT         2                             0             0           404.088          404.088    
+LA         2                2                                                                        0.422031E-04           2    50    50  lay row col    
+LA         2                2                                                                        0.976050E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 122 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3351,16 +4288,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      122
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   122
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -55862.8       -19.7622       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           293239.          293239.    
-        1               12                                                                       -0.220435               2   100   100  lay row col
-        1               12                                                                       -0.263774E-02                 1           CLN-node number
-        2                             0             0           333.645          333.645    
-        2                2                                                                        0.372378E-04           2    50    50  lay row col
-        2                2                                                                        0.860829E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           293239.          293239.    
+LA         1               12                                                                       -0.220435               2   100   100  lay row col    
+LA         1               12                                                                       -0.263774E-02                 1           CLN-node number
+UR         1                                                                                        -0.220435               2   100   100  lay row col    
+UR         1                                                                                        -0.263774E-02                 1           CLN-node number
+BT         2                             0             0           333.645          333.645    
+LA         2                2                                                                        0.372378E-04           2    50    50  lay row col    
+LA         2                2                                                                        0.860829E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 123 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3376,47 +4324,73 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      123
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   123
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -55328.0       -19.7647       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           287143.          287143.    
-        1               12                                                                       -0.218045               2   100   100  lay row col
-        1               12                                                                       -0.252998E-02                 1           CLN-node number
-        2                             0             0           751534.          751534.    
-        2                9                                                                        0.415385E-01           2    50    50  lay row col
-        2                9                                                                       -0.382896E-03                 1           CLN-node number
-        3                             0             0           6495.09          6495.09    
-        3                7                                                                        0.410891E-02           2    50    50  lay row col
-        3                7                                                                        0.867385E-05                 1           CLN-node number
-        4                             0             0           5.55571          5.55571    
-        4                2                                                                        0.120759E-03           2    50    50  lay row col
-        4                2                                                                        0.669517E-06                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           287143.          287143.    
+LA         1               12                                                                       -0.218045               2   100   100  lay row col    
+LA         1               12                                                                       -0.252998E-02                 1           CLN-node number
+UR         1                                                                                        -0.218045               2   100   100  lay row col    
+UR         1                                                                                        -0.252998E-02                 1           CLN-node number
+BT         2                             0             0           751534.          751534.    
+LA         2                9                                                                        0.415385E-01           2    50    50  lay row col    
+LA         2                9                                                                       -0.382896E-03                 1           CLN-node number
+UR         2                                                                                         0.373846E-01           2    50    50  lay row col    
+UR         2                                                                                        -0.382896E-03                 1           CLN-node number
+BT         3                             0             0           6495.09          6495.09    
+LA         3                7                                                                        0.410891E-02           2    50    50  lay row col    
+LA         3                7                                                                        0.867385E-05                 1           CLN-node number
+UR         3                                                                                         0.398564E-02           2    50    50  lay row col    
+UR         3                                                                                         0.780647E-05                 1           CLN-node number
+BT         4                             0             0           5.55571          5.55571    
+LA         4                2                                                                        0.120759E-03           2    50    50  lay row col    
+LA         4                2                                                                        0.669517E-06                 1           CLN-node number
      4 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 124 STRESS PERIOD   1
 
  TOTAL OF       4OUTER ITERATIONS
   MAXIMUM CHANGE FOR EACH ITERATION:
   MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL
  ------------------------------------------------------------------------------------------------------------------------------------------
-  -0.2180     (    2,  100,  100)  0.4154E-01 (    2,   50,   50)  0.4109E-02 (    2,   50,   50)  0.1208E-03 (    2,   50,   50)
+  -0.2180     (    2,  100,  100)  0.3738E-01 (    2,   50,   50)  0.3986E-02 (    2,   50,   50)  0.1208E-03 (    2,   50,   50)
 
   MAXIMUM CHANGE FOR CLN NODE AT EACH ITERATION:
    MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL
  ------------------------------------------------------------------------------------------------------------------------------------
-  -0.25300E-02,          1 -0.38290E-03,          1  0.86739E-05,          1  0.66952E-06,          1
+  -0.25300E-02,          1 -0.38290E-03,          1  0.78065E-05,          1  0.66952E-06,          1
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      124
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   124
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -54700.5       -19.7676       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           299831.          299831.    
-        1               12                                                                       -0.215307               2   100   100  lay row col
-        1               12                                                                       -0.316597E-02                 1           CLN-node number
-        2                             0             0           624.060          624.060    
-        2                4                                                                       -0.110980E-03           2    50    50  lay row col
-        2                4                                                                        0.104408E-03                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           299831.          299831.    
+LA         1               12                                                                       -0.215307               2   100   100  lay row col    
+LA         1               12                                                                       -0.316597E-02                 1           CLN-node number
+UR         1                                                                                        -0.215307               2   100   100  lay row col    
+UR         1                                                                                        -0.316597E-02                 1           CLN-node number
+BT         2                             0             0           624.060          624.060    
+LA         2                4                                                                       -0.110980E-03           2    50    50  lay row col    
+LA         2                4                                                                        0.104408E-03                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 125 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3432,16 +4406,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      125
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   125
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -54018.0       -19.7707       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           297889.          297889.    
-        1               13                                                                       -0.212533               2   100   100  lay row col
-        1               13                                                                       -0.305239E-02                 1           CLN-node number
-        2                             0             0           530.017          530.017    
-        2                3                                                                       -0.114693E-03           2    50    50  lay row col
-        2                3                                                                        0.930170E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           297889.          297889.    
+LA         1               13                                                                       -0.212533               2   100   100  lay row col    
+LA         1               13                                                                       -0.305239E-02                 1           CLN-node number
+UR         1                                                                                        -0.212533               2   100   100  lay row col    
+UR         1                                                                                        -0.305239E-02                 1           CLN-node number
+BT         2                             0             0           530.017          530.017    
+LA         2                3                                                                       -0.114693E-03           2    50    50  lay row col    
+LA         2                3                                                                        0.930170E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 126 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3457,16 +4442,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      126
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   126
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -53338.6       -19.7736       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           291079.          291079.    
-        1               13                                                                       -0.209671               2   100   100  lay row col
-        1               13                                                                       -0.291700E-02                 1           CLN-node number
-        2                             0             0           438.500          438.500    
-        2                3                                                                       -0.115786E-03           2    50    50  lay row col
-        2                3                                                                        0.820101E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           291079.          291079.    
+LA         1               13                                                                       -0.209671               2   100   100  lay row col    
+LA         1               13                                                                       -0.291700E-02                 1           CLN-node number
+UR         1                                                                                        -0.209671               2   100   100  lay row col    
+UR         1                                                                                        -0.291700E-02                 1           CLN-node number
+BT         2                             0             0           438.500          438.500    
+LA         2                3                                                                       -0.115786E-03           2    50    50  lay row col    
+LA         2                3                                                                        0.820101E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 127 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3482,16 +4478,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      127
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   127
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -52670.2       -19.7765       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           283742.          283742.    
-        1               13                                                                       -0.206766               2   100   100  lay row col
-        1               13                                                                       -0.279217E-02                 1           CLN-node number
-        2                             0             0           365.145          365.145    
-        2                3                                                                       -0.116034E-03           2    50    50  lay row col
-        2                3                                                                        0.727194E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           283742.          283742.    
+LA         1               13                                                                       -0.206766               2   100   100  lay row col    
+LA         1               13                                                                       -0.279217E-02                 1           CLN-node number
+UR         1                                                                                        -0.206766               2   100   100  lay row col    
+UR         1                                                                                        -0.279217E-02                 1           CLN-node number
+BT         2                             0             0           365.145          365.145    
+LA         2                3                                                                       -0.116034E-03           2    50    50  lay row col    
+LA         2                3                                                                        0.727194E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 128 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3507,16 +4514,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      128
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   128
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -52013.5       -19.7792       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           276565.          276565.    
-        1               13                                                                       -0.203852               2   100   100  lay row col
-        1               13                                                                       -0.267986E-02                 1           CLN-node number
-        2                             0             0           306.981          306.981    
-        2                3                                                                       -0.115899E-03           2    50    50  lay row col
-        2                3                                                                        0.649244E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           276565.          276565.    
+LA         1               13                                                                       -0.203852               2   100   100  lay row col    
+LA         1               13                                                                       -0.267986E-02                 1           CLN-node number
+UR         1                                                                                        -0.203852               2   100   100  lay row col    
+UR         1                                                                                        -0.267986E-02                 1           CLN-node number
+BT         2                             0             0           306.981          306.981    
+LA         2                3                                                                       -0.115899E-03           2    50    50  lay row col    
+LA         2                3                                                                        0.649244E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 129 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3532,16 +4550,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      129
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   129
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -51368.2       -19.7818       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           269617.          269617.    
-        1               13                                                                       -0.200951               2   100   100  lay row col
-        1               13                                                                       -0.257826E-02                 1           CLN-node number
-        2                             0             0           260.278          260.278    
-        2                3                                                                       -0.115484E-03           2    50    50  lay row col
-        2                3                                                                        0.583152E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           269617.          269617.    
+LA         1               13                                                                       -0.200951               2   100   100  lay row col    
+LA         1               13                                                                       -0.257826E-02                 1           CLN-node number
+UR         1                                                                                        -0.200951               2   100   100  lay row col    
+UR         1                                                                                        -0.257826E-02                 1           CLN-node number
+BT         2                             0             0           260.278          260.278    
+LA         2                3                                                                       -0.115484E-03           2    50    50  lay row col    
+LA         2                3                                                                        0.583152E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 130 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3557,16 +4586,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      130
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   130
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -50734.1       -19.7843       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           262891.          262891.    
-        1               13                                                                       -0.198077               2   100   100  lay row col
-        1               13                                                                       -0.248563E-02                 1           CLN-node number
-        2                             0             0           222.279          222.279    
-        2                3                                                                       -0.114835E-03           2    50    50  lay row col
-        2                3                                                                        0.526499E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           262891.          262891.    
+LA         1               13                                                                       -0.198077               2   100   100  lay row col    
+LA         1               13                                                                       -0.248563E-02                 1           CLN-node number
+UR         1                                                                                        -0.198077               2   100   100  lay row col    
+UR         1                                                                                        -0.248563E-02                 1           CLN-node number
+BT         2                             0             0           222.279          222.279    
+LA         2                3                                                                       -0.114835E-03           2    50    50  lay row col    
+LA         2                3                                                                        0.526499E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 131 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3582,16 +4622,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      131
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   131
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -50110.8       -19.7868       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           256377.          256377.    
-        1               13                                                                       -0.195238               2   100   100  lay row col
-        1               13                                                                       -0.240059E-02                 1           CLN-node number
-        2                             0             0           191.009          191.009    
-        2                3                                                                       -0.113989E-03           2    50    50  lay row col
-        2                3                                                                        0.477475E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           256377.          256377.    
+LA         1               13                                                                       -0.195238               2   100   100  lay row col    
+LA         1               13                                                                       -0.240059E-02                 1           CLN-node number
+UR         1                                                                                        -0.195238               2   100   100  lay row col    
+UR         1                                                                                        -0.240059E-02                 1           CLN-node number
+BT         2                             0             0           191.009          191.009    
+LA         2                3                                                                       -0.113989E-03           2    50    50  lay row col    
+LA         2                3                                                                        0.477475E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 132 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3607,16 +4658,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      132
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   132
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -49498.1       -19.7891       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           250065.          250065.    
-        1               13                                                                       -0.192437               2   100   100  lay row col
-        1               13                                                                       -0.232206E-02                 1           CLN-node number
-        2                             0             0           165.024          165.024    
-        2                3                                                                       -0.112971E-03           2    50    50  lay row col
-        2                3                                                                        0.434707E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           250065.          250065.    
+LA         1               13                                                                       -0.192437               2   100   100  lay row col    
+LA         1               13                                                                       -0.232206E-02                 1           CLN-node number
+UR         1                                                                                        -0.192437               2   100   100  lay row col    
+UR         1                                                                                        -0.232206E-02                 1           CLN-node number
+BT         2                             0             0           165.024          165.024    
+LA         2                3                                                                       -0.112971E-03           2    50    50  lay row col    
+LA         2                3                                                                        0.434707E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 133 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3632,16 +4694,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      133
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   133
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -48895.7       -19.7914       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           243947.          243947.    
-        1               13                                                                       -0.189679               2   100   100  lay row col
-        1               13                                                                       -0.224918E-02                 1           CLN-node number
-        2                             0             0           143.250          143.250    
-        2                2                                                                       -0.111580E-03           2    50    50  lay row col
-        2                2                                                                        0.397142E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           243947.          243947.    
+LA         1               13                                                                       -0.189679               2   100   100  lay row col    
+LA         1               13                                                                       -0.224918E-02                 1           CLN-node number
+UR         1                                                                                        -0.189679               2   100   100  lay row col    
+UR         1                                                                                        -0.224918E-02                 1           CLN-node number
+BT         2                             0             0           143.250          143.250    
+LA         2                2                                                                       -0.111580E-03           2    50    50  lay row col    
+LA         2                2                                                                        0.397142E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 134 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3657,16 +4730,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      134
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   134
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -48303.5       -19.7936       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           238014.          238014.    
-        1               13                                                                       -0.186963               2   100   100  lay row col
-        1               13                                                                       -0.218126E-02                 1           CLN-node number
-        2                             0             0           124.870          124.870    
-        2                2                                                                       -0.110523E-03           2    50    50  lay row col
-        2                2                                                                        0.363847E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           238014.          238014.    
+LA         1               13                                                                       -0.186963               2   100   100  lay row col    
+LA         1               13                                                                       -0.218126E-02                 1           CLN-node number
+UR         1                                                                                        -0.186963               2   100   100  lay row col    
+UR         1                                                                                        -0.218126E-02                 1           CLN-node number
+BT         2                             0             0           124.870          124.870    
+LA         2                2                                                                       -0.110523E-03           2    50    50  lay row col    
+LA         2                2                                                                        0.363847E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 135 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3682,16 +4766,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      135
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   135
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -47721.3       -19.7958       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           232259.          232259.    
-        1               13                                                                       -0.184290               2   100   100  lay row col
-        1               13                                                                       -0.211773E-02                 1           CLN-node number
-        2                             0             0           109.254          109.254    
-        2                2                                                                       -0.109404E-03           2    50    50  lay row col
-        2                2                                                                        0.334220E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           232259.          232259.    
+LA         1               13                                                                       -0.184290               2   100   100  lay row col    
+LA         1               13                                                                       -0.211773E-02                 1           CLN-node number
+UR         1                                                                                        -0.184290               2   100   100  lay row col    
+UR         1                                                                                        -0.211773E-02                 1           CLN-node number
+BT         2                             0             0           109.254          109.254    
+LA         2                2                                                                       -0.109404E-03           2    50    50  lay row col    
+LA         2                2                                                                        0.334220E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 136 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3707,16 +4802,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      136
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   136
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -47148.8       -19.7978       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           226677.          226677.    
-        1               13                                                                       -0.181661               2   100   100  lay row col
-        1               13                                                                       -0.205809E-02                 1           CLN-node number
-        2                             0             0           95.9103          95.9103    
-        2                2                                                                       -0.108235E-03           2    50    50  lay row col
-        2                2                                                                        0.307724E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           226677.          226677.    
+LA         1               13                                                                       -0.181661               2   100   100  lay row col    
+LA         1               13                                                                       -0.205809E-02                 1           CLN-node number
+UR         1                                                                                        -0.181661               2   100   100  lay row col    
+UR         1                                                                                        -0.205809E-02                 1           CLN-node number
+BT         2                             0             0           95.9103          95.9103    
+LA         2                2                                                                       -0.108235E-03           2    50    50  lay row col    
+LA         2                2                                                                        0.307724E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 137 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3732,16 +4838,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      137
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   137
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -46585.9       -19.7999       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           221261.          221261.    
-        1               13                                                                       -0.179073               2   100   100  lay row col
-        1               13                                                                       -0.200194E-02                 1           CLN-node number
-        2                             0             0           84.4493          84.4493    
-        2                2                                                                       -0.107026E-03           2    50    50  lay row col
-        2                2                                                                        0.283917E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           221261.          221261.    
+LA         1               13                                                                       -0.179073               2   100   100  lay row col    
+LA         1               13                                                                       -0.200194E-02                 1           CLN-node number
+UR         1                                                                                        -0.179073               2   100   100  lay row col    
+UR         1                                                                                        -0.200194E-02                 1           CLN-node number
+BT         2                             0             0           84.4493          84.4493    
+LA         2                2                                                                       -0.107026E-03           2    50    50  lay row col    
+LA         2                2                                                                        0.283917E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 138 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3757,16 +4874,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      138
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   138
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -46032.4       -19.8018       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           216005.          216005.    
-        1               13                                                                       -0.176529               2   100   100  lay row col
-        1               13                                                                       -0.194894E-02                 1           CLN-node number
-        2                             0             0           74.5594          74.5594    
-        2                2                                                                       -0.105786E-03           2    50    50  lay row col
-        2                2                                                                        0.262438E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           216005.          216005.    
+LA         1               13                                                                       -0.176529               2   100   100  lay row col    
+LA         1               13                                                                       -0.194894E-02                 1           CLN-node number
+UR         1                                                                                        -0.176529               2   100   100  lay row col    
+UR         1                                                                                        -0.194894E-02                 1           CLN-node number
+BT         2                             0             0           74.5594          74.5594    
+LA         2                2                                                                       -0.105786E-03           2    50    50  lay row col    
+LA         2                2                                                                        0.262438E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 139 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3782,16 +4910,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      139
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   139
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -45488.1       -19.8038       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           210904.          210904.    
-        1               13                                                                       -0.174025               2   100   100  lay row col
-        1               13                                                                       -0.189878E-02                 1           CLN-node number
-        2                             0             0           65.9893          65.9893    
-        2                2                                                                       -0.104522E-03           2    50    50  lay row col
-        2                2                                                                        0.242984E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           210904.          210904.    
+LA         1               13                                                                       -0.174025               2   100   100  lay row col    
+LA         1               13                                                                       -0.189878E-02                 1           CLN-node number
+UR         1                                                                                        -0.174025               2   100   100  lay row col    
+UR         1                                                                                        -0.189878E-02                 1           CLN-node number
+BT         2                             0             0           65.9893          65.9893    
+LA         2                2                                                                       -0.104522E-03           2    50    50  lay row col    
+LA         2                2                                                                        0.242984E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 140 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3807,16 +4946,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      140
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   140
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -44952.9       -19.8056       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           205952.          205952.    
-        1               13                                                                       -0.171563               2   100   100  lay row col
-        1               13                                                                       -0.185121E-02                 1           CLN-node number
-        2                             0             0           58.5344          58.5344    
-        2                2                                                                       -0.103239E-03           2    50    50  lay row col
-        2                2                                                                        0.225302E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           205952.          205952.    
+LA         1               13                                                                       -0.171563               2   100   100  lay row col    
+LA         1               13                                                                       -0.185121E-02                 1           CLN-node number
+UR         1                                                                                        -0.171563               2   100   100  lay row col    
+UR         1                                                                                        -0.185121E-02                 1           CLN-node number
+BT         2                             0             0           58.5344          58.5344    
+LA         2                2                                                                       -0.103239E-03           2    50    50  lay row col    
+LA         2                2                                                                        0.225302E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 141 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3832,16 +4982,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      141
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   141
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -44426.5       -19.8075       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           201145.          201145.    
-        1               13                                                                       -0.169142               2   100   100  lay row col
-        1               13                                                                       -0.180600E-02                 1           CLN-node number
-        2                             0             0           52.0269          52.0269    
-        2                2                                                                       -0.101943E-03           2    50    50  lay row col
-        2                2                                                                        0.209178E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           201145.          201145.    
+LA         1               13                                                                       -0.169142               2   100   100  lay row col    
+LA         1               13                                                                       -0.180600E-02                 1           CLN-node number
+UR         1                                                                                        -0.169142               2   100   100  lay row col    
+UR         1                                                                                        -0.180600E-02                 1           CLN-node number
+BT         2                             0             0           52.0269          52.0269    
+LA         2                2                                                                       -0.101943E-03           2    50    50  lay row col    
+LA         2                2                                                                        0.209178E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 142 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3857,16 +5018,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      142
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   142
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -43908.9       -19.8092       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           196478.          196478.    
-        1               13                                                                       -0.166760               2   100   100  lay row col
-        1               13                                                                       -0.176295E-02                 1           CLN-node number
-        2                             0             0           46.3283          46.3283    
-        2                2                                                                       -0.100638E-03           2    50    50  lay row col
-        2                2                                                                        0.194431E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           196478.          196478.    
+LA         1               13                                                                       -0.166760               2   100   100  lay row col    
+LA         1               13                                                                       -0.176295E-02                 1           CLN-node number
+UR         1                                                                                        -0.166760               2   100   100  lay row col    
+UR         1                                                                                        -0.176295E-02                 1           CLN-node number
+BT         2                             0             0           46.3283          46.3283    
+LA         2                2                                                                       -0.100638E-03           2    50    50  lay row col    
+LA         2                2                                                                        0.194431E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 143 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3882,16 +5054,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      143
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   143
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -43399.8       -19.8110       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           191945.          191945.    
-        1               13                                                                       -0.164418               2   100   100  lay row col
-        1               13                                                                       -0.172188E-02                 1           CLN-node number
-        2                             0             0           41.3234          41.3234    
-        2                2                                                                       -0.993285E-04           2    50    50  lay row col
-        2                2                                                                        0.180906E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           191945.          191945.    
+LA         1               13                                                                       -0.164418               2   100   100  lay row col    
+LA         1               13                                                                       -0.172188E-02                 1           CLN-node number
+UR         1                                                                                        -0.164418               2   100   100  lay row col    
+UR         1                                                                                        -0.172188E-02                 1           CLN-node number
+BT         2                             0             0           41.3234          41.3234    
+LA         2                2                                                                       -0.993285E-04           2    50    50  lay row col    
+LA         2                2                                                                        0.180906E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 144 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3907,16 +5090,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      144
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   144
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -42899.1       -19.8127       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           187544.          187544.    
-        1               13                                                                       -0.162114               2   100   100  lay row col
-        1               13                                                                       -0.168264E-02                 1           CLN-node number
-        2                             0             0           36.9159          36.9159    
-        2                2                                                                       -0.980164E-04           2    50    50  lay row col
-        2                2                                                                        0.168470E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           187544.          187544.    
+LA         1               13                                                                       -0.162114               2   100   100  lay row col    
+LA         1               13                                                                       -0.168264E-02                 1           CLN-node number
+UR         1                                                                                        -0.162114               2   100   100  lay row col    
+UR         1                                                                                        -0.168264E-02                 1           CLN-node number
+BT         2                             0             0           36.9159          36.9159    
+LA         2                2                                                                       -0.980164E-04           2    50    50  lay row col    
+LA         2                2                                                                        0.168470E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 145 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3932,16 +5126,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      145
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   145
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -42406.7       -19.8144       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           183268.          183268.    
-        1               13                                                                       -0.159848               2   100   100  lay row col
-        1               13                                                                       -0.164509E-02                 1           CLN-node number
-        2                             0             0           33.0251          33.0251    
-        2                2                                                                       -0.967048E-04           2    50    50  lay row col
-        2                2                                                                        0.157008E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           183268.          183268.    
+LA         1               13                                                                       -0.159848               2   100   100  lay row col    
+LA         1               13                                                                       -0.164509E-02                 1           CLN-node number
+UR         1                                                                                        -0.159848               2   100   100  lay row col    
+UR         1                                                                                        -0.164509E-02                 1           CLN-node number
+BT         2                             0             0           33.0251          33.0251    
+LA         2                2                                                                       -0.967048E-04           2    50    50  lay row col    
+LA         2                2                                                                        0.157008E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 146 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3957,16 +5162,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      146
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   146
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -41922.3       -19.8160       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           179115.          179115.    
-        1               13                                                                       -0.157619               2   100   100  lay row col
-        1               13                                                                       -0.160911E-02                 1           CLN-node number
-        2                             0             0           29.5825          29.5825    
-        2                2                                                                       -0.953958E-04           2    50    50  lay row col
-        2                2                                                                        0.146419E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           179115.          179115.    
+LA         1               13                                                                       -0.157619               2   100   100  lay row col    
+LA         1               13                                                                       -0.160911E-02                 1           CLN-node number
+UR         1                                                                                        -0.157619               2   100   100  lay row col    
+UR         1                                                                                        -0.160911E-02                 1           CLN-node number
+BT         2                             0             0           29.5825          29.5825    
+LA         2                2                                                                       -0.953958E-04           2    50    50  lay row col    
+LA         2                2                                                                        0.146419E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 147 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -3982,16 +5198,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      147
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   147
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -41445.9       -19.8176       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           175080.          175080.    
-        1               13                                                                       -0.155427               2   100   100  lay row col
-        1               13                                                                       -0.157459E-02                 1           CLN-node number
-        2                             0             0           26.5301          26.5301    
-        2                2                                                                       -0.940914E-04           2    50    50  lay row col
-        2                2                                                                        0.136617E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           175080.          175080.    
+LA         1               13                                                                       -0.155427               2   100   100  lay row col    
+LA         1               13                                                                       -0.157459E-02                 1           CLN-node number
+UR         1                                                                                        -0.155427               2   100   100  lay row col    
+UR         1                                                                                        -0.157459E-02                 1           CLN-node number
+BT         2                             0             0           26.5301          26.5301    
+LA         2                2                                                                       -0.940914E-04           2    50    50  lay row col    
+LA         2                2                                                                        0.136617E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 148 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -4007,16 +5234,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      148
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   148
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -40977.2       -19.8191       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           171159.          171159.    
-        1               13                                                                       -0.153270               2   100   100  lay row col
-        1               13                                                                       -0.154142E-02                 1           CLN-node number
-        2                             0             0           23.8186          23.8186    
-        2                2                                                                       -0.927933E-04           2    50    50  lay row col
-        2                2                                                                        0.127525E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           171159.          171159.    
+LA         1               13                                                                       -0.153270               2   100   100  lay row col    
+LA         1               13                                                                       -0.154142E-02                 1           CLN-node number
+UR         1                                                                                        -0.153270               2   100   100  lay row col    
+UR         1                                                                                        -0.154142E-02                 1           CLN-node number
+BT         2                             0             0           23.8186          23.8186    
+LA         2                2                                                                       -0.927933E-04           2    50    50  lay row col    
+LA         2                2                                                                        0.127525E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 149 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -4032,16 +5270,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      149
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   149
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -40516.3       -19.8207       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           167349.          167349.    
-        1               13                                                                       -0.151149               2   100   100  lay row col
-        1               13                                                                       -0.150952E-02                 1           CLN-node number
-        2                             0             0           21.4055          21.4055    
-        2                2                                                                       -0.915028E-04           2    50    50  lay row col
-        2                2                                                                        0.119077E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           167349.          167349.    
+LA         1               13                                                                       -0.151149               2   100   100  lay row col    
+LA         1               13                                                                       -0.150952E-02                 1           CLN-node number
+UR         1                                                                                        -0.151149               2   100   100  lay row col    
+UR         1                                                                                        -0.150952E-02                 1           CLN-node number
+BT         2                             0             0           21.4055          21.4055    
+LA         2                2                                                                       -0.915028E-04           2    50    50  lay row col    
+LA         2                2                                                                        0.119077E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 150 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -4057,16 +5306,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      150
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   150
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -40062.8       -19.8222       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           163647.          163647.    
-        1               13                                                                       -0.149063               2   100   100  lay row col
-        1               13                                                                       -0.147880E-02                 1           CLN-node number
-        2                             0             0           19.2545          19.2545    
-        2                2                                                                       -0.902211E-04           2    50    50  lay row col
-        2                2                                                                        0.111213E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           163647.          163647.    
+LA         1               13                                                                       -0.149063               2   100   100  lay row col    
+LA         1               13                                                                       -0.147880E-02                 1           CLN-node number
+UR         1                                                                                        -0.149063               2   100   100  lay row col    
+UR         1                                                                                        -0.147880E-02                 1           CLN-node number
+BT         2                             0             0           19.2545          19.2545    
+LA         2                2                                                                       -0.902211E-04           2    50    50  lay row col    
+LA         2                2                                                                        0.111213E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 151 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -4082,16 +5342,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      151
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   151
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -39616.7       -19.8236       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           160047.          160047.    
-        1               13                                                                       -0.147011               2   100   100  lay row col
-        1               13                                                                       -0.144920E-02                 1           CLN-node number
-        2                             0             0           17.3342          17.3342    
-        2                2                                                                       -0.889492E-04           2    50    50  lay row col
-        2                2                                                                        0.103882E-04                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           160047.          160047.    
+LA         1               13                                                                       -0.147011               2   100   100  lay row col    
+LA         1               13                                                                       -0.144920E-02                 1           CLN-node number
+UR         1                                                                                        -0.147011               2   100   100  lay row col    
+UR         1                                                                                        -0.144920E-02                 1           CLN-node number
+BT         2                             0             0           17.3342          17.3342    
+LA         2                2                                                                       -0.889492E-04           2    50    50  lay row col    
+LA         2                2                                                                        0.103882E-04                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 152 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -4107,44 +5378,68 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      152
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   152
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -39177.8       -19.8251       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           156549.          156549.    
-        1               13                                                                       -0.144992               2   100   100  lay row col
-        1               13                                                                       -0.142063E-02                 1           CLN-node number
-        2                             0             0           3774.40          3774.40    
-        2                7                                                                        0.366424E-02           2    50    49  lay row col
-        2                7                                                                        0.492502E-04                 1           CLN-node number
-        3                             0             0           37.6120          37.6120    
-        3                4                                                                        0.365055E-03           2    50    49  lay row col
-        3                4                                                                        0.476670E-05                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           156549.          156549.    
+LA         1               13                                                                       -0.144992               2   100   100  lay row col    
+LA         1               13                                                                       -0.142063E-02                 1           CLN-node number
+UR         1                                                                                        -0.144992               2   100   100  lay row col    
+UR         1                                                                                        -0.142063E-02                 1           CLN-node number
+BT         2                             0             0           3774.40          3774.40    
+LA         2                7                                                                        0.366424E-02           2    50    49  lay row col    
+LA         2                7                                                                        0.492502E-04                 1           CLN-node number
+UR         2                                                                                         0.329782E-02           2    50    49  lay row col    
+UR         2                                                                                         0.443252E-04                 1           CLN-node number
+BT         3                             0             0           37.6120          37.6120    
+LA         3                4                                                                        0.365055E-03           2    50    49  lay row col    
+LA         3                4                                                                        0.476670E-05                 1           CLN-node number
      3 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 153 STRESS PERIOD   1
 
  TOTAL OF       3OUTER ITERATIONS
   MAXIMUM CHANGE FOR EACH ITERATION:
   MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL MAX. CHANGE   LAYER,  ROW,  COL
  ------------------------------------------------------------------------------------------------------------------------------------------
-  -0.1450     (    2,  100,  100)  0.3664E-02 (    2,   50,   49)  0.3651E-03 (    2,   50,   49)
+  -0.1450     (    2,  100,  100)  0.3298E-02 (    2,   50,   49)  0.3651E-03 (    2,   50,   49)
 
   MAXIMUM CHANGE FOR CLN NODE AT EACH ITERATION:
    MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL  MAX. CHANGE    CLN-CELL
  ------------------------------------------------------------------------------------------------------------------------------------
-  -0.14206E-02,          1  0.49250E-04,          1  0.47667E-05,          1
+  -0.14206E-02,          1  0.44325E-04,          1  0.47667E-05,          1
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      153
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   153
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -38758.2       -19.8265       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           153074.          153074.    
-        1               13                                                                       -0.142855               2   100   100  lay row col
-        1               13                                                                       -0.107018E-02                 1           CLN-node number
-        2                             0             0           5.42460          5.42460    
-        2                2                                                                       -0.299343E-04           2    50    49  lay row col
-        2                2                                                                        0.676041E-05                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           153074.          153074.    
+LA         1               13                                                                       -0.142855               2   100   100  lay row col    
+LA         1               13                                                                       -0.107018E-02                 1           CLN-node number
+UR         1                                                                                        -0.142855               2   100   100  lay row col    
+UR         1                                                                                        -0.107018E-02                 1           CLN-node number
+BT         2                             0             0           5.42460          5.42460    
+LA         2                2                                                                       -0.299343E-04           2    50    49  lay row col    
+LA         2                2                                                                        0.676041E-05                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 154 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -4160,16 +5455,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      154
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   154
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -38431.9       -19.8275       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           191891.          191891.    
-        1               13                                                                       -0.140615               2   100   100  lay row col
-        1               13                                                                       -0.126408E-02                 1           CLN-node number
-        2                             0             0           8.96463          8.96463    
-        2                2                                                                       -0.474632E-04           2    50    49  lay row col
-        2                2                                                                        0.867216E-05                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           191891.          191891.    
+LA         1               13                                                                       -0.140615               2   100   100  lay row col    
+LA         1               13                                                                       -0.126408E-02                 1           CLN-node number
+UR         1                                                                                        -0.140615               2   100   100  lay row col    
+UR         1                                                                                        -0.126408E-02                 1           CLN-node number
+BT         2                             0             0           8.96463          8.96463    
+LA         2                2                                                                       -0.474632E-04           2    50    49  lay row col    
+LA         2                2                                                                        0.867216E-05                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 155 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -4185,16 +5491,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      155
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   155
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -38045.8       -19.8288       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           221318.          221318.    
-        1               13                                                                       -0.138323               2   100   100  lay row col
-        1               13                                                                       -0.135583E-02                 1           CLN-node number
-        2                             0             0           10.6965          10.6965    
-        2                2                                                                       -0.548707E-04           2    49    50  lay row col
-        2                2                                                                        0.933241E-05                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           221318.          221318.    
+LA         1               13                                                                       -0.138323               2   100   100  lay row col    
+LA         1               13                                                                       -0.135583E-02                 1           CLN-node number
+UR         1                                                                                        -0.138323               2   100   100  lay row col    
+UR         1                                                                                        -0.135583E-02                 1           CLN-node number
+BT         2                             0             0           10.6965          10.6965    
+LA         2                2                                                                       -0.548707E-04           2    49    50  lay row col    
+LA         2                2                                                                        0.933241E-05                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 156 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -4210,16 +5527,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      156
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   156
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -37630.7       -19.8301       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           232710.          232710.    
-        1               13                                                                       -0.136057               2   100   100  lay row col
-        1               13                                                                       -0.138182E-02                 1           CLN-node number
-        2                             0             0           10.8186          10.8186    
-        2                2                                                                       -0.577215E-04           2    49    50  lay row col
-        2                2                                                                        0.927490E-05                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           232710.          232710.    
+LA         1               13                                                                       -0.136057               2   100   100  lay row col    
+LA         1               13                                                                       -0.138182E-02                 1           CLN-node number
+UR         1                                                                                        -0.136057               2   100   100  lay row col    
+UR         1                                                                                        -0.138182E-02                 1           CLN-node number
+BT         2                             0             0           10.8186          10.8186    
+LA         2                2                                                                       -0.577215E-04           2    49    50  lay row col    
+LA         2                2                                                                        0.927490E-05                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 157 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -4235,16 +5563,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      157
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   157
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -37206.5       -19.8315       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           235220.          235220.    
-        1               13                                                                       -0.133859               2   100   100  lay row col
-        1               13                                                                       -0.137861E-02                 1           CLN-node number
-        2                             0             0           10.2012          10.2012    
-        2                2                                                                       -0.584924E-04           2    49    50  lay row col
-        2                2                                                                        0.891486E-05                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           235220.          235220.    
+LA         1               13                                                                       -0.133859               2   100   100  lay row col    
+LA         1               13                                                                       -0.137861E-02                 1           CLN-node number
+UR         1                                                                                        -0.133859               2   100   100  lay row col    
+UR         1                                                                                        -0.137861E-02                 1           CLN-node number
+BT         2                             0             0           10.2012          10.2012    
+LA         2                2                                                                       -0.584924E-04           2    49    50  lay row col    
+LA         2                2                                                                        0.891486E-05                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 158 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -4260,16 +5599,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      158
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   158
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -36782.2       -19.8329       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           233659.          233659.    
-        1               13                                                                       -0.131744               2   100   100  lay row col
-        1               13                                                                       -0.136266E-02                 1           CLN-node number
-        2                             0             0           9.32003          9.32003    
-        2                2                                                                       -0.582897E-04           2    49    50  lay row col
-        2                2                                                                        0.844024E-05                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           233659.          233659.    
+LA         1               13                                                                       -0.131744               2   100   100  lay row col    
+LA         1               13                                                                       -0.136266E-02                 1           CLN-node number
+UR         1                                                                                        -0.131744               2   100   100  lay row col    
+UR         1                                                                                        -0.136266E-02                 1           CLN-node number
+BT         2                             0             0           9.32003          9.32003    
+LA         2                2                                                                       -0.582897E-04           2    49    50  lay row col    
+LA         2                2                                                                        0.844024E-05                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 159 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -4285,16 +5635,27 @@ FROM THE SOLVER INPUT FILE.
 
  NO OUTPUT CONTROL FOR STRESS PERIOD        1   TIME STEP      159
  
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   159
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -36361.9       -19.8342       -20.0000    
+ 
  SOLVING FOR HEAD 
 
- Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum HeadChange      Maximum Head Change
-     Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
-        1                             0             0           230260.          230260.    
-        1               13                                                                       -0.129708               2   100   100  lay row col
-        1               13                                                                       -0.134118E-02                 1           CLN-node number
-        2                             0             0           18.0555          18.0555    
-        2                3                                                                        0.228556E-03           2    49    49  lay row col
-        2                3                                                                        0.946588E-05                 1           CLN-node number
+
+ OUTER ITERATION SUMMARY
+ -----------------------
+ BT: Backtracking; LA: Linear Acceleration; UR: Under-relaxation
+
+    Outer-Iteration  Inner-Iteration  Backtracking  Number of        Incoming       Outgoing  Maximum Head Change     Maximum Head Change
+        Number           Count           Flag       Backtracks       Residual       Residual           Value              Location
+BT         1                             0             0           230260.          230260.    
+LA         1               13                                                                       -0.129708               2   100   100  lay row col    
+LA         1               13                                                                       -0.134118E-02                 1           CLN-node number
+UR         1                                                                                        -0.129708               2   100   100  lay row col    
+UR         1                                                                                        -0.134118E-02                 1           CLN-node number
+BT         2                             0             0           18.0555          18.0555    
+LA         2                3                                                                        0.228556E-03           2    49    49  lay row col    
+LA         2                3                                                                        0.946588E-05                 1           CLN-node number
      2 CALLS TO SPARSE MATRIX SOLVER PACKAGE  IN FLOW TIME STEP 160 STRESS PERIOD   1
 
  TOTAL OF       2OUTER ITERATIONS
@@ -4315,16 +5676,22 @@ FROM THE SOLVER INPUT FILE.
     SAVE BUDGET
     SAVE DRAWDOWN FOR ALL LAYERS
     SAVE HEAD FOR ALL LAYERS
- UBDSV1 SAVING "         STORAGE" ON UNIT  50 AT TIME STEP    160, STRESS PERIOD      1
- UBDSV1 SAVING "     CLN STORAGE" ON UNIT  35 AT TIME STEP    160, STRESS PERIOD      1
- UBDSV2 SAVING "   CONSTANT HEAD" ON UNIT  50 AT TIME STEP    160, STRESS PERIOD      1
- UBDSV1 SAVING "FLOW RIGHT FACE " ON UNIT  50 AT TIME STEP    160, STRESS PERIOD      1
- UBDSV1 SAVING "FLOW FRONT FACE " ON UNIT  50 AT TIME STEP    160, STRESS PERIOD      1
- UBDSV1 SAVING "FLOW LOWER FACE " ON UNIT  50 AT TIME STEP    160, STRESS PERIOD      1
+ UBDSV1  SAVING "         STORAGE" ON UNIT  50 AT TIME STEP    160, STRESS PERIOD      1
+ UBDSV1  SAVING "     CLN STORAGE" ON UNIT  35 AT TIME STEP    160, STRESS PERIOD      1
+ UBDSV2  SAVING "   CONSTANT HEAD" ON UNIT  50 AT TIME STEP    160, STRESS PERIOD      1
+ UBDSV1  SAVING "FLOW RIGHT FACE " ON UNIT  50 AT TIME STEP    160, STRESS PERIOD      1
+ UBDSV1  SAVING "FLOW FRONT FACE " ON UNIT  50 AT TIME STEP    160, STRESS PERIOD      1
+ UBDSV1  SAVING "FLOW LOWER FACE " ON UNIT  50 AT TIME STEP    160, STRESS PERIOD      1
+ UBDSV2  SAVING "             CLN" ON UNIT  50 AT TIME STEP    160, STRESS PERIOD      1
  UBDSV2U SAVING "  CLN CONST HEAD" ON UNIT  35 AT TIME STEP    160, STRESS PERIOD      1
  UBDSV1U SAVING "   FLOW CLN FACE" ON UNIT  35 AT TIME STEP    160, STRESS PERIOD      1
- UBDSV1U SAVING "      GWF TO CLN" ON UNIT  35 AT TIME STEP    160, STRESS PERIOD      1
- UBDSV4 SAVING "           WELLS" ON UNIT  50 AT TIME STEP    160, STRESS PERIOD      1
+ UBDSV2U SAVING "             GWF" ON UNIT  35 AT TIME STEP    160, STRESS PERIOD      1
+ UBDSV4  SAVING "           WELLS" ON UNIT  50 AT TIME STEP    160, STRESS PERIOD      1
+ UBDSV4U SAVING "           WELLS" ON UNIT  35 AT TIME STEP    160, STRESS PERIOD      1
+ 
+ WELLS WITH REDUCED PUMPING FOR STRESS PERIOD     1 TIME STEP   160
+WELL.NO  CLN NODE     APPL.Q          ACT.Q        GW_HEAD       CELL_BOT
+      1         1   -62840.0       -35947.7       -19.8355       -20.0000    
 1
               HEAD IN LAYER   1 AT END OF TIME STEP 160 IN STRESS PERIOD    1
   ---------------------------------------------------------------------------
@@ -4340,377 +5707,377 @@ FROM THE SOLVER INPUT FILE.
            81          82          83          84          85          86          87          88          89          90
            91          92          93          94          95          96          97          98          99         100
  ........................................................................................................................
-   1    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-   2    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-   3    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-   4    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-   5    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-   6    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-   7    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-   8    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-   9    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  10    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
-        9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  11    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999       9.999       9.999    
+   1   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+   2   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+   3   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+   4   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+   5   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+   6   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+   7   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+   8   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+   9   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  10   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  11   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
-        9.999       9.999       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  12    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       9.999       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  12   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000       9.999       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
-        9.999       9.999       9.999       9.999       9.999       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  13    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999       9.999      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  13   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
-        9.999       9.999       9.999       9.999       9.999       9.999       9.999       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  14    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
-        9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
-        9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
-        9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  15    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999       9.999    
+        9.999       9.999       9.999       9.999       9.999       9.999       9.999      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  14   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  15   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
-        9.999       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  16    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
+        9.999      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  16   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
         9.999       9.998       9.998       9.998       9.998       9.998       9.998       9.998       9.998       9.998    
         9.998       9.998       9.998       9.998       9.998       9.998       9.998       9.998       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
-        9.999       9.999       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  17    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  17   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998    
         9.998       9.998       9.998       9.998       9.998       9.998       9.998       9.998       9.998       9.998    
         9.998       9.998       9.998       9.998       9.998       9.998       9.998       9.998       9.998       9.998    
         9.998       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
-        9.999       9.999       9.999       9.999       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  18    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       9.999       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  18   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000       9.999       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.998       9.998       9.998    
         9.998       9.998       9.997       9.997       9.997       9.997       9.997       9.997       9.997       9.997    
         9.997       9.997       9.997       9.997       9.997       9.997       9.997       9.998       9.998       9.998    
         9.998       9.998       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999    
-        9.999       9.999       9.999       9.999       9.999       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  19    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999       9.999      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  19   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.999       9.998       9.998       9.998       9.998       9.998       9.998       9.997    
         9.997       9.997       9.997       9.997       9.996       9.996       9.996       9.996       9.996       9.996    
         9.996       9.996       9.996       9.996       9.996       9.997       9.997       9.997       9.997       9.997    
         9.998       9.998       9.998       9.998       9.998       9.998       9.999       9.999       9.999       9.999    
-        9.999       9.999       9.999       9.999       9.999       9.999       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  20    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999       9.999       9.999      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  20   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.998       9.998       9.998       9.998       9.997       9.997       9.997       9.997    
         9.996       9.996       9.996       9.996       9.995       9.995       9.995       9.995       9.995       9.995    
         9.995       9.995       9.995       9.995       9.995       9.996       9.996       9.996       9.996       9.997    
         9.997       9.997       9.997       9.998       9.998       9.998       9.998       9.999       9.999       9.999    
-        9.999       9.999       9.999       9.999       9.999       9.999       9.999       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  21    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999       9.999       9.999       9.999      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  21   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
         9.998       9.998       9.998       9.998       9.997       9.997       9.997       9.996       9.996       9.996    
         9.995       9.995       9.995       9.994       9.994       9.994       9.994       9.993       9.993       9.993    
         9.993       9.993       9.994       9.994       9.994       9.994       9.995       9.995       9.995       9.996    
         9.996       9.996       9.997       9.997       9.997       9.998       9.998       9.998       9.998       9.999    
-        9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  22    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
+        9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  22   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.998    
         9.998       9.998       9.997       9.997       9.997       9.996       9.996       9.995       9.995       9.994    
         9.994       9.994       9.993       9.993       9.992       9.992       9.992       9.992       9.991       9.991    
         9.991       9.992       9.992       9.992       9.992       9.993       9.993       9.994       9.994       9.994    
         9.995       9.995       9.996       9.996       9.997       9.997       9.997       9.998       9.998       9.998    
-        9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  23    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999    
+        9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  23   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.998    
         9.998       9.997       9.997       9.996       9.996       9.995       9.995       9.994       9.994       9.993    
         9.992       9.992       9.991       9.991       9.990       9.990       9.989       9.989       9.989       9.989    
         9.989       9.989       9.989       9.990       9.990       9.991       9.991       9.992       9.992       9.993    
         9.994       9.994       9.995       9.995       9.996       9.996       9.997       9.997       9.998       9.998    
         9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  24    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999       9.999    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  24   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.998       9.997    
         9.997       9.997       9.996       9.996       9.995       9.994       9.993       9.993       9.992       9.991    
         9.990       9.990       9.989       9.988       9.987       9.987       9.986       9.986       9.986       9.986    
         9.986       9.986       9.986       9.987       9.987       9.988       9.989       9.990       9.990       9.991    
         9.992       9.993       9.993       9.994       9.995       9.996       9.996       9.997       9.997       9.997    
         9.998       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
-        9.999       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  25    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999       9.999       9.999    
+        9.999      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  25   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.998       9.997       9.997    
         9.996       9.996       9.995       9.994       9.994       9.993       9.992       9.991       9.990       9.989    
         9.988       9.987       9.986       9.985       9.984       9.983       9.983       9.982       9.982       9.982    
         9.982       9.982       9.983       9.983       9.984       9.985       9.986       9.987       9.988       9.989    
         9.990       9.991       9.992       9.993       9.994       9.994       9.995       9.996       9.996       9.997    
         9.997       9.998       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999    
-        9.999       9.999       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  26    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       9.999       9.999       9.999       9.999    
+        9.999       9.999      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  26   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000       9.999       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.998       9.998       9.998       9.997       9.997       9.996    
         9.996       9.995       9.994       9.993       9.992       9.991       9.990       9.989       9.987       9.986    
         9.985       9.983       9.982       9.981       9.980       9.979       9.978       9.977       9.977       9.977    
         9.977       9.977       9.978       9.979       9.980       9.981       9.982       9.983       9.985       9.986    
         9.987       9.989       9.990       9.991       9.992       9.993       9.994       9.995       9.996       9.996    
         9.997       9.997       9.998       9.998       9.998       9.999       9.999       9.999       9.999       9.999    
-        9.999       9.999       9.999       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  27    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  27   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000       9.999       9.999       9.999       9.999    
         9.999       9.999       9.999       9.998       9.998       9.998       9.997       9.997       9.996       9.995    
         9.995       9.994       9.993       9.992       9.990       9.989       9.987       9.986       9.984       9.982    
         9.981       9.979       9.977       9.976       9.974       9.973       9.972       9.971       9.971       9.971    
         9.971       9.971       9.972       9.973       9.974       9.976       9.977       9.979       9.981       9.982    
         9.984       9.986       9.987       9.989       9.990       9.992       9.993       9.994       9.995       9.995    
         9.996       9.997       9.997       9.998       9.998       9.998       9.999       9.999       9.999       9.999    
-        9.999       9.999       9.999       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  28    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  28   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.998       9.998       9.998       9.997       9.997       9.996       9.995       9.995    
         9.994       9.992       9.991       9.990       9.988       9.986       9.984       9.982       9.980       9.978    
         9.976       9.974       9.972       9.970       9.968       9.966       9.965       9.964       9.963       9.963    
         9.963       9.964       9.965       9.966       9.968       9.970       9.972       9.974       9.976       9.978    
         9.980       9.982       9.984       9.986       9.988       9.990       9.991       9.992       9.994       9.995    
         9.995       9.996       9.997       9.997       9.998       9.998       9.998       9.999       9.999       9.999    
-        9.999       9.999       9.999       9.999       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  29    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       9.999       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  29   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000       9.999       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.998       9.998       9.997       9.997       9.996       9.995       9.994       9.993    
         9.992       9.991       9.989       9.987       9.985       9.983       9.981       9.978       9.976       9.973    
         9.970       9.967       9.964       9.962       9.960       9.958       9.956       9.955       9.954       9.954    
         9.954       9.955       9.956       9.958       9.960       9.962       9.964       9.967       9.970       9.973    
         9.976       9.978       9.981       9.983       9.985       9.987       9.989       9.991       9.992       9.993    
         9.994       9.995       9.996       9.997       9.997       9.998       9.998       9.999       9.999       9.999    
-        9.999       9.999       9.999       9.999       9.999       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  30    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       9.999       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999       9.999      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  30   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000       9.999       9.999       9.999       9.999       9.999       9.999    
         9.999       9.998       9.998       9.997       9.997       9.996       9.995       9.995       9.993       9.992    
         9.991       9.989       9.987       9.985       9.982       9.979       9.976       9.973       9.970       9.966    
         9.963       9.959       9.956       9.953       9.950       9.947       9.945       9.943       9.942       9.942    
         9.942       9.943       9.945       9.947       9.950       9.953       9.956       9.959       9.963       9.966    
         9.970       9.973       9.976       9.979       9.982       9.985       9.987       9.989       9.991       9.992    
         9.993       9.995       9.995       9.996       9.997       9.997       9.998       9.998       9.999       9.999    
-        9.999       9.999       9.999       9.999       9.999       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  31    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999       9.999      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  31   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
         9.998       9.998       9.998       9.997       9.996       9.996       9.995       9.994       9.992       9.991    
         9.989       9.987       9.984       9.981       9.978       9.975       9.971       9.967       9.963       9.959    
         9.954       9.950       9.945       9.941       9.938       9.934       9.932       9.929       9.928       9.928    
         9.928       9.929       9.932       9.934       9.938       9.941       9.945       9.950       9.954       9.959    
         9.963       9.967       9.971       9.975       9.978       9.981       9.984       9.987       9.989       9.991    
         9.992       9.994       9.995       9.996       9.996       9.997       9.998       9.998       9.998       9.999    
-        9.999       9.999       9.999       9.999       9.999       9.999       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  32    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999       9.999       9.999      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  32   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
         9.998       9.998       9.997       9.997       9.996       9.995       9.994       9.992       9.991       9.989    
         9.987       9.984       9.981       9.978       9.974       9.970       9.965       9.960       9.955       9.950    
         9.944       9.938       9.933       9.928       9.923       9.919       9.915       9.912       9.911       9.910    
         9.911       9.912       9.915       9.919       9.923       9.928       9.933       9.938       9.944       9.950    
         9.955       9.960       9.965       9.970       9.974       9.978       9.981       9.984       9.987       9.989    
         9.991       9.992       9.994       9.995       9.996       9.997       9.997       9.998       9.998       9.999    
-        9.999       9.999       9.999       9.999       9.999       9.999       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  33    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.998    
+        9.999       9.999       9.999       9.999       9.999       9.999      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  33   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.998    
         9.998       9.997       9.997       9.996       9.995       9.994       9.993       9.991       9.989       9.987    
         9.984       9.981       9.977       9.973       9.969       9.964       9.958       9.952       9.946       9.939    
         9.932       9.925       9.918       9.911       9.905       9.900       9.895       9.892       9.890       9.889    
         9.890       9.892       9.895       9.900       9.905       9.911       9.918       9.925       9.932       9.939    
         9.946       9.952       9.958       9.964       9.969       9.973       9.977       9.981       9.984       9.987    
         9.989       9.991       9.993       9.994       9.995       9.996       9.997       9.997       9.998       9.998    
-        9.999       9.999       9.999       9.999       9.999       9.999       9.999       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  34    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998    
+        9.999       9.999       9.999       9.999       9.999       9.999       9.999      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  34   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000       9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998    
         9.998       9.997       9.996       9.996       9.994       9.993       9.992       9.990       9.987       9.985    
         9.981       9.978       9.973       9.969       9.963       9.957       9.950       9.943       9.935       9.926    
         9.917       9.909       9.900       9.891       9.884       9.877       9.871       9.867       9.864       9.863    
         9.864       9.867       9.871       9.877       9.884       9.891       9.900       9.909       9.917       9.926    
         9.935       9.943       9.950       9.957       9.963       9.969       9.973       9.978       9.981       9.985    
         9.987       9.990       9.992       9.993       9.994       9.996       9.996       9.997       9.998       9.998    
-        9.998       9.999       9.999       9.999       9.999       9.999       9.999       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  35    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998    
+        9.998       9.999       9.999       9.999       9.999       9.999       9.999      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  35   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998    
         9.997       9.997       9.996       9.995       9.994       9.992       9.990       9.988       9.985       9.982    
         9.978       9.974       9.969       9.963       9.956       9.949       9.941       9.932       9.922       9.911    
         9.901       9.890       9.878       9.868       9.858       9.849       9.842       9.836       9.833       9.832    
         9.833       9.836       9.842       9.849       9.858       9.868       9.878       9.890       9.901       9.911    
         9.922       9.932       9.941       9.949       9.956       9.963       9.969       9.974       9.978       9.982    
         9.985       9.988       9.990       9.992       9.994       9.995       9.996       9.997       9.997       9.998    
-        9.998       9.999       9.999       9.999       9.999       9.999       9.999       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  36    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.998    
+        9.998       9.999       9.999       9.999       9.999       9.999       9.999      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  36   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000       9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.998    
         9.997       9.996       9.995       9.994       9.993       9.991       9.989       9.986       9.983       9.979    
         9.975       9.970       9.964       9.957       9.949       9.940       9.930       9.919       9.907       9.894    
         9.881       9.867       9.853       9.840       9.827       9.816       9.807       9.800       9.795       9.794    
         9.795       9.800       9.807       9.816       9.827       9.840       9.853       9.867       9.881       9.894    
         9.907       9.919       9.930       9.940       9.949       9.957       9.964       9.970       9.975       9.979    
         9.983       9.986       9.989       9.991       9.993       9.994       9.995       9.996       9.997       9.998    
-        9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  37    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.997    
+        9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  37   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000       9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.997    
         9.997       9.996       9.995       9.993       9.992       9.990       9.987       9.984       9.981       9.976    
         9.971       9.965       9.958       9.950       9.941       9.930       9.918       9.905       9.890       9.875    
         9.858       9.841       9.824       9.807       9.791       9.777       9.765       9.755       9.750       9.748    
         9.750       9.755       9.765       9.777       9.791       9.807       9.824       9.841       9.858       9.875    
         9.890       9.905       9.918       9.930       9.941       9.950       9.958       9.965       9.971       9.976    
         9.981       9.984       9.987       9.990       9.992       9.993       9.995       9.996       9.997       9.997    
-        9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  38    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
+        9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  38   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.997    
         9.996       9.995       9.994       9.993       9.991       9.989       9.986       9.982       9.978       9.973    
         9.967       9.960       9.952       9.943       9.932       9.919       9.905       9.889       9.872       9.853    
@@ -4718,9 +6085,9 @@ FROM THE SOLVER INPUT FILE.
         9.695       9.702       9.714       9.730       9.749       9.769       9.790       9.812       9.833       9.853    
         9.872       9.889       9.905       9.919       9.932       9.943       9.952       9.960       9.967       9.973    
         9.978       9.982       9.986       9.989       9.991       9.993       9.994       9.995       9.996       9.997    
-        9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999       9.999       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  39    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
+        9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999       9.999      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  39   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
         9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.998       9.997    
         9.996       9.995       9.994       9.992       9.990       9.987       9.984       9.980       9.976       9.970    
         9.963       9.955       9.946       9.935       9.922       9.907       9.890       9.872       9.851       9.828    
@@ -4728,9 +6095,9 @@ FROM THE SOLVER INPUT FILE.
         9.629       9.639       9.655       9.675       9.699       9.724       9.751       9.778       9.804       9.828    
         9.851       9.872       9.890       9.907       9.922       9.935       9.946       9.955       9.963       9.970    
         9.976       9.980       9.984       9.987       9.990       9.992       9.994       9.995       9.996       9.997    
-        9.998       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  40    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
+        9.998       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  40   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
         9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.997       9.997    
         9.996       9.994       9.993       9.991       9.989       9.986       9.982       9.978       9.973       9.966    
         9.959       9.950       9.939       9.926       9.911       9.894       9.875       9.853       9.828       9.801    
@@ -4738,9 +6105,9 @@ FROM THE SOLVER INPUT FILE.
         9.550       9.563       9.583       9.610       9.640       9.673       9.706       9.739       9.771       9.801    
         9.828       9.853       9.875       9.894       9.911       9.926       9.939       9.950       9.959       9.966    
         9.973       9.978       9.982       9.986       9.989       9.991       9.993       9.994       9.996       9.997    
-        9.997       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  41    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
+        9.997       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  41   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
         9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.997       9.996    
         9.995       9.994       9.992       9.990       9.988       9.985       9.981       9.976       9.970       9.963    
         9.954       9.944       9.932       9.917       9.901       9.881       9.858       9.833       9.804       9.771    
@@ -4748,9 +6115,9 @@ FROM THE SOLVER INPUT FILE.
         9.454       9.471       9.499       9.533       9.573       9.614       9.656       9.697       9.735       9.771    
         9.804       9.833       9.858       9.881       9.901       9.917       9.932       9.944       9.954       9.963    
         9.970       9.976       9.981       9.985       9.988       9.990       9.992       9.994       9.995       9.996    
-        9.997       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  42    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999    
+        9.997       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  42   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999    
         9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.998       9.997       9.996    
         9.995       9.994       9.992       9.990       9.987       9.983       9.979       9.974       9.967       9.959    
         9.950       9.938       9.925       9.909       9.890       9.867       9.841       9.812       9.778       9.739    
@@ -4759,8 +6126,8 @@ FROM THE SOLVER INPUT FILE.
         9.778       9.812       9.841       9.867       9.890       9.909       9.925       9.938       9.950       9.959    
         9.967       9.974       9.979       9.983       9.987       9.990       9.992       9.994       9.995       9.996    
         9.997       9.998       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  43    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  43   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999    
         9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.997       9.997       9.996    
         9.995       9.993       9.991       9.989       9.986       9.982       9.977       9.972       9.964       9.956    
         9.945       9.933       9.918       9.900       9.878       9.853       9.824       9.790       9.751       9.706    
@@ -4769,8 +6136,8 @@ FROM THE SOLVER INPUT FILE.
         9.751       9.790       9.824       9.853       9.878       9.900       9.918       9.933       9.945       9.956    
         9.964       9.972       9.977       9.982       9.986       9.989       9.991       9.993       9.995       9.996    
         9.997       9.997       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  44    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  44   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999    
         9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.997       9.997       9.996    
         9.994       9.993       9.991       9.988       9.985       9.981       9.976       9.970       9.962       9.953    
         9.941       9.928       9.911       9.891       9.868       9.840       9.807       9.769       9.724       9.673    
@@ -4779,8 +6146,8 @@ FROM THE SOLVER INPUT FILE.
         9.724       9.769       9.807       9.840       9.868       9.891       9.911       9.928       9.941       9.953    
         9.962       9.970       9.976       9.981       9.985       9.988       9.991       9.993       9.994       9.996    
         9.997       9.997       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  45    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  45   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999    
         9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.997       9.996       9.995    
         9.994       9.992       9.990       9.987       9.984       9.980       9.974       9.968       9.960       9.950    
         9.938       9.923       9.905       9.884       9.858       9.827       9.791       9.749       9.699       9.640    
@@ -4789,8 +6156,8 @@ FROM THE SOLVER INPUT FILE.
         9.699       9.749       9.791       9.827       9.858       9.884       9.905       9.923       9.938       9.950    
         9.960       9.968       9.974       9.980       9.984       9.987       9.990       9.992       9.994       9.995    
         9.996       9.997       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  46    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  46   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999    
         9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.997       9.996       9.995    
         9.994       9.992       9.990       9.987       9.983       9.979       9.973       9.966       9.958       9.947    
         9.934       9.919       9.900       9.877       9.849       9.816       9.777       9.730       9.675       9.610    
@@ -4799,8 +6166,8 @@ FROM THE SOLVER INPUT FILE.
         9.675       9.730       9.777       9.816       9.849       9.877       9.900       9.919       9.934       9.947    
         9.958       9.966       9.973       9.979       9.983       9.987       9.990       9.992       9.994       9.995    
         9.996       9.997       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  47    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  47   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999    
         9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.997       9.996       9.995    
         9.994       9.992       9.989       9.986       9.983       9.978       9.972       9.965       9.956       9.945    
         9.932       9.915       9.895       9.871       9.842       9.807       9.765       9.714       9.655       9.583    
@@ -4809,8 +6176,8 @@ FROM THE SOLVER INPUT FILE.
         9.655       9.714       9.765       9.807       9.842       9.871       9.895       9.915       9.932       9.945    
         9.956       9.965       9.972       9.978       9.983       9.986       9.989       9.992       9.994       9.995    
         9.996       9.997       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  48    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  48   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999    
         9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.997       9.996       9.995    
         9.993       9.992       9.989       9.986       9.982       9.977       9.971       9.964       9.955       9.943    
         9.929       9.912       9.892       9.867       9.836       9.800       9.755       9.702       9.639       9.563    
@@ -4819,8 +6186,8 @@ FROM THE SOLVER INPUT FILE.
         9.639       9.702       9.755       9.800       9.836       9.867       9.892       9.912       9.929       9.943    
         9.955       9.964       9.971       9.977       9.982       9.986       9.989       9.992       9.993       9.995    
         9.996       9.997       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  49    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  49   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999    
         9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.997       9.996       9.995    
         9.993       9.991       9.989       9.986       9.982       9.977       9.971       9.963       9.954       9.942    
         9.928       9.911       9.890       9.864       9.833       9.795       9.750       9.695       9.629       9.550    
@@ -4829,8 +6196,8 @@ FROM THE SOLVER INPUT FILE.
         9.629       9.695       9.750       9.795       9.833       9.864       9.890       9.911       9.928       9.942    
         9.954       9.963       9.971       9.977       9.982       9.986       9.989       9.991       9.993       9.995    
         9.996       9.997       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  50    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  50   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999    
         9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.997       9.996       9.995    
         9.993       9.991       9.989       9.986       9.982       9.977       9.971       9.963       9.954       9.942    
         9.928       9.910       9.889       9.863       9.832       9.794       9.748       9.692       9.626       9.545    
@@ -4839,8 +6206,8 @@ FROM THE SOLVER INPUT FILE.
         9.626       9.692       9.748       9.794       9.832       9.863       9.889       9.910       9.928       9.942    
         9.954       9.963       9.971       9.977       9.982       9.986       9.989       9.991       9.993       9.995    
         9.996       9.997       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  51    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  51   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999    
         9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.997       9.996       9.995    
         9.993       9.991       9.989       9.986       9.982       9.977       9.971       9.963       9.954       9.942    
         9.928       9.911       9.890       9.864       9.833       9.795       9.750       9.695       9.629       9.550    
@@ -4849,8 +6216,8 @@ FROM THE SOLVER INPUT FILE.
         9.629       9.695       9.750       9.795       9.833       9.864       9.890       9.911       9.928       9.942    
         9.954       9.963       9.971       9.977       9.982       9.986       9.989       9.991       9.993       9.995    
         9.996       9.997       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  52    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  52   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999    
         9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.997       9.996       9.995    
         9.993       9.992       9.989       9.986       9.982       9.977       9.971       9.964       9.955       9.943    
         9.929       9.912       9.892       9.867       9.836       9.800       9.755       9.702       9.639       9.563    
@@ -4859,8 +6226,8 @@ FROM THE SOLVER INPUT FILE.
         9.639       9.702       9.755       9.800       9.836       9.867       9.892       9.912       9.929       9.943    
         9.955       9.964       9.971       9.977       9.982       9.986       9.989       9.992       9.993       9.995    
         9.996       9.997       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  53    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  53   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999    
         9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.997       9.996       9.995    
         9.994       9.992       9.989       9.986       9.983       9.978       9.972       9.965       9.956       9.945    
         9.932       9.915       9.895       9.871       9.842       9.807       9.765       9.714       9.655       9.583    
@@ -4869,8 +6236,8 @@ FROM THE SOLVER INPUT FILE.
         9.655       9.714       9.765       9.807       9.842       9.871       9.895       9.915       9.932       9.945    
         9.956       9.965       9.972       9.978       9.983       9.986       9.989       9.992       9.994       9.995    
         9.996       9.997       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  54    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  54   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999    
         9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.997       9.996       9.995    
         9.994       9.992       9.990       9.987       9.983       9.979       9.973       9.966       9.958       9.947    
         9.934       9.919       9.900       9.877       9.849       9.816       9.777       9.730       9.675       9.610    
@@ -4879,8 +6246,8 @@ FROM THE SOLVER INPUT FILE.
         9.675       9.730       9.777       9.816       9.849       9.877       9.900       9.919       9.934       9.947    
         9.958       9.966       9.973       9.979       9.983       9.987       9.990       9.992       9.994       9.995    
         9.996       9.997       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  55    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  55   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999    
         9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.997       9.996       9.995    
         9.994       9.992       9.990       9.987       9.984       9.980       9.974       9.968       9.960       9.950    
         9.938       9.923       9.905       9.884       9.858       9.827       9.791       9.749       9.699       9.640    
@@ -4889,8 +6256,8 @@ FROM THE SOLVER INPUT FILE.
         9.699       9.749       9.791       9.827       9.858       9.884       9.905       9.923       9.938       9.950    
         9.960       9.968       9.974       9.980       9.984       9.987       9.990       9.992       9.994       9.995    
         9.996       9.997       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  56    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  56   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999    
         9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.997       9.997       9.996    
         9.994       9.993       9.991       9.988       9.985       9.981       9.976       9.970       9.962       9.953    
         9.941       9.928       9.911       9.891       9.868       9.840       9.807       9.769       9.724       9.673    
@@ -4899,8 +6266,8 @@ FROM THE SOLVER INPUT FILE.
         9.724       9.769       9.807       9.840       9.868       9.891       9.911       9.928       9.941       9.953    
         9.962       9.970       9.976       9.981       9.985       9.988       9.991       9.993       9.994       9.996    
         9.997       9.997       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  57    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  57   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999    
         9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.997       9.997       9.996    
         9.995       9.993       9.991       9.989       9.986       9.982       9.977       9.972       9.964       9.956    
         9.945       9.933       9.918       9.900       9.878       9.853       9.824       9.790       9.751       9.706    
@@ -4909,8 +6276,8 @@ FROM THE SOLVER INPUT FILE.
         9.751       9.790       9.824       9.853       9.878       9.900       9.918       9.933       9.945       9.956    
         9.964       9.972       9.977       9.982       9.986       9.989       9.991       9.993       9.995       9.996    
         9.997       9.997       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  58    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  58   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999    
         9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.998       9.997       9.996    
         9.995       9.994       9.992       9.990       9.987       9.983       9.979       9.974       9.967       9.959    
         9.950       9.938       9.925       9.909       9.890       9.867       9.841       9.812       9.778       9.739    
@@ -4919,8 +6286,8 @@ FROM THE SOLVER INPUT FILE.
         9.778       9.812       9.841       9.867       9.890       9.909       9.925       9.938       9.950       9.959    
         9.967       9.974       9.979       9.983       9.987       9.990       9.992       9.994       9.995       9.996    
         9.997       9.998       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  59    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  59   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
         9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.997       9.996    
         9.995       9.994       9.992       9.990       9.988       9.985       9.981       9.976       9.970       9.963    
         9.954       9.944       9.932       9.917       9.901       9.881       9.858       9.833       9.804       9.771    
@@ -4928,9 +6295,9 @@ FROM THE SOLVER INPUT FILE.
         9.454       9.471       9.499       9.533       9.573       9.614       9.656       9.697       9.735       9.771    
         9.804       9.833       9.858       9.881       9.901       9.917       9.932       9.944       9.954       9.963    
         9.970       9.976       9.981       9.985       9.988       9.990       9.992       9.994       9.995       9.996    
-        9.997       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  60    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
+        9.997       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  60   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
         9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.997       9.997    
         9.996       9.994       9.993       9.991       9.989       9.986       9.982       9.978       9.973       9.966    
         9.959       9.950       9.939       9.926       9.911       9.894       9.875       9.853       9.828       9.801    
@@ -4938,9 +6305,9 @@ FROM THE SOLVER INPUT FILE.
         9.550       9.563       9.583       9.610       9.640       9.673       9.706       9.739       9.771       9.801    
         9.828       9.853       9.875       9.894       9.911       9.926       9.939       9.950       9.959       9.966    
         9.973       9.978       9.982       9.986       9.989       9.991       9.993       9.994       9.996       9.997    
-        9.997       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  61    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
+        9.997       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  61   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
         9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.998       9.997    
         9.996       9.995       9.994       9.992       9.990       9.987       9.984       9.980       9.976       9.970    
         9.963       9.955       9.946       9.935       9.922       9.907       9.890       9.872       9.851       9.828    
@@ -4948,9 +6315,9 @@ FROM THE SOLVER INPUT FILE.
         9.629       9.639       9.655       9.675       9.699       9.724       9.751       9.778       9.804       9.828    
         9.851       9.872       9.890       9.907       9.922       9.935       9.946       9.955       9.963       9.970    
         9.976       9.980       9.984       9.987       9.990       9.992       9.994       9.995       9.996       9.997    
-        9.998       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  62    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
+        9.998       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  62   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.997    
         9.996       9.995       9.994       9.993       9.991       9.989       9.986       9.982       9.978       9.973    
         9.967       9.960       9.952       9.943       9.932       9.919       9.905       9.889       9.872       9.853    
@@ -4958,388 +6325,388 @@ FROM THE SOLVER INPUT FILE.
         9.695       9.702       9.714       9.730       9.749       9.769       9.790       9.812       9.833       9.853    
         9.872       9.889       9.905       9.919       9.932       9.943       9.952       9.960       9.967       9.973    
         9.978       9.982       9.986       9.989       9.991       9.993       9.994       9.995       9.996       9.997    
-        9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999       9.999       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  63    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.997    
+        9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999       9.999      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  63   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000       9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.997    
         9.997       9.996       9.995       9.993       9.992       9.990       9.987       9.984       9.981       9.976    
         9.971       9.965       9.958       9.950       9.941       9.930       9.918       9.905       9.890       9.875    
         9.858       9.841       9.824       9.807       9.791       9.777       9.765       9.755       9.750       9.748    
         9.750       9.755       9.765       9.777       9.791       9.807       9.824       9.841       9.858       9.875    
         9.890       9.905       9.918       9.930       9.941       9.950       9.958       9.965       9.971       9.976    
         9.981       9.984       9.987       9.990       9.992       9.993       9.995       9.996       9.997       9.997    
-        9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  64    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.998    
+        9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  64   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000       9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.998    
         9.997       9.996       9.995       9.994       9.993       9.991       9.989       9.986       9.983       9.979    
         9.975       9.970       9.964       9.957       9.949       9.940       9.930       9.919       9.907       9.894    
         9.881       9.867       9.853       9.840       9.827       9.816       9.807       9.800       9.795       9.794    
         9.795       9.800       9.807       9.816       9.827       9.840       9.853       9.867       9.881       9.894    
         9.907       9.919       9.930       9.940       9.949       9.957       9.964       9.970       9.975       9.979    
         9.983       9.986       9.989       9.991       9.993       9.994       9.995       9.996       9.997       9.998    
-        9.998       9.999       9.999       9.999       9.999       9.999       9.999       9.999       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  65    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998    
+        9.998       9.999       9.999       9.999       9.999       9.999       9.999       9.999      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  65   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998    
         9.997       9.997       9.996       9.995       9.994       9.992       9.990       9.988       9.985       9.982    
         9.978       9.974       9.969       9.963       9.956       9.949       9.941       9.932       9.922       9.911    
         9.901       9.890       9.878       9.868       9.858       9.849       9.842       9.836       9.833       9.832    
         9.833       9.836       9.842       9.849       9.858       9.868       9.878       9.890       9.901       9.911    
         9.922       9.932       9.941       9.949       9.956       9.963       9.969       9.974       9.978       9.982    
         9.985       9.988       9.990       9.992       9.994       9.995       9.996       9.997       9.997       9.998    
-        9.998       9.999       9.999       9.999       9.999       9.999       9.999       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  66    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998    
+        9.998       9.999       9.999       9.999       9.999       9.999       9.999      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  66   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000       9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998    
         9.998       9.997       9.996       9.996       9.994       9.993       9.992       9.990       9.987       9.985    
         9.981       9.978       9.973       9.969       9.963       9.957       9.950       9.943       9.935       9.926    
         9.917       9.909       9.900       9.891       9.884       9.877       9.871       9.867       9.864       9.863    
         9.864       9.867       9.871       9.877       9.884       9.891       9.900       9.909       9.917       9.926    
         9.935       9.943       9.950       9.957       9.963       9.969       9.973       9.978       9.981       9.985    
         9.987       9.990       9.992       9.993       9.994       9.996       9.996       9.997       9.998       9.998    
-        9.998       9.999       9.999       9.999       9.999       9.999       9.999       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  67    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.998    
+        9.998       9.999       9.999       9.999       9.999       9.999       9.999      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  67   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.998    
         9.998       9.997       9.997       9.996       9.995       9.994       9.993       9.991       9.989       9.987    
         9.984       9.981       9.977       9.973       9.969       9.964       9.958       9.952       9.946       9.939    
         9.932       9.925       9.918       9.911       9.905       9.900       9.895       9.892       9.890       9.889    
         9.890       9.892       9.895       9.900       9.905       9.911       9.918       9.925       9.932       9.939    
         9.946       9.952       9.958       9.964       9.969       9.973       9.977       9.981       9.984       9.987    
         9.989       9.991       9.993       9.994       9.995       9.996       9.997       9.997       9.998       9.998    
-        9.999       9.999       9.999       9.999       9.999       9.999       9.999       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  68    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999       9.999       9.999       9.999      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  68   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
         9.998       9.998       9.997       9.997       9.996       9.995       9.994       9.992       9.991       9.989    
         9.987       9.984       9.981       9.978       9.974       9.970       9.965       9.960       9.955       9.950    
         9.944       9.938       9.933       9.928       9.923       9.919       9.915       9.912       9.911       9.910    
         9.911       9.912       9.915       9.919       9.923       9.928       9.933       9.938       9.944       9.950    
         9.955       9.960       9.965       9.970       9.974       9.978       9.981       9.984       9.987       9.989    
         9.991       9.992       9.994       9.995       9.996       9.997       9.997       9.998       9.998       9.999    
-        9.999       9.999       9.999       9.999       9.999       9.999       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  69    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999       9.999       9.999      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  69   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
         9.998       9.998       9.998       9.997       9.996       9.996       9.995       9.994       9.992       9.991    
         9.989       9.987       9.984       9.981       9.978       9.975       9.971       9.967       9.963       9.959    
         9.954       9.950       9.945       9.941       9.938       9.934       9.932       9.929       9.928       9.928    
         9.928       9.929       9.932       9.934       9.938       9.941       9.945       9.950       9.954       9.959    
         9.963       9.967       9.971       9.975       9.978       9.981       9.984       9.987       9.989       9.991    
         9.992       9.994       9.995       9.996       9.996       9.997       9.998       9.998       9.998       9.999    
-        9.999       9.999       9.999       9.999       9.999       9.999       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  70    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       9.999       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999       9.999       9.999      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  70   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000       9.999       9.999       9.999       9.999       9.999       9.999    
         9.999       9.998       9.998       9.997       9.997       9.996       9.995       9.995       9.993       9.992    
         9.991       9.989       9.987       9.985       9.982       9.979       9.976       9.973       9.970       9.966    
         9.963       9.959       9.956       9.953       9.950       9.947       9.945       9.943       9.942       9.942    
         9.942       9.943       9.945       9.947       9.950       9.953       9.956       9.959       9.963       9.966    
         9.970       9.973       9.976       9.979       9.982       9.985       9.987       9.989       9.991       9.992    
         9.993       9.995       9.995       9.996       9.997       9.997       9.998       9.998       9.999       9.999    
-        9.999       9.999       9.999       9.999       9.999       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  71    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       9.999       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999       9.999      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  71   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000       9.999       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.998       9.998       9.997       9.997       9.996       9.995       9.994       9.993    
         9.992       9.991       9.989       9.987       9.985       9.983       9.981       9.978       9.976       9.973    
         9.970       9.967       9.964       9.962       9.960       9.958       9.956       9.955       9.954       9.954    
         9.954       9.955       9.956       9.958       9.960       9.962       9.964       9.967       9.970       9.973    
         9.976       9.978       9.981       9.983       9.985       9.987       9.989       9.991       9.992       9.993    
         9.994       9.995       9.996       9.997       9.997       9.998       9.998       9.999       9.999       9.999    
-        9.999       9.999       9.999       9.999       9.999       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  72    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999       9.999      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  72   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.998       9.998       9.998       9.997       9.997       9.996       9.995       9.995    
         9.994       9.992       9.991       9.990       9.988       9.986       9.984       9.982       9.980       9.978    
         9.976       9.974       9.972       9.970       9.968       9.966       9.965       9.964       9.963       9.963    
         9.963       9.964       9.965       9.966       9.968       9.970       9.972       9.974       9.976       9.978    
         9.980       9.982       9.984       9.986       9.988       9.990       9.991       9.992       9.994       9.995    
         9.995       9.996       9.997       9.997       9.998       9.998       9.998       9.999       9.999       9.999    
-        9.999       9.999       9.999       9.999       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  73    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  73   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000       9.999       9.999       9.999       9.999    
         9.999       9.999       9.999       9.998       9.998       9.998       9.997       9.997       9.996       9.995    
         9.995       9.994       9.993       9.992       9.990       9.989       9.987       9.986       9.984       9.982    
         9.981       9.979       9.977       9.976       9.974       9.973       9.972       9.971       9.971       9.971    
         9.971       9.971       9.972       9.973       9.974       9.976       9.977       9.979       9.981       9.982    
         9.984       9.986       9.987       9.989       9.990       9.992       9.993       9.994       9.995       9.995    
         9.996       9.997       9.997       9.998       9.998       9.998       9.999       9.999       9.999       9.999    
-        9.999       9.999       9.999       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  74    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  74   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000       9.999       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.998       9.998       9.998       9.997       9.997       9.996    
         9.996       9.995       9.994       9.993       9.992       9.991       9.990       9.989       9.987       9.986    
         9.985       9.983       9.982       9.981       9.980       9.979       9.978       9.977       9.977       9.977    
         9.977       9.977       9.978       9.979       9.980       9.981       9.982       9.983       9.985       9.986    
         9.987       9.989       9.990       9.991       9.992       9.993       9.994       9.995       9.996       9.996    
         9.997       9.997       9.998       9.998       9.998       9.999       9.999       9.999       9.999       9.999    
-        9.999       9.999       9.999       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  75    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999       9.999       9.999    
+        9.999       9.999       9.999      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  75   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.998       9.997       9.997    
         9.996       9.996       9.995       9.994       9.994       9.993       9.992       9.991       9.990       9.989    
         9.988       9.987       9.986       9.985       9.984       9.983       9.983       9.982       9.982       9.982    
         9.982       9.982       9.983       9.983       9.984       9.985       9.986       9.987       9.988       9.989    
         9.990       9.991       9.992       9.993       9.994       9.994       9.995       9.996       9.996       9.997    
         9.997       9.998       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999    
-        9.999       9.999       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  76    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999       9.999    
+        9.999       9.999      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  76   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.998       9.997    
         9.997       9.997       9.996       9.996       9.995       9.994       9.993       9.993       9.992       9.991    
         9.990       9.990       9.989       9.988       9.987       9.987       9.986       9.986       9.986       9.986    
         9.986       9.986       9.986       9.987       9.987       9.988       9.989       9.990       9.990       9.991    
         9.992       9.993       9.993       9.994       9.995       9.996       9.996       9.997       9.997       9.997    
         9.998       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
-        9.999       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  77    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999    
+        9.999      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  77   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.998    
         9.998       9.997       9.997       9.996       9.996       9.995       9.995       9.994       9.994       9.993    
         9.992       9.992       9.991       9.991       9.990       9.990       9.989       9.989       9.989       9.989    
         9.989       9.989       9.989       9.990       9.990       9.991       9.991       9.992       9.992       9.993    
         9.994       9.994       9.995       9.995       9.996       9.996       9.997       9.997       9.998       9.998    
         9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  78    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  78   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.998    
         9.998       9.998       9.997       9.997       9.997       9.996       9.996       9.995       9.995       9.994    
         9.994       9.994       9.993       9.993       9.992       9.992       9.992       9.992       9.991       9.991    
         9.991       9.992       9.992       9.992       9.992       9.993       9.993       9.994       9.994       9.994    
         9.995       9.995       9.996       9.996       9.997       9.997       9.997       9.998       9.998       9.998    
-        9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  79    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  79   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
         9.998       9.998       9.998       9.998       9.997       9.997       9.997       9.996       9.996       9.996    
         9.995       9.995       9.995       9.994       9.994       9.994       9.994       9.993       9.993       9.993    
         9.993       9.993       9.994       9.994       9.994       9.994       9.995       9.995       9.995       9.996    
         9.996       9.996       9.997       9.997       9.997       9.998       9.998       9.998       9.998       9.999    
-        9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  80    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  80   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.998       9.998       9.998       9.998       9.997       9.997       9.997       9.997    
         9.996       9.996       9.996       9.996       9.995       9.995       9.995       9.995       9.995       9.995    
         9.995       9.995       9.995       9.995       9.995       9.996       9.996       9.996       9.996       9.997    
         9.997       9.997       9.997       9.998       9.998       9.998       9.998       9.999       9.999       9.999    
-        9.999       9.999       9.999       9.999       9.999       9.999       9.999       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  81    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999       9.999       9.999       9.999      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  81   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.999       9.998       9.998       9.998       9.998       9.998       9.998       9.997    
         9.997       9.997       9.997       9.997       9.996       9.996       9.996       9.996       9.996       9.996    
         9.996       9.996       9.996       9.996       9.996       9.997       9.997       9.997       9.997       9.997    
         9.998       9.998       9.998       9.998       9.998       9.998       9.999       9.999       9.999       9.999    
-        9.999       9.999       9.999       9.999       9.999       9.999       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  82    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       9.999       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999       9.999       9.999      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  82   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000       9.999       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.998       9.998       9.998       9.998       9.998    
         9.998       9.998       9.997       9.997       9.997       9.997       9.997       9.997       9.997       9.997    
         9.997       9.997       9.997       9.997       9.997       9.997       9.997       9.998       9.998       9.998    
         9.998       9.998       9.998       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
-        9.999       9.999       9.999       9.999       9.999       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  83    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999       9.999      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  83   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.998       9.998    
         9.998       9.998       9.998       9.998       9.998       9.998       9.998       9.998       9.998       9.998    
         9.998       9.998       9.998       9.998       9.998       9.998       9.998       9.998       9.998       9.998    
         9.998       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
-        9.999       9.999       9.999       9.999       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  84    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  84   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
         9.999       9.998       9.998       9.998       9.998       9.998       9.998       9.998       9.998       9.998    
         9.998       9.998       9.998       9.998       9.998       9.998       9.998       9.998       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
-        9.999       9.999       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  85    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999       9.999    
+        9.999       9.999      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  85   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
-        9.999       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  86    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
+        9.999      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  86   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
-        9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  87    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  87   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
-        9.999       9.999       9.999       9.999       9.999       9.999       9.999       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  88    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999       9.999       9.999       9.999      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  88   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
-        9.999       9.999       9.999       9.999       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  89    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  89   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
         9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
-        9.999       9.999       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  90    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
-        9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  91    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  92    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  93    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  94    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  95    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  96    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  97    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  98    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-  99    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
- 100    10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
-        10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00       10.00    
+        9.999       9.999      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  90   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999    
+        9.999       9.999       9.999       9.999       9.999       9.999       9.999       9.999      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  91   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  92   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  93   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  94   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  95   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  96   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  97   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  98   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+  99   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+ 100   10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
+       10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000      10.000    
 1
               HEAD IN LAYER   2 AT END OF TIME STEP 160 IN STRESS PERIOD    1
   ---------------------------------------------------------------------------
@@ -5840,7 +7207,7 @@ FROM THE SOLVER INPUT FILE.
        -6.909      -6.937      -6.967      -6.998      -7.032      -7.067      -7.105      -7.145      -7.188      -7.234    
        -7.283      -7.335      -7.391      -7.451      -7.516      -7.586      -7.661      -7.744      -7.834      -7.933    
        -8.043      -8.166      -8.306      -8.468      -8.658      -8.887      -9.172      -9.537      -10.00      -10.47    
-      -10.000      -9.535      -9.169      -8.883      -8.654      -8.463      -8.301      -8.160      -8.035      -7.925    
+       -10.00      -9.535      -9.169      -8.883      -8.654      -8.463      -8.301      -8.160      -8.035      -7.925    
        -7.825      -7.734      -7.651      -7.574      -7.504      -7.438      -7.377      -7.320      -7.267      -7.218    
        -7.171      -7.127      -7.086      -7.047      -7.011      -6.976      -6.944      -6.914      -6.885      -6.858    
        -6.833      -6.810      -6.788      -6.767      -6.748      -6.730      -6.714      -6.699      -6.685      -6.672    
@@ -5859,7 +7226,7 @@ FROM THE SOLVER INPUT FILE.
        -6.717      -6.730      -6.744      -6.760      -6.777      -6.795      -6.815      -6.836      -6.858      -6.883    
        -6.909      -6.936      -6.966      -6.997      -7.031      -7.066      -7.104      -7.145      -7.188      -7.233    
        -7.282      -7.335      -7.390      -7.451      -7.515      -7.585      -7.661      -7.743      -7.833      -7.932    
-       -8.042      -8.165      -8.306      -8.467      -8.657      -8.886      -9.171      -9.536     -10.000      -10.46    
+       -8.042      -8.165      -8.306      -8.467      -8.657      -8.886      -9.171      -9.536      -10.00      -10.46    
        -9.999      -9.534      -9.168      -8.883      -8.653      -8.462      -8.300      -8.159      -8.035      -7.924    
        -7.824      -7.733      -7.650      -7.573      -7.503      -7.437      -7.376      -7.320      -7.267      -7.217    
        -7.170      -7.126      -7.085      -7.046      -7.010      -6.976      -6.943      -6.913      -6.885      -6.858    
@@ -8428,11 +9795,11 @@ FROM THE SOLVER INPUT FILE.
          CLN STORAGE =           0.0000           CLN STORAGE =           0.0000
        CONSTANT HEAD =           0.0000         CONSTANT HEAD =           0.0000
       CLN CONST HEAD =           0.0000        CLN CONST HEAD =           0.0000
-               WELLS =     9318736.2266                 WELLS =       35947.7031
+               WELLS =     9318736.2195                 WELLS =       35947.7031
 
-           TOTAL OUT =     9319080.2988             TOTAL OUT =       35947.9351
+           TOTAL OUT =     9319080.2917             TOTAL OUT =       35947.9351
 
-            IN - OUT =         -73.5472              IN - OUT =           0.3524
+            IN - OUT =         -73.5401              IN - OUT =           0.3524
 
  PERCENT DISCREPANCY =          -0.00     PERCENT DISCREPANCY =           0.00
 
@@ -8444,11 +9811,11 @@ FROM THE SOLVER INPUT FILE.
           TIME SUMMARY AT END OF TIME STEP       160 IN STRESS PERIOD         1
                     SECONDS     MINUTES      HOURS       DAYS        YEARS
                     -----------------------------------------------------------
-   TIME STEP LENGTH  86400.      1440.0      24.000     1.00000     2.73785E-03
+   TIME STEP LENGTH  86400.      1440.0      24.000      1.0000     2.73785E-03
  STRESS PERIOD TIME 1.38240E+07 2.30400E+05  3840.0      160.00     0.43806    
          TOTAL TIME 1.38240E+07 2.30400E+05  3840.0      160.00     0.43806    
 1
 
- Run end date and time (yyyy/mm/dd hh:mm:ss): 2014/03/21  7:23:56
- Elapsed run time: 19.532 Seconds
+ Run end date and time (yyyy/mm/dd hh:mm:ss): 2019/08/14 12:41:51
+ Elapsed run time: 16.780 Seconds
 

--- a/flopy/utils/mflistfile.py
+++ b/flopy/utils/mflistfile.py
@@ -619,7 +619,7 @@ class ListBudget(object):
                     # Add list to overall list of data
                     lsData.append(ls)
         f.close()
-        
+
         return(np.rec.fromrecords([tuple(x) for x in lsData],
                                   dtype=dtype))
 

--- a/flopy/utils/mflistfile.py
+++ b/flopy/utils/mflistfile.py
@@ -11,6 +11,7 @@ import re
 import sys
 from datetime import timedelta
 import numpy as np
+import errno
 
 from ..utils.utils_def import totim_to_datetime
 
@@ -509,6 +510,118 @@ class ListBudget(object):
             df_flux.sort_index(axis=1, inplace=True)
             df_vol.sort_index(axis=1, inplace=True)
             return df_flux, df_vol
+
+    def get_reduced_pumping(self):
+        """
+        Get numpy recarray of reduced pumping data from a list file.
+        Reduced pumping data most have been written to the list file
+        during the model run. Works with MfListBudget and MfusgListBudget.
+
+        Returns
+        -------
+        numpy recarray
+            A numpy recarray with the reduced pumping data from the list
+            file.
+
+        Example
+        --------
+        >>> objLST = MfListBudget("my_model.lst")
+        >>> raryReducedPpg = objLST.get_reduced_pumping()
+        >>> dfReducedPpg = pd.DataFrame.from_records(raryReducedPpg)
+
+        """
+
+        # Ensure list file exists
+        if not os.path.isfile(self.f.name):
+            raise FileNotFoundError(errno.ENOENT,
+                                    os.strerror(errno.ENOENT),
+                                    self.f.name)
+
+        # Eval based on model list type
+        if isinstance(self, MfListBudget):
+            # Check if reduced pumping data was set to be written
+            #to list file
+            sCheck = 'WELLS WITH REDUCED PUMPING WILL BE REPORTED '+\
+                     'TO THE MAIN LISTING FILE'
+            assert open(self.f.name).read().find(sCheck) > 0,\
+                   'Pumping reductions not written to list file. ' +\
+                   'Try removing "noprint" keyword from well file.'
+
+            # Set dtypes for resulting data
+            dtype = np.dtype([('SP', np.int32), ('TS', np.int32),
+                              ('LAY', np.int32), ('ROW', np.int32),
+                              ('COL', np.int32), ('APPL.Q', np.float64),
+                              ('ACT.Q', np.float64),
+                              ('GW-HEAD', np.float64),
+                              ('CELL-BOT', np.float64)])
+
+            # Define string to id start of reduced ppg data
+            sKey = 'WELLS WITH REDUCED PUMPING FOR STRESS PERIOD'
+
+        elif isinstance(self, MfusgListBudget):
+            # Check if reduced pumping data was written and if set to
+            #be written to list file
+            sCheck = 'WELL REDUCTION INFO WILL BE WRITTEN TO UNIT:'
+            bLstUnit = False
+            bRdcdPpg = False
+            for l in open(self.f.name):
+                # Assumes LST unit always first
+                if 'UNIT' in l and not bLstUnit:
+                    iLstUnit = int(l.strip().split()[-1])
+                    bLstUnit = True
+                if sCheck in l:
+                    bRdcdPpg = True
+                    assert int(l.strip().split()[-1]) == iLstUnit,\
+                    'Pumping reductions not written to list file. ' +\
+                    'Try setting iunitafr to the list file unit number.'
+            assert bRdcdPpg, 'Auto pumping reductions not active.'
+
+            # Set dtypes for resulting data
+            dtype = np.dtype([('SP', np.int32), ('TS', np.int32),
+                              ('WELL.NO', np.int32),
+                              ('CLN NODE', np.int32),
+                              ('APPL.Q', np.float64),
+                              ('ACT.Q', np.float64),
+                              ('GW_HEAD', np.float64),
+                              ('CELL_BOT', np.float64)])
+
+            # Define string to id start of reduced ppg data
+            sKey = 'WELLS WITH REDUCED PUMPING FOR STRESS PERIOD'
+
+        #elif isinstance(self, other ListBudget class):
+
+        else:
+            msg = 'get_reduced_pumping() is only implemented for the ' +\
+                  'MfListBudget or MfusgListBudget classes. Please ' +\
+                  'feel free to expand the functionality to other ' +\
+                  'ListBudget classes.'
+            raise NotImplementedError(msg)
+
+        # Iterate through list file to read in reduced ppg info
+        f = open(self.f.name)
+        lsData = []
+        for l in f:
+            # If l is reduced ppg header row
+            if sKey in l:
+                # Extract sp and ts
+                ts, sp = self._get_ts_sp(l)
+                l = f.readline()
+                # Iterate through lines of reduced ppg data
+                while True:
+                    l = f.readline()
+                    # Condition to exit loop
+                    if len(l.strip().split()) < 6:
+                        break
+                    # Create list of hold line of data
+                    ls = [sp,ts]
+                    # Add other data to list
+                    ls.extend([float(x) for x in l.split()])
+                    # Add list to overall list of data
+                    lsData.append(ls)
+        f.close()
+        
+        return(np.rec.fromrecords([tuple(x) for x in lsData],
+                                  dtype=dtype))
 
     def _build_index(self, maxentries):
         self.idx_map = self._get_index(maxentries)

--- a/flopy/utils/mflistfile.py
+++ b/flopy/utils/mflistfile.py
@@ -540,12 +540,12 @@ class ListBudget(object):
         # Eval based on model list type
         if isinstance(self, MfListBudget):
             # Check if reduced pumping data was set to be written
-            #to list file
-            sCheck = 'WELLS WITH REDUCED PUMPING WILL BE REPORTED '+\
+            # to list file
+            sCheck = 'WELLS WITH REDUCED PUMPING WILL BE REPORTED ' +\
                      'TO THE MAIN LISTING FILE'
             assert open(self.f.name).read().find(sCheck) > 0,\
-                   'Pumping reductions not written to list file. ' +\
-                   'Try removing "noprint" keyword from well file.'
+                'Pumping reductions not written to list file. ' +\
+                'Try removing "noprint" keyword from well file.'
 
             # Set dtypes for resulting data
             dtype = np.dtype([('SP', np.int32), ('TS', np.int32),
@@ -560,7 +560,7 @@ class ListBudget(object):
 
         elif isinstance(self, MfusgListBudget):
             # Check if reduced pumping data was written and if set to
-            #be written to list file
+            # be written to list file
             sCheck = 'WELL REDUCTION INFO WILL BE WRITTEN TO UNIT:'
             bLstUnit = False
             bRdcdPpg = False
@@ -572,8 +572,8 @@ class ListBudget(object):
                 if sCheck in l:
                     bRdcdPpg = True
                     assert int(l.strip().split()[-1]) == iLstUnit,\
-                    'Pumping reductions not written to list file. ' +\
-                    'Try setting iunitafr to the list file unit number.'
+                        'Pumping reductions not written to list file. ' +\
+                        'Try setting iunitafr to the list file unit number.'
             assert bRdcdPpg, 'Auto pumping reductions not active.'
 
             # Set dtypes for resulting data
@@ -588,7 +588,7 @@ class ListBudget(object):
             # Define string to id start of reduced ppg data
             sKey = 'WELLS WITH REDUCED PUMPING FOR STRESS PERIOD'
 
-        #elif isinstance(self, other ListBudget class):
+        # elif isinstance(self, other ListBudget class):
 
         else:
             msg = 'get_reduced_pumping() is only implemented for the ' +\
@@ -600,12 +600,16 @@ class ListBudget(object):
         # Iterate through list file to read in reduced ppg info
         f = open(self.f.name)
         lsData = []
-        for l in f:
+        while True:
+            l = f.readline()
+            if l == '':
+                break
             # If l is reduced ppg header row
             if sKey in l:
                 # Extract sp and ts
                 ts, sp = self._get_ts_sp(l)
-                l = f.readline()
+                # Skip line of data column titles
+                f.readline()
                 # Iterate through lines of reduced ppg data
                 while True:
                     l = f.readline()
@@ -613,7 +617,7 @@ class ListBudget(object):
                     if len(l.strip().split()) < 6:
                         break
                     # Create list of hold line of data
-                    ls = [sp,ts]
+                    ls = [sp, ts]
                     # Add other data to list
                     ls.extend([float(x) for x in l.split()])
                     # Add list to overall list of data


### PR DESCRIPTION
Adds a method to the ListBudget class to read in data from the list file on automatic reductions to WEL extractions. This method supports both NWT and USG list files. Adds auto tests for both success and failure. I couldn't find any included data sets with reductions written to the LST, so I updated a USG data set to allow for the auto test.