### PR TITLE
fix(dfns): update MODFLOW 6 dfns for next flopy (3.3.0) and mf6 (6.1.0) releases

### DIFF
--- a/flopy/mf6/data/dfn/gwf-csub.dfn
+++ b/flopy/mf6/data/dfn/gwf-csub.dfn
@@ -74,7 +74,7 @@ type keyword
 reader urword
 optional true
 longname keyword to indicate CR and CC are read instead of SSE and SSV
-description keyword to indicate that the the recompression (CR) and compression (CC) indices are specified instead of the elastic specific storage (SSE) and inelastic specific storage (SSV) coefficients. If not specified, then elastic specific storage (SSE) and inelastic specific storage (SSV) coefficients must be specified.
+description keyword to indicate that the recompression (CR) and compression (CC) indices are specified instead of the elastic specific storage (SSE) and inelastic specific storage (SSV) coefficients. If not specified, then elastic specific storage (SSE) and inelastic specific storage (SSV) coefficients must be specified.
 
 block options
 name update_material_properties
@@ -98,7 +98,7 @@ type keyword
 reader urword
 optional true
 longname keyword to indicate that absolute initial states will be specified
-description keyword to indicate that absolute preconsolidation stresses (heads) and delay bed heads will be specified for interbeds defined in the PACKAGEDATA block. The SPECIFIED\_INITIAL\_INTERBED\_STATE option is equivalent to specifying the SPECIFIED\_INITIAL\_PRECONSOLITATION\_STRESS and SPECIFIED\_INITIAL\_DELAY\_HEAD. If SPECIFIED\_INITIAL\_INTERBED\_STATE is not specified then preconsolidation stress (head) and delay bed head values specified in the PACKAGEDATA block are relative to simulated values if the first stress period is steady-state or initial stresses and GWF heads if the first stress period is transient.
+description keyword to indicate that absolute preconsolidation stresses (heads) and delay bed heads will be specified for interbeds defined in the PACKAGEDATA block. The SPECIFIED\_INITIAL\_INTERBED\_STATE option is equivalent to specifying the SPECIFIED\_INITIAL\_PRECONSOLITATION\_STRESS and SPECIFIED\_INITIAL\_DELAY\_HEAD. If SPECIFIED\_INITIAL\_INTERBED\_STATE is not specified then preconsolidation stress (head) and delay bed head values specified in the PACKAGEDATA block are relative to simulated values of the first stress period if steady-state or initial stresses and GWF heads if the first stress period is transient.
 
 block options
 name specified_initial_preconsolidation_stress
@@ -114,7 +114,7 @@ type keyword
 reader urword
 optional true
 longname keyword to indicate that absolute initial delay bed heads will be specified
-description keyword to indicate that absolute initial delay bed head will be specified for interbeds defined in the PACKAGEDATA block. If SPECIFIED\_INITIAL\_DELAY\_HEAD and SPECIFIED\_INITIAL\_INTERBED\_STATE are not specified then delay bead head values specified in the PACKAGEDATA block are relative to simulated values if the first stress period is steady-state or initial GWF heads if the first stress period is transient.
+description keyword to indicate that absolute initial delay bed head will be specified for interbeds defined in the PACKAGEDATA block. If SPECIFIED\_INITIAL\_DELAY\_HEAD and SPECIFIED\_INITIAL\_INTERBED\_STATE are not specified then delay bed head values specified in the PACKAGEDATA block are relative to simulated values if the first stress period is steady-state or initial GWF heads if the first stress period is transient.
 
 block options
 name effective_stress_lag

