### PR TITLE
fix(Python 2): use a few aliases for exceptions

### DIFF
--- a/autotest/t011_test.py
+++ b/autotest/t011_test.py
@@ -4,9 +4,13 @@ Some basic tests for mflistfile.py module (not super rigorous)
 """
 
 import os
+import sys
 import flopy
 import numpy as np
 from nose.tools import raises
+
+if sys.version_info[0] == 2:
+    FileNotFoundError = IOError
 
 
 def test_mflistfile():

--- a/flopy/utils/gridintersect.py
+++ b/flopy/utils/gridintersect.py
@@ -1,11 +1,14 @@
 import numpy as np
+import sys
+if sys.version_info[0] == 2:
+    ModuleNotFoundError = ImportError
 from .geometry import transform
 try:
     from shapely.geometry import MultiPoint, Point, Polygon, box
     from shapely.strtree import STRtree
     from shapely.affinity import translate, rotate
 except ModuleNotFoundError:
-    print("Shapely is needed for grid intersect operations!"
+    print("Shapely is needed for grid intersect operations! "
           "Please install shapely.")
 
 

--- a/flopy/utils/mflistfile.py
+++ b/flopy/utils/mflistfile.py
@@ -15,6 +15,9 @@ import errno
 
 from ..utils.utils_def import totim_to_datetime
 
+if sys.version_info[0] == 2:
+    FileNotFoundError = IOError
+
 
 class ListBudget(object):
     """


### PR DESCRIPTION
While Python 2 is still supported, fix this issue:
```
Python 2.7.16 |Anaconda, Inc.| (default, Mar 14 2019, 15:42:17) [MSC v.1500 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import flopy
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "flopy\__init__.py", line 33, in <module>
    from . import modflow
  File "flopy\modflow\__init__.py", line 1, in <module>
    from .mf import Modflow
  File "flopy\modflow\mf.py", line 14, in <module>
    from ..mbase import BaseModel
  File "flopy\mbase.py", line 24, in <module>
    from flopy import utils, discretization
  File "flopy\utils\__init__.py", line 48, in <module>
    from .gridintersect import GridIntersect,ModflowGridIndices
  File "flopy\utils\gridintersect.py", line 7, in <module>
    except ModuleNotFoundError:
NameError: name 'ModuleNotFoundError' is not defined
```