### PR TITLE
fix(ModflowDis.sr): rotate model prior to calculating xll and yll from xul and yul

### DIFF
--- a/autotest/t007_test.py
+++ b/autotest/t007_test.py
@@ -545,6 +545,32 @@ def test_sr():
         raise AssertionError()
 
 
+def test_dis_sr():
+    import flopy
+    import numpy as np
+
+    delr = 640
+    delc = 640
+    nrow = np.ceil(59040. / delc).astype(int)
+    ncol = np.ceil(33128. / delr).astype(int)
+    nlay = 3
+
+    xul = 2746975.089
+    yul = 1171446.45
+    rotation = -39
+    bg = flopy.modflow.Modflow(modelname='base')
+    dis = flopy.modflow.ModflowDis(bg, nlay=nlay, nrow=nrow, ncol=ncol,
+                                   delr=delr, delc=delc, lenuni=1,
+                                   rotation=rotation, xul=xul, yul=yul,
+                                   proj4_str='epsg:2243')
+
+    if abs(dis.sr.xul - xul) > 0.01:
+        raise AssertionError()
+
+    if abs(dis.sr.yul - yul) > 0.01:
+        raise AssertionError()
+
+
 def test_mg():
     import flopy
     from flopy.utils import geometry

--- a/flopy/modflow/mfdis.py
+++ b/flopy/modflow/mfdis.py
@@ -211,6 +211,8 @@ class ModflowDis(Package):
         xll = None
         yll = None
         mg = model.modelgrid
+        if rotation is not None:
+            mg.set_coord_info(xoff=None, yoff=None, angrot=rotation)
         if xul is not None:
             xll = mg._xul_to_xll(xul)
         if yul is not None:


### PR DESCRIPTION
 issue #733 