### PR TITLE
refactor(travis): use script files rather than awkward YAML file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,21 @@ services:
 - xvfb
 matrix:
   include:
-  - env: TVER=PY27
+  - env: RUN_TYPE=test
     python: 2.7
-  - env: TVER=PY35
+  - env: RUN_TYPE=test
     python: 3.5
-  - env: TVER=PY36
+  - env: RUN_TYPE=test
     python: 3.6
-  - env: TVER=PY37
+  - env: RUN_TYPE=test
     python: 3.7
-  - env: TVER=PY37N
+  - env: RUN_TYPE=misc
     python: 3.7
-  - env: TVER=PY37D
-    python: 3.7-dev
-  allow_failures:
-  - env: TVER=PY37D
+# - env: RUN_TYPE=test
+#   python: 3.8-dev
+# allow_failures:
+# - env: RUN_TYPE=test
+#   python: 3.8-dev
 cache:
   pip: true
   directories:
@@ -32,7 +33,6 @@ addons:
     packages:
     - gfortran-8
     - g++-8
-    - python-pip
     - libhdf5-serial-dev
     - netcdf-bin
     - libnetcdf-dev
@@ -40,53 +40,11 @@ addons:
     - libgdal-dev
 env:
   global:
-  - NO_NET=1
-install:
-- if [[ ! -d "$HOME/.local/bin" ]]; then mkdir "$HOME/.local/bin"; fi
-- export PATH="$HOME/.local/bin:$PATH"
-- ln -fs /usr/bin/gfortran-8 "$HOME/.local/bin/gfortran" && gfortran --version
-- ls -l /usr/bin/gfortran-8
-- ln -fs /usr/bin/gcc-8 "$HOME/.local/bin/gcc" && gcc --version
-- ls -l /usr/bin/gcc-8
-- ln -fs /usr/bin/g++-8 "$HOME/.local/bin/g++" && g++ --version
-- ls -l /usr/bin/g++-8
-- export CXX="g++"
-- if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install -r requirements27.travis.txt;
-  echo requests version1; python -c "import requests; print(requests.__version__)";
-  else pip install -r requirements.travis.txt;
-  pip install --no-binary rasterio rasterio;
-  pip install --upgrade numpy;
-  fi
-- pip install https://github.com/modflowpy/pymake/zipball/master
-- pip install --upgrade jupyter
-- pip install shapely[vectorize]
-- pip install nbconvert
-- pip install nose-timer
-- pip install coveralls
-- pip install pylint
-script:
-- export PYTHONPATH=$PYTHONPATH:.
-- echo python path; python -c "from __future__ import print_function; import sys;
-  print(sys.path)"
-- python -c "import os; is_travis = 'TRAVIS' in os.environ; print('TRAVIS {}'.format(is_travis))"
-- echo flopy version; python -c "from __future__ import print_function; import flopy;
-  print(flopy.__version__)"
-- echo numpy version; python -c "import numpy; print(numpy.version.version)"
-- echo pandas version; python -c "import pandas as pd; print(pd.__version__)"
-- echo pyshp; python -c "import shapefile; print(shapefile.__version__)"
-- echo nosetests version; nosetests --version
-- echo jupyter version; jupyter --version
-- echo jupyter runtime directory; jupyter --runtime-dir
-- echo pylint version; pylint --version
-- nosetests -v build_exes.py --with-id --with-timer -w ./autotest
-- if [[ $TVER == PY37N ]]; then nosetests -v autotest_scripts.py --with-id --with-timer
-  -w ./autotest --with-coverage --cover-package=flopy; nosetests -v autotest_notebooks.py
-  --with-id --with-timer -w ./autotest --with-coverage --cover-package=flopy; else
-  nosetests -v --with-id --with-timer -w ./autotest --with-coverage --cover-package=flopy;
-  fi
-after_success:
-- coveralls
-- if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then pylint --errors-only ./flopy; fi
+  - PYTHONPATH=$PYTHONPATH:.
+install: ./travis/install.sh
+before_script: ./travis/before_script.sh
+script: ./travis/script.sh
+after_success: coveralls
 notifications:
   slack:
     secure: mwy5srgrEc1TWc5x0sOTGxVoSWSHYj8afkVyGtgVonI4b+816BIW0qLy7SIX46vtR+oexXoAWsYXmgNwItFWIDhP6uNN1o5yyVIU7WI68Y3k8KpdfNC90d2HIH3TIxdIR1ezrATOWDAGoG3lnprAI6I3zVVUga4EwUMnwc+/GoK3qluxp/0yEK114n2j7LuAXOzCgyuaaelPLrDwTo8ZIWLKaV3yg5oM/mYpP2PGbYsnvs+FpAfMN9GkEGzgDgATNs+O455s1Dx1cdxtgJVw91b74Fc+eOlk4Ywrdg6PcQYeHFLehSxXDkCkLYSjktDRvX07Dlg9CG3nr5y1RBB2p33L73A1kLUjEfvZB9yaYm3Pow9PxUDJcb//GAQauWiQZQw84mfHVqer3HBA8S5AwcWMHPUo2/9jfkyT7+tOAghUYLt2LdKnTXrf8ZFSG1NN4aR8RMUyxHFaXgVrCbWy35wl59fgoUY3q6IzNVjgobkJGeapVOeqiut2UHB6b6lNDEGoGr9dLcpB09IYEIDpVq5bqnflC3ZuihlzQS/k/EW/L2StFN3xIg7RumuEwvkhsOHxoeWcbfmQreGBwWrp2jP5Sl8q8Ymu2WcO4F6r3sC+9VaK8nEWR/CHurnnBsGqH6Inng00Y6cRp4gP1R9zIJNpxz51spZbspFAEzMpst4=

