### PR TITLE
Allow Stress Periods Beyond Nper (#694) and Allow Setting Simulation Name File Options on Init (#704) 

### DIFF
--- a/autotest/t066_test_copy.py
+++ b/autotest/t066_test_copy.py
@@ -108,9 +108,14 @@ def package_is_copy(pk1, pk2):
         elif type(v) == bool:
             if not v == v2:
                 return False
-        elif type(v) in [str, int, float, dict, list]:
+        elif type(v) in [str, int, float, dict]:
             if v != v2:
                 return False
+        elif type(v) == list:
+            for item, item2 in zip(v, v2):
+                if not isinstance(item, mf6.mfpackage.MFPackage):
+                    if item != item2:
+                        return False
         elif isinstance(v, ModelInterface):
             # weak, but calling model_eq would result in recursion
             if v.__repr__() != v2.__repr__():

--- a/autotest/t504_test.py
+++ b/autotest/t504_test.py
@@ -1,4 +1,4 @@
-import os
+import os, copy
 
 import numpy as np
 
@@ -248,6 +248,11 @@ def test005_advgw_tidal():
     assert(digits == 10)
     names = ghb.ts.time_series_namerecord.get_data()
     assert(names[0][0] == 'tides')
+
+    # add a stress period beyond nper
+    spd = ghb.stress_period_data.get_data()
+    spd[20] = copy.deepcopy(spd[9])
+    ghb.stress_period_data.set_data(spd)
 
     # make temp folder to save simulation
     sim.simulation_data.mfpath.set_sim_path(run_folder)
@@ -732,7 +737,6 @@ def test001e_uzf_3lay():
                                 load_only=load_only)
         model = sim.get_model()
         for package in model_package_check:
-            print(package)
             assert (package in model.package_type_dict) == \
                    (package in load_only or '{}6'.format(package) in load_only)
     if run:

--- a/autotest/t505_test.py
+++ b/autotest/t505_test.py
@@ -71,7 +71,13 @@ def np001():
 
     # model tests
     test_sim = MFSimulation(sim_name=test_ex_name, version='mf6',
-                            exe_name=exe_name, sim_ws=run_folder)
+                            exe_name=exe_name, sim_ws=run_folder,
+                            continue_=True, memory_print_option='summary')
+    name = test_sim.name_file
+    assert name.continue_.get_data() == True
+    assert name.nocheck.get_data() == None
+    assert name.memory_print_option.get_data() == 'summary'
+
     kwargs = {}
     kwargs['bad_kwarg'] = 20
     try:
@@ -305,7 +311,12 @@ def np002():
 
     # create simulation
     sim = MFSimulation(sim_name=test_ex_name, version='mf6', exe_name=exe_name,
-                       sim_ws=run_folder)
+                       sim_ws=run_folder, nocheck=True)
+    name = sim.name_file
+    assert name.continue_.get_data() == None
+    assert name.nocheck.get_data() == True
+    assert name.memory_print_option.get_data() == None
+
     tdis_rc = [(6.0, 2, 1.0), (6.0, 3, 1.0)]
     tdis_package = ModflowTdis(sim, time_units='DAYS', nper=2,
                                perioddata=tdis_rc)

--- a/examples/data/mf6/test005_advgw_tidal/AdvGW_tidal.ghb
+++ b/examples/data/mf6/test005_advgw_tidal/AdvGW_tidal.ghb
@@ -44,3 +44,8 @@ BEGIN PERIOD  1
   3 15 10  tides  1500.0  estuary-l3
 END PERIOD  1
 
+BEGIN PERIOD  10
+  2 1 10  2.0  15.0  estuary-l2
+  2 2 10  3.0  15.0  estuary-l2
+  2 3 10  4.0  15.0  estuary-l2
+END PERIOD  10

--- a/flopy/mf6/data/mfdata.py
+++ b/flopy/mf6/data/mfdata.py
@@ -2,7 +2,7 @@ from operator import itemgetter
 import sys
 import inspect
 from ..mfbase import MFDataException, MFInvalidTransientBlockHeaderException, \
-                     FlopyException
+                     FlopyException, VerbosityLevel
 from ..data.mfstructure import DatumType
 from ..coordinates.modeldimensions import DataDimensions, DiscretizationType
 from ...datbase import DataInterface, DataType
@@ -151,9 +151,12 @@ class MFTransient(object):
                                  'nper).')
         nper = self._simulation_data.mfdata[('tdis', 'dimensions', 'nper')]
         if not (sp_num <= nper.get_data()):
-            raise FlopyException('Stress period value sp_num ({}) is greater '
-                                 'than the number of stress periods defined '
-                                 'in nper.'.format(sp_num))
+            if self._simulation_data.verbosity_level.value >= \
+                    VerbosityLevel.normal.value:
+                print('WARNING: Stress period value {} in package {} is '
+                      'greater than the number of stress periods defined '
+                      'in nper.'.format(sp_num + 1,
+                                        self.structure.get_package()))
         return True
 
 

--- a/flopy/mf6/data/mfdatalist.py
+++ b/flopy/mf6/data/mfdatalist.py
@@ -179,7 +179,6 @@ class MFList(mfdata.MFMultiDimVar, DataListInterface):
 
         for name, arr in arrays.items():
             cnt = np.zeros(shape, dtype=np.float64)