--- a/flopy/mf6/data/dfn/gwf-csub.dfn
+++ b/flopy/mf6/data/dfn/gwf-csub.dfn
@@ -1,0 +1,717 @@
+# --------------------- gwf csub options ---------------------
+
+block options
+name boundnames
+type keyword
+shape
+reader urword
+optional true
+longname
+description REPLACE boundnames {'{#1}': 'CSUB'}
+
+block options
+name print_input
+type keyword
+reader urword
+optional true
+longname print input to listing file
+description REPLACE print_input {'{#1}': 'CSUB'}
+
+block options
+name save_flows
+type keyword
+reader urword
+optional true
+longname keyword to save CSUB flows
+description keyword to indicate that cell-by-cell flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.
+
+# csub options
+block options
+name gammaw
+type double precision
+reader urword
+optional true
+longname unit weight of water
+description unit weight of water. For freshwater, GAMMAW is 9806.65 Newtons/cubic meters or 62.48 lb/cubic foot in SI and English units, respectively. By default, GAMMAW is 9806.65 Newtons/cubic meters.
+default_value 9806.65
+
+block options
+name beta
+type double precision
+reader urword
+optional true
+longname compressibility of water
+description compressibility of water. Typical values of BETA are 4.6512e-10 1/Pa or 2.2270e-8 lb/square foot in SI and English units, respectively. By default, BETA is 4.6512e-10 1/Pa.
+default_value 4.6512e-10
+
+block options
+name head_based
+type keyword
+reader urword
+optional true
+longname keyword to indicate the head-based formulation will be used
+description keyword to indicate the head-based formulation will be used to simulate coarse-grained aquifer materials and no-delay and delay interbeds. Specifying HEAD\_BASED also specifies the INITIAL\_PRECONSOLIDATION\_HEAD option.
+
+block options
+name initial_preconsolidation_head
+type keyword
+reader urword
+optional true
+longname keyword to indicate that preconsolidation heads will be specified
+description keyword to indicate that preconsolidation heads will be specified for no-delay and delay interbeds in the PACKAGEDATA block. If the SPECIFIED\_INITIAL\_INTERBED\_STATE option is specified in the OPTIONS block, user-specified preconsolidation heads in the PACKAGEDATA block are absolute values. Otherwise, user-specified preconsolidation heads in the PACKAGEDATA block are relative to steady-state or initial heads.
+
+block options
+name ndelaycells
+type integer
+reader urword
+optional true
+longname number of interbed cell nodes
+description number of nodes used to discretize delay interbeds. If not specified, then a default value of 19 is assigned.
+
+block options
+name compression_indices
+type keyword
+reader urword
+optional true
+longname keyword to indicate CR and CC are read instead of SSE and SSV
+description keyword to indicate that the the recompression (CR) and compression (CC) indices are specified instead of the elastic specific storage (SSE) and inelastic specific storage (SSV) coefficients. If not specified, then elastic specific storage (SSE) and inelastic specific storage (SSV) coefficients must be specified.
+
+block options
+name update_material_properties
+type keyword
+reader urword
+optional true
+longname keyword to indicate material properties can change during the simulations
+description keyword to indicate that the thickness and void ratio of coarse-grained and interbed sediments (delay and no-delay) will vary during the simulation. If not specified, the thickness and void ratio of coarse-grained and interbed sediments will not vary during the simulation.
+
+block options
+name cell_fraction
+type keyword
+reader urword
+optional true
+longname keyword to indicate cell fraction interbed thickness
+description keyword to indicate that the thickness of interbeds will be specified in terms of the fraction of cell thickness. If not specified, interbed thicknness must be specified.
+
+block options
+name specified_initial_interbed_state
+type keyword
+reader urword
+optional true
+longname keyword to indicate that absolute initial states will be specified
+description keyword to indicate that absolute preconsolidation stresses (heads) and delay bed heads will be specified for interbeds defined in the PACKAGEDATA block. The SPECIFIED\_INITIAL\_INTERBED\_STATE option is equivalent to specifying the SPECIFIED\_INITIAL\_PRECONSOLITATION\_STRESS and SPECIFIED\_INITIAL\_DELAY\_HEAD. If SPECIFIED\_INITIAL\_INTERBED\_STATE is not specified then preconsolidation stress (head) and delay bed head values specified in the PACKAGEDATA block are relative to simulated values if the first stress period is steady-state or initial stresses and GWF heads if the first stress period is transient.
+
+block options
+name specified_initial_preconsolidation_stress
+type keyword
+reader urword
+optional true
+longname keyword to indicate that absolute initial preconsolidation stresses (head) will be specified
+description keyword to indicate that absolute preconsolidation stresses (heads) will be specified for interbeds defined in the PACKAGEDATA block. If SPECIFIED\_INITIAL\_PRECONSOLITATION\_STRESS and SPECIFIED\_INITIAL\_INTERBED\_STATE are not specified then preconsolidation stress (head) values specified in the PACKAGEDATA block are relative to simulated values if the first stress period is steady-state or initial stresses (heads) if the first stress period is transient.
+
+block options
+name specified_initial_delay_head
+type keyword
+reader urword
+optional true
+longname keyword to indicate that absolute initial delay bed heads will be specified
+description keyword to indicate that absolute initial delay bed head will be specified for interbeds defined in the PACKAGEDATA block. If SPECIFIED\_INITIAL\_DELAY\_HEAD and SPECIFIED\_INITIAL\_INTERBED\_STATE are not specified then delay bead head values specified in the PACKAGEDATA block are relative to simulated values if the first stress period is steady-state or initial GWF heads if the first stress period is transient.
+
+block options
+name effective_stress_lag
+type keyword
+reader urword
+optional true
+longname keyword to indicate that specific storage will be calculate using the effective stress from the previous time step
+description keyword to indicate the effective stress from the previous time step will be used to calculate specific storage values. This option can 1) help with convergence in models with thin cells and water table elevations close to land surface; 2) is identical to the approach used in the SUBWT package for MODFLOW-2005; and 3) is only used if the effective-stress formulation is being used. By default, current effective stress values are used to calculate specific storage values.
+
+
+# csub csv strain output
+block options
+name strainib_filerecord
+type record strain_csv_interbed fileout interbedstrain_filename
+shape
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name strain_csv_interbed
+type keyword
+shape
+in_record true
+reader urword
+tagged true
+optional false
+longname budget keyword
+description keyword to specify the record that corresponds to final interbed strain output.
+
+block options
+name fileout
+type keyword
+shape
+in_record true
+reader urword
+tagged true
+optional false
+longname file keyword
+description keyword to specify that an output filename is expected next.
+
+block options
+name interbedstrain_filename
+type string
+shape
+in_record true
+reader urword
+tagged false
+optional false
+longname file keyword
+description name of the comma-separated-values output file to write final interbed strain information.
+
+block options
+name straincg_filerecord
+type record strain_csv_coarse fileout coarsestrain_filename
+shape
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name strain_csv_coarse
+type keyword
+shape
+in_record true
+reader urword
+tagged true
+optional false
+longname budget keyword
+description keyword to specify the record that corresponds to final coarse-grained material strain output.
+
+block options
+name coarsestrain_filename
+type string
+shape
+in_record true
+reader urword
+tagged false
+optional false
+longname file keyword
+description name of the comma-separated-values output file to write final coarse-grained material strain information.
+
+# binary compaction output
+block options
+name compaction_filerecord
+type record compaction fileout compaction_filename
+shape
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name compaction
+type keyword
+shape
+in_record true
+reader urword
+tagged true
+optional false
+longname compaction keyword
+description keyword to specify that record corresponds to the compaction.
+
+block options
+name fileout
+type keyword
+shape
+in_record true
+reader urword
+tagged true
+optional false
+longname file keyword
+description keyword to specify that an output filename is expected next.
+
+block options
+name compaction_filename
+type string
+shape
+in_record true
+reader urword
+tagged false
+optional false
+longname file keyword
+description name of the binary output file to write compaction information.
+
+block options
+name compaction_elastic_filerecord
+type record compaction_elastic fileout elastic_compaction_filename
+shape
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name compaction_elastic
+type keyword
+shape
+in_record true
+reader urword
+tagged true
+optional false
+longname elastic interbed compaction keyword
+description keyword to specify that record corresponds to the elastic interbed compaction binary file.
+
+block options
+name elastic_compaction_filename
+type string
+shape
+in_record true
+reader urword
+tagged false
+optional false
+longname file keyword
+description name of the binary output file to write elastic interbed compaction information.
+
+block options
+name compaction_inelastic_filerecord
+type record compaction_inelastic fileout inelastic_compaction_filename
+shape
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name compaction_inelastic
+type keyword
+shape
+in_record true
+reader urword
+tagged true
+optional false
+longname inelastic interbed compaction keyword
+description keyword to specify that record corresponds to the inelastic interbed compaction binary file.
+
+block options
+name inelastic_compaction_filename
+type string
+shape
+in_record true
+reader urword
+tagged false
+optional false
+longname file keyword
+description name of the binary output file to write inelastic interbed compaction information.
+
+block options
+name compaction_interbed_filerecord
+type record compaction_interbed fileout interbed_compaction_filename
+shape
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name compaction_interbed
+type keyword
+shape
+in_record true
+reader urword
+tagged true
+optional false
+longname interbed compaction keyword
+description keyword to specify that record corresponds to the interbed compaction binary file.
+
+block options
+name interbed_compaction_filename
+type string
+shape
+in_record true
+reader urword
+tagged false
+optional false
+longname file keyword
+description name of the binary output file to write interbed compaction information.
+
+block options
+name compaction_coarse_filerecord
+type record compaction_coarse fileout coarse_compaction_filename
+shape
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name compaction_coarse
+type keyword
+shape
+in_record true
+reader urword
+tagged true
+optional false
+longname coarse compaction keyword
+description keyword to specify that record corresponds to the elastic coarse-grained material compaction binary file.
+
+block options
+name coarse_compaction_filename
+type string
+shape
+in_record true
+reader urword
+tagged false
+optional false
+longname file keyword
+description name of the binary output file to write elastic coarse-grained material compaction information.
+
+block options
+name zdisplacement_filerecord
+type record zdisplacement fileout zdisplacement_filename
+shape
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name zdisplacement
+type keyword
+shape
+in_record true
+reader urword
+tagged true
+optional false
+longname budget keyword
+description keyword to specify that record corresponds to the z-displacement binary file.
+
+block options
+name zdisplacement_filename
+type string
+shape
+in_record true
+reader urword
+tagged false
+optional false
+longname file keyword
+description name of the binary output file to write z-displacement information.
+
+block options
+name ts_filerecord
+type record ts6 filein ts6_filename
+shape
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name ts6
+type keyword
+shape
+in_record true
+reader urword
+tagged true
+optional false
+longname head keyword
+description keyword to specify that record corresponds to a time-series file.
+
+block options
+name filein
+type keyword
+shape
+in_record true
+reader urword
+tagged true
+optional false
+longname file keyword
+description keyword to specify that an input filename is expected next.
+
+block options
+name ts6_filename
+type string
+in_record true
+reader urword
+optional false
+tagged false
+longname file name of time series information
+description REPLACE timeseriesfile {}
+
+block options
+name obs_filerecord
+type record obs6 filein obs6_filename
+shape
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name obs6
+type keyword
+shape
+in_record true
+reader urword
+tagged true
+optional false
+longname obs keyword
+description keyword to specify that record corresponds to an observations file.
+
+block options
+name obs6_filename
+type string
+in_record true
+tagged false
+reader urword
+optional false
+longname obs6 input filename
+description REPLACE obs6_filename {'{#1}': 'CSUB'}
+
+# --------------------- gwf csub dimensions ---------------------
+
+block dimensions
+name ninterbeds
+type integer
+reader urword
+optional false
+longname number of CSUB interbed systems
+description is the number of CSUB interbed systems.  More than 1 CSUB interbed systems can be assigned to a GWF cell; however, only 1 GWF cell can be assigned to a single CSUB interbed system.
+
+block dimensions
+name maxsig0
+type integer
+reader urword
+optional true
+longname maximum number of stress offset cells
+description is the maximum number of cells that can have a specified stress offset.  More than 1 stress offset can be assigned to a GWF cell. By default, MAXSIG0 is 0.
+
+
+# --------------------- gwf csub griddata ---------------------
+
+block griddata
+name cg_ske_cr
+type double precision
+shape (nodes)
+valid
+reader readarray
+longname elastic coarse specific storage
+description is the initial elastic coarse-grained material specific storage or recompression index. The recompression index is specified if COMPRESSION\_INDICES is specified in the OPTIONS block.  Specified or calculated elastic coarse-grained material specific storage values are not adjusted from initial values if HEAD\_BASED is specified in the OPTIONS block.
+default_value 1e-5
+
+block griddata
+name cg_theta
+type double precision
+shape (nodes)
+valid
+reader readarray
+longname initial coarse-grained material porosity
+description is the initial porosity of coarse-grained materials.
+default_value 0.2
+
+block griddata
+name sgm
+type double precision
+shape (nodes)
+valid
+reader readarray
+optional true
+longname specific gravity of moist sediments
+description is the specific gravity of moist or unsaturated sediments.  If not specified, then a default value of 1.7 is assigned.
+
+block griddata
+name sgs
+type double precision
+shape (nodes)
+valid
+reader readarray
+optional true
+longname specific gravity of saturated sediments
+description is the specific gravity of saturated sediments. If not specified, then a default value of 2.0 is assigned.
+
+# --------------------- gwf csub packagedata ---------------------
+
+block packagedata
+name packagedata
+type recarray icsubno cellid cdelay pcs0 thick_frac rnb ssv_cc sse_cr theta kv h0 boundname
+shape (ncsubcells)
+reader urword
+longname
+description
+
+block packagedata
+name icsubno
+type integer
+shape
+tagged false
+in_record true
+reader urword
+longname CSUB id number for this entry
+description integer value that defines the CSUB interbed number associated with the specified PACKAGEDATA data on the line. CSUBNO must be greater than zero and less than or equal to NCSUBCELLS.  CSUB information must be specified for every CSUB cell or the program will terminate with an error.  The program will also terminate with an error if information for a CSUB interbed number is specified more than once.
+numeric_index true
+
+block packagedata
+name cellid
+type integer
+shape (ncelldim)
+tagged false
+in_record true
+reader urword
+longname cell identifier
+description REPLACE cellid {}
+
+block packagedata
+name cdelay
+type string
+shape
+tagged false
+in_record true
+reader urword
+longname initial water content
+description character string that defines the subsidence delay type for the interbed. Possible subsidence package CDELAY strings include: NODELAY--character keyword to indicate that delay will not be simulated in the interbed.  DELAY--character keyword to indicate that delay will be simulated in the interbed.
+
+block packagedata
+name pcs0
+type double precision
+shape
+tagged false
+in_record true
+reader urword
+longname initial stress
+description is the initial offset from the calculated initial effective stress or initial preconsolidation stress in the interbed, in units of height of a column of water. PCS0 is the initial preconsolidation stress if SPECIFIED\_INITIAL\_INTERBED\_STATE or SPECIFIED\_INITIAL\_PRECONSOLIDATION\_STRESS are specified in the OPTIONS block. If HEAD\_BASED is specified in the OPTIONS block, PCS0 is the initial offset from the calculated initial head or initial preconsolidation head in the CSUB interbed and the initial preconsolidation stress is calculated from the calculated initial effective stress or calculated initial geostatic stress, respectively.
+
+block packagedata
+name thick_frac
+type double precision
+shape
+tagged false
+in_record true
+reader urword
+longname interbed thickness or cell fraction
+description is the interbed thickness or cell fraction of the interbed. Interbed thickness is specified as a fraction of the cell thickness if CELL\_FRACTION is specified in the OPTIONS block.
+
+block packagedata
+name rnb
+type double precision
+shape
+tagged false
+in_record true
+reader urword
+longname delay interbed material factor
+description is the interbed material factor equivalent number of interbeds in the interbed system represented by the interbed. RNB must be greater than or equal to 1 if CDELAY is DELAY. Otherwise, RNB can be any value.
+
+block packagedata
+name ssv_cc
+type double precision
+shape
+tagged false
+in_record true
+reader urword
+longname initial interbed inelastic specific storage
+description is the initial inelastic specific storage or compression index of the interbed. The compression index is specified if COMPRESSION\_INDICES is specified in the OPTIONS block. Specified or calculated interbed inelastic specific storage values are not adjusted from initial values if HEAD\_BASED is specified in the OPTIONS block.
+
+block packagedata
+name sse_cr
+type double precision
+shape
+tagged false
+in_record true
+reader urword
+longname initial elastic interbed specific storage
+description is the initial elastic coarse-grained material specific storage or recompression index of the interbed. The recompression index is specified if COMPRESSION\_INDICES is specified in the OPTIONS block. Specified or calculated interbed elastic specific storage values are not adjusted from initial values if HEAD\_BASED is specified in the OPTIONS block.
+
+block packagedata
+name theta
+type double precision
+shape
+tagged false
+in_record true
+reader urword
+longname initial interbed porosity
+description is the initial porosity of the interbed.
+default_value 0.2
+
+block packagedata
+name kv
+type double precision
+shape
+tagged false
+in_record true
+reader urword
+longname delay interbed vertical hydraulic conductivity
+description is the vertical hydraulic conductivity of the delay interbed. KV must be greater than 0 if CDELAY is DELAY. Otherwise, KV can be any value.
+
+block packagedata
+name h0
+type double precision
+shape
+tagged false
+in_record true
+reader urword
+longname initial delay interbed head
+description is the initial offset from the head in cell cellid or the initial head in the delay interbed. H0 is the initial head in the delay bed if SPECIFIED\_INITIAL\_INTERBED\_STATE or SPECIFIED\_INITIAL\_DELAY\_HEAD are specified in the OPTIONS block. H0 can be any value if CDELAY is NODELAY.
+
+block packagedata
+name boundname
+type string
+shape
+tagged false
+in_record true
+reader urword
+optional true
+longname well name
+description REPLACE boundname {'{#1}': 'CSUB'}
+
+# --------------------- gwf csub period ---------------------
+
+block period
+name iper
+type integer
+block_variable True
+in_record true
+tagged false
+shape
+valid
+reader urword
+optional false
+longname stress period number
+description REPLACE iper {}
+
+block period
+name stress_period_data
+type recarray cellid sig0
+shape (maxsig0)
+reader urword
+longname
+description
+
+block period
+name cellid
+type integer
+shape (ncelldim)
+tagged false
+in_record true
+reader urword
+longname cell identifier
+description REPLACE cellid {}
+
+block period
+name sig0
+type double precision
+shape
+tagged false
+in_record true
+reader urword
+time_series true
+longname well stress offset
+description is the stress offset for the cell. SIG0 is added to the calculated geostatic stress for the cell. SIG0 is specified only if MAXSIG0 is specified to be greater than 0 in the DIMENSIONS block.

