### PR TITLE
Check Python code with flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,30 @@
+[flake8]
+exclude =
+    .git,
+    __pycache__,
+    build,
+    dist
+ignore =
+    # https://flake8.pycqa.org/en/latest/user/error-codes.html
+    F401, # 'module' imported but unused
+    # https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
+    E121, # continuation line under-indented for hanging indent
+    E122, # continuation line missing indentation or outdented
+    E126, # continuation line over-indented for hanging indent
+    E127, # continuation line over-indented for visual indent
+    E128, # continuation line under-indented for visual indent
+    E221, # multiple spaces before operator
+    E222, # multiple spaces after operator
+    E226, # missing whitespace around arithmetic operator
+    E231, # missing whitespace after ','
+    E241, # multiple spaces after ','
+    E402, # module level import not at top of file
+    E501, # line too long (> 79 characters)
+    E722, # do not use bare 'except'
+    W291, # trailing whitespace
+    W292, # no newline at end of file
+    W293, # blank line contains whitespace
+    W391, # blank line at end of file
+    W503, # line break before binary operator
+    W504  # line break after binary operator
+statistics = True

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -7,13 +7,12 @@ if [ "${TRAVIS_PYTHON_VERSION}" = "2.7" ]; then
   pip install -r requirements27.travis.txt
 else
   pip install -r requirements.travis.txt
-  pip install --no-binary rasterio rasterio
+  pip install rasterio
   pip install --upgrade numpy
 fi
 if [ "${RUN_TYPE}" = "misc" ]; then
-  pip install --upgrade jupyter
-  pip install nbconvert
-  pip install pylint pylint-exit
+  pip install flake8 pylint pylint-exit
+  pip install jupyter nbconvert
 fi
 pip install https://github.com/modflowpy/pymake/zipball/master
 pip install shapely[vectorize]

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -9,15 +9,20 @@ if [ "${RUN_TYPE}" = "test" ]; then
   nosetests -v --with-id --with-timer -w ./autotest \
     --with-coverage --cover-package=flopy
 elif [ "${RUN_TYPE}" = "misc" ]; then
-  echo "Checking Python code..."
+  echo "Checking Python code with flake8..."
+  flake8 --exit-zero
+  echo "Checking Python code with pylint..."
   pylint --jobs=2 --errors-only ./flopy || pylint-exit $?
-  echo "TODO: exit code was $?"
+  if [ $? -ne 0 ]; then
+    echo "An error occurred while running pylint." >&2
+    exit 1
+  fi
   echo "Running notebook autotest suite..."
   nosetests -v autotest_scripts.py --with-id --with-timer -w ./autotest \
     --with-coverage --cover-package=flopy
   nosetests -v autotest_notebooks.py --with-id --with-timer -w ./autotest \
     --with-coverage --cover-package=flopy
 else
-  echo "Unhandled RUN_TYPE=${RUN_TYPE}"
+  echo "Unhandled RUN_TYPE=${RUN_TYPE}" >&2
   exit 1
 fi


### PR DESCRIPTION
This PR reviews Python errors and code styles, and shows them in the "misc" Travis CI build (now done before Notebook tests). This complements pylint checks also done in that build.

This highlights obvious bugs like:

    ./flopy/modflow/mfde4.py:274:24: F821 undefined name 'tline'

it also shows many other non-bugs like whitespace warnings. Most of these are ignored, in the `.flake8` file, as they aren't that important. Currently, this tool does not fail the build, via `--exit-zero`.

Anyone can run this locally too, just type `flake8` from the base source directory.

Some other minor adjustments in this PR is to fine-tune the `pip install` commands to install components quicker. Also, pylint can now fail a build (currently it does not).