### PR TITLE
MFList Crash Fix

### DIFF
--- a/flopy/mf6/data/mffileaccess.py
+++ b/flopy/mf6/data/mffileaccess.py
@@ -1002,7 +1002,8 @@ class MFFileAccessList(MFFileAccess):
                                          len(self._last_line_info):]:
                             if arr_line_len <= data_index:
                                 break
-                            if arr_line[data_index][0] == '#':
+                            if len(arr_line[data_index]) > 0 and \
+                                    arr_line[data_index][0] == '#':
                                 break
                             elif data_item.name == 'aux':
                                 data_index, self._data_line = \


### PR DESCRIPTION
fix(mflist optimization): The mflist optimization code crashed when a line contained a word that only contained quote characters. Fix implemented to handle this case.