--- a/flopy/mf6/data/dfn/gwf-disu.dfn
+++ b/flopy/mf6/data/dfn/gwf-disu.dfn
@@ -92,6 +92,15 @@ reader readarray
 longname cell surface area
 description is the cell surface area (in plan view).
 
+block griddata
+name idomain
+type integer
+shape (nodes)
+reader readarray
+layered true
+optional true
+longname idomain existence array
+description is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.  IDOMAIN values of -1 cannot be specified for the DISU Package.
 
 # --------------------- gwf disu connectiondata ---------------------
 

--- a/flopy/mf6/data/dfn/gwf-lak.dfn
+++ b/flopy/mf6/data/dfn/gwf-lak.dfn
@@ -621,7 +621,7 @@ numeric_index true
 
 block period
 name laksetting
-type keystring status stage rainfall evaporation runoff withdrawal auxiliaryrecord
+type keystring status stage rainfall evaporation runoff inflow withdrawal auxiliaryrecord
 shape
 tagged false
 in_record true
@@ -682,6 +682,17 @@ reader urword
 time_series true
 longname runoff rate
 description real or character value that defines the runoff rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.
+
+block period
+name inflow
+type string
+shape
+tagged true
+in_record true
+reader urword
+time_series true
+longname inflow rate
+description real or character value that defines the volumetric inflow rate $(L^3 T^{-1})$ for the lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, inflow rates are zero for each lake.
 
 block period
 name withdrawal

--- a/flopy/mf6/data/dfn/gwf-npf.dfn
+++ b/flopy/mf6/data/dfn/gwf-npf.dfn
@@ -135,6 +135,22 @@ optional true
 longname keyword to save specific discharge
 description keyword to indicate that x, y, and z components of specific discharge will be calculated at cell centers and written to the cell-by-cell flow file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  If this option is activated, then additional information may be required in the discretization packages and the GWF Exchange package (if GWF models are coupled).  Specifically, ANGLDEGX must be specified in the CONNECTIONDATA block of the DISU Package; ANGLDEGX must also be specified for the GWF Exchange as an auxiliary variable.
 
+block options
+name k22overk
+type keyword
+reader urword
+optional true
+longname keyword to indicate that specified K22 is a ratio
+description keyword to indicate that specified K22 is a ratio of K22 divided by K.  If this option is specified, then the K22 array entered in the NPF Package will be multiplied by K after being read.
+
+block options
+name k33overk
+type keyword
+reader urword
+optional true
+longname keyword to indicate that specified K33 is a ratio
+description keyword to indicate that specified K33 is a ratio of K33 divided by K.  If this option is specified, then the K33 array entered in the NPF Package will be multiplied by K after being read.
+
 
 # --------------------- gwf npf griddata ---------------------
 
@@ -171,7 +187,7 @@ reader readarray
 layered true
 optional true
 longname hydraulic conductivity of second ellipsoid axis
-description is the hydraulic conductivity of the second ellipsoid axis; for an unrotated case this is the hydraulic conductivity in the y direction.  If K22 is not included in the GRIDDATA block, then K22 is set equal to K.  For a regular MODFLOW grid (DIS Package is used) in which no rotation angles are specified, K22 is the hydraulic conductivity along columns in the y direction. For an unstructured DISU grid, the user must assign principal x and y axes and provide the angle for each cell face relative to the assigned x direction.  All included cells (IDOMAIN $>$ 0) must have a K22 value greater than zero.
+description is the hydraulic conductivity of the second ellipsoid axis (or the ratio of K22/K if the K22OVERK option is specified); for an unrotated case this is the hydraulic conductivity in the y direction.  If K22 is not included in the GRIDDATA block, then K22 is set equal to K.  For a regular MODFLOW grid (DIS Package is used) in which no rotation angles are specified, K22 is the hydraulic conductivity along columns in the y direction. For an unstructured DISU grid, the user must assign principal x and y axes and provide the angle for each cell face relative to the assigned x direction.  All included cells (IDOMAIN $>$ 0) must have a K22 value greater than zero.
 
 block griddata
 name k33
@@ -182,7 +198,7 @@ reader readarray
 layered true
 optional true
 longname hydraulic conductivity of third ellipsoid axis (L/T)
-description is the hydraulic conductivity of the third ellipsoid axis; for an unrotated case, this is the vertical hydraulic conductivity.  When anisotropy is applied, K33 corresponds to the K33 tensor component.  All included cells (IDOMAIN $>$ 0) must have a K33 value greater than zero.
+description is the hydraulic conductivity of the third ellipsoid axis (or the ratio of K33/K if the K33OVERK option is specified); for an unrotated case, this is the vertical hydraulic conductivity.  When anisotropy is applied, K33 corresponds to the K33 tensor component.  All included cells (IDOMAIN $>$ 0) must have a K33 value greater than zero.
 
 block griddata
 name angle1

--- a/flopy/mf6/data/dfn/sim-nam.dfn
+++ b/flopy/mf6/data/dfn/sim-nam.dfn
@@ -24,6 +24,13 @@ optional true
 longname memory print option
 description is a flag that controls printing of detailed memory manager usage to the end of the simulation list file.  NONE means do not print detailed information. SUMMARY means print only the total memory for each simulation component. ALL means print information for each variable stored in the memory manager. NONE is default if MEMORY\_PRINT\_OPTION is not specified.
 
+block options
+name maxerrors
+type integer
+reader urword
+optional true
+longname maximum number of errors
+description maximum number of errors that will be stored and printed.
 
 
 # --------------------- sim nam timing ---------------------

--- a/flopy/mf6/modflow/__init__.py
+++ b/flopy/mf6/modflow/__init__.py
@@ -35,3 +35,4 @@ from .mfgwfuzf import ModflowGwfuzf
 from .mfgwfmvr import ModflowGwfmvr
 from .mfgwfgnc import ModflowGwfgnc
 from .mfgwfoc import ModflowGwfoc
+from .mfgwfcsub import ModflowGwfcsub