--- a/travis/before_script.sh
+++ b/travis/before_script.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+if [[ ! -d "$HOME/.local/bin" ]]; then
+  mkdir "$HOME/.local/bin"
+fi
+echo "PATH=$PATH"
+echo "PYTHONPATH=$PYTHONPATH"
+
+echo "Setting up GCC 8 aliases..."
+ln -fs /usr/bin/gfortran-8 "$HOME/.local/bin/gfortran"
+ln -fs /usr/bin/gcc-8 "$HOME/.local/bin/gcc"
+ln -fs /usr/bin/g++-8 "$HOME/.local/bin/g++"
+ls -l "$HOME/.local/bin"
+
+echo "Showing version information..."
+gfortran --version
+gcc --version
+g++ --version
+python -c "import sys; print('python sys.path: {}'.format(sys.path))"
+python -c "import os; is_travis = 'TRAVIS' in os.environ; print('TRAVIS {}'.format(is_travis))"
+python -c "import flopy; print('flopy: {}'.format(flopy.__version__))"
+python -c "import numpy; print('numpy: {}'.format(numpy.version.version))"
+python -c "import pandas as pd; print('pandas: {}'.format(pd.__version__))"
+python -c "import requests; print('requests: {}'.format(requests.__version__))"
+python -c "import shapefile; print('pyshp: {}'.format(shapefile.__version__))"
+if [ "${RUN_TYPE}" = "misc" ]; then
+  echo "jupyter: $(jupyter --version); $(jupyter --runtime-dir)"
+  pylint --version
+fi
+nosetests --version

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+echo "Installing pip for Python ${TRAVIS_PYTHON_VERSION} ${RUN_TYPE} run"
+pip install --upgrade pip
+if [ "${TRAVIS_PYTHON_VERSION}" = "2.7" ]; then
+  pip install -r requirements27.travis.txt
+else
+  pip install -r requirements.travis.txt
+  pip install --no-binary rasterio rasterio
+  pip install --upgrade numpy
+fi
+if [ "${RUN_TYPE}" = "misc" ]; then
+  pip install --upgrade jupyter
+  pip install nbconvert
+  pip install pylint pylint-exit
+fi
+pip install https://github.com/modflowpy/pymake/zipball/master
+pip install shapely[vectorize]
+pip install coveralls nose-timer

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+echo "Building executables..."
+nosetests -v build_exes.py --with-id --with-timer -w ./autotest
+
+if [ "${RUN_TYPE}" = "test" ]; then
+  echo "Running flopy autotest suite..."
+  nosetests -v --with-id --with-timer -w ./autotest \
+    --with-coverage --cover-package=flopy
+elif [ "${RUN_TYPE}" = "misc" ]; then
+  echo "Checking Python code..."
+  pylint --jobs=2 --errors-only ./flopy || pylint-exit $?
+  echo "TODO: exit code was $?"
+  echo "Running notebook autotest suite..."
+  nosetests -v autotest_scripts.py --with-id --with-timer -w ./autotest \
+    --with-coverage --cover-package=flopy
+  nosetests -v autotest_notebooks.py --with-id --with-timer -w ./autotest \
+    --with-coverage --cover-package=flopy
+else
+  echo "Unhandled RUN_TYPE=${RUN_TYPE}"
+  exit 1
+fi


### PR DESCRIPTION
* Replace `TVER` with `RUN_TYPE` with either "test" or "misc" (for other tests, like pylint and notebook tests)
* Remove Python 3.7-dev and leave commented-out 3.8-dev, when ready
* Move/refactor version showing to `before_script` hook
* Move pylint to script section, with pylint-exit to handle exit code
* `PATH` already has `$HOME/.local/bin` but this directory needs to be created

The `install.sh` script installs the dependencies, which are different for the different build types and Python version. The `before_script.py` shows the paths and much of the version numbers of various components. The main part of the testing is in `script.sh`. Currently, `after_success` is a single command to `coveralls`.

A few other minor details are that "export CXX="g++"", "NO_NET=1" and "python-pip" are removed, as they don't appear to be necessary. Also pylint is possibly sped up by using `--jobs=2`, as there are two cores available on each build VM.

Finally, Python 3.8 was released earlier this week, but it is not yet supported by many of the components, including Travis CI, so it should be held off for now. There does not seem to be any benefit from the 3.7-dev test, so I dropped it to speed the overall testing up.