### PR TITLE
fix(flake8 code W605): invalid escape sequence '\s' (or similar)

### DIFF
--- a/flopy/modflow/mfsfr2.py
+++ b/flopy/modflow/mfsfr2.py
@@ -2829,9 +2829,9 @@ def _fmt_string(array, float_format='{!s}'):
         elif vtype == 'o':
             fmt_string += '{} '
         elif vtype == 's':
-            raise Exception("MfList error: '\str\' type found it dtype." + \
+            raise Exception("MfList error: 'str' type found in dtype." + \
                             " This gives unpredictable results when " + \
-                            "recarray to file - change to \'object\' type")
+                            "recarray to file - change to 'object' type")
         else:
             raise Exception("MfList.fmt_string error: unknown vtype " + \
                             "in dtype:" + vtype)
@@ -2851,9 +2851,9 @@ def _fmt_string_list(array, float_format='{!s}'):
         elif (vtype == 'o'):
             fmt_string += ['{}']
         elif (vtype == 's'):
-            raise Exception("MfList error: '\str\' type found it dtype." + \
+            raise Exception("MfList error: 'str' type found in dtype." + \
                             " This gives unpredictable results when " + \
-                            "recarray to file - change to \'object\' type")
+                            "recarray to file - change to 'object' type")
         else:
             raise Exception("MfList.fmt_string error: unknown vtype " + \
                             "in dtype:" + vtype)

--- a/flopy/mt3d/mtlkt.py
+++ b/flopy/mt3d/mtlkt.py
@@ -285,10 +285,10 @@ class Mt3dLkt(Package):
         --------
 
         >>> import flopy
-        >>> import os
-        >>> os.chdir(r'C:\temp\LKT')
-        >>> mt = flopy.mt3d.Mt3dms.load('lkt_mt.nam', exe_name = 'mt3d-usgs_1.0.00.exe',
-        >>>                            load_only='btn')
+        >>> datadir = 'examples/data/mt3d_test/mfnwt_mt3dusgs/lkt'
+        >>> mt = flopy.mt3d.Mt3dms.load(
+        ...     'lkt_mt.nam', exe_name='mt3d-usgs_1.0.00.exe',
+        ...     model_ws=datadir, load_only='btn')
         >>> lkt = flopy.mt3d.Mt3dLkt.load('test.lkt', mt)
 
         """

--- a/flopy/mt3d/mtsft.py
+++ b/flopy/mt3d/mtsft.py
@@ -167,18 +167,17 @@ class Mt3dSft(Package):
     Examples
     --------
 
-    >>> mf = flopy.modflow.Modflow.load('CrnkNic_mf.nam',
-    >>>                                  load_only=['dis', 'bas6'])
+    >>> import flopy
+    >>> datadir = 'examples/data/mt3d_test/mfnwt_mt3dusgs/sft_crnkNic'
+    >>> mf = flopy.modflow.Modflow.load(
+    ...     'CrnkNic.nam', model_ws=datadir, load_only=['dis', 'bas6'])
     >>> sfr = flopy.modflow.ModflowSfr2.load('CrnkNic.sfr2', mf)
     >>> chk = sfr.check()
-
     >>> # initialize an MT3D-USGS model
-    >>> mt = flopy.mt3d.Mt3dms.load('CrnkNic_mt.nam',
-    >>>        exe_name = 'mt3d-usgs_1.0.00.exe',
-    >>>        model_ws = r'.\CrnkNic',
-    >>>        load_only='btn')
+    >>> mt = flopy.mt3d.Mt3dms.load(
+    ...     'CrnkNic.mtnam', exe_name='mt3d-usgs_1.0.00.exe',
+    >>>     model_ws=datadir, load_only='btn')
     >>> sft = flopy.mt3d.Mt3dSft.load(mt, 'CrnkNic.sft')
-
 
     """
 
@@ -327,12 +326,12 @@ class Mt3dSft(Package):
 
         Examples
         --------