--- a/flopy/mf6/modflow/mfgwfcsub.py
+++ b/flopy/mf6/modflow/mfgwfcsub.py
@@ -1,0 +1,568 @@
+# DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
+# mf6/utils/createpackages.py
+from .. import mfpackage
+from ..data.mfdatautil import ListTemplateGenerator, ArrayTemplateGenerator
+
+
+class ModflowGwfcsub(mfpackage.MFPackage):
+    """
+    ModflowGwfcsub defines a csub package within a gwf6 model.
+
+    Parameters
+    ----------
+    model : MFModel
+        Model that this package is a part of.  Package is automatically
+        added to model when it is initialized.
+    loading_package : bool
+        Do not set this parameter. It is intended for debugging and internal
+        processing purposes only.
+    boundnames : boolean
+        * boundnames (boolean) keyword to indicate that boundary names may be
+          provided with the list of CSUB cells.
+    print_input : boolean
+        * print_input (boolean) keyword to indicate that the list of CSUB
+          information will be written to the listing file immediately after it
+          is read.
+    save_flows : boolean
+        * save_flows (boolean) keyword to indicate that cell-by-cell flow terms
+          will be written to the file specified with "BUDGET SAVE FILE" in
+          Output Control.
+    gammaw : double
+        * gammaw (double) unit weight of water. For freshwater, GAMMAW is
+          9806.65 Newtons/cubic meters or 62.48 lb/cubic foot in SI and English
+          units, respectively. By default, GAMMAW is 9806.65 Newtons/cubic
+          meters.
+    beta : double
+        * beta (double) compressibility of water. Typical values of BETA are
+          4.6512e-10 1/Pa or 2.2270e-8 lb/square foot in SI and English units,
+          respectively. By default, BETA is 4.6512e-10 1/Pa.
+    head_based : boolean
+        * head_based (boolean) keyword to indicate the head-based formulation
+          will be used to simulate coarse-grained aquifer materials and no-
+          delay and delay interbeds. Specifying HEAD_BASED also specifies the
+          INITIAL_PRECONSOLIDATION_HEAD option.
+    initial_preconsolidation_head : boolean
+        * initial_preconsolidation_head (boolean) keyword to indicate that
+          preconsolidation heads will be specified for no-delay and delay
+          interbeds in the PACKAGEDATA block. If the
+          SPECIFIED_INITIAL_INTERBED_STATE option is specified in the OPTIONS
+          block, user-specified preconsolidation heads in the PACKAGEDATA block
+          are absolute values. Otherwise, user-specified preconsolidation heads
+          in the PACKAGEDATA block are relative to steady-state or initial
+          heads.
+    ndelaycells : integer
+        * ndelaycells (integer) number of nodes used to discretize delay
+          interbeds. If not specified, then a default value of 19 is assigned.
+    compression_indices : boolean
+        * compression_indices (boolean) keyword to indicate that the the
+          recompression (CR) and compression (CC) indices are specified instead
+          of the elastic specific storage (SSE) and inelastic specific storage
+          (SSV) coefficients. If not specified, then elastic specific storage
+          (SSE) and inelastic specific storage (SSV) coefficients must be
+          specified.
+    update_material_properties : boolean
+        * update_material_properties (boolean) keyword to indicate that the
+          thickness and void ratio of coarse-grained and interbed sediments
+          (delay and no-delay) will vary during the simulation. If not
+          specified, the thickness and void ratio of coarse-grained and
+          interbed sediments will not vary during the simulation.
+    cell_fraction : boolean
+        * cell_fraction (boolean) keyword to indicate that the thickness of
+          interbeds will be specified in terms of the fraction of cell
+          thickness. If not specified, interbed thicknness must be specified.
+    specified_initial_interbed_state : boolean
+        * specified_initial_interbed_state (boolean) keyword to indicate that
+          absolute preconsolidation stresses (heads) and delay bed heads will
+          be specified for interbeds defined in the PACKAGEDATA block. The
+          SPECIFIED_INITIAL_INTERBED_STATE option is equivalent to specifying
+          the SPECIFIED_INITIAL_PRECONSOLITATION_STRESS and
+          SPECIFIED_INITIAL_DELAY_HEAD. If SPECIFIED_INITIAL_INTERBED_STATE is
+          not specified then preconsolidation stress (head) and delay bed head
+          values specified in the PACKAGEDATA block are relative to simulated
+          values if the first stress period is steady-state or initial stresses
+          and GWF heads if the first stress period is transient.
+    specified_initial_preconsolidation_stress : boolean
+        * specified_initial_preconsolidation_stress (boolean) keyword to
+          indicate that absolute preconsolidation stresses (heads) will be
+          specified for interbeds defined in the PACKAGEDATA block. If
+          SPECIFIED_INITIAL_PRECONSOLITATION_STRESS and
+          SPECIFIED_INITIAL_INTERBED_STATE are not specified then
+          preconsolidation stress (head) values specified in the PACKAGEDATA
+          block are relative to simulated values if the first stress period is
+          steady-state or initial stresses (heads) if the first stress period
+          is transient.
+    specified_initial_delay_head : boolean
+        * specified_initial_delay_head (boolean) keyword to indicate that
+          absolute initial delay bed head will be specified for interbeds
+          defined in the PACKAGEDATA block. If SPECIFIED_INITIAL_DELAY_HEAD and
+          SPECIFIED_INITIAL_INTERBED_STATE are not specified then delay bead
+          head values specified in the PACKAGEDATA block are relative to
+          simulated values if the first stress period is steady-state or
+          initial GWF heads if the first stress period is transient.
+    effective_stress_lag : boolean
+        * effective_stress_lag (boolean) keyword to indicate the effective
+          stress from the previous time step will be used to calculate specific
+          storage values. This option can 1) help with convergence in models
+          with thin cells and water table elevations close to land surface; 2)
+          is identical to the approach used in the SUBWT package for
+          MODFLOW-2005; and 3) is only used if the effective-stress formulation
+          is being used. By default, current effective stress values are used
+          to calculate specific storage values.
+    strainib_filerecord : [interbedstrain_filename]
+        * interbedstrain_filename (string) name of the comma-separated-values
+          output file to write final interbed strain information.
+    straincg_filerecord : [coarsestrain_filename]
+        * coarsestrain_filename (string) name of the comma-separated-values
+          output file to write final coarse-grained material strain
+          information.
+    compaction_filerecord : [compaction_filename]
+        * compaction_filename (string) name of the binary output file to write
+          compaction information.
+    fileout : boolean
+        * fileout (boolean) keyword to specify that an output filename is
+          expected next.
+    compaction_elastic_filerecord : [elastic_compaction_filename]
+        * elastic_compaction_filename (string) name of the binary output file
+          to write elastic interbed compaction information.
+    compaction_inelastic_filerecord : [inelastic_compaction_filename]
+        * inelastic_compaction_filename (string) name of the binary output file
+          to write inelastic interbed compaction information.
+    compaction_interbed_filerecord : [interbed_compaction_filename]
+        * interbed_compaction_filename (string) name of the binary output file
+          to write interbed compaction information.
+    compaction_coarse_filerecord : [coarse_compaction_filename]
+        * coarse_compaction_filename (string) name of the binary output file to
+          write elastic coarse-grained material compaction information.
+    zdisplacement_filerecord : [zdisplacement_filename]
+        * zdisplacement_filename (string) name of the binary output file to
+          write z-displacement information.
+    timeseries : {varname:data} or timeseries data
+        * Contains data for the ts package. Data can be stored in a dictionary
+          containing data for the ts package with variable names as keys and
+          package data as values. Data just for the timeseries variable is also
+          acceptable. See ts package documentation for more information.
+    observations : {varname:data} or continuous data
+        * Contains data for the obs package. Data can be stored in a dictionary
+          containing data for the obs package with variable names as keys and
+          package data as values. Data just for the observations variable is
+          also acceptable. See obs package documentation for more information.
+    ninterbeds : integer
+        * ninterbeds (integer) is the number of CSUB interbed systems. More
+          than 1 CSUB interbed systems can be assigned to a GWF cell; however,
+          only 1 GWF cell can be assigned to a single CSUB interbed system.
+    maxsig0 : integer
+        * maxsig0 (integer) is the maximum number of cells that can have a
+          specified stress offset. More than 1 stress offset can be assigned to
+          a GWF cell. By default, MAXSIG0 is 0.
+    cg_ske_cr : [double]
+        * cg_ske_cr (double) is the initial elastic coarse-grained material
+          specific storage or recompression index. The recompression index is
+          specified if COMPRESSION_INDICES is specified in the OPTIONS block.
+          Specified or calculated elastic coarse-grained material specific
+          storage values are not adjusted from initial values if HEAD_BASED is
+          specified in the OPTIONS block.
+    cg_theta : [double]
+        * cg_theta (double) is the initial porosity of coarse-grained
+          materials.
+    sgm : [double]
+        * sgm (double) is the specific gravity of moist or unsaturated
+          sediments. If not specified, then a default value of 1.7 is assigned.
+    sgs : [double]
+        * sgs (double) is the specific gravity of saturated sediments. If not
+          specified, then a default value of 2.0 is assigned.
+    packagedata : [icsubno, cellid, cdelay, pcs0, thick_frac, rnb, ssv_cc,
+      sse_cr, theta, kv, h0, boundname]
+        * icsubno (integer) integer value that defines the CSUB interbed number
+          associated with the specified PACKAGEDATA data on the line. CSUBNO
+          must be greater than zero and less than or equal to NCSUBCELLS. CSUB
+          information must be specified for every CSUB cell or the program will
+          terminate with an error. The program will also terminate with an
+          error if information for a CSUB interbed number is specified more
+          than once.
+        * cellid ((integer, ...)) is the cell identifier, and depends on the
+          type of grid that is used for the simulation. For a structured grid
+          that uses the DIS input file, CELLID is the layer, row, and column.
+          For a grid that uses the DISV input file, CELLID is the layer and
+          CELL2D number. If the model uses the unstructured discretization
+          (DISU) input file, CELLID is the node number for the cell.
+        * cdelay (string) character string that defines the subsidence delay
+          type for the interbed. Possible subsidence package CDELAY strings
+          include: NODELAY--character keyword to indicate that delay will not
+          be simulated in the interbed. DELAY--character keyword to indicate
+          that delay will be simulated in the interbed.
+        * pcs0 (double) is the initial offset from the calculated initial
+          effective stress or initial preconsolidation stress in the interbed,
+          in units of height of a column of water. PCS0 is the initial
+          preconsolidation stress if SPECIFIED_INITIAL_INTERBED_STATE or
+          SPECIFIED_INITIAL_PRECONSOLIDATION_STRESS are specified in the
+          OPTIONS block. If HEAD_BASED is specified in the OPTIONS block, PCS0
+          is the initial offset from the calculated initial head or initial
+          preconsolidation head in the CSUB interbed and the initial
+          preconsolidation stress is calculated from the calculated initial
+          effective stress or calculated initial geostatic stress,
+          respectively.
+        * thick_frac (double) is the interbed thickness or cell fraction of the
+          interbed. Interbed thickness is specified as a fraction of the cell
+          thickness if CELL_FRACTION is specified in the OPTIONS block.
+        * rnb (double) is the interbed material factor equivalent number of
+          interbeds in the interbed system represented by the interbed. RNB
+          must be greater than or equal to 1 if CDELAY is DELAY. Otherwise, RNB
+          can be any value.
+        * ssv_cc (double) is the initial inelastic specific storage or
+          compression index of the interbed. The compression index is specified
+          if COMPRESSION_INDICES is specified in the OPTIONS block. Specified
+          or calculated interbed inelastic specific storage values are not
+          adjusted from initial values if HEAD_BASED is specified in the
+          OPTIONS block.
+        * sse_cr (double) is the initial elastic coarse-grained material
+          specific storage or recompression index of the interbed. The
+          recompression index is specified if COMPRESSION_INDICES is specified
+          in the OPTIONS block. Specified or calculated interbed elastic
+          specific storage values are not adjusted from initial values if
+          HEAD_BASED is specified in the OPTIONS block.
+        * theta (double) is the initial porosity of the interbed.
+        * kv (double) is the vertical hydraulic conductivity of the delay
+          interbed. KV must be greater than 0 if CDELAY is DELAY. Otherwise, KV
+          can be any value.
+        * h0 (double) is the initial offset from the head in cell cellid or the
+          initial head in the delay interbed. H0 is the initial head in the
+          delay bed if SPECIFIED_INITIAL_INTERBED_STATE or
+          SPECIFIED_INITIAL_DELAY_HEAD are specified in the OPTIONS block. H0
+          can be any value if CDELAY is NODELAY.
+        * boundname (string) name of the CSUB cell. BOUNDNAME is an ASCII
+          character variable that can contain as many as 40 characters. If
+          BOUNDNAME contains spaces in it, then the entire name must be
+          enclosed within single quotes.
+    stress_period_data : [cellid, sig0]
+        * cellid ((integer, ...)) is the cell identifier, and depends on the
+          type of grid that is used for the simulation. For a structured grid
+          that uses the DIS input file, CELLID is the layer, row, and column.
+          For a grid that uses the DISV input file, CELLID is the layer and
+          CELL2D number. If the model uses the unstructured discretization
+          (DISU) input file, CELLID is the node number for the cell.
+        * sig0 (double) is the stress offset for the cell. SIG0 is added to the
+          calculated geostatic stress for the cell. SIG0 is specified only if
+          MAXSIG0 is specified to be greater than 0 in the DIMENSIONS block.
+    filename : String
+        File name for this package.
+    pname : String
+        Package name for this package.
+    parent_file : MFPackage
+        Parent package file that references this package. Only needed for
+        utility packages (mfutl*). For example, mfutllaktab package must have 
+        a mfgwflak package parent_file.
+
+    """
+    strainib_filerecord = ListTemplateGenerator(('gwf6', 'csub',
+                                                 'options',
+                                                 'strainib_filerecord'))
+    straincg_filerecord = ListTemplateGenerator(('gwf6', 'csub',
+                                                 'options',
+                                                 'straincg_filerecord'))
+    compaction_filerecord = ListTemplateGenerator(('gwf6', 'csub',
+                                                   'options',
+                                                   'compaction_filerecord'))
+    compaction_elastic_filerecord = ListTemplateGenerator((
+        'gwf6', 'csub', 'options', 'compaction_elastic_filerecord'))
+    compaction_inelastic_filerecord = ListTemplateGenerator((
+        'gwf6', 'csub', 'options', 'compaction_inelastic_filerecord'))
+    compaction_interbed_filerecord = ListTemplateGenerator((
+        'gwf6', 'csub', 'options', 'compaction_interbed_filerecord'))
+    compaction_coarse_filerecord = ListTemplateGenerator((
+        'gwf6', 'csub', 'options', 'compaction_coarse_filerecord'))
+    zdisplacement_filerecord = ListTemplateGenerator((
+        'gwf6', 'csub', 'options', 'zdisplacement_filerecord'))
+    ts_filerecord = ListTemplateGenerator(('gwf6', 'csub', 'options',
+                                           'ts_filerecord'))
+    obs_filerecord = ListTemplateGenerator(('gwf6', 'csub', 'options',
+                                            'obs_filerecord'))
+    cg_ske_cr = ArrayTemplateGenerator(('gwf6', 'csub', 'griddata',
+                                        'cg_ske_cr'))
+    cg_theta = ArrayTemplateGenerator(('gwf6', 'csub', 'griddata',
+                                       'cg_theta'))
+    sgm = ArrayTemplateGenerator(('gwf6', 'csub', 'griddata', 'sgm'))
+    sgs = ArrayTemplateGenerator(('gwf6', 'csub', 'griddata', 'sgs'))
+    packagedata = ListTemplateGenerator(('gwf6', 'csub', 'packagedata',
+                                         'packagedata'))
+    stress_period_data = ListTemplateGenerator(('gwf6', 'csub', 'period',
+                                                'stress_period_data'))
+    package_abbr = "gwfcsub"
+    _package_type = "csub"
+    dfn_file_name = "gwf-csub.dfn"
+
+    dfn = [["block options", "name boundnames", "type keyword", "shape",
+            "reader urword", "optional true"],
+           ["block options", "name print_input", "type keyword",
+            "reader urword", "optional true"],
+           ["block options", "name save_flows", "type keyword",
+            "reader urword", "optional true"],
+           ["block options", "name gammaw", "type double precision",
+            "reader urword", "optional true", "default_value 9806.65"],
+           ["block options", "name beta", "type double precision",
+            "reader urword", "optional true", "default_value 4.6512e-10"],
+           ["block options", "name head_based", "type keyword",
+            "reader urword", "optional true"],
+           ["block options", "name initial_preconsolidation_head",
+            "type keyword", "reader urword", "optional true"],
+           ["block options", "name ndelaycells", "type integer",
+            "reader urword", "optional true"],
+           ["block options", "name compression_indices", "type keyword",
+            "reader urword", "optional true"],
+           ["block options", "name update_material_properties",
+            "type keyword", "reader urword", "optional true"],
+           ["block options", "name cell_fraction", "type keyword",
+            "reader urword", "optional true"],
+           ["block options", "name specified_initial_interbed_state",
+            "type keyword", "reader urword", "optional true"],
+           ["block options",
+            "name specified_initial_preconsolidation_stress", "type keyword",
+            "reader urword", "optional true"],
+           ["block options", "name specified_initial_delay_head",
+            "type keyword", "reader urword", "optional true"],
+           ["block options", "name effective_stress_lag", "type keyword",
+            "reader urword", "optional true"],
+           ["block options", "name strainib_filerecord",
+            "type record strain_csv_interbed fileout interbedstrain_filename",
+            "shape", "reader urword", "tagged true", "optional true"],
+           ["block options", "name strain_csv_interbed", "type keyword",
+            "shape", "in_record true", "reader urword", "tagged true",
+            "optional false"],
+           ["block options", "name fileout", "type keyword", "shape",
+            "in_record true", "reader urword", "tagged true",
+            "optional false"],
+           ["block options", "name interbedstrain_filename", "type string",
+            "shape", "in_record true", "reader urword", "tagged false",
+            "optional false"],
+           ["block options", "name straincg_filerecord",
+            "type record strain_csv_coarse fileout coarsestrain_filename",
+            "shape", "reader urword", "tagged true", "optional true"],
+           ["block options", "name strain_csv_coarse", "type keyword",
+            "shape", "in_record true", "reader urword", "tagged true",
+            "optional false"],
+           ["block options", "name coarsestrain_filename", "type string",
+            "shape", "in_record true", "reader urword", "tagged false",
+            "optional false"],
+           ["block options", "name compaction_filerecord",
+            "type record compaction fileout compaction_filename", "shape",
+            "reader urword", "tagged true", "optional true"],
+           ["block options", "name compaction", "type keyword", "shape",
+            "in_record true", "reader urword", "tagged true",
+            "optional false"],
+           ["block options", "name fileout", "type keyword", "shape",
+            "in_record true", "reader urword", "tagged true",
+            "optional false"],
+           ["block options", "name compaction_filename", "type string",
+            "shape", "in_record true", "reader urword", "tagged false",
+            "optional false"],
+           ["block options", "name compaction_elastic_filerecord",
+            "type record compaction_elastic fileout elastic_compaction_filename",
+            "shape", "reader urword", "tagged true", "optional true"],
+           ["block options", "name compaction_elastic", "type keyword",
+            "shape", "in_record true", "reader urword", "tagged true",
+            "optional false"],
+           ["block options", "name elastic_compaction_filename",
+            "type string", "shape", "in_record true", "reader urword",
+            "tagged false", "optional false"],
+           ["block options", "name compaction_inelastic_filerecord",
+            "type record compaction_inelastic fileout "
+            "inelastic_compaction_filename",
+            "shape", "reader urword", "tagged true", "optional true"],
+           ["block options", "name compaction_inelastic", "type keyword",
+            "shape", "in_record true", "reader urword", "tagged true",
+            "optional false"],
+           ["block options", "name inelastic_compaction_filename",
+            "type string", "shape", "in_record true", "reader urword",
+            "tagged false", "optional false"],
+           ["block options", "name compaction_interbed_filerecord",
+            "type record compaction_interbed fileout "
+            "interbed_compaction_filename",
+            "shape", "reader urword", "tagged true", "optional true"],
+           ["block options", "name compaction_interbed", "type keyword",
+            "shape", "in_record true", "reader urword", "tagged true",
+            "optional false"],
+           ["block options", "name interbed_compaction_filename",
+            "type string", "shape", "in_record true", "reader urword",
+            "tagged false", "optional false"],
+           ["block options", "name compaction_coarse_filerecord",
+            "type record compaction_coarse fileout coarse_compaction_filename",
+            "shape", "reader urword", "tagged true", "optional true"],
+           ["block options", "name compaction_coarse", "type keyword",
+            "shape", "in_record true", "reader urword", "tagged true",
+            "optional false"],
+           ["block options", "name coarse_compaction_filename",
+            "type string", "shape", "in_record true", "reader urword",
+            "tagged false", "optional false"],
+           ["block options", "name zdisplacement_filerecord",
+            "type record zdisplacement fileout zdisplacement_filename",
+            "shape", "reader urword", "tagged true", "optional true"],
+           ["block options", "name zdisplacement", "type keyword", "shape",
+            "in_record true", "reader urword", "tagged true",
+            "optional false"],
+           ["block options", "name zdisplacement_filename", "type string",
+            "shape", "in_record true", "reader urword", "tagged false",
+            "optional false"],
+           ["block options", "name ts_filerecord",
+            "type record ts6 filein ts6_filename", "shape", "reader urword",
+            "tagged true", "optional true", "construct_package ts",
+            "construct_data timeseries", "parameter_name timeseries"],
+           ["block options", "name ts6", "type keyword", "shape",
+            "in_record true", "reader urword", "tagged true",
+            "optional false"],
+           ["block options", "name filein", "type keyword", "shape",
+            "in_record true", "reader urword", "tagged true",
+            "optional false"],
+           ["block options", "name ts6_filename", "type string",
+            "in_record true", "reader urword", "optional false",
+            "tagged false"],
+           ["block options", "name obs_filerecord",
+            "type record obs6 filein obs6_filename", "shape", "reader urword",
+            "tagged true", "optional true", "construct_package obs",
+            "construct_data continuous", "parameter_name observations"],
+           ["block options", "name obs6", "type keyword", "shape",
+            "in_record true", "reader urword", "tagged true",
+            "optional false"],
+           ["block options", "name obs6_filename", "type string",
+            "in_record true", "tagged false", "reader urword",
+            "optional false"],
+           ["block dimensions", "name ninterbeds", "type integer",
+            "reader urword", "optional false"],
+           ["block dimensions", "name maxsig0", "type integer",
+            "reader urword", "optional true"],
+           ["block griddata", "name cg_ske_cr", "type double precision",
+            "shape (nodes)", "valid", "reader readarray",
+            "default_value 1e-5"],
+           ["block griddata", "name cg_theta", "type double precision",
+            "shape (nodes)", "valid", "reader readarray", "default_value 0.2"],
+           ["block griddata", "name sgm", "type double precision",
+            "shape (nodes)", "valid", "reader readarray", "optional true"],
+           ["block griddata", "name sgs", "type double precision",
+            "shape (nodes)", "valid", "reader readarray", "optional true"],
+           ["block packagedata", "name packagedata",
+            "type recarray icsubno cellid cdelay pcs0 thick_frac rnb ssv_cc "
+            "sse_cr theta kv h0 boundname",
+            "shape (ncsubcells)", "reader urword"],
+           ["block packagedata", "name icsubno", "type integer", "shape",
+            "tagged false", "in_record true", "reader urword",
+            "numeric_index true"],
+           ["block packagedata", "name cellid", "type integer",
+            "shape (ncelldim)", "tagged false", "in_record true",
+            "reader urword"],
+           ["block packagedata", "name cdelay", "type string", "shape",
+            "tagged false", "in_record true", "reader urword"],
+           ["block packagedata", "name pcs0", "type double precision",
+            "shape", "tagged false", "in_record true", "reader urword"],
+           ["block packagedata", "name thick_frac", "type double precision",
+            "shape", "tagged false", "in_record true", "reader urword"],
+           ["block packagedata", "name rnb", "type double precision",
+            "shape", "tagged false", "in_record true", "reader urword"],
+           ["block packagedata", "name ssv_cc", "type double precision",
+            "shape", "tagged false", "in_record true", "reader urword"],
+           ["block packagedata", "name sse_cr", "type double precision",
+            "shape", "tagged false", "in_record true", "reader urword"],
+           ["block packagedata", "name theta", "type double precision",
+            "shape", "tagged false", "in_record true", "reader urword",
+            "default_value 0.2"],
+           ["block packagedata", "name kv", "type double precision",
+            "shape", "tagged false", "in_record true", "reader urword"],
+           ["block packagedata", "name h0", "type double precision",
+            "shape", "tagged false", "in_record true", "reader urword"],
+           ["block packagedata", "name boundname", "type string", "shape",
+            "tagged false", "in_record true", "reader urword",
+            "optional true"],
+           ["block period", "name iper", "type integer",
+            "block_variable True", "in_record true", "tagged false", "shape",
+            "valid", "reader urword", "optional false"],
+           ["block period", "name stress_period_data",
+            "type recarray cellid sig0", "shape (maxsig0)", "reader urword"],
+           ["block period", "name cellid", "type integer",
+            "shape (ncelldim)", "tagged false", "in_record true",
+            "reader urword"],
+           ["block period", "name sig0", "type double precision", "shape",
+            "tagged false", "in_record true", "reader urword",
+            "time_series true"]]
+
+    def __init__(self, model, loading_package=False, boundnames=None,
+                 print_input=None, save_flows=None, gammaw=9806.65,
+                 beta=4.6512e-10, head_based=None,
+                 initial_preconsolidation_head=None, ndelaycells=None,
+                 compression_indices=None, update_material_properties=None,
+                 cell_fraction=None, specified_initial_interbed_state=None,
+                 specified_initial_preconsolidation_stress=None,
+                 specified_initial_delay_head=None, effective_stress_lag=None,
+                 strainib_filerecord=None, straincg_filerecord=None,
+                 compaction_filerecord=None, fileout=None,
+                 compaction_elastic_filerecord=None,
+                 compaction_inelastic_filerecord=None,
+                 compaction_interbed_filerecord=None,
+                 compaction_coarse_filerecord=None,
+                 zdisplacement_filerecord=None, timeseries=None,
+                 observations=None, ninterbeds=None, maxsig0=None,
+                 cg_ske_cr=1e-5, cg_theta=0.2, sgm=None, sgs=None,
+                 packagedata=None, stress_period_data=None, filename=None,
+                 pname=None, parent_file=None):
+        super(ModflowGwfcsub, self).__init__(model, "csub", filename, pname,
+                                             loading_package, parent_file)
+
+        # set up variables
+        self.boundnames = self.build_mfdata("boundnames", boundnames)
+        self.print_input = self.build_mfdata("print_input", print_input)
+        self.save_flows = self.build_mfdata("save_flows", save_flows)
+        self.gammaw = self.build_mfdata("gammaw", gammaw)
+        self.beta = self.build_mfdata("beta", beta)
+        self.head_based = self.build_mfdata("head_based", head_based)
+        self.initial_preconsolidation_head = self.build_mfdata(
+            "initial_preconsolidation_head", initial_preconsolidation_head)
+        self.ndelaycells = self.build_mfdata("ndelaycells", ndelaycells)
+        self.compression_indices = self.build_mfdata("compression_indices",
+                                                     compression_indices)
+        self.update_material_properties = self.build_mfdata(
+            "update_material_properties", update_material_properties)
+        self.cell_fraction = self.build_mfdata("cell_fraction", cell_fraction)
+        self.specified_initial_interbed_state = self.build_mfdata(
+            "specified_initial_interbed_state",
+            specified_initial_interbed_state)
+        self.specified_initial_preconsolidation_stress = self.build_mfdata(
+            "specified_initial_preconsolidation_stress",
+            specified_initial_preconsolidation_stress)
+        self.specified_initial_delay_head = self.build_mfdata(
+            "specified_initial_delay_head", specified_initial_delay_head)
+        self.effective_stress_lag = self.build_mfdata("effective_stress_lag",
+                                                      effective_stress_lag)
+        self.strainib_filerecord = self.build_mfdata("strainib_filerecord",
+                                                     strainib_filerecord)
+        self.straincg_filerecord = self.build_mfdata("straincg_filerecord",
+                                                     straincg_filerecord)
+        self.compaction_filerecord = self.build_mfdata("compaction_filerecord",
+                                                       compaction_filerecord)
+        self.fileout = self.build_mfdata("fileout", fileout)
+        self.compaction_elastic_filerecord = self.build_mfdata(
+            "compaction_elastic_filerecord", compaction_elastic_filerecord)
+        self.compaction_inelastic_filerecord = self.build_mfdata(
+            "compaction_inelastic_filerecord",
+            compaction_inelastic_filerecord)
+        self.compaction_interbed_filerecord = self.build_mfdata(
+            "compaction_interbed_filerecord", compaction_interbed_filerecord)
+        self.compaction_coarse_filerecord = self.build_mfdata(
+            "compaction_coarse_filerecord", compaction_coarse_filerecord)
+        self.zdisplacement_filerecord = self.build_mfdata(
+            "zdisplacement_filerecord", zdisplacement_filerecord)
+        self._ts_filerecord = self.build_mfdata("ts_filerecord",
+                                                None)
+        self._ts_package = self.build_child_package("ts", timeseries,
+                                                    "timeseries",
+                                                    self._ts_filerecord)
+        self._obs_filerecord = self.build_mfdata("obs_filerecord",
+                                                 None)
+        self._obs_package = self.build_child_package("obs", observations,
+                                                     "continuous",
+                                                     self._obs_filerecord)
+        self.ninterbeds = self.build_mfdata("ninterbeds", ninterbeds)
+        self.maxsig0 = self.build_mfdata("maxsig0", maxsig0)
+        self.cg_ske_cr = self.build_mfdata("cg_ske_cr", cg_ske_cr)
+        self.cg_theta = self.build_mfdata("cg_theta", cg_theta)
+        self.sgm = self.build_mfdata("sgm", sgm)
+        self.sgs = self.build_mfdata("sgs", sgs)
+        self.packagedata = self.build_mfdata("packagedata", packagedata)
+        self.stress_period_data = self.build_mfdata("stress_period_data",
+                                                    stress_period_data)
+        self._init_complete = True

