### PR TITLE
Close opened files after loading

### DIFF
--- a/flopy/modflow/mfbas.py
+++ b/flopy/modflow/mfbas.py
@@ -302,9 +302,11 @@ class ModflowBas(Package):
             ncol = None
 
         # open the file if not already open
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
+
         # dataset 0 -- header
         while True:
             line = f.readline()
@@ -339,7 +341,8 @@ class ModflowBas(Package):
         # dataset 4 -- strt
         strt = Util3d.load(f, model, (nlay, nrow, ncol), np.float32, 'strt',
                            ext_unit_dict)
-        f.close()
+        if openfile:
+            f.close()
 
         # set package unit number
         unitnumber = None

--- a/flopy/modflow/mfbcf.py
+++ b/flopy/modflow/mfbcf.py
@@ -269,7 +269,8 @@ class ModflowBcf(Package):
         if model.verbose:
             sys.stdout.write('loading bcf package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
 
@@ -405,6 +406,9 @@ class ModflowBcf(Package):
                 t = Util2d.load(f, model, (nrow, ncol), np.float32, 'wetdry',
                                 ext_unit_dict)
                 wetdry[k] = t
+
+        if openfile:
+            f.close()
 
         # set package unit number
         unitnumber = None

--- a/flopy/modflow/mfde4.py
+++ b/flopy/modflow/mfde4.py
@@ -239,9 +239,11 @@ class ModflowDe4(Package):
         if model.verbose:
             sys.stdout.write('loading de4 package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
+
         # read dataset 0 -- header
         while True:
             line = f.readline()
@@ -276,6 +278,9 @@ class ModflowDe4(Package):
             accl = float(line[20:30].strip())
             hclose = float(line[30:40].strip())
             iprd4 = int(line[40:50].strip())
+
+        if openfile:
+            f.close()
 
         # set package unit number
         unitnumber = None

--- a/flopy/modflow/mfdis.py
+++ b/flopy/modflow/mfdis.py
@@ -859,9 +859,11 @@ class ModflowDis(Package):
         if model.verbose:
             sys.stdout.write('loading dis package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
+
         # dataset 0 -- header
         header = ''
         while True:
@@ -999,6 +1001,9 @@ class ModflowDis(Package):
             nstp.append(a2)
             tsmult.append(a3)
             steady.append(a4)
+
+        if openfile:
+            f.close()
 
         # set package unit number
         unitnumber = None

--- a/flopy/modflow/mfdisu.py
+++ b/flopy/modflow/mfdisu.py
@@ -459,7 +459,8 @@ class ModflowDisU(Package):
             print(msg)
             model.version = 'mfusg'
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
 
@@ -655,6 +656,9 @@ class ModflowDisU(Package):
             print('   NSTP {}'.format(nstp))
             print('   TSMULT {}'.format(tsmult))
             print('   STEADY {}'.format(steady))
+
+        if openfile:
+            f.close()
 
         # set package unit number
         unitnumber = None

--- a/flopy/modflow/mfevt.py
+++ b/flopy/modflow/mfevt.py
@@ -226,9 +226,11 @@ class ModflowEvt(Package):
         if model.verbose:
             sys.stdout.write('loading evt package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
+
         # Dataset 0 -- header
         while True:
             line = f.readline()
@@ -330,6 +332,9 @@ class ModflowEvt(Package):
                                     ext_unit_dict)
                     current_ievt = t
                 ievt[iper] = current_ievt
+
+        if openfile:
+            f.close()
 
         # create evt object
         args = {}

--- a/flopy/modflow/mffhb.py
+++ b/flopy/modflow/mffhb.py
@@ -423,7 +423,8 @@ class ModflowFhb(Package):
         if model.verbose:
             sys.stdout.write('loading fhb package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
 
@@ -667,6 +668,9 @@ class ModflowFhb(Package):
                         raw = line.strip().split()
                         current[n] = tuple(raw[:len(dtype.names)])
                     ds8.append(current.copy())
+
+        if openfile:
+            f.close()
 
         # determine specified unit number
         unitnumber = None

--- a/flopy/modflow/mfflwob.py
+++ b/flopy/modflow/mfflwob.py
@@ -389,7 +389,8 @@ class ModflowFlwob(Package):
         if model.verbose:
             sys.stdout.write('loading flwob package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
 
@@ -483,8 +484,8 @@ class ModflowFlwob(Package):
         column = np.array(column) - 1
         factor = np.array(factor)
 
-        # close the file
-        f.close()
+        if openfile:
+            f.close()
 
         # get ext_unit_dict if none passed
         if ext_unit_dict is None:

--- a/flopy/modflow/mfgage.py
+++ b/flopy/modflow/mfgage.py
@@ -294,7 +294,8 @@ class ModflowGage(Package):
         if model.verbose:
             sys.stdout.write('loading gage package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             if sys.version_info[0] == 2:
                 f = open(filename, 'r')
@@ -350,6 +351,9 @@ class ModflowGage(Package):
                                                  model.model_ws)
                         files.append(relpth)
                         break
+
+        if openfile:
+            f.close()
 
         # determine specified unit number
         unitnumber = None

--- a/flopy/modflow/mfgmg.py
+++ b/flopy/modflow/mfgmg.py
@@ -319,9 +319,11 @@ class ModflowGmg(Package):
         if model.verbose:
             sys.stdout.write('loading gmg package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
+
         # dataset 0 -- header
         while True:
             line = f.readline()
@@ -358,8 +360,8 @@ class ModflowGmg(Package):
         t = line.strip().split()
         relax = float(t[0])
 
-        # close the open file
-        f.close()
+        if openfile:
+            f.close()
 
         # determine specified unit number
         unitnumber = None

--- a/flopy/modflow/mfhfb.py
+++ b/flopy/modflow/mfhfb.py
@@ -262,9 +262,11 @@ class ModflowHfb(Package):
         if model.verbose:
             sys.stdout.write('loading hfb6 package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
+
         # dataset 0 -- header
         while True:
             line = f.readline()
@@ -360,6 +362,10 @@ class ModflowHfb(Package):
                 else:
                     bnd_output = stack_arrays((bnd_output, par_current),
                                               asrecarray=True, usemask=False)
+
+        if openfile:
+            f.close()
+
         # set package unit number
         unitnumber = None
         filenames = [None]

--- a/flopy/modflow/mfhob.py
+++ b/flopy/modflow/mfhob.py
@@ -319,9 +319,11 @@ class ModflowHob(Package):
         if model.verbose:
             sys.stdout.write('loading hob package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
+
         # dataset 0 -- header
         while True:
             line = f.readline()
@@ -417,8 +419,8 @@ class ModflowHob(Package):
             if nobs == nh:
                 break
 
-        # close the file
-        f.close()
+        if openfile:
+            f.close()
 
         # set package unit number
         unitnumber = None

--- a/flopy/modflow/mfhyd.py
+++ b/flopy/modflow/mfhyd.py
@@ -299,7 +299,8 @@ class ModflowHyd(Package):
         if model.verbose:
             sys.stdout.write('loading hydmod package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
 
@@ -327,8 +328,8 @@ class ModflowHyd(Package):
             obs['yl'][idx] = float(t[5])
             obs['hydlbl'][idx] = t[6].strip()
 
-        # close the file
-        f.close()
+        if openfile:
+            f.close()
 
         # set package unit number
         unitnumber = None

--- a/flopy/modflow/mflak.py
+++ b/flopy/modflow/mflak.py
@@ -611,7 +611,8 @@ class ModflowLak(Package):
         if model.verbose:
             sys.stdout.write('loading lak package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             if sys.version_info[0] == 2:
                 f = open(filename, 'r')
@@ -788,6 +789,9 @@ class ModflowLak(Package):
                         tds.append(0.)
                     ds9[n] = tds
                 flux_data[iper] = ds9
+
+        if openfile:
+            f.close()
 
         # convert lake data to Transient3d objects
         lake_loc = Transient3d(model, (nlay, nrow, ncol), np.int32,

--- a/flopy/modflow/mflmt.py
+++ b/flopy/modflow/mflmt.py
@@ -183,18 +183,25 @@ class ModflowLmt(Package):
         if model.verbose:
             sys.stdout.write('loading lmt package file...\n')
 
+        openfile = not hasattr(f, 'read')
+        if openfile:
+            filename = f
+            f = open(filename, 'r')
+        elif hasattr(f, 'name'):
+            filename = f.name
+        else:
+            filename = None
+
         # set default values
-        prefix = os.path.basename(f)
-        prefix = prefix[:prefix.rfind('.')]
-        output_file_name = prefix + '.ftl'
+        if filename:
+            prefix = os.path.splitext(os.path.basename(filename))[0]
+            output_file_name = prefix + '.ftl'
+        else:
+            output_file_name = model.name + '.ftl'
         output_file_unit = 333
         output_file_header = 'standard'
         output_file_format = 'unformatted'
         package_flows = []
-
-        if not hasattr(f, 'read'):
-            filename = f
-            f = open(filename, 'r')
 
         for line in f:
             if line[0] == '#':
@@ -215,6 +222,9 @@ class ModflowLmt(Package):
                 if len(t) > 1:
                     for i in range(1, len(t)):
                         package_flows.append(t[i])
+
+        if openfile:
+            f.close()
 
         # determine specified unit number
         unitnumber = None

--- a/flopy/modflow/mflpf.py
+++ b/flopy/modflow/mflpf.py
@@ -388,9 +388,11 @@ class ModflowLpf(Package):
         if model.verbose:
             sys.stdout.write('loading lpf package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
+
         # dataset 0 -- header
         while True:
             line = f.readline()
@@ -589,6 +591,9 @@ class ModflowLpf(Package):
                 t = Util2d.load(f, model, (nrow, ncol), np.float32, 'wetdry',
                                 ext_unit_dict)
                 wetdry[k] = t
+
+        if openfile:
+            f.close()
 
         # set package unit number
         unitnumber = None

--- a/flopy/modflow/mfmlt.py
+++ b/flopy/modflow/mfmlt.py
@@ -154,9 +154,11 @@ class ModflowMlt(Package):
         if model.verbose:
             sys.stdout.write('loading mult package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
+
         # dataset 0 -- header
         while True:
             line = f.readline()
@@ -201,6 +203,9 @@ class ModflowMlt(Package):
                 t = [kwrd, line]
                 t = ModflowMlt.mult_function(mult_dict, line)
             mult_dict[mltnam] = t
+
+        if openfile:
+            f.close()
 
         # set package unit number
         unitnumber = None

--- a/flopy/modflow/mfmnw1.py
+++ b/flopy/modflow/mfmnw1.py
@@ -190,7 +190,8 @@ class ModflowMnw1(Package):
             nrow, ncol, nlay, nper = model.get_nrow_ncol_nlay_nper()
             nper = 1 if nper == 0 else nper  # otherwise iterations from 0, nper won't run
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
 
@@ -246,6 +247,9 @@ class ModflowMnw1(Package):
                 for n in dtype.descr:
                     spd[n[0]] = tmp[n[0]]
                 stress_period_data[per] = spd
+
+        if openfile:
+            f.close()
 
         return ModflowMnw1(model, mxmnw=mxmnw, ipakcb=ipakcb, iwelpt=iwelpt,
                            nomoiter=nomoiter,

--- a/flopy/modflow/mfmnw2.py
+++ b/flopy/modflow/mfmnw2.py
@@ -1206,9 +1206,11 @@ class ModflowMnw2(Package):
             nrow, ncol, nlay, nper = model.get_nrow_ncol_nlay_nper()
             nper = 1 if nper == 0 else nper  # otherwise iterations from 0, nper won't run
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
+
         # dataset 0 (header)
         while True:
             line = next(f)
@@ -1266,7 +1268,9 @@ class ModflowMnw2(Package):
                 mnw[wellid].stress_period_data[per] = \
                     mnw[wellid].stress_period_data[per - 1]
             itmp.append(itmp_per)
-        f.close()
+
+        if openfile:
+            f.close()
 
         # determine specified unit number
         unitnumber = None

--- a/flopy/modflow/mfmnwi.py
+++ b/flopy/modflow/mfmnwi.py
@@ -176,7 +176,8 @@ class ModflowMnwi(Package):
             # otherwise iterations from 0, nper won't run
             nper = 1 if nper == 0 else nper
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
 
@@ -209,6 +210,9 @@ class ModflowMnwi(Package):
                 wellid_unit_qndflag_qhbflag_concflag.append(tmp)
                 if unit not in unique_units:
                     unique_units.append(unit)
+
+        if openfile:
+            f.close()
 
         for unit in unique_units:
             model.add_pop_key_list(unit)

--- a/flopy/modflow/mfnwt.py
+++ b/flopy/modflow/mfnwt.py
@@ -374,14 +374,18 @@ class ModflowNwt(Package):
             print(msg)
             model.version = 'mfnwt'
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
-        # dataset 0 -- header
 
         # dataset 0 -- header
         flines = [line.strip() for line in f.readlines() if
                   not line.strip().startswith('#')]
+
+        if openfile:
+            f.close()
+
         line = flines.pop(0)
 
         # dataset 1

--- a/flopy/modflow/mfoc.py
+++ b/flopy/modflow/mfoc.py
@@ -630,8 +630,8 @@ class ModflowOc(Package):
 
         numericformat = False
 
-        # open file
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
 
@@ -688,8 +688,8 @@ class ModflowOc(Package):
             if iddnun in ext_unit_dict:
                 fddn = ext_unit_dict[iddnun]
 
-        # close the oc file
-        f.close()
+        if openfile:
+            f.close()
 
         # return
         return ihedun, fhead, iddnun, fddn
@@ -788,8 +788,8 @@ class ModflowOc(Package):
 
         stress_period_data = {}
 
-        # open file
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
         else:
@@ -1003,6 +1003,9 @@ class ModflowOc(Package):
                 if iempty == True:
                     kperkstp = (iperoc1 - 1, itsoc1 - 1)
                     stress_period_data[kperkstp] = []
+
+        if openfile:
+            f.close()
 
         # reset unit numbers
         unitnumber = [14, 0, 0, 0, 0]

--- a/flopy/modflow/mfpcg.py
+++ b/flopy/modflow/mfpcg.py
@@ -230,9 +230,11 @@ class ModflowPcg(Package):
         if model.verbose:
             sys.stdout.write('loading pcg package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
+
         # dataset 0 -- header
         while True:
             line = f.readline()
@@ -305,8 +307,8 @@ class ModflowPcg(Package):
             if damp < 0.:
                 dampt = float(line[70:80].strip())
 
-        # close the open file
-        f.close()
+        if openfile:
+            f.close()
 
         # set package unit number
         unitnumber = None

--- a/flopy/modflow/mfpcgn.py
+++ b/flopy/modflow/mfpcgn.py
@@ -380,7 +380,8 @@ class ModflowPcgn(Package):
         if model.verbose:
             sys.stdout.write('loading pcgn package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
 
@@ -486,8 +487,8 @@ class ModflowPcgn(Package):
             rate_c = None
             ipunit = None
 
-        # close the open file
-        f.close()
+        if openfile:
+            f.close()
 
         # determine specified unit number
         unitnumber = None

--- a/flopy/modflow/mfpks.py
+++ b/flopy/modflow/mfpks.py
@@ -231,17 +231,19 @@ class ModflowPks(Package):
         if model.verbose:
             sys.stdout.write('loading pks package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
+
         # dataset 0 -- header
 
         msg = 3 * ' ' + \
               'Warning: load method not completed. default pks object created.'
         print(msg)
 
-        # close the open file
-        f.close()
+        if openfile:
+            f.close()
 
         # set package unit number
         unitnumber = None

--- a/flopy/modflow/mfpval.py
+++ b/flopy/modflow/mfpval.py
@@ -159,7 +159,8 @@ class ModflowPval(Package):
         if model.verbose:
             sys.stdout.write('loading pval package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
         else:
@@ -190,6 +191,9 @@ class ModflowPval(Package):
                 pvalnam = t[0].lower()
 
             pval_dict[pvalnam] = float(t[1])
+
+        if openfile:
+            f.close()
 
         # set package unit number
         unitnumber = None

--- a/flopy/modflow/mfrch.py
+++ b/flopy/modflow/mfrch.py
@@ -344,9 +344,11 @@ class ModflowRch(Package):
         if model.verbose:
             sys.stdout.write('loading rch package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
+
         # dataset 0 -- header
         while True:
             line = f.readline()
@@ -426,6 +428,9 @@ class ModflowRch(Package):
                                     ext_unit_dict)
                     current_irch = t
                 irch[iper] = current_irch
+
+        if openfile:
+            f.close()
 
         # determine specified unit number
         unitnumber = None

--- a/flopy/modflow/mfsfr2.py
+++ b/flopy/modflow/mfsfr2.py
@@ -749,9 +749,11 @@ class ModflowSfr2(Package):
             nper = model.nper
             nper = 1 if nper == 0 else nper  # otherwise iterations from 0, nper won't run
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
+
         # Item 0 -- header
         while True:
             line = f.readline()
@@ -889,6 +891,9 @@ class ModflowSfr2(Package):
 
             else:
                 continue
+
+        if openfile:
+            f.close()
 
         # determine specified unit number
         unitnumber = None

--- a/flopy/modflow/mfsip.py
+++ b/flopy/modflow/mfsip.py
@@ -194,9 +194,11 @@ class ModflowSip(Package):
         if model.verbose:
             sys.stdout.write('loading sip package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
+
         # dataset 0 -- header
         while True:
             line = f.readline()
@@ -227,8 +229,8 @@ class ModflowSip(Package):
             wseed = float(line[30:40].strip())
             iprsip = int(line[40:50].strip())
 
-        # close the open file
-        f.close()
+        if openfile:
+            f.close()
 
         # set package unit number
         unitnumber = None

--- a/flopy/modflow/mfsms.py
+++ b/flopy/modflow/mfsms.py
@@ -378,7 +378,8 @@ class ModflowSms(Package):
             print(msg)
             model.version = 'mfusg'
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
 
@@ -525,6 +526,9 @@ class ModflowSms(Package):
                 print('   IORD {}'.format(iord))
                 print('   RCLOSEPCGU {}'.format(rclosepcgu))
                 print('   RELAXPCGU {}'.format(relaxpcgu))
+
+        if openfile:
+            f.close()
 
         # set package unit number
         unitnumber = None

--- a/flopy/modflow/mfsor.py
+++ b/flopy/modflow/mfsor.py
@@ -167,17 +167,19 @@ class ModflowSor(Package):
         if model.verbose:
             sys.stdout.write('loading sor package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
+
         # dataset 0 -- header
 
         msg = 3 * ' ' + 'Warning: load method not completed. ' + \
               'Default sor object created.'
         print(msg)
 
-        # close the open file
-        f.close()
+        if openfile:
+            f.close()
 
         # set package unit number
         unitnumber = None

--- a/flopy/modflow/mfstr.py
+++ b/flopy/modflow/mfstr.py
@@ -552,7 +552,8 @@ class ModflowStr(Package):
         if model.verbose:
             sys.stdout.write('loading str package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
 
@@ -807,6 +808,9 @@ class ModflowStr(Package):
             else:
                 stress_period_data[iper] = bnd_output
                 segment_data[iper] = seg_output
+
+        if openfile:
+            f.close()
 
         # determine specified unit number
         unitnumber = None

--- a/flopy/modflow/mfsub.py
+++ b/flopy/modflow/mfsub.py
@@ -518,9 +518,11 @@ class ModflowSub(Package):
         if model.verbose:
             sys.stdout.write('loading sub package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
+
         # dataset 0 -- header
         while True:
             line = f.readline()
@@ -701,9 +703,11 @@ class ModflowSub(Package):
                 t = read1d(f, t)
                 t[0:4] -= 1
                 ids16[k] = t
+
+        if openfile:
+            f.close()
+
         model.add_pop_key_list(2051)
-        # close file
-        f.close()
 
         # determine specified unit number
         unitnumber = None

--- a/flopy/modflow/mfswi2.py
+++ b/flopy/modflow/mfswi2.py
@@ -480,9 +480,11 @@ class ModflowSwi2(Package):
         if model.verbose:
             sys.stdout.write('loading swi2 package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
+
         # dataset 0 -- header
         while True:
             line = f.readline()
@@ -663,6 +665,9 @@ class ModflowSwi2(Package):
                 jj = int(t[3]) - 1
                 obslrc.append([kk, ii, jj])
                 nobs = len(obsname)
+
+        if openfile:
+            f.close()
 
         # determine specified unit number
         unitnumber = None

--- a/flopy/modflow/mfswr1.py
+++ b/flopy/modflow/mfswr1.py
@@ -152,15 +152,17 @@ class ModflowSwr1(Package):
             sys.stdout.write('loading swr1 process file...\n')
 
         # todo: everything
-        if not hasattr(f, 'read'):
+
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
 
         print(
             'Warning: load method not completed. default swr1 object created.')
 
-        # close open file
-        f.close()
+        if openfile:
+            f.close()
 
         # determine specified unit number
         unitnumber = None

--- a/flopy/modflow/mfswt.py
+++ b/flopy/modflow/mfswt.py
@@ -523,9 +523,11 @@ class ModflowSwt(Package):
         if model.verbose:
             sys.stdout.write('loading swt package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
+
         # dataset 0 -- header
         while True:
             line = f.readline()
@@ -704,8 +706,8 @@ class ModflowSwt(Package):
                 t[0:4] -= 1
                 ids17[k] = t
 
-        # close file
-        f.close()
+        if openfile:
+            f.close()
 
         # determine specified unit number
         unitnumber = None

--- a/flopy/modflow/mfupw.py
+++ b/flopy/modflow/mfupw.py
@@ -331,9 +331,11 @@ class ModflowUpw(Package):
             print(msg)
             model.version = 'mfnwt'
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
+
         # dataset 0 -- header
         while True:
             line = f.readline()
@@ -478,6 +480,9 @@ class ModflowUpw(Package):
                     t = mfpar.parameter_fill(model, (nrow, ncol), 'vkcb',
                                              parm_dict, findlayer=k)
                 vkcb[k] = t
+
+        if openfile:
+            f.close()
 
         # determine specified unit number
         unitnumber = None

--- a/flopy/modflow/mfuzf1.py
+++ b/flopy/modflow/mfuzf1.py
@@ -769,9 +769,11 @@ class ModflowUzf1(Package):
         if model.verbose:
             sys.stdout.write('loading uzf package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
+
         # dataset 0 -- header
         while True:
             # can't use next() because util2d uses readline()

--- a/flopy/modflow/mfzon.py
+++ b/flopy/modflow/mfzon.py
@@ -157,9 +157,11 @@ class ModflowZon(Package):
         if model.verbose:
             sys.stdout.write('loading zone package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
+
         # dataset 0 -- header
         while True:
             line = f.readline()
@@ -193,6 +195,9 @@ class ModflowZon(Package):
             if t.locat is not None:
                 model.add_pop_key_list(t.locat)
             zone_dict[zonnam] = t
+
+        if openfile:
+            f.close()
 
         # set package unit number
         unitnumber = None

--- a/flopy/modflowlgr/mflgr.py
+++ b/flopy/modflowlgr/mflgr.py
@@ -420,8 +420,8 @@ class ModflowLgr(BaseModel):
 
         Parameters
         ----------
-        f : MODFLOW name file
-            File to load.
+        f : filename or file handle
+            MODFLOW name file to load.
 
         model_ws : model workspace path
 
@@ -448,7 +448,8 @@ class ModflowLgr(BaseModel):
         else:
             modelname = f
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = os.path.join(model_ws, f)
             f = open(filename, 'r')
 
@@ -587,6 +588,9 @@ class ModflowLgr(BaseModel):
             children.append(Modflow.load(cn, verbose=verbose, model_ws=cws,
                                          load_only=load_only, forgive=forgive,
                                          check=check))
+
+        if openfile:
+            f.close()
 
         lgr = ModflowLgr(version=version, exe_name=exe_name,
                          modelname=modelname, model_ws=model_ws,

--- a/flopy/mt3d/mt.py
+++ b/flopy/mt3d/mt.py
@@ -654,7 +654,7 @@ class Mt3dms(BaseModel):
         if mt.verbose:
             sys.stdout.write('   {:4s} package load...success\n'
                              .format(pck.name[0]))
-        ext_unit_dict.pop(btn_key)
+        ext_unit_dict.pop(btn_key).filehandle.close()
         ncomp = mt.btn.ncomp
         # reserved unit numbers for .ucn, s.ucn, .obs, .mas, .cnf
         poss_output_units = set(list(range(201, 201+ncomp)) +
@@ -691,7 +691,7 @@ class Mt3dms(BaseModel):
                 if item.filetype in load_only:
                     if forgive:
                         try:
-                            pck = item.package.load(item.filename, mt,
+                            pck = item.package.load(item.filehandle, mt,
                                                     ext_unit_dict=ext_unit_dict)
                             files_successfully_loaded.append(item.filename)
                             if mt.verbose:
@@ -705,7 +705,7 @@ class Mt3dms(BaseModel):
                                         .format(item.filetype, o))
                             files_not_loaded.append(item.filename)
                     else:
-                        pck = item.package.load(item.filename, mt,
+                        pck = item.package.load(item.filehandle, mt,
                                                 ext_unit_dict=ext_unit_dict)
                         files_successfully_loaded.append(item.filename)
                         if mt.verbose:
@@ -746,9 +746,10 @@ class Mt3dms(BaseModel):
         for key in mt.pop_key_list:
             try:
                 mt.remove_external(unit=key)
-                if key != btn_key:  # btn_key already popped above
-                    ext_unit_dict.pop(key)
-            except:
+                item = ext_unit_dict.pop(key)
+                if hasattr(item.filehandle, 'close'):
+                    item.filehandle.close()
+            except KeyError:
                 if mt.verbose:
                     sys.stdout.write(
                         "Warning: external file unit "

--- a/flopy/mt3d/mtadv.py
+++ b/flopy/mt3d/mtadv.py
@@ -279,7 +279,8 @@ class Mt3dAdv(Package):
             sys.stdout.write('loading adv package file...\n')
 
         # Open file, if necessary
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
 
@@ -371,6 +372,9 @@ class Mt3dAdv(Package):
             dchmoc = float(line[0:10])
             if model.verbose:
                 print('   DCHMOC {}'.format(dchmoc))
+
+        if openfile:
+            f.close()
 
         # set package unit number
         unitnumber = None

--- a/flopy/mt3d/mtbtn.py
+++ b/flopy/mt3d/mtbtn.py
@@ -660,7 +660,8 @@ class Mt3dBtn(Package):
         >>> btn = flopy.mt3d.Mt3dBtn.load('test.btn', mt)
 
         """
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
 
@@ -947,8 +948,8 @@ class Mt3dBtn(Package):
             print('   TTSMULT {}'.format(ttsmult))
             print('   TTSMAX {}'.format(ttsmax))
 
-        # Close the file
-        f.close()
+        if openfile:
+            f.close()
 
         # set package unit number
         unitnumber = None

--- a/flopy/mt3d/mtcts.py
+++ b/flopy/mt3d/mtcts.py
@@ -194,7 +194,8 @@ class Mt3dCts(Package):
         #     sys.stdout.write('loading cts package file...\n')
         #
         # # Open file, if necessary
-        # if not hasattr(f, 'read'):
+        # openfile = not hasattr(f, 'read')
+        # if openfile:
         #     filename = f
         #     f = open(filename, 'r')
         #
@@ -249,6 +250,9 @@ class Mt3dCts(Package):
         #         next = int(m_arr[1])
         #         ninj = int(m_arr[2])
         #         itrtinj = int(m_arr[3])
+        #
+        # if openfile:
+        #     f.close()
 
     @staticmethod
     def get_default_CTS_dtype(ncomp=1, iforce=0):

--- a/flopy/mt3d/mtdsp.py
+++ b/flopy/mt3d/mtdsp.py
@@ -264,7 +264,8 @@ class Mt3dDsp(Package):
             ncol = model.ncol
 
         # Open file, if necessary
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
 
@@ -335,6 +336,9 @@ class Mt3dDsp(Package):
             #         u2d = Util2d.load(f, model, (nlay,), np.float32, name,
             #                     ext_unit_dict, array_format="mt3d")
             #         kwargs[name] = u2d
+
+        if openfile:
+            f.close()
 
         # set package unit number
         unitnumber = None

--- a/flopy/mt3d/mtgcg.py
+++ b/flopy/mt3d/mtgcg.py
@@ -168,7 +168,8 @@ class Mt3dGcg(Package):
             sys.stdout.write('loading gcg package file...\n')
 
         # Open file, if necessary
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
 
@@ -204,6 +205,9 @@ class Mt3dGcg(Package):
             print('   ACCL {}'.format(accl))
             print('   CCLOSE {}'.format(cclose))
             print('   IPRGCG {}'.format(iprgcg))
+
+        if openfile:
+            f.close()
 
         # set package unit number
         unitnumber = None

--- a/flopy/mt3d/mtlkt.py
+++ b/flopy/mt3d/mtlkt.py
@@ -295,7 +295,8 @@ class Mt3dLkt(Package):
         if model.verbose:
             sys.stdout.write('loading lkt package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
 
@@ -416,6 +417,9 @@ class Mt3dLkt(Package):
                 if model.verbose:
                     print('   No transient boundary conditions specified')
                 pass
+
+        if openfile:
+            f.close()
 
         if len(lk_stress_period_data) == 0:
             lk_stress_period_data = None

--- a/flopy/mt3d/mtrct.py
+++ b/flopy/mt3d/mtrct.py
@@ -421,7 +421,8 @@ class Mt3dRct(Package):
             sys.stdout.write('loading rct package file...\n')
 
         # Open file, if necessary
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
 
@@ -580,8 +581,8 @@ class Mt3dRct(Package):
                     if model.verbose:
                         print('   RC2{} {}'.format(icomp, u3d))
 
-        # Close the file
-        f.close()
+        if openfile:
+            f.close()
 
         # set package unit number
         unitnumber = None

--- a/flopy/mt3d/mtsft.py
+++ b/flopy/mt3d/mtsft.py
@@ -458,7 +458,8 @@ class Mt3dSft(Package):
         if model.verbose:
             sys.stdout.write('loading sft package file...\n')
 
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
 
@@ -661,6 +662,9 @@ class Mt3dSft(Package):
                 if model.verbose:
                     print('   No transient boundary conditions specified')
                 pass
+
+        if openfile:
+            f.close()
 
         # 1 item for SFT input file, 1 item for SFTOBS file
         unitnumber = None

--- a/flopy/mt3d/mtssm.py
+++ b/flopy/mt3d/mtssm.py
@@ -488,7 +488,8 @@ class Mt3dSsm(Package):
             sys.stdout.write('loading ssm package file...\n')
 
         # Open file, if necessary
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
 
@@ -700,6 +701,9 @@ class Mt3dSsm(Package):
                 current['j'] -= 1
                 current = current.view(np.recarray)
             stress_period_data[iper] = current
+
+        if openfile:
+            f.close()
 
         # set package unit number
         unitnumber = None

--- a/flopy/mt3d/mtuzt.py
+++ b/flopy/mt3d/mtuzt.py
@@ -381,7 +381,8 @@ class Mt3dUzt(Package):
             print('loading uzt package file...\n')
 
         # Open file if necessary
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
 
@@ -599,6 +600,9 @@ class Mt3dUzt(Package):
                               '{0:5d}'.format(iper) + ' in kper ' \
                                                       '{0:5d}'.format(
                             iper + 1))
+
+        if openfile:
+            f.close()
 
         unitnumber = None
         filenames = [None, None]

--- a/flopy/pakbase.py
+++ b/flopy/pakbase.py
@@ -667,7 +667,8 @@ class Package(PackageInterface):
             check = True
 
         # open the file if not already open
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             if platform.system().lower() == 'windows' and \
                     sys.version_info[0] < 3:
@@ -675,6 +676,10 @@ class Package(PackageInterface):
                 f = io.open(filename, 'r')
             else:
                 f = open(filename, 'r')
+        elif hasattr(f, 'name'):
+            filename = f.name
+        else:
+            filename = '?'
 
         # set string from pak_type
         pak_type_str = str(pak_type).lower()
@@ -955,6 +960,9 @@ class Package(PackageInterface):
 
         dtype = pak_type.get_empty(0, aux_names=aux_names,
                                    structured=model.structured).dtype
+
+        if openfile:
+            f.close()
 
         # set package unit number
         filenames = [None, None]

--- a/flopy/seawat/swtvdf.py
+++ b/flopy/seawat/swtvdf.py
@@ -346,7 +346,8 @@ class SeawatVdf(Package):
             sys.stdout.write('loading vdf package file...\n')
 
         # Open file, if necessary
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
 
@@ -473,6 +474,9 @@ class SeawatVdf(Package):
 
             # Set indense = 1 because all concentrations converted to density
             indense = 1
+
+        if openfile:
+            f.close()
 
         # set package unit number
         unitnumber = None

--- a/flopy/seawat/swtvsc.py
+++ b/flopy/seawat/swtvsc.py
@@ -297,7 +297,8 @@ class SeawatVsc(Package):
             sys.stdout.write('loading vsc package file...\n')
 
         # Open file, if necessary
-        if not hasattr(f, 'read'):
+        openfile = not hasattr(f, 'read')
+        if openfile:
             filename = f
             f = open(filename, 'r')
 
@@ -443,6 +444,9 @@ class SeawatVsc(Package):
 
             # Set invisc = 1 because all concentrations converted to density
             invisc = 1
+
+        if openfile:
+            f.close()
 
         # set package unit number
         unitnumber = None

--- a/flopy/utils/mfreadnam.py
+++ b/flopy/utils/mfreadnam.py
@@ -179,11 +179,15 @@ def parsenamefile(namfilename, packages, verbose=True):
                 idx = lownams.index(bname.lower())
                 fname = os.path.join(dn, fls[idx])
         # open the file
-        openmode = 'r'
+        kwargs = {}
         if ftype == 'DATA(BINARY)':
             openmode = 'rb'
+        else:
+            openmode = 'r'
+            if sys.version_info[0] > 2:
+                kwargs['errors'] = 'replace'
         try:
-            filehandle = open(fname, openmode)
+            filehandle = open(fname, openmode, **kwargs)
         except IOError:
             if verbose:
                 print('could not set filehandle to {0:s}'.format(fpath))

--- a/flopy/utils/optionblock.py
+++ b/flopy/utils/optionblock.py
@@ -333,10 +333,8 @@ class OptionBlock(object):
         """
         context = package._options
 
-        if hasattr(options, "read"):
-            pass
-
-        else:
+        openfile = not hasattr(options, 'read')
+        if openfile:
             try:
                 options = open(options, "r")
             except IOError:
@@ -381,6 +379,8 @@ class OptionBlock(object):
                             ix += 1
 
             else:
+                if openfile:
+                    options.close()
                 return OptionBlock(options_line=option_line,
                                    package=package)
 

--- a/flopy/utils/util_array.py
+++ b/flopy/utils/util_array.py
@@ -2328,7 +2328,8 @@ class Util2d(DataInterface):
         nrow, ncol = shape
         data = np.ma.zeros(shape, dtype=dtype)
         data.mask = True
-        if not hasattr(file_in, 'read'):
+        openfile = not hasattr(file_in, 'read')
+        if openfile:
             file_in = open(file_in, 'r')
         line = file_in.readline().strip()
         nblock = int(line.split()[0])
@@ -2341,6 +2342,8 @@ class Util2d(DataInterface):
             i1, i2 = int(raw[0]) - 1, int(raw[1])
             j1, j2 = int(raw[2]) - 1, int(raw[3])
             data[i1:i2, j1:j2] = raw[4]
+        if openfile:
+            file_in.close()
         if data.mask.any():
             warn('Util2d.load_block(): blocks do not cover full array')
         return data.data
@@ -2377,7 +2380,8 @@ class Util2d(DataInterface):
             raise ValueError(
                 'Util2d.load_txt(): expected 1 or 2 dimensions, found shape {0}'
                     .format(shape))
-        if not hasattr(file_in, 'read'):
+        openfile = not hasattr(file_in, 'read')
+        if openfile:
             file_in = open(file_in, 'r')
         npl, fmt, width, decimal = ArrayFormat.decode_fortran_descriptor(fmtin)
         items = []
@@ -2408,6 +2412,8 @@ class Util2d(DataInterface):
                             items.append(item)
                     except IndexError:
                         break
+        if openfile:
+            file_in.close()
         data = np.fromiter(items, dtype=dtype, count=num_items)
         if data.size != num_items:
             raise ValueError('Util2d.load_txt(): expected array size {0},'
@@ -2522,13 +2528,16 @@ class Util2d(DataInterface):
                 warn('Util2d: setting integer dtype from {0} to int32'
                      .format(dtype))
             dtype = np.int32
-        if not hasattr(file_in, 'read'):
+        openfile = not hasattr(file_in, 'read')
+        if openfile:
             file_in = open(file_in, 'rb')
         header_data = None
         if bintype is not None and np.issubdtype(dtype, np.floating):
             header_dtype = bf.BinaryHeader.set_dtype(bintype=bintype)
             header_data = np.fromfile(file_in, dtype=header_dtype, count=1)
         data = np.fromfile(file_in, dtype=dtype, count=num_items)
+        if openfile:
+            file_in.close()
         if data.size != num_items:
             raise ValueError('Util2d.load_bin(): expected array size {0},'
                              ' but found size {1}'.format(num_items,


### PR DESCRIPTION
Using model load functions (e.g. `Modflow.load('file.nam')`) opens each package file twice:
1. in mfreadnam, creating an opened `filehandle` property, then
2. by calling `package.load(item.filename ...`, which sometimes closed the `f` file handle at the end, depending on the package.

This PR does a few things:
* When loading a nam file, open each package file once, via mfreadnam, then close them when done. This clears up a pile of `ResourceWarning` messages in Python 3, which are silent by default.
* Also in mfreadnam with Python 3 text files, use `open(..., errors='replace')`, as is done in (e.g.) mflak's load method, to avoid "UnicodeDecodeError: 'utf-8' codec can't decode byte ..." errors while reading non-ISO extended-ASCII text files like `examples/data/mf2005_test/l1b2k_bath.lak`
* For each load method, only close the file if it was opened by the method (i.e. the "[leave the gate as you found it](https://en.wikipedia.org/wiki/Leave_the_gate_as_you_found_it)" rule); this is the bulk of the changes to each source file in this PR
* Fix bug with mflmt's load method, if `f` was a file handle