### PR TITLE
fix(flopy3_MT3DMS_examples.ipynb): incremental change to 4d np array indices swapped

### DIFF
--- a/examples/Notebooks/flopy3_MT3DMS_examples.ipynb
+++ b/examples/Notebooks/flopy3_MT3DMS_examples.ipynb
@@ -2077,8 +2077,8 @@
     "    plt.plot(sr.xcenter[j], sr.ycenter[i], 'ks')\n",
     "\n",
     "ax = fig.add_subplot(2, 2, 4, aspect='equal')\n",
-    "c = conctvd[1, 3]\n",
-    "chmoc = conchmoc[1, 3]\n",
+    "c = conctvd[2, 2]\n",
+    "chmoc = conchmoc[2, 2]\n",
     "mm = flopy.plot.PlotMapView(model=mf)\n",
     "mm.plot_grid(color='.5', alpha=0.2)\n",
     "cs = mm.contour_array(c, levels=np.arange(20, 200, 20))\n",
@@ -2219,7 +2219,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
4th plot of p10 was showing concentration @ 750 days for layer 4, not concentration @ 1,000 days for layer 3 as labels indicate