--- a/flopy/mf6/modflow/mfgwfcsub.py
+++ b/flopy/mf6/modflow/mfgwfcsub.py
@@ -54,7 +54,7 @@ class ModflowGwfcsub(mfpackage.MFPackage):
         * ndelaycells (integer) number of nodes used to discretize delay
           interbeds. If not specified, then a default value of 19 is assigned.
     compression_indices : boolean
-        * compression_indices (boolean) keyword to indicate that the the
+        * compression_indices (boolean) keyword to indicate that the
           recompression (CR) and compression (CC) indices are specified instead
           of the elastic specific storage (SSE) and inelastic specific storage
           (SSV) coefficients. If not specified, then elastic specific storage
@@ -79,7 +79,7 @@ class ModflowGwfcsub(mfpackage.MFPackage):
           SPECIFIED_INITIAL_DELAY_HEAD. If SPECIFIED_INITIAL_INTERBED_STATE is
           not specified then preconsolidation stress (head) and delay bed head
           values specified in the PACKAGEDATA block are relative to simulated
-          values if the first stress period is steady-state or initial stresses
+          values of the first stress period if steady-state or initial stresses
           and GWF heads if the first stress period is transient.
     specified_initial_preconsolidation_stress : boolean
         * specified_initial_preconsolidation_stress (boolean) keyword to