-        >>> mt = flopy.mt3d.Mt3dms.load('CrnkNic_mt.nam',
-        >>>      exe_name = 'mt3d-usgs_1.0.00.exe',
-        >>>      model_ws = r'C:\EDM_LT\GitHub\mt3d-usgs\autotest\temp\CrnkNic',
-        >>>      verbose=True)
+        >>> import flopy
+        >>> datadir = .examples/data/mt3d_test/mfnwt_mt3dusgs/sft_crnkNic
+        >>> mt = flopy.mt3d.Mt3dms.load(
+        ...     'CrnkNic.mtnam', exe_name='mt3d-usgs_1.0.00.exe',
+        ...     model_ws=datadir, verbose=True)
         >>> mt.name = 'CrnkNic_rewrite'
-        >>>
         >>> mt.sft.dispsf.fmtin = '(10F12.2)'
         >>> mt.write_input()
 

--- a/flopy/mt3d/mtuzt.py
+++ b/flopy/mt3d/mtuzt.py
@@ -124,10 +124,10 @@ class Mt3dUzt(Package):
     --------
 
     >>> import flopy
-    >>> import os
-    >>> mt = flopy.mt3d.Mt3dms.load('Keat_UZF_mt.nam',
-    ... exe_name = 'mt3d-usgs_1.0.00.exe',
-    ... model_ws = r'C:\temp\Keating_UZF', load_only='btn')
+    >>> datadir = 'examples/data/mt3d_test/mfnwt_mt3dusgs/keat_uzf'
+    >>> mt = flopy.mt3d.Mt3dms.load(
+    ...     'Keat_UZF_mt.nam', exe_name='mt3d-usgs_1.0.00.exe',
+    ...     model_ws=datadir, load_only='btn')
     >>> uzt = flopy.mt3d.Mt3dUzt('Keat_UZF.uzt', mt)
 
     """

--- a/flopy/utils/check.py
+++ b/flopy/utils/check.py
@@ -569,9 +569,9 @@ def _fmt_string_list(array, float_format='{}'):
         elif (vtype == 'o'):
             fmt_string += ['{}']
         elif (vtype == 's'):
-            raise Exception("MfList error: '\str\' type found it dtype." + \
+            raise Exception("MfList error: 'str' type found in dtype." + \
                             " This gives unpredictable results when " + \
-                            "recarray to file - change to \'object\' type")
+                            "recarray to file - change to 'object' type")
         else:
             raise Exception("MfList.fmt_string error: unknown vtype " + \
                             "in dtype:" + vtype)

--- a/flopy/utils/flopy_io.py
+++ b/flopy/utils/flopy_io.py
@@ -37,9 +37,9 @@ def _fmt_string(array, float_format='{}'):
         elif vtype == 'o':
             fmt_string += '{} '
         elif vtype == 's':
-            raise Exception("MfList error: '\str\' type found it dtype." + \
+            raise Exception("MfList error: 'str' type found in dtype." + \
                             " This gives unpredictable results when " + \
-                            "recarray to file - change to \'object\' type")
+                            "recarray to file - change to 'object' type")
         else:
             raise Exception("MfList.fmt_string error: unknown vtype " + \
                             "in dtype:" + vtype)

--- a/flopy/utils/mtlistfile.py
+++ b/flopy/utils/mtlistfile.py
@@ -330,7 +330,7 @@ class MtListBudget(object):
                 break
     def _parse_gw_line(self, line):
         raw = line.lower().split(':')
-        item = raw[0].strip().strip('[\|]').replace(' ', '_')
+        item = raw[0].strip().strip(r'[\|]').replace(' ', '_')
         idx_ival = 0
         idx_oval = 1
         if self.imm:
@@ -445,7 +445,7 @@ class MtListBudget(object):
     def _parse_sw_line(self, line):
         # print(line)
         raw = line.strip().split('=')
-        citem = raw[0].strip().strip('[\|]').replace(" ", "_")
+        citem = raw[0].strip().strip(r'[\|]').replace(" ", "_")
         cval = float(raw[1].split()[0])
         if len(raw) < 3:  # deal with flow error if written
             fval = None


### PR DESCRIPTION
Some of these fixes were to LaTeX in docstrings or paths to directories in the examples, which were updated to somewhat work with the current structure of directories and file names.

This will also remove a warning:
> DeprecationWarning: invalid escape sequence \s
>    raise Exception("MfList error: '\str\' type found it dtype." + \ ...