### PR TITLE
fix(mtbtn): options from load method ignored

### DIFF
--- a/autotest/t012_test.py
+++ b/autotest/t012_test.py
@@ -39,6 +39,12 @@ def test_mf2005_p07():
     namfile = 'p7mt.nam'
     mt = flopy.mt3d.mt.Mt3dms.load(namfile, model_ws=pth, verbose=True,
                                    exe_name=mt3d_exe)
+    # Optional keyword line is absent in this example, ensure defaults are kept
+    assert mt.btn.DRYCell is False
+    assert mt.btn.Legacy99Stor is False
+    assert mt.btn.MFStyleArr is False
+    assert mt.btn.AltWTSorb is False
+
     mt.model_ws = cpth
     ftlfile = 'p7.ftl'
     mt.ftlfilename = ftlfile
@@ -374,6 +380,12 @@ def test_mfnwt_keat_uzf():
     namefile = 'Keat_UZF_mt.nam'
     mt = flopy.mt3d.mt.Mt3dms.load(namefile, model_ws=pth, verbose=True,
                                    version='mt3d-usgs', exe_name=mt3d_usgs_exe)
+    # Check a few options specified as optional keywords on line 3
+    assert mt.btn.DRYCell is True
+    assert mt.btn.Legacy99Stor is False
+    assert mt.btn.MFStyleArr is True
+    assert mt.btn.AltWTSorb is False
+
     mt.model_ws = cpth
     ftlfile = 'Keat_UZF.ftl'
     mt.ftlfilename = ftlfile

--- a/flopy/mt3d/mtbtn.py
+++ b/flopy/mt3d/mtbtn.py
@@ -690,6 +690,8 @@ class Mt3dBtn(Package):
         AltWTSorb = False
         if m_arr[
             0].strip().isdigit() is not True:  # If m_arr[0] is not a digit, it is a keyword
+            if model.verbose:
+                print('   loading optional keywords: {}'.format(line.strip()))
             for i in range(0, len(m_arr)):
                 if m_arr[i].upper() == "MODFLOWSTYLEARRAYS":
                     MFStyleArr = True
@@ -705,8 +707,10 @@ class Mt3dBtn(Package):
                     NoWetDryPrint = True
                 if m_arr[i].upper() == "OMITDRYCELLBUDGET":
                     OmitDryBud = True
-                if m_arr[i].upper() == "AltWTSorb":
+                if m_arr[i].upper() == "ALTWTSORB":
                     AltWTSorb = True
+        elif model.verbose:
+            print('   optional keywords not identifed/loaded')
 
         # A3
         if model.verbose:
@@ -954,7 +958,11 @@ class Mt3dBtn(Package):
                 model.get_ext_dict_attr(ext_unit_dict,
                                         filetype=Mt3dBtn.ftype())
 
-        btn = Mt3dBtn(model, nlay=nlay, nrow=nrow, ncol=ncol, nper=nper,
+        btn = Mt3dBtn(model, MFStyleArr=MFStyleArr, DRYCell=DRYCell,
+                      Legacy99Stor=Legacy99Stor, FTLPrint=FTLPrint,
+                      NoWetDryPrint=NoWetDryPrint, OmitDryBud=OmitDryBud,
+                      AltWTSorb=AltWTSorb,
+                      nlay=nlay, nrow=nrow, ncol=ncol, nper=nper,
                       ncomp=ncomp, mcomp=mcomp, tunit=tunit,
                       laycon=laycon, delr=delr, delc=delc, htop=htop, dz=dz,
                       lunit=lunit, munit=munit, prsity=prsity, icbund=icbund,


### PR DESCRIPTION
* Pass options from load method to class constructor
* Correct case for "ALTWTSORB" case
* Show verbose message for optional keywords
* Add a unit tests to check options