@@ -95,7 +95,7 @@ class ModflowGwfcsub(mfpackage.MFPackage):
         * specified_initial_delay_head (boolean) keyword to indicate that
           absolute initial delay bed head will be specified for interbeds
           defined in the PACKAGEDATA block. If SPECIFIED_INITIAL_DELAY_HEAD and
-          SPECIFIED_INITIAL_INTERBED_STATE are not specified then delay bead
+          SPECIFIED_INITIAL_INTERBED_STATE are not specified then delay bed
           head values specified in the PACKAGEDATA block are relative to
           simulated values if the first stress period is steady-state or
           initial GWF heads if the first stress period is transient.

--- a/flopy/mf6/modflow/mfgwfdisu.py
+++ b/flopy/mf6/modflow/mfgwfdisu.py
@@ -67,6 +67,15 @@ class ModflowGwfdisu(mfpackage.MFPackage):
         * bot (double) is the bottom elevation for each cell.
     area : [double]
         * area (double) is the cell surface area (in plan view).
+    idomain : [integer]
+        * idomain (integer) is an optional array that characterizes the
+          existence status of a cell. If the IDOMAIN array is not specified,
+          then all model cells exist within the solution. If the IDOMAIN value
+          for a cell is 0, the cell does not exist in the simulation. Input and
+          output values will be read and written for the cell, but internal to
+          the program, the cell is excluded from the solution. If the IDOMAIN
+          value for a cell is 1, the cell exists in the simulation. IDOMAIN
+          values of -1 cannot be specified for the DISU Package.
     iac : [integer]
         * iac (integer) is the number of connections (plus 1) for each cell.
           The sum of all the entries in IAC must be equal to NJA.
