### PR TITLE
refactor(namefile): format values as native strings and remove extra "; "

### DIFF
--- a/autotest/t007_test.py
+++ b/autotest/t007_test.py
@@ -548,7 +548,7 @@ def test_mg():
     ms.modelgrid.set_coord_info()
 
     xll, yll = 321., 123.
-    angrot = 20
+    angrot = 20.
     ms.modelgrid = flopy.discretization.StructuredGrid(delc=ms.dis.delc.array,
                                                        delr=ms.dis.delr.array,
                                                        xoff=xll, yoff=xll,

--- a/flopy/discretization/grid.py
+++ b/flopy/discretization/grid.py
@@ -162,19 +162,20 @@ class Grid(object):
     # access to basic grid properties
     ###################################
     def __repr__(self):
+        items = []
         if self.xoffset is not None and self.yoffset is not None \
                 and self.angrot is not None:
-            s = "xll:{0:<.10G}; yll:{1:<.10G}; rotation:{2:<G}; ". \
-                format(self.xoffset, self.yoffset, self.angrot)
-        else:
-            s = ''
+            items += [
+                "xll:" + str(self.xoffset),
+                "yll:" + str(self.yoffset),
+                "rotation:" + str(self.angrot)]
         if self.proj4 is not None:
-            s += "proj4_str:{0}; ".format(self.proj4)
+            items.append("proj4_str:" + str(self.proj4))
         if self.units is not None:
-            s += "units:{0}; ".format(self.units)
+            items.append("units:" + str(self.units))
         if self.lenuni is not None:
-            s += "lenuni:{0}; ".format(self.lenuni)
-        return s
+            items.append("lenuni:" + str(self.lenuni))
+        return '; '.join(items)
 
     @property
     def is_valid(self):


### PR DESCRIPTION
This re-adds #622 refactor to remove the `; ` gap found in the metadata on the second line of the nam file. Also, values are formatted as native strings with `str()`, which generally does "the right thing".

E.g., before:

    #xll:0; yll:0; rotation:0; units:undefined; lenuni:0; ; start_datetime:1-1-1970

after:

    #xll:0.0; yll:0.0; rotation:0.0; units:undefined; lenuni:0; start_datetime:1-1-1970
