### PR TITLE
Add feature to allow 'with' context statement to read Head/CellBudget files

### DIFF
--- a/flopy/modflow/mfsfr2.py
+++ b/flopy/modflow/mfsfr2.py
@@ -80,7 +80,7 @@ class ModflowSfr2(Package):
         Output Control (see Harbaugh and others, 2000, pages 52-55). If
         ipakcb = 0, leakage values will not be printed or saved. Printing to
         the listing file (ipakcb < 0) is not supported.
-    istcsb2 : integer
+    istcb2 : integer
         An integer value used as a flag for writing to a separate formatted
         file all information on inflows and outflows from each reach; on
         stream depth, width, and streambed conductance; and on head difference

--- a/flopy/utils/binaryfile.py
+++ b/flopy/utils/binaryfile.py
@@ -261,6 +261,12 @@ class BinaryLayerFile(LayerFile):
                                               kwargs)
         return
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
     def _build_index(self):
         """
         Build the recordarray and iposarray, which maps the header information
@@ -628,6 +634,12 @@ class CellBudgetFile(object):
         # self.value = np.empty((self.nlay, self.nrow, self.ncol),
         #                      dtype=self.realtype)
         return
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
 
     def _totim_from_kstpkper(self, kstpkper):
         if self.dis is None:
@@ -1014,7 +1026,7 @@ class CellBudgetFile(object):
 
         Parameters
         ----------
-        idx : int
+        idx : int or list
             The zero-based record number.  The first record is record 0.
         kstpkper : tuple of ints
             A tuple containing the time step and stress period (kstp, kper).
@@ -1121,6 +1133,11 @@ class CellBudgetFile(object):
         # case where only text is entered
         elif text is not None:
             select_indices = np.where((self.recordarray['text'] == text16))
+
+        else:
+            raise TypeError(
+                "get_data() missing 1 required argument: 'kstpkper', 'totim', "
+                "'idx', or 'text'")
 
         # build and return the record list
         if isinstance(select_indices, tuple):


### PR DESCRIPTION
Here are the primary changes in this PR, related to the Head/CellBudget file readers:
* Allow Head/CellBudgetFile to be opened/closed in a ['with' statement](https://docs.python.org/3/reference/compound_stmts.html#with) which closes the file automatically when done or if an exception is raised
* Raise TypeError if CellBudgetFile.get_data() is called without arguments -- previous behavior raised a different and distracting exception
* Document and test idx as either an int or list of integers -- this is not a new behavior
* Close a few file handles in the test suite

An unrelated commit fixes a typo for a variable name in a docstring for ModflowSfr2