@@ -154,6 +163,8 @@ class ModflowGwfdisu(mfpackage.MFPackage):
     top = ArrayTemplateGenerator(('gwf6', 'disu', 'griddata', 'top'))
     bot = ArrayTemplateGenerator(('gwf6', 'disu', 'griddata', 'bot'))
     area = ArrayTemplateGenerator(('gwf6', 'disu', 'griddata', 'area'))
+    idomain = ArrayTemplateGenerator(('gwf6', 'disu', 'griddata',
+                                      'idomain'))
     iac = ArrayTemplateGenerator(('gwf6', 'disu', 'connectiondata',
                                   'iac'))
     ja = ArrayTemplateGenerator(('gwf6', 'disu', 'connectiondata',
@@ -195,6 +206,9 @@ class ModflowGwfdisu(mfpackage.MFPackage):
             "shape (nodes)", "reader readarray"],
            ["block griddata", "name area", "type double precision",
             "shape (nodes)", "reader readarray"],
+           ["block griddata", "name idomain", "type integer",
+            "shape (nodes)", "reader readarray", "layered true",
+            "optional true"],
            ["block connectiondata", "name iac", "type integer",
             "shape (nodes)", "reader readarray"],
            ["block connectiondata", "name ja", "type integer",
@@ -241,9 +255,9 @@ class ModflowGwfdisu(mfpackage.MFPackage):
     def __init__(self, model, loading_package=False, length_units=None,
                  nogrb=None, xorigin=None, yorigin=None, angrot=None,
                  nodes=None, nja=None, nvert=None, top=None, bot=None,
-                 area=None, iac=None, ja=None, ihc=None, cl12=None, hwva=None,
-                 angldegx=None, vertices=None, cell2d=None, filename=None,
-                 pname=None, parent_file=None):
+                 area=None, idomain=None, iac=None, ja=None, ihc=None,
+                 cl12=None, hwva=None, angldegx=None, vertices=None,
+                 cell2d=None, filename=None, pname=None, parent_file=None):
         super(ModflowGwfdisu, self).__init__(model, "disu", filename, pname,
                                              loading_package, parent_file)
 
@@ -259,6 +273,7 @@ class ModflowGwfdisu(mfpackage.MFPackage):
         self.top = self.build_mfdata("top", top)
         self.bot = self.build_mfdata("bot", bot)
         self.area = self.build_mfdata("area", area)
+        self.idomain = self.build_mfdata("idomain", idomain)
         self.iac = self.build_mfdata("iac", iac)
         self.ja = self.build_mfdata("ja", ja)
         self.ihc = self.build_mfdata("ihc", ihc)

--- a/flopy/mf6/modflow/mfgwflak.py
+++ b/flopy/mf6/modflow/mfgwflak.py
@@ -295,6 +295,14 @@ class ModflowGwflak(mfpackage.MFPackage):
                   a TIMESERIESFILE entry (see the "Time-Variable Input"
                   section), values can be obtained from a time series by
                   entering the time-series name in place of a numeric value.
+            inflow : [string]
+                * inflow (string) real or character value that defines the
+                  volumetric inflow rate :math:`(L^3 T^{-1})` for the lake. If
+                  the Options block includes a TIMESERIESFILE entry (see the
+                  "Time-Variable Input" section), values can be obtained from a
+                  time series by entering the time-series name in place of a
+                  numeric value. By default, inflow rates are zero for each
+                  lake.
             withdrawal : [string]
                 * withdrawal (string) real or character value that defines the
                   maximum withdrawal rate :math:`(L^3 T^{-1})` for the lake.
@@ -561,7 +569,7 @@ class ModflowGwflak(mfpackage.MFPackage):
             "tagged false", "in_record true", "reader urword",
             "numeric_index true"],
            ["block period", "name laksetting",
-            "type keystring status stage rainfall evaporation runoff "
+            "type keystring status stage rainfall evaporation runoff inflow "
             "withdrawal auxiliaryrecord",
             "shape", "tagged false", "in_record true", "reader urword"],
            ["block period", "name status", "type string", "shape",
@@ -576,6 +584,9 @@ class ModflowGwflak(mfpackage.MFPackage):
             "tagged true", "in_record true", "reader urword",
             "time_series true"],
            ["block period", "name runoff", "type string", "shape",
+            "tagged true", "in_record true", "reader urword",
+            "time_series true"],
+           ["block period", "name inflow", "type string", "shape",
             "tagged true", "in_record true", "reader urword",
             "time_series true"],
            ["block period", "name withdrawal", "type string", "shape",

--- a/flopy/mf6/modflow/mfgwfnpf.py
+++ b/flopy/mf6/modflow/mfgwfnpf.py
@@ -74,6 +74,14 @@ class ModflowGwfnpf(mfpackage.MFPackage):
           Specifically, ANGLDEGX must be specified in the CONNECTIONDATA block
           of the DISU Package; ANGLDEGX must also be specified for the GWF
           Exchange as an auxiliary variable.
+    k22overk : boolean
+        * k22overk (boolean) keyword to indicate that specified K22 is a ratio
+          of K22 divided by K. If this option is specified, then the K22 array
+          entered in the NPF Package will be multiplied by K after being read.
+    k33overk : boolean
+        * k33overk (boolean) keyword to indicate that specified K33 is a ratio
+          of K33 divided by K. If this option is specified, then the K33 array
+          entered in the NPF Package will be multiplied by K after being read.
     icelltype : [integer]
         * icelltype (integer) flag for each cell that specifies how saturated
           thickness is treated. 0 means saturated thickness is held constant;
@@ -95,10 +103,11 @@ class ModflowGwfnpf(mfpackage.MFPackage):
           must have a K value greater than zero.
     k22 : [double]
         * k22 (double) is the hydraulic conductivity of the second ellipsoid
-          axis; for an unrotated case this is the hydraulic conductivity in the
-          y direction. If K22 is not included in the GRIDDATA block, then K22
-          is set equal to K. For a regular MODFLOW grid (DIS Package is used)
-          in which no rotation angles are specified, K22 is the hydraulic
+          axis (or the ratio of K22/K if the K22OVERK option is specified); for
+          an unrotated case this is the hydraulic conductivity in the y
+          direction. If K22 is not included in the GRIDDATA block, then K22 is
+          set equal to K. For a regular MODFLOW grid (DIS Package is used) in
+          which no rotation angles are specified, K22 is the hydraulic
           conductivity along columns in the y direction. For an unstructured
           DISU grid, the user must assign principal x and y axes and provide
           the angle for each cell face relative to the assigned x direction.
@@ -106,10 +115,11 @@ class ModflowGwfnpf(mfpackage.MFPackage):
           greater than zero.
     k33 : [double]
         * k33 (double) is the hydraulic conductivity of the third ellipsoid
-          axis; for an unrotated case, this is the vertical hydraulic
-          conductivity. When anisotropy is applied, K33 corresponds to the K33
-          tensor component. All included cells (IDOMAIN :math:`>` 0) must have
-          a K33 value greater than zero.
+          axis (or the ratio of K33/K if the K33OVERK option is specified); for
+          an unrotated case, this is the vertical hydraulic conductivity. When
+          anisotropy is applied, K33 corresponds to the K33 tensor component.
+          All included cells (IDOMAIN :math:`>` 0) must have a K33 value
+          greater than zero.
     angle1 : [double]
         * angle1 (double) is a rotation angle of the hydraulic conductivity
           tensor in degrees. The angle represents the first of three sequential
@@ -227,6 +237,10 @@ class ModflowGwfnpf(mfpackage.MFPackage):
             "reader urword", "optional true"],
            ["block options", "name save_specific_discharge", "type keyword",
             "reader urword", "optional true"],
+           ["block options", "name k22overk", "type keyword",
+            "reader urword", "optional true"],
+           ["block options", "name k33overk", "type keyword",
+            "reader urword", "optional true"],
            ["block griddata", "name icelltype", "type integer",
             "shape (nodes)", "valid", "reader readarray", "layered true",
             "optional", "default_value 0"],
