### PR TITLE
mnw2 missing itmp when zero

### DIFF
--- a/flopy/modflow/mfmnw2.py
+++ b/flopy/modflow/mfmnw2.py
@@ -1270,7 +1270,7 @@ class ModflowMnw2(Package):
                                        hlim, qcut, qfrcmn, qfrcmx] + xyz)
                 stress_period_data[per] = current_4
             elif itmp_per == 0:  # no active mnws this stress period
-                continue
+                pass
             else:
                 # copy pumping rates from previous stress period
                 mnw[wellid].stress_period_data[per] = \


### PR DESCRIPTION
Resolves issue where mnw2 itmp list didn't include zeros for when a stress period had no discharge assigned. The "continue" advanced to the next iteration, missing the line where zero would be added to the itmp list. This was causing issues when rewriting a mnw2 file.