### PR TITLE
fix(flopy3_MT3DMS_examples.ipynb): match constant heads to original 

### DIFF
--- a/examples/Notebooks/flopy3_MT3DMS_examples.ipynb
+++ b/examples/Notebooks/flopy3_MT3DMS_examples.ipynb
@@ -1900,8 +1900,15 @@
     "                                   botm=botm,\n",
     "                                   perlen=perlen_mf)\n",
     "    ibound = np.ones((nlay, nrow, ncol), dtype=np.int)\n",
+    "\n",
+    "    # left side\n",
     "    ibound[:, :, 0] = -1\n",
+    "    # right side\n",
     "    ibound[:, :, -1] = -1\n",
+    "    # top\n",
+    "    ibound[:, 0, :] = -1\n",
+    "    # bottom\n",
+    "    ibound[:, -1, :] = -1\n",
     "\n",
     "    f = open(os.path.join(datadir, 'p10shead.dat'))\n",
     "    s0 = np.empty((nrow * ncol), dtype=np.float)\n",
@@ -2212,7 +2219,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.5.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In the MT3DMS manual, constant heads are specified along the top and bottom boundaries, not just the sides within problem 10 (see pg 158 of manual)