### PR TITLE
updated triangle to support shapely polygons

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Additional dependencies to use optional FloPy helper methods are listed below.
 | `Raster()` in `flopy.utils.Raster`                                                   | **rasterio**, **affine**, and **scipy**            |
 | `Raster().sample_polygon()` in `flopy.utils.Raster`                                  | **shapely**                                        |
 | `Raster().crop()` in `flopy.utils.Raster`                                            | **shapely**                                        |
+| `Triangle().add_polygon()` in `flopy.utils.Triangle`                                            | **shapely**                                        |
 
 How to Cite
 -----------------------------------------------

--- a/flopy/utils/triangle.py
+++ b/flopy/utils/triangle.py
@@ -5,6 +5,10 @@ from ..mbase import which
 from ..utils.cvfdutil import centroid_of_polygon
 from ..plot.plotutil import plot_cvfd
 
+try:
+    import shapely
+except ImportError:
+    shapely = None
 
 class Triangle(object):
     """
@@ -53,14 +57,24 @@ class Triangle(object):
 
         Parameters
         ----------
-        polygon : list
-            polygon is a list of (x, y) points
+        polygon : list/shapely.geometry.polygon.Polygon
+            if type is list, polygon is a list of (x, y) points
 
         Returns
         -------
         None
 
         """
+        if shapely is not None:
+            from shapely.geometry.polygon import Polygon
+            # if the type of polygon is a shapely Polygon object, deconstruct into points
+            if type(polygon) is Polygon:
+                poly = []
+                for x, y in zip(polygon.boundary.xy[0],
+                                polygon.boundary.xy[1]):
+                    poly.append((float(x), float(y)))
+                polygon = poly
+
         self._polygons.append(polygon)
         return
 

--- a/flopy/utils/triangle.py
+++ b/flopy/utils/triangle.py
@@ -69,7 +69,7 @@ class Triangle(object):
             from shapely.geometry.polygon import Polygon
             # if the type of polygon is a shapely Polygon object,
             # deconstruct into points
-            if type(polygon) is Polygon:
+            if isinstance(polygon, Polygon):
                 poly = []
                 for x, y in zip(polygon.boundary.xy[0],
                                 polygon.boundary.xy[1]):

--- a/flopy/utils/triangle.py
+++ b/flopy/utils/triangle.py
@@ -67,7 +67,8 @@ class Triangle(object):
         """
         if shapely is not None:
             from shapely.geometry.polygon import Polygon
-            # if the type of polygon is a shapely Polygon object, deconstruct into points
+            # if the type of polygon is a shapely Polygon object,
+            # deconstruct into points
             if type(polygon) is Polygon:
                 poly = []
                 for x, y in zip(polygon.boundary.xy[0],


### PR DESCRIPTION
Added a trap in triangle so that in addition to passing a list of (x,y) coordinate pairs you can also pass a shapely polygon object in `add_polygon`.

New functionality just splits the boundary of the polygon into the list of (x,y) pairs and passes it along.