### PR TITLE
fix(multiple blocks): reading repeating blocks with the same block name but different header

### DIFF
--- a/autotest/t505_test.py
+++ b/autotest/t505_test.py
@@ -929,6 +929,28 @@ def test005_advgw_tidal():
     tdis_file = os.path.join(run_folder, 'all_files_same_name.tdis')
     assert os.path.exists(tdis_file)
 
+    # load simulation
+    sim_load = MFSimulation.load(sim.name, 'mf6', exe_name,
+                                 sim.simulation_data.mfpath.get_sim_path(),
+                                 verbosity_level=0)
+    model = sim_load.get_model()
+    # confirm ghb obs data has two blocks with correct file names
+    ghb = model.get_package('ghb')
+    obs = ghb.obs
+    obs_data = obs.continuous.get_data()
+    found_flows = False
+    found_obs = False
+    for key, value in obs_data.items():
+        if key.lower() == 'ghb_flows.csv':
+            # there should be only one
+            assert not found_flows
+            found_flows = True
+        if key.lower() == 'ghb_obs.csv':
+            # there should be only one
+            assert not found_obs
+            found_obs = True
+    assert found_flows and found_obs
+
     # clean up
     sim.delete_output_files()
 

--- a/flopy/mf6/mfpackage.py
+++ b/flopy/mf6/mfpackage.py
@@ -93,17 +93,31 @@ class MFBlockHeader(object):
         self.data_items.append(new_data)
 
     def is_same_header(self, block_header):
-        if len(self.data_items) == 0 or \
-                        len(block_header.variable_strings) == 0:
-            return True
-        typ_obj = self.data_items[0].structure.data_item_structures[0].type_obj
-        if typ_obj == int or typ_obj == float:
-            if self.variable_strings[0] == block_header.variable_strings[0]:
-                return True
-            else:
+        if len(self.variable_strings) > 0:
+            if len(self.variable_strings) != \
+                    len(block_header.variable_strings):
                 return False
-        else:
+            else:
+                for sitem, oitem in zip(self.variable_strings,
+                                        block_header.variable_strings):
+                    if sitem != oitem:
+                        return False
             return True
+        elif len(self.data_items) > 0 and \
+                len(block_header.variable_strings) > 0:
+            typ_obj = self.data_items[0].structure.data_item_structures[0].\
+                type_obj
+            if typ_obj == int or typ_obj == float:
+                if self.variable_strings[0] == \
+                        block_header.variable_strings[0]:
+                    return True
+                else:
+                    return False
+            else:
+                return True
+        elif len(self.data_items) == len(block_header.variable_strings):
+            return True
+        return False
 
     def get_comment(self):
         if self.simulation_data is None:

--- a/flopy/mf6/mfpackage.py
+++ b/flopy/mf6/mfpackage.py
@@ -108,11 +108,8 @@ class MFBlockHeader(object):
             typ_obj = self.data_items[0].structure.data_item_structures[0].\
                 type_obj
             if typ_obj == int or typ_obj == float:
-                if self.variable_strings[0] == \
-                        block_header.variable_strings[0]:
-                    return True
-                else:
-                    return False
+                return bool(self.variable_strings[0] == \
+                        block_header.variable_strings[0])
             else:
                 return True
         elif len(self.data_items) == len(block_header.variable_strings):


### PR DESCRIPTION
Repeating blocks with the same block name but different header were not being read correctly in some cases of the observation package's continuous block. Flopy now properly distinguishes between these repeating blocks.