-            #print(name,kper)
             for sp_rec in sarr:
                 if sp_rec is not None:
                     for rec in sp_rec:

--- a/flopy/mf6/mfpackage.py
+++ b/flopy/mf6/mfpackage.py
@@ -1815,32 +1815,18 @@ class MFChildPackages(object):
         self._cpparent = parent
         self._pkg_type = pkg_type
         self._package_class = package_class
-        self._inattr = False
-
-    def __getattribute__(self, name):
-        if name == '_MFChildPackages_packages' or name == \
-                '_MFChildPackages_inattr' or name == '_packages' or \
-                name == '_inattr':
-            return super(MFChildPackages, self).__getattribute__(name)
-
-        if self._inattr is not None and not self._inattr:
-            if self._packages and hasattr(self._packages[0], name):
-                self._inattr = True
-                item = getattr(self._packages[0], name)
-                self._inattr = False
-                return item
-        return super(MFChildPackages, self).__getattribute__(name)
 
     def __getattr__(self, attr):
-        if attr == '_MFChildPackages_inattr' or attr == '_inattr':
-            return None
+        if '_packages' in self.__dict__ and len(self._packages) > 0 and hasattr(self._packages[0], attr):
+            item = getattr(self._packages[0], attr)
+            return item
         raise AttributeError(attr)
 
     def __getitem__(self, k):
         if isinstance(k, int):
             if k < len(self._packages):
                 return self._packages[k]
-        raise Exception('Package index {} does not exist.'.format(k))
+        raise ValueError('Package index {} does not exist.'.format(k))
 
     def __setattr__(self, key, value):
         if key != '_packages' and key != '_model' and key != '_cpparent' and \

--- a/flopy/mf6/mfpackage.py
+++ b/flopy/mf6/mfpackage.py
@@ -1817,7 +1817,8 @@ class MFChildPackages(object):
         self._package_class = package_class
 
     def __getattr__(self, attr):
-        if '_packages' in self.__dict__ and len(self._packages) > 0 and hasattr(self._packages[0], attr):
+        if '_packages' in self.__dict__ and len(self._packages) > 0 and \
+                hasattr(self._packages[0], attr):
             item = getattr(self._packages[0], attr)
             return item
         raise AttributeError(attr)

--- a/flopy/mf6/modflow/mfsimulation.py
+++ b/flopy/mf6/modflow/mfsimulation.py
@@ -226,10 +226,27 @@ class MFSimulation(PackageContainer):
     verbosity_level : int
         verbosity level of standard output
             0 : no standard output
-            1 : standard error/warning messages with some informational messages
+            1 : standard error/warning messages with some informational
+                messages
             2 : verbose mode with full error/warning/informational messages.
                 this is ideal for debugging
-
+    continue_ : bool
+        sets the continue option in the simulation name file. the continue
+        option is a keyword flag to indicate that the simulation should
+        continue even if one or more solutions do not converge.
+    nocheck : bool
+         sets the nocheck option in the simulation name file. the nocheck
+         option is a keyword flag to indicate that the model input check
+         routines should not be called prior to each time step. checks
+         are performed by default.
+    memory_print_option : str
+         sets memory_print_option in the simulation name file.
+         memory_print_option is a flag that controls printing of detailed
+         memory manager usage to the end of the simulation list file.  NONE
+         means do not print detailed information. SUMMARY means print only
+         the total memory for each simulation component. ALL means print
+         information for each variable stored in the memory manager. NONE is
+         default if memory_print_option is not specified.
     Attributes
     ----------
     sim_name : string
@@ -296,9 +313,9 @@ class MFSimulation(PackageContainer):
     >>> s = flopy6.mfsimulation.load('my simulation', 'simulation.nam')
 
     """
-    def __init__(self, sim_name='sim', version='mf6',
-                 exe_name='mf6.exe', sim_ws='.',
-                 verbosity_level=1):
+    def __init__(self, sim_name='sim', version='mf6', exe_name='mf6.exe',
+                 sim_ws='.', verbosity_level=1, continue_=None,
+                 nocheck=None, memory_print_option=None):
         super(MFSimulation, self).__init__(MFSimulationData(sim_ws), sim_name)
         self.simulation_data.verbosity_level = self._resolve_verbosity_level(
             verbosity_level)
@@ -332,7 +349,9 @@ class MFSimulation(PackageContainer):
         self.simulation_data.mfpath.set_last_accessed_path()
 
         # build simulation name file
-        self.name_file = mfnam.ModflowNam(self, filename='mfsim.nam')
+        self.name_file = mfnam.ModflowNam(
+            self, filename='mfsim.nam', continue_=continue_, nocheck=nocheck,
+            memory_print_option=memory_print_option)
 
         # try to build directory structure
         sim_path = self.simulation_data.mfpath.get_sim_path()


### PR DESCRIPTION
feat(#694): When stress packages have data for periods beyond nper flopy now issues a warning message (flopy use to raise an exception).

feat(#704): Allow user to set simulation name file options while initializing a simulation.