### PR TITLE
fix(flake8 code F632): use '==' instead of 'is'

### DIFF
--- a/flopy/mf6/utils/binaryfile_utils.py
+++ b/flopy/mf6/utils/binaryfile_utils.py
@@ -357,10 +357,10 @@ def _reshape_binary_data(data, dtype=None):
     data = np.array(data)
     if dtype is None:
         return data
-    elif dtype is 'V':
+    elif dtype == 'V':
         nodes = len(data[0][0][0])
         data.shape = (time, -1, nodes)
-    elif dtype is 'U':
+    elif dtype == 'U':
         data.shape = (time, -1)
     else:
         err = "Invalid dtype flag supplied, valid are dtype='U', dtype='V'"

--- a/flopy/mf6/utils/mfobservation.py
+++ b/flopy/mf6/utils/mfobservation.py
@@ -304,16 +304,16 @@ class Observations:
 
         # create list of datetimes
         t0 = dt.datetime(year, month, day, hour, minute, second)
-        if unit is 'Y':
+        if unit == 'Y':
             dtlist = [dt.datetime(int(year + time), month, day, hour, minute,
                                   second) for time in times]
-        elif unit is 'D':
+        elif unit == 'D':
             dtlist = [t0+dt.timedelta(days=time) for time in times]
-        elif unit is 'H':
+        elif unit == 'H':
             dtlist = [t0+dt.timedelta(hours=time) for time in times]
-        elif unit is 'M':
+        elif unit == 'M':
             dtlist = [t0+dt.timedelta(minutes=time) for time in times]
-        elif unit is 'S':
+        elif unit == 'S':
             dtlist = [t0+dt.timedelta(seconds=time) for time in times]
         else:
             raise TypeError('invalid time unit supplied')

--- a/flopy/utils/gridintersect.py
+++ b/flopy/utils/gridintersect.py
@@ -567,7 +567,7 @@ class GridIntersect:
             return np.recarray(0, names=["cellids", "vertices",
                                          "lengths", "ixshapes"],
                                formats=["O", "O", "f8", "O"])
-        if lineclip.geom_type is 'MultiLineString':  # there are multiple lines
+        if lineclip.geom_type == 'MultiLineString':  # there are multiple lines
             nodelist, lengths, vertices = [], [], []
             ixshapes = []
             for ls in lineclip:

--- a/flopy/utils/util_array.py
+++ b/flopy/utils/util_array.py
@@ -2081,7 +2081,7 @@ class Util2d(DataInterface):
                 locat = -1 * np.abs(locat)
         if locat is None:
             locat = 0
-        if locat is 0:
+        if locat == 0:
             fformat = ''
         if self.dtype == np.int32:
             cr = '{0:>10.0f}{1:>10.0f}{2:>19s}{3:>10.0f} #{4}\n' \

--- a/flopy/utils/util_list.py
+++ b/flopy/utils/util_list.py
@@ -453,9 +453,9 @@ class MfList(DataInterface, DataListInterface):
         dfs = []
         for per in self.data.keys():
             recs = self.data[per]
-            if recs is None or recs is 0:
+            if recs is None or len(recs) == 0:
                 # add an empty dataframe if a stress period is
-                # set to 0 (e.g. no pumping during a predevelopment
+                # empty (e.g. no pumping during a predevelopment
                 # period)
                 columns = names + list(['{}{}'.format(c, per)
                                         for c in varnames])


### PR DESCRIPTION
Furthermore, with Python 3.8 raises `SyntaxWarning` as [seen with a Python 3.8 test](https://travis-ci.org/modflowpy/flopy/jobs/614263195#L1659), e.g.:
> flopy/flopy/mf6/utils/binaryfile_utils.py:360: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif dtype is 'V':
  ...

this Python 3.8 warning is resolved with this PR.