@@ -255,10 +269,10 @@ class ModflowGwfnpf(mfpackage.MFPackage):
     def __init__(self, model, loading_package=False, save_flows=None,
                  alternative_cell_averaging=None, thickstrt=None,
                  cvoptions=None, perched=None, rewet_record=None,
-                 xt3doptions=None, save_specific_discharge=None, icelltype=0,
-                 k=1.0, k22=None, k33=None, angle1=None, angle2=None,
-                 angle3=None, wetdry=None, filename=None, pname=None,
-                 parent_file=None):
+                 xt3doptions=None, save_specific_discharge=None, k22overk=None,
+                 k33overk=None, icelltype=0, k=1.0, k22=None, k33=None,
+                 angle1=None, angle2=None, angle3=None, wetdry=None,
+                 filename=None, pname=None, parent_file=None):
         super(ModflowGwfnpf, self).__init__(model, "npf", filename, pname,
                                             loading_package, parent_file)
 
@@ -273,6 +287,8 @@ class ModflowGwfnpf(mfpackage.MFPackage):
         self.xt3doptions = self.build_mfdata("xt3doptions", xt3doptions)
         self.save_specific_discharge = self.build_mfdata(
             "save_specific_discharge", save_specific_discharge)
+        self.k22overk = self.build_mfdata("k22overk", k22overk)
+        self.k33overk = self.build_mfdata("k33overk", k33overk)
         self.icelltype = self.build_mfdata("icelltype", icelltype)
         self.k = self.build_mfdata("k", k)
         self.k22 = self.build_mfdata("k22", k22)

--- a/flopy/mf6/modflow/mfims.py
+++ b/flopy/mf6/modflow/mfims.py
@@ -58,19 +58,15 @@ class ModflowIms(mfpackage.MFPackage):
           information for the solution and each model (if the solution includes
           more than one model) and linear acceleration information for each
           inner iteration.
-    no_ptc : boolean
-        * no_ptc (boolean) is a flag that is used to disable pseudo-transient
-          continuation (PTC). Option only applies to steady-state stress
-          periods for models using the Newton-Raphson formulation. For many
-          problems, PTC can significantly improve convergence behavior for
-          steady-state simulations, and for this reason it is active by
-          default. In some cases, however, PTC can worsen the convergence
-          behavior, especially when the initial conditions are similar to the
-          solution. When the initial conditions are similar to, or exactly the
-          same as, the solution and convergence is slow, then this NO_PTC
-          option should be used to deactivate PTC. This NO_PTC option should
-          also be used in order to compare convergence behavior with other
-          MODFLOW versions, as PTC is only available in MODFLOW 6.
+    no_ptcrecord : [no_ptc_option]
+        * no_ptc_option (string) is an optional keyword that is used to define
+          options for disabling pseudo-transient continuation (PTC). FIRST is
+          an optional keyword to disable PTC for the first stress period, if
+          steady-state and one or more model is using the Newton-Raphson
+          formulation. ALL is an optional keyword to disable PTC for all
+          steady-state stress periods for models using the Newton-Raphson
+          formulation. If NO_PTC_OPTION is not specified, the NO_PTC ALL option
+          is used.
     outer_hclose : double
         * outer_hclose (double) real value defining the head change criterion
           for convergence of the outer (nonlinear) iterations, in units of
@@ -286,6 +282,8 @@ class ModflowIms(mfpackage.MFPackage):
     """
     csv_output_filerecord = ListTemplateGenerator(('ims', 'options',
                                                    'csv_output_filerecord'))
+    no_ptcrecord = ListTemplateGenerator(('ims', 'options',
+                                          'no_ptcrecord'))
     rcloserecord = ListTemplateGenerator(('ims', 'linear',
                                           'rcloserecord'))
     package_abbr = "ims"
@@ -308,8 +306,15 @@ class ModflowIms(mfpackage.MFPackage):
            ["block options", "name csvfile", "type string",
             "preserve_case true", "shape", "in_record true", "reader urword",
             "tagged false", "optional false"],
-           ["block options", "name no_ptc", "type keyword", "reader urword",
+           ["block options", "name no_ptcrecord",
+            "type record no_ptc no_ptc_option", "reader urword",
             "optional true"],
+           ["block options", "name no_ptc", "type keyword",
+            "in_record true", "reader urword", "optional false",
+            "tagged true"],
+           ["block options", "name no_ptc_option", "type string",
+            "in_record true", "reader urword", "optional true",
+            "tagged false"],
            ["block nonlinear", "name outer_hclose", "type double precision",
             "reader urword", "optional false"],
            ["block nonlinear", "name outer_rclosebnd",
@@ -363,12 +368,12 @@ class ModflowIms(mfpackage.MFPackage):
             "reader urword", "optional true"]]
 
     def __init__(self, simulation, loading_package=False, print_option=None,
-                 complexity=None, csv_output_filerecord=None, no_ptc=None,
-                 outer_hclose=None, outer_rclosebnd=None, outer_maximum=None,
-                 under_relaxation=None, under_relaxation_theta=None,
-                 under_relaxation_kappa=None, under_relaxation_gamma=None,
-                 under_relaxation_momentum=None, backtracking_number=None,
-                 backtracking_tolerance=None,
+                 complexity=None, csv_output_filerecord=None,
+                 no_ptcrecord=None, outer_hclose=None, outer_rclosebnd=None,
+                 outer_maximum=None, under_relaxation=None,
+                 under_relaxation_theta=None, under_relaxation_kappa=None,
+                 under_relaxation_gamma=None, under_relaxation_momentum=None,
+                 backtracking_number=None, backtracking_tolerance=None,
                  backtracking_reduction_factor=None,
                  backtracking_residual_limit=None, inner_maximum=None,
                  inner_hclose=None, rcloserecord=None,
@@ -386,7 +391,7 @@ class ModflowIms(mfpackage.MFPackage):
         self.complexity = self.build_mfdata("complexity", complexity)
         self.csv_output_filerecord = self.build_mfdata("csv_output_filerecord",
                                                        csv_output_filerecord)
-        self.no_ptc = self.build_mfdata("no_ptc", no_ptc)
+        self.no_ptcrecord = self.build_mfdata("no_ptcrecord", no_ptcrecord)
         self.outer_hclose = self.build_mfdata("outer_hclose", outer_hclose)
         self.outer_rclosebnd = self.build_mfdata("outer_rclosebnd",
                                                  outer_rclosebnd)

--- a/flopy/mf6/modflow/mfnam.py
+++ b/flopy/mf6/modflow/mfnam.py
@@ -30,6 +30,9 @@ class ModflowNam(mfpackage.MFPackage):
           only the total memory for each simulation component. ALL means print
           information for each variable stored in the memory manager. NONE is
           default if MEMORY_PRINT_OPTION is not specified.
+    maxerrors : integer
+        * maxerrors (integer) maximum number of errors that will be stored and
+          printed.
     tdis6 : string
         * tdis6 (string) is the name of the Temporal Discretization (TDIS)
           Input File.
@@ -82,6 +85,8 @@ class ModflowNam(mfpackage.MFPackage):
             "reader urword", "optional true"],
            ["block options", "name memory_print_option", "type string",
             "reader urword", "optional true"],
+           ["block options", "name maxerrors", "type integer",
+            "reader urword", "optional true"],
            ["block timing", "name tdis6", "preserve_case true",
             "type string", "reader urword", "optional"],
            ["block models", "name models",
@@ -120,9 +125,10 @@ class ModflowNam(mfpackage.MFPackage):
             "in_record true", "shape (:)", "tagged false", "reader urword"]]
 
     def __init__(self, simulation, loading_package=False, continue_=None,
-                 nocheck=None, memory_print_option=None, tdis6=None,
-                 models=None, exchanges=None, mxiter=None, solutiongroup=None,
-                 filename=None, pname=None, parent_file=None):
+                 nocheck=None, memory_print_option=None, maxerrors=None,
+                 tdis6=None, models=None, exchanges=None, mxiter=None,
+                 solutiongroup=None, filename=None, pname=None,
+                 parent_file=None):
         super(ModflowNam, self).__init__(simulation, "nam", filename, pname,
                                          loading_package, parent_file)
 
@@ -131,6 +137,7 @@ class ModflowNam(mfpackage.MFPackage):
         self.nocheck = self.build_mfdata("nocheck", nocheck)
         self.memory_print_option = self.build_mfdata("memory_print_option",
                                                      memory_print_option)
+        self.maxerrors = self.build_mfdata("maxerrors", maxerrors)
         self.tdis6 = self.build_mfdata("tdis6", tdis6)
         self.models = self.build_mfdata("models", models)
         self.exchanges = self.build_mfdata("exchanges", exchanges)

--- a/flopy/mf6/utils/createpackages.py
+++ b/flopy/mf6/utils/createpackages.py
@@ -280,12 +280,15 @@ def build_model_load(model_type):
                  "modelname='NewModel',\n             " \
                  "model_nam_file='modflowtest.nam', version='mf6',\n" \
                  "             exe_name='mf6.exe', strict=True, " \
-                 "model_rel_path='.'):\n        " \
+                 "model_rel_path='.',\n" \
+                 "             load_only=None):\n        " \
                  "return mfmodel.MFModel.load_base(simulation, structure, " \
                  "modelname,\n                                         " \
                  "model_nam_file, '{}', version,\n" \
-                 "                                         exe_name, strict, " \
-                 "model_rel_path)\n".format(model_type)
+                 "                                         exe_name, strict, "\
+                 "model_rel_path,\n" \
+                 "                                         load_only)" \
+                 "\n".format(model_type)
     return model_load, model_load_c
 
 


### PR DESCRIPTION
Please check that these dfn updates are ok. Also running the `update_flopy.py` script in mf6/autotest/ wanted to make change in `mfgwf.py`

![image](https://user-images.githubusercontent.com/2073498/70729650-91517a00-1cd1-11ea-8ca6-cca3a84a6d58.png)

Not sure if something needs to be modifies on the flopy side to retain the `load_only` keyword in the `mfgwf` class.