### PR TITLE
Budget and specific discharge when stresses applied along boundaries

### DIFF
--- a/autotest/t006_test.py
+++ b/autotest/t006_test.py
@@ -24,6 +24,7 @@ def test_binaryfile_reference():
 
     if matplotlib is not None:
         assert isinstance(h.plot(), matplotlib.axes.Axes)
+        matplotlib.pyplot.close()
     return
 
 
@@ -36,6 +37,7 @@ def test_formattedfile_reference():
 
     if matplotlib is not None:
         assert isinstance(h.plot(masked_values=[6999.000]), matplotlib.axes.Axes)
+        matplotlib.pyplot.close()
     return
 
 

--- a/autotest/t007_test.py
+++ b/autotest/t007_test.py
@@ -1304,6 +1304,7 @@ def test_tricontour_NaN():
     from flopy.plot import PlotMapView
     import numpy as np
     from flopy.discretization import StructuredGrid
+    import matplotlib.pyplot as plt
 
     arr = np.random.rand(10, 10) * 100
     arr[-1, :] = np.nan
@@ -1335,6 +1336,8 @@ def test_tricontour_NaN():
         if not np.allclose(lev, levels[ix]):
             raise AssertionError("TriContour NaN catch Failed")
 
+    plt.close()
+
 
 def test_get_vertices():
     from flopy.utils.reference import SpatialReference
@@ -1365,6 +1368,7 @@ def test_get_vertices():
 
 
 def test_vertex_model_dot_plot():
+    import matplotlib.pyplot as plt
     # load up the vertex example problem
     sim_name = "mfsim.nam"
     sim_path = "../examples/data/mf6/test003_gwftri_disv"
@@ -1374,13 +1378,16 @@ def test_vertex_model_dot_plot():
     disv_ml = disv_sim.get_model('gwf_1')
     ax = disv_ml.plot()
     assert ax
+    plt.close('all')
 
 
 def test_model_dot_plot():
+    import matplotlib.pyplot as plt
     loadpth = os.path.join('..', 'examples', 'data', 'secp')
     ml = flopy.modflow.Modflow.load('secp.nam', model_ws=loadpth)
     ax = ml.plot()
     assert ax
+    plt.close('all')
 
 
 def test_get_rc_from_node_coordinates():
@@ -1597,6 +1604,7 @@ def test_export_contourf():
     cs = plt.contourf(a)
     export_contourf(filename, cs)
     assert os.path.isfile(filename), 'did not create contourf shapefile'
+    plt.close()
     return
 
 def main():

--- a/autotest/t009_test.py
+++ b/autotest/t009_test.py
@@ -166,6 +166,7 @@ def test_sfr():
     if matplotlib is not None:
         assert isinstance(sfr.plot()[0],
                           matplotlib.axes.Axes)  # test the plot() method
+        matplotlib.pyplot.close()
 
     # trout lake example (only sfr file is included)
     # can add tests for sfr connection with lak package
@@ -559,6 +560,7 @@ def test_sfr_plot():
     #sfr.plot(key='strtop')
     #plt.show()
     #assert True
+    #plt.close()
     pass
 
 

--- a/autotest/t015_test.py
+++ b/autotest/t015_test.py
@@ -26,6 +26,7 @@ def test_str_plot():
                                    verbose=True)
     if matplotlib is not None:
         assert isinstance(m.str.plot()[0], matplotlib.axes.Axes)
+        matplotlib.pyplot.close()
 
 
 if __name__ == '__main__':

--- a/autotest/t070_test_spedis.py
+++ b/autotest/t070_test_spedis.py
@@ -1,0 +1,389 @@
+# Test postprocessing and plotting functions related to specific discharge:
+# - get_extended_budget()
+# - get_specific_discharge()
+# - PlotMapView.plot_vector()
+# - PlotCrossSection.plot_vector()
+
+# More precisely:
+# - two models are created: one for mf005 and one for mf6
+# - the two models are virtually identical; in fact, the options are such that
+#   the calculated heads are indeed exactly the same (which is, by the way,
+#   quite remarkable!)
+# - the model is a very small synthetic test case that just contains enough
+#   things to allow for the functions to be thoroughly tested
+
+import flopy
+import os
+import numpy as np
+import flopy.utils.binaryfile as bf
+
+# model names, file names and locations
+modelname_mf2005 = 't070_mf2005'
+modelname_mf6 = 't070_mf6'
+postproc_test_ws = os.path.join('.', 'temp', 't070')
+modelws_mf2005 = os.path.join(postproc_test_ws, modelname_mf2005)
+modelws_mf6 = os.path.join(postproc_test_ws, modelname_mf6)
+cbcfile_mf2005 = os.path.join(modelws_mf2005, modelname_mf2005 + '.cbc')
+cbcfile_mf6 = os.path.join(modelws_mf6, modelname_mf6 + '.cbc')
+hdsfile_mf2005 = os.path.join(modelws_mf2005, modelname_mf2005 + '.hds')
+hdsfile_mf6 = os.path.join(modelws_mf6, modelname_mf6 + '.hds')
+namfile_mf2005 = os.path.join(modelws_mf2005, modelname_mf2005 + '.nam')
+namfile_mf6 = os.path.join(modelws_mf6, modelname_mf6 + '.nam')
+
+# model domain, grid definition and properties
+Lx = 100.
+Ly = 100.
+ztop = 0.
+zbot = -100.
+nlay = 4
+nrow = 4
+ncol = 4
+delr = Lx/ncol
+delc = Ly/nrow
+delv = (ztop - zbot) / nlay
+botm = np.linspace(ztop, zbot, nlay + 1)
+hk=1.
+rchrate = 0.1
+lay_to_plot = 1
+
+# variables for the BAS (mf2005) or DIS (mf6) package
+ibound = np.ones((nlay, nrow, ncol), dtype=np.int32)
+ibound[1, 0, 1] = 0 # set a no-flow cell
+strt = np.ones((nlay, nrow, ncol), dtype=np.float32)
+
+# add inflow through west boundary using WEL package
+Q = 100.
+wel_list = []
+wel_list_iface = []
+for k in range(nlay):
+    for i in range(nrow):
+        wel_list.append([k, i, 0, Q])
+        wel_list_iface.append(wel_list[-1] + [1])
+
+# allow flow through north, south, and bottom boundaries using GHB package
+ghb_head = -30. # low enough to have dry cells in first layer
+ghb_cond = hk * delr * delv / (0.5 * delc)
+ghb_list = []
+ghb_list_iface = []
+for k in range(1, nlay):
+    for j in range(ncol):
+        if not (k==1 and j==1): # skip no-flow cell
+            ghb_list.append([k, 0, j, ghb_head, ghb_cond])
+            ghb_list_iface.append(ghb_list[-1] + [4])
+        ghb_list.append([k, nrow-1, j, ghb_head, ghb_cond])
+        ghb_list_iface.append(ghb_list[-1] + [3])
+for i in range(nrow):
+    for j in range(ncol):
+        ghb_list.append([nlay-1, i, j, ghb_head, ghb_cond])
+        ghb_list_iface.append(ghb_list[-1] + [5])
+
+# river in the eastern part
+riv_stage = -30.
+riv_cond = hk * delr * delc / (0.5 * delv)
+riv_rbot = riv_stage - 5.
+riv_list = []
+for i in range(nrow):
+    riv_list.append([1, i, ncol-1, riv_stage, riv_cond, riv_rbot])
+
+# drain in the south part
+drn_stage = -30.
+drn_cond = hk * delc * delv / (0.5 * delr)
+drn_list = []
+for j in range(ncol):
+    drn_list.append([1, i, nrow-1, drn_stage, drn_cond])
+
+boundary_ifaces = {'WELLS': wel_list_iface,
+                   'HEAD DEP BOUNDS': ghb_list_iface,
+                   'RIVER LEAKAGE': 2,
+                   'DRAIN': 3,
+                   'RECHARGE': 6}
+
+def build_model_mf2005():
+
+    # create folders
+    if not os.path.isdir(modelws_mf2005):
+        os.makedirs(modelws_mf2005)
+
+    # create modflow model
+    mf = flopy.modflow.Modflow(modelname_mf2005, model_ws=modelws_mf2005,
+                               exe_name='mf2005')
+
+    # cell by cell flow file unit number
+    cbc_unit_nb = 53
+
+    # create DIS package
+    dis = flopy.modflow.ModflowDis(mf, nlay, nrow, ncol, delr=delr, delc=delc,
+                                   top=ztop, botm=botm[1:])
+
+    # create BAS package
+    bas = flopy.modflow.ModflowBas(mf, ibound=ibound, strt=strt)
+
+    # create LPF package
+    laytyp = np.zeros(nlay)
+    laytyp[0] = 1
+    laywet = np.zeros(nlay)
+    laywet[0] = 1
+    lpf = flopy.modflow.ModflowLpf(mf, hk=hk, ipakcb=cbc_unit_nb,
+                                   laytyp=laytyp, laywet=laywet, wetdry=-0.01)
+
+    # create WEL package
+    wel_dict = {0: wel_list}
+    wel = flopy.modflow.ModflowWel(mf, stress_period_data=wel_dict,
+                                   ipakcb=cbc_unit_nb)
+
+    # create GHB package
+    ghb_dict = {0: ghb_list}
+    ghb = flopy.modflow.ModflowGhb(mf, stress_period_data=ghb_dict,
+                                   ipakcb=cbc_unit_nb)
+
+    # create RIV package
+    riv_dict = {0: riv_list}
+    riv = flopy.modflow.ModflowRiv(mf, stress_period_data=riv_dict,
+                                   ipakcb=cbc_unit_nb)
+
+    # create DRN package
+    drn_dict = {0: drn_list}
+    drn = flopy.modflow.ModflowDrn(mf, stress_period_data=drn_dict,
+                                   ipakcb=cbc_unit_nb)
+
+    # create RCH package
+    rch = flopy.modflow.ModflowRch(mf, rech=rchrate, ipakcb=cbc_unit_nb)
+
+    # create OC package
+    spd = {(0, 0): ['print head', 'print budget', 'save head', 'save budget']}
+    oc = flopy.modflow.ModflowOc(mf, stress_period_data=spd, compact=True)
+
+    # create PCG package
+    pcg = flopy.modflow.ModflowPcg(mf)
+
+    # write the MODFLOW model input files
+    mf.write_input()
+
+    # run the MODFLOW model
+    success, buff = mf.run_model()
+    return
+
+def build_model_mf6():
+
+    if not os.path.isdir(modelws_mf6):
+        os.makedirs(modelws_mf6)
+
+    # create simulation
+    simname = modelname_mf6
+    sim = flopy.mf6.MFSimulation(sim_name=simname, version='mf6',
+                                 exe_name='mf6', sim_ws=modelws_mf6)
+
+    # create tdis package
+    tdis_rc = [(1.0, 1, 1.0)]
+    tdis = flopy.mf6.ModflowTdis(sim, pname='tdis', time_units='DAYS',
+                                 perioddata=tdis_rc)
+
+    # create gwf model
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=modelname_mf6,
+                               model_nam_file='{}.nam'.format(modelname_mf6))
+    gwf.name_file.save_flows = True
+
+    # create iterative model solution and register the gwf model with it
+    rcloserecord = [1e-5, 'STRICT']
+    ims = flopy.mf6.ModflowIms(sim, pname='ims', print_option='SUMMARY',
+                               complexity='SIMPLE', outer_hclose=1.e-5,
+                               outer_maximum=50, under_relaxation='NONE',
+                               inner_maximum=30, inner_hclose=1.e-5,
+                               rcloserecord=rcloserecord,
+                               linear_acceleration='CG',
+                               scaling_method='NONE', reordering_method='NONE',
+                               relaxation_factor=0.99)
+    sim.register_ims_package(ims, [gwf.name])
+
+    # create dis package
+    dis = flopy.mf6.ModflowGwfdis(gwf, nlay=nlay, nrow=nrow, ncol=ncol,
+                                  delr=delr, delc=delc,
+                                  top=ztop, botm=botm[1:], idomain=ibound)
+
+    # initial conditions
+    ic = flopy.mf6.ModflowGwfic(gwf, pname='ic', strt=strt)
+
+    # create node property flow package
+    rewet_record = [('WETFCT', 0.1, 'IWETIT', 1, 'IHDWET', 0)]
+    icelltype = np.zeros(ibound.shape)
+    icelltype[0, :, :] = 1
+    wetdry = np.zeros(ibound.shape)
+    wetdry[0, :, :] = -0.01
+    npf = flopy.mf6.ModflowGwfnpf(gwf,
+                                  icelltype=icelltype,
+                                  k=hk,
+                                  rewet_record=rewet_record,
+                                  wetdry=wetdry,
+                                  cvoptions=[()],
+                                  save_specific_discharge=True)
+
+    # create wel package
+    welspd = [[(wel_i[0], wel_i[1], wel_i[2]), wel_i[3]] for wel_i in wel_list]
+    wel = flopy.mf6.ModflowGwfwel(gwf, print_input=True,
+                                  stress_period_data=welspd)
+
+    # create ghb package
+    ghbspd = [[(ghb_i[0], ghb_i[1], ghb_i[2]), ghb_i[3], ghb_i[4]]
+              for ghb_i in ghb_list]
+    ghb = flopy.mf6.ModflowGwfghb(gwf, print_input=True,
+                                  stress_period_data=ghbspd)
+
+    # create riv package
+    rivspd = [[(riv_i[0], riv_i[1], riv_i[2]), riv_i[3], riv_i[4], riv_i[5]]
+              for riv_i in riv_list]
+    riv = flopy.mf6.ModflowGwfriv(gwf, stress_period_data=rivspd)
+
+    # create drn package
+    drnspd = [[(drn_i[0], drn_i[1], drn_i[2]), drn_i[3], drn_i[4]]
+              for drn_i in drn_list]
+    drn = flopy.mf6.ModflowGwfdrn(gwf, print_input=True,
+                                  stress_period_data=drnspd)
+
+    # create rch package
+    rch = flopy.mf6.ModflowGwfrcha(gwf, recharge=rchrate)
+
+    # output control
+    oc = flopy.mf6.ModflowGwfoc(gwf, pname='oc', budget_filerecord=
+                                '{}.cbc'.format(modelname_mf6),
+                                head_filerecord='{}.hds'.format(modelname_mf6),
+                                headprintrecord=[('COLUMNS', 10, 'WIDTH', 15,
+                                                  'DIGITS', 6, 'GENERAL')],
+                                saverecord=[('HEAD', 'ALL'),
+                                            ('BUDGET', 'ALL')],
+                                printrecord=[('HEAD', 'ALL'),
+                                             ('BUDGET', 'ALL')])
+
+    # write input files
+    sim.write_simulation()
+
+    # run simulation
+    sim.run_simulation()
+    return
+
+def basic_check(Qx_ext, Qy_ext, Qz_ext):
+    # check shape
+    assert Qx_ext.shape == (nlay, nrow, ncol+1)
+    assert Qy_ext.shape == (nlay, nrow+1, ncol)
+    assert Qz_ext.shape == (nlay+1, nrow, ncol)
+
+    # check sign
+    assert Qx_ext[2, 1, 1] > 0
+    assert Qy_ext[2, 1, 1] > 0
+    assert Qz_ext[2, 1, 1] < 0
+    return
+
+def local_balance_check(Qx_ext, Qy_ext, Qz_ext, hdsfile=None, model=None):
+    # calculate water blance at every cell
+    local_balance = Qx_ext[:, :, :-1] - Qx_ext[:, :, 1:] + \
+                    Qy_ext[:, 1:, :] - Qy_ext[:, :-1, :] + \
+                    Qz_ext[1:, :, :] - Qz_ext[:-1, :, :]
+
+    # calculate total flow through every cell
+    local_total = np.abs(Qx_ext[:, :, :-1]) + np.abs(Qx_ext[:, :, 1:]) + \
+                  np.abs(Qy_ext[:, 1:, :]) + np.abs(Qy_ext[:, :-1, :]) + \
+                  np.abs(Qz_ext[1:, :, :]) + np.abs(Qz_ext[:-1, :, :])
+
+    # we should disregard no-flow and dry cells
+    if hdsfile is not None and model is not None:
+        hds = bf.HeadFile(hdsfile, precision='single')
+        head = hds.get_data()
+        noflo_or_dry = np.logical_or(head==model.hnoflo, head==model.hdry)
+        local_balance[noflo_or_dry] = np.nan
+
+    # check water balance = 0 at every cell
+    rel_err = local_balance / local_total
+    max_rel_err = np.nanmax(rel_err)
+    assert np.allclose(max_rel_err + 1., 1.)
+
+def test_extended_budget_default():
+    # build and run MODFLOW 2005 model
+    build_model_mf2005()
+
+    # load and postprocess
+    Qx_ext, Qy_ext, Qz_ext = \
+        flopy.utils.postprocessing.get_extended_budget(cbcfile_mf2005)
+
+    # basic check
+    basic_check(Qx_ext, Qy_ext, Qz_ext)
+
+    # overall check
+    overall = np.sum(Qx_ext) + np.sum(Qy_ext) + np.sum(Qz_ext)
+    assert np.allclose(overall, -1122.4931640625)
+    return
+
+def test_extended_budget_comprehensive():
+    # load and postprocess
+    mf = flopy.modflow.Modflow.load(namfile_mf2005, check=False)
+    Qx_ext, Qy_ext, Qz_ext = \
+        flopy.utils.postprocessing.get_extended_budget(cbcfile_mf2005,
+                    boundary_ifaces=boundary_ifaces,
+                    hdsfile=hdsfile_mf2005, model=mf)
+
+    # basic check
+    basic_check(Qx_ext, Qy_ext, Qz_ext)
+
+    # local balance check
+    local_balance_check(Qx_ext, Qy_ext, Qz_ext, hdsfile_mf2005, mf)
+
+    # overall check
+    overall = np.sum(Qx_ext) + np.sum(Qy_ext) + np.sum(Qz_ext)
+    assert np.allclose(overall, -1110.646240234375)
+    return
+
+def test_specific_discharge_default():
+    # load and postprocess
+    mf = flopy.modflow.Modflow.load(namfile_mf2005, check=False)
+    qx, qy, qz = flopy.utils.postprocessing.get_specific_discharge(mf,
+                                            cbcfile_mf2005)
+
+    # overall check
+    overall = np.sum(qx) + np.sum(qy) + np.sum(qz)
+    assert np.allclose(overall, -1.7959892749786377)
+    return
+
+def test_specific_discharge_comprehensive():
+    # load and postprocess
+    mf = flopy.modflow.Modflow.load(namfile_mf2005, check=False)
+    qx, qy, qz = flopy.utils.postprocessing.get_specific_discharge(mf,
+                             cbcfile_mf2005,
+                             boundary_ifaces=boundary_ifaces,
+                             hdsfile=hdsfile_mf2005)
+
+    # check nan values
+    assert np.isnan(qx[0, 0, 2])
+    assert np.isnan(qx[1, 0, 1])
+
+    # overall check
+    overall = np.nansum(qx) + np.nansum(qy) + np.nansum(qz)
+    assert np.allclose(overall, -0.8086609840393066)
+    return
+
+def test_specific_discharge_mf6():
+    from flopy.mf6.modflow.mfsimulation import MFSimulation
+
+    # build and run MODFLOW 6 model
+    build_model_mf6()
+
+    # load and postprocess
+    sim = MFSimulation.load(sim_name=modelname_mf6, sim_ws=modelws_mf6,
+                            verbosity_level=0)
+    gwf = sim.get_model(modelname_mf6)
+    qx, qy, qz = flopy.utils.postprocessing.get_specific_discharge(gwf,
+                       cbcfile_mf6, precision='double',
+                       hdsfile=hdsfile_mf6)
+
+    # check nan values
+    assert np.isnan(qx[0, 0, 2])
+    assert np.isnan(qx[1, 0, 1])
+
+    # overall check
+    overall = np.nansum(qx) + np.nansum(qy) + np.nansum(qz)
+    assert np.allclose(overall, -2.5768726154495947)
+    return
+
+if __name__ == '__main__':
+    test_extended_budget_default()
+    test_extended_budget_comprehensive()
+    test_specific_discharge_default()
+    test_specific_discharge_comprehensive()
+    test_specific_discharge_mf6()

--- a/examples/Testing/testunitcbc.py
+++ b/examples/Testing/testunitcbc.py
@@ -6,6 +6,7 @@ import flopy
 # Assign name and create modflow model object
 modelname = 'units'
 mf = flopy.modflow.Modflow(modelname, exe_name='mf2005', model_ws=os.path.join('data'))
+cbc_unit_nb = 1053
 
 # Model domain and grid definition
 Lx = 1000.
@@ -34,10 +35,10 @@ strt[:, :, -1] = 0.
 bas = flopy.modflow.ModflowBas(mf, ibound=ibound, strt=strt)
 
 # Add LPF package to the MODFLOW model
-lpf = flopy.modflow.ModflowLpf(mf, hk=10., vka=10.)
+lpf = flopy.modflow.ModflowLpf(mf, hk=10., vka=10., ipakcb=cbc_unit_nb)
 
 # add well
-wel = flopy.modflow.ModflowWel(mf, ipakcb=1053, stress_period_data={0:[0, 4, 4, -100.]})
+wel = flopy.modflow.ModflowWel(mf, ipakcb=cbc_unit_nb, stress_period_data={0:[0, 4, 4, -100.]})
 
 # Add OC package to the MODFLOW model
 spd = {(0, 0): ['print head', 'print budget', 'save head', 'save budget']}

--- a/flopy/discretization/grid.py
+++ b/flopy/discretization/grid.py
@@ -277,20 +277,17 @@ class Grid(object):
     @property
     def shape(self):
         raise NotImplementedError(
-            'must define extent in child '
-            'class to use this base class')
+            'must define shape in child class')
 
     @property
     def extent(self):
         raise NotImplementedError(
-            'must define extent in child '
-            'class to use this base class')
+            'must define extent in child class')
 
     @property
     def grid_lines(self):
         raise NotImplementedError(
-            'must define get_cellcenters in child '
-            'class to use this base class')
+            'must define grid_lines in child class')
 
     @property
     def xcellcenters(self):
@@ -325,8 +322,7 @@ class Grid(object):
     @property
     def xyzvertices(self):
         raise NotImplementedError(
-            'must define xyzgrid in child '
-            'class to use this base class')
+            'must define xyzvertices in child class')
 
     #@property
     #def indices(self):

--- a/flopy/discretization/grid.py
+++ b/flopy/discretization/grid.py
@@ -270,6 +270,11 @@ class Grid(object):
         return copy.deepcopy(self._idomain)
 
     @property
+    def nnodes(self):
+        raise NotImplementedError(
+            'must define nnodes in child class')
+
+    @property
     def shape(self):
         raise NotImplementedError(
             'must define extent in child '

--- a/flopy/discretization/structuredgrid.py
+++ b/flopy/discretization/structuredgrid.py
@@ -98,6 +98,10 @@ class StructuredGrid(Grid):
         return self.__ncol
 
     @property
+    def nnodes(self):
+        return self.__nlay * self.__nrow * self.__ncol
+
+    @property
     def shape(self):
         return self.__nlay, self.__nrow, self.__ncol
 

--- a/flopy/discretization/structuredgrid.py
+++ b/flopy/discretization/structuredgrid.py
@@ -124,6 +124,11 @@ class StructuredGrid(Grid):
     @property
     def xyzvertices(self):
         """
+        Method to get all grid vertices in a layer
+
+        Returns:
+            []
+            2D array
         """
         cache_index = 'xyzgrid'
         if cache_index not in self._cache_dict or \
@@ -152,6 +157,11 @@ class StructuredGrid(Grid):
 
     @property
     def xyedges(self):
+        """
+        Return a list of two 1D numpy arrays: one with the cell edge x
+        coordinate (size = ncol+1) and the other with the cell edge y
+        coordinate (size = nrow+1) in model space - not offset or rotated.
+        """
         cache_index = 'xyedges'
         if cache_index not in self._cache_dict or \
                 self._cache_dict[cache_index].out_of_date:

--- a/flopy/discretization/unstructuredgrid.py
+++ b/flopy/discretization/unstructuredgrid.py
@@ -146,7 +146,7 @@ class UnstructuredGrid(Grid):
     @property
     def xyzcellcenters(self):
         """
-        Internal method to get cell centers and set to grid
+        Method to get cell centers and set to grid
         """
         cache_index = 'cellcenters'
         if cache_index not in self._cache_dict or \
@@ -160,7 +160,7 @@ class UnstructuredGrid(Grid):
     @property
     def xyzvertices(self):
         """
-        Internal method to get model grid verticies
+        Method to get model grid verticies
 
         Returns:
             list of dimension ncpl by nvertices

--- a/flopy/discretization/unstructuredgrid.py
+++ b/flopy/discretization/unstructuredgrid.py
@@ -29,9 +29,9 @@ class UnstructuredGrid(Grid):
                  top=None, botm=None, idomain=None, lenuni=None,
                  ncpl=None, epsg=None, proj4=None, prj=None,
                  xoff=0., yoff=0., angrot=0., layered=True, nodes=None):
-        super(UnstructuredGrid, self).__init__(self.grid_type, top, botm, idomain,
-                                               lenuni, epsg, proj4, prj,
-                                               xoff, yoff, angrot)
+        super(UnstructuredGrid, self).__init__('unstructured', top, botm,
+                                               idomain, lenuni, epsg, proj4,
+                                               prj, xoff, yoff, angrot)
 
         self._vertices = vertices
         self._iverts = iverts
@@ -67,10 +67,6 @@ class UnstructuredGrid(Grid):
                 super(UnstructuredGrid, self).is_complete:
             return True
         return False
-
-    @property
-    def grid_type(self):
-        return "unstructured"
 
     @property
     def nlay(self):

--- a/flopy/discretization/vertexgrid.py
+++ b/flopy/discretization/vertexgrid.py
@@ -127,7 +127,7 @@ class VertexGrid(Grid):
     @property
     def xyzcellcenters(self):
         """
-        Internal method to get cell centers and set to grid
+        Method to get cell centers and set to grid
         """
         cache_index = 'cellcenters'
         if cache_index not in self._cache_dict or \
@@ -141,10 +141,10 @@ class VertexGrid(Grid):
     @property
     def xyzvertices(self):
         """
-        Internal method to get model grid verticies
+        Method to get all grid vertices in a layer, arranged per cell
 
         Returns:
-            list of dimension ncpl by nvertices
+            list of size sum(nvertices per cell)
         """
         cache_index = 'xyzgrid'
         if cache_index not in self._cache_dict or \

--- a/flopy/discretization/vertexgrid.py
+++ b/flopy/discretization/vertexgrid.py
@@ -83,6 +83,10 @@ class VertexGrid(Grid):
             return len(self._botm[0])
         else:
             return self._ncpl
+    
+    @property
+    def nnodes(self):
+        return self.nlay * self.ncpl
 
     @property
     def shape(self):

--- a/flopy/discretization/vertexgrid.py
+++ b/flopy/discretization/vertexgrid.py
@@ -34,9 +34,9 @@ class VertexGrid(Grid):
 
     def __init__(self, vertices=None, cell2d=None, top=None,
                  botm=None, idomain=None, lenuni=None, epsg=None, proj4=None,
-                 prj=None, xoff=0.0, yoff=0.0, angrot=0.0, grid_type='vertex',
+                 prj=None, xoff=0.0, yoff=0.0, angrot=0.0,
                  nlay=None, ncpl=None, cell1d=None):
-        super(VertexGrid, self).__init__(grid_type, top, botm, idomain, lenuni,
+        super(VertexGrid, self).__init__('vertex', top, botm, idomain, lenuni,
                                          epsg, proj4, prj, xoff, yoff, angrot)
         self._vertices = vertices
         self._cell1d = cell1d

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -664,7 +664,7 @@ class BaseModel(ModelInterface):
     def add_output_file(self, unit, fname=None, extension='cbc',
                         binflag=True, package=None):
         """
-        Add an ascii or binary output file file for a package
+        Add an ascii or binary output file for a package
 
         Parameters
         ----------

--- a/flopy/mf6/modflow/mfgwfnpf.py
+++ b/flopy/mf6/modflow/mfgwfnpf.py
@@ -47,7 +47,7 @@ class ModflowGwfnpf(mfpackage.MFPackage):
           is equal to the head in the overlying cell minus the bottom elevation
           of the overlying cell. If not specified, then the default is to use
           the head difference between the two cells.
-    rewet_record : [wetfct, iwetit, ihdwet]
+    rewet_record : [('WETFCT', wetfct, 'IWETIT', iwetit, 'IHDWET', ihdwet)]
         * wetfct (double) is a keyword and factor that is included in the
           calculation of the head that is initially established at a cell when
           that cell is converted from dry to wet.

--- a/flopy/modflow/mffhb.py
+++ b/flopy/modflow/mffhb.py
@@ -68,7 +68,7 @@ class ModflowFhb(Package):
     ds5 : list or numpy array or recarray
         Each FHB flwrat cell (dataset 5) is defined through definition of
         layer(int), row(int), column(int), iaux(int), flwrat[nbdtime](float).
-        There are nflw entries. (default is None)
+        There should be nflw entries. (default is None)
         The simplest form is a list of lists with the FHB flow boundaries.
         This gives the form of::
 
@@ -80,14 +80,12 @@ class ModflowFhb(Package):
                 [lay, row, col, iaux, flwrat1, flwra2, ..., flwrat(nbdtime)]
             ]
 
-        Note there should be nflw rows in ds7.
-
     cnstm7 : float
         A constant multiplier for data list sbhedt. (default is 1.0)
     ds7 : list or numpy array or recarray
         Each FHB sbhed cell (dataset 7) is defined through definition of
         layer(int), row(int), column(int), iaux(int), sbhed[nbdtime](float).
-        There are nflw entries. (default is None)
+        There should be nhed entries. (default is None)
         The simplest form is a list of lists with the FHB flow boundaries.
         This gives the form of::
 
@@ -98,8 +96,6 @@ class ModflowFhb(Package):
                 [lay, row, col, iaux, sbhed1, sbhed2, ..., sbhed(nbdtime)],
                 [lay, row, col, iaux, sbhed1, sbhed2, ..., sbhed(nbdtime)]
             ]
-
-        Note there should be nhed rows in ds7.
 
     extension : string
         Filename extension (default is 'fhb')

--- a/flopy/modflow/mflpf.py
+++ b/flopy/modflow/mflpf.py
@@ -30,7 +30,7 @@ class ModflowLpf(Package):
     ipakcb : int
         A flag that is used to determine if cell-by-cell budget data should be
         saved. If ipakcb is non-zero cell-by-cell budget data will be saved.
-        (default is 53)
+        (default is 0)
     hdry : float
         Is the head that is assigned to cells that are converted to dry during
         a simulation. Although this value plays no role in the model

--- a/flopy/modflow/mfoc.py
+++ b/flopy/modflow/mfoc.py
@@ -67,7 +67,7 @@ class ModflowOc(Package):
         text files, but they are not generally transportable among different
         computer operating systems or different Fortran compilers.
         (default is None)
-    stress_period_data : dictionary of of lists
+    stress_period_data : dictionary of lists
         Dictionary key is a tuple with the zero-based period and step
         (IPEROC, ITSOC) for each print/save option list. If stress_period_data
         is None, then heads are saved for the last time step of each stress

--- a/flopy/modflow/mfoc.py
+++ b/flopy/modflow/mfoc.py
@@ -153,7 +153,7 @@ class ModflowOc(Package):
 
         """
         if unitnumber is None:
-            unitnumber = [ModflowOc.defaultunit(), 0, 0, 0, 0]
+            unitnumber = ModflowOc.defaultunit()
         elif isinstance(unitnumber, list):
             if len(unitnumber) < 5:
                 for idx in range(len(unitnumber), 6):

--- a/flopy/plot/map.py
+++ b/flopy/plot/map.py
@@ -126,7 +126,7 @@ class PlotMapView(object):
         elif self.mg.grid_type == "vertex":
             if a.ndim == 3:
                 if a.shape[0] == 1:
-                    a = np.squeeze(a, axis=1)
+                    a = np.squeeze(a, axis=0)
                     plotarray = a[self.layer, :]
                 elif a.shape[1] == 1:
                     a = np.squeeze(a, axis=1)
@@ -243,7 +243,7 @@ class PlotMapView(object):
         elif self.mg.grid_type == "vertex":
             if a.ndim == 3:
                 if a.shape[0] == 1:
-                    a = np.squeeze(a, axis=1)
+                    a = np.squeeze(a, axis=0)
                     plotarray = a[self.layer, :]
                 elif a.shape[1] == 1:
                     a = np.squeeze(a, axis=1)
@@ -889,8 +889,9 @@ class PlotMapView(object):
             for ix, tup in enumerate(temp):
                 spdis[ix] = tup
 
-            self.plot_specific_discharge(spdis, istep=istep, jstep=jstep,
-                                         normalize=normalize, **kwargs)
+            return self.plot_specific_discharge(spdis, istep=istep,
+                                                jstep=jstep,
+                                                normalize=normalize, **kwargs)
 
     def plot_pathline(self, pl, travel_time=None, **kwargs):
         """

--- a/flopy/plot/map.py
+++ b/flopy/plot/map.py
@@ -151,6 +151,9 @@ class PlotMapView(object):
             for mval in masked_values:
                 plotarray = np.ma.masked_equal(plotarray, mval)
 
+        # add NaN values to mask
+        plotarray = np.ma.masked_where(np.isnan(plotarray), plotarray)
+
         if 'ax' in kwargs:
             ax = kwargs.pop('ax')
         else:
@@ -679,6 +682,12 @@ class PlotMapView(object):
                 else:
                     t = np.equal(plotarray, mval)
                     ismasked += t
+
+        # add NaN values to mask
+        if ismasked is None:
+            ismasked = np.isnan(plotarray)
+        else:
+            ismasked += np.isnan(plotarray)
 
         if 'ax' in kwargs:
             ax = kwargs.pop('ax')

--- a/flopy/plot/map.py
+++ b/flopy/plot/map.py
@@ -710,9 +710,96 @@ class PlotMapView(object):
 
         return contour_set
 
+    def plot_vector(self, vx, vy, istep=1, jstep=1, normalize=False,
+                    masked_values=None, **kwargs):
+        """
+        Plot a vector.
+
+        Parameters
+        ----------
+        vx : np.ndarray
+            x component of the vector to be plotted (non-rotated)
+            array shape must be (nlay, nrow, ncol) for a structured grid
+            array shape must be (nlay, ncpl) for a unstructured grid
+        vy : np.ndarray
+            y component of the vector to be plotted (non-rotated)
+            array shape must be (nlay, nrow, ncol) for a structured grid
+            array shape must be (nlay, ncpl) for a unstructured grid
+        istep : int
+            row frequency to plot (default is 1)
+        jstep : int
+            column frequency to plot (default is 1)
+        normalize : bool
+            boolean flag used to determine if vectors should be normalized
+            using the vector magnitude in each cell (default is False)
+        masked_values : iterable of floats
+            values to mask
+        kwargs : matplotlib.pyplot keyword arguments for the
+            plt.quiver method
+
+        Returns
+        -------
+        quiver : matplotlib.pyplot.quiver
+            result of the quiver function
+
+        """
+        if 'pivot' in kwargs:
+            pivot = kwargs.pop('pivot')
+        else:
+            pivot = 'middle'
+
+        if 'ax' in kwargs:
+            ax = kwargs.pop('ax')
+        else:
+            ax = self.ax
+
+        # get actual values to plot
+        if self.mg.grid_type == "structured":
+            x = self.mg.xcellcenters[::istep, ::jstep]
+            y = self.mg.ycellcenters[::istep, ::jstep]
+            u = vx[self.layer, ::istep, ::jstep]
+            v = vy[self.layer, ::istep, ::jstep]
+        else:
+            x = self.mg.xcellcenters[::istep]
+            y = self.mg.ycellcenters[::istep]
+            u = vx[self.layer, ::istep]
+            v = vy[self.layer, ::istep]
+
+        # if necessary, copy to avoid changing the passed values
+        if masked_values is not None or normalize:
+            import copy
+            u = copy.copy(u)
+            v = copy.copy(v)
+
+        # mask values
+        if masked_values is not None:
+            for mval in masked_values:
+                to_mask = np.logical_or(u==mval, v==mval)
+                u[to_mask] = np.nan
+                v[to_mask] = np.nan
+
+        # normalize
+        if normalize:
+            vmag = np.sqrt(u ** 2. + v ** 2.)
+            idx = vmag > 0.
+            u[idx] /= vmag[idx]
+            v[idx] /= vmag[idx]
+
+        # rotate and plot, offsets must be zero since
+        # these are vectors not locations
+        urot, vrot = geometry.rotate(u, v, 0., 0., self.mg.angrot_radians)
+
+        # plot with quiver
+        quiver = ax.quiver(x, y, urot, vrot, pivot=pivot, **kwargs)
+
+        return quiver
+
     def plot_specific_discharge(self, spdis, istep=1,
                                 jstep=1, normalize=False, **kwargs):
         """
+        DEPRECATED. Use plot_vector() instead, which should follow after
+        postprocessing.get_specific_discharge().
+
         Method to plot specific discharge from discharge vectors
         provided by the cell by cell flow output file. In MODFLOW-6
         this option is controled in the NPF options block. This method
@@ -735,6 +822,11 @@ class PlotMapView(object):
             quiver plot of discharge vectors
 
         """
+        warnings.warn('plot_specific_discharge() has been deprecated. Use '
+                      'plot_vector() instead, which should follow after '
+                      'postprocessing.get_specific_discharge()',
+                      DeprecationWarning)
+
         if 'pivot' in kwargs:
             pivot = kwargs.pop('pivot')
         else:
@@ -803,6 +895,9 @@ class PlotMapView(object):
                        flf=None, head=None, istep=1, jstep=1,
                        normalize=False, **kwargs):
         """
+        DEPRECATED. Use plot_vector() instead, which should follow after
+        postprocessing.get_specific_discharge().
+
         Use quiver to plot vectors.
 
         Parameters
@@ -833,6 +928,11 @@ class PlotMapView(object):
             Vectors of specific discharge.
 
         """
+        warnings.warn('plot_discharge() has been deprecated. Use '
+                      'plot_vector() instead, which should follow after '
+                      'postprocessing.get_specific_discharge()',
+                      DeprecationWarning)
+
         if self.mg.grid_type != "structured":
             err_msg = "Use plot_specific_discharge for " \
                       "{} grids".format(self.mg.grid_type)

--- a/flopy/plot/plotutil.py
+++ b/flopy/plot/plotutil.py
@@ -2410,6 +2410,10 @@ def plot_cvfd(verts, iverts, ax=None, layer=0, cmap='Dark2',
         if masked_values is not None:
             for mval in masked_values:
                 a = np.ma.masked_equal(a, mval)
+
+        # add NaN values to mask
+        a = np.ma.masked_where(np.isnan(a), a)
+
         if edgecolor == 'scaled':
             pc.set_edgecolor('none')
         else:

--- a/flopy/plot/plotutil.py
+++ b/flopy/plot/plotutil.py
@@ -1640,6 +1640,8 @@ class PlotUtilities(object):
     @staticmethod
     def centered_specific_discharge(Qx, Qy, Qz, delr, delc, sat_thk):
         """
+        DEPRECATED. Use postprocessing.get_specific_discharge() instead.
+
         Using the MODFLOW discharge, calculate the cell centered specific discharge
         by dividing by the flow width and then averaging to the cell center.
 
@@ -1666,6 +1668,11 @@ class PlotUtilities(object):
             Specific discharge arrays that have been interpolated to cell centers.
 
         """
+        import warnings
+        warnings.warn('centered_specific_discharge() has been deprecated. Use '
+                      'postprocessing.get_specific_discharge() instead.',
+                      DeprecationWarning)
+
         qx = None
         qy = None
         qz = None

--- a/flopy/utils/postprocessing.py
+++ b/flopy/utils/postprocessing.py
@@ -245,3 +245,440 @@ def get_gradients(heads, m, nodata, per_idx=None):
         # convert to nan-filled array, as is expected(!?)
         grad.append((dh / dz).filled(np.nan))
     return np.squeeze(grad)
+
+def get_extended_budget(cbcfile, precision='single', idx=None,
+                        kstpkper=None, totim=None, boundary_ifaces=None,
+                        hdsfile=None, model=None):
+    """
+    Get the flow rate across cell faces including potential stresses applied
+    along boundaries at a given time. Only implemented for "classical" MODFLOW
+    versions where the budget is recorded as FLOW RIGHT FACE, FLOW FRONT FACE
+    and FLOW LOWER FACE arrays.
+
+    Parameters
+    ----------
+    cbcfile : str
+        Cell by cell file produced by Modflow.
+    precision : str
+        Binary file precision, default is 'single'.
+    idx : int or list
+            The zero-based record number.
+    kstpkper : tuple of ints
+        A tuple containing the time step and stress period (kstp, kper).
+        The kstp and kper values are zero based.
+    totim : float
+        The simulation time.
+    boundary_ifaces : dictionary {str: int or list}
+        A dictionary defining how to treat stress flows at boundary cells.
+        The keys are budget terms corresponding to stress packages (same term
+        as in the overall volumetric budget printed in the listing file).
+        The values are either a single iface number to be applied to all cells
+        for the stress package, or a list of lists describing individual
+        boundary cells in the same way as in the package input plus the iface
+        number appended. The iface number indicates the face to which the
+        stress flow is assigned, following the MODPATH convention (see MODPATH
+        user guide).
+        Example:
+        boundary_ifaces = {
+        'RECHARGE': 6,
+        'RIVER LEAKAGE': 6,
+        'CONSTANT HEAD': [[lay, row, col, iface], ...],
+        'WELLS': [[lay, row, col, flux, iface], ...],
+        'HEAD DEP BOUNDS': [[lay, row, col, head, cond, iface], ...]}.
+        Note: stresses that are not informed in boundary_ifaces are implicitly
+        treated as internally-distributed sinks/sources.
+    hdsfile : str
+        Head file produced by MODFLOW (only required if boundary_ifaces is
+        used).
+    model : flopy.modflow.Modflow object
+        Modflow model instance (only required if boundary_ifaces is used).
+
+    Returns
+    -------
+    (Qx_ext, Qy_ext, Qz_ext) : tuple
+        Flow rates across cell faces.
+        Qx_ext is a ndarray of size (nlay, nrow, ncol + 1).
+        Qy_ext is a ndarray of size (nlay, nrow + 1, ncol). The sign is such
+        that the y axis is considered to increase in the north direction.
+        Qz_ext is a ndarray of size (nlay + 1, nrow, ncol). The sign is such
+        that the z axis is considered to increase in the upward direction.
+    """
+    import flopy.utils.binaryfile as bf
+
+    # define useful stuff
+    cbf = bf.CellBudgetFile(cbcfile, precision=precision)
+    nlay, nrow, ncol = cbf.nlay, cbf.nrow, cbf.ncol
+    rec_names = cbf.get_unique_record_names(decode=True)
+    err_msg = ' not found in the budget file.'
+
+    # get flow across right face
+    Qx_ext = np.zeros((nlay, nrow, ncol + 1), dtype=np.float32)
+    if ncol > 1:
+        budget_term = 'FLOW RIGHT FACE'
+        matched_name = [s for s in rec_names if budget_term in s]
+        if not matched_name:
+            raise RuntimeError(budget_term + err_msg)
+        frf = cbf.get_data(idx=idx, kstpkper=kstpkper, totim=totim,
+                           text=budget_term)
+        Qx_ext[:, :, 1:] = frf[0]
+        # SWI2 package
+        budget_term_swi = 'SWIADDTOFRF'
+        matched_name_swi = [s for s in rec_names if budget_term_swi in s]
+        if matched_name_swi:
+            frf_swi = cbf.get_data(idx=idx, kstpkper=kstpkper, totim=totim,
+                                   text=budget_term_swi)
+            Qx_ext[:, :, 1:] += frf_swi[0]
+
+    # get flow across front face
+    Qy_ext = np.zeros((nlay, nrow + 1, ncol), dtype=np.float32)
+    if nrow > 1:
+        budget_term = 'FLOW FRONT FACE'
+        matched_name = [s for s in rec_names if budget_term in s]
+        if not matched_name:
+            raise RuntimeError(budget_term + err_msg)
+        fff = cbf.get_data(idx=idx, kstpkper=kstpkper, totim=totim,
+                           text=budget_term)
+        Qy_ext[:, 1:, :] = - fff[0]
+        # SWI2 package
+        budget_term_swi = 'SWIADDTOFFF'
+        matched_name_swi = [s for s in rec_names if budget_term_swi in s]
+        if matched_name_swi:
+            fff_swi = cbf.get_data(idx=idx, kstpkper=kstpkper, totim=totim,
+                                   text=budget_term_swi)
+            Qy_ext[:, 1:, :] -= fff_swi[0]
+
+    # get flow across lower face
+    Qz_ext = np.zeros((nlay + 1, nrow, ncol), dtype=np.float32)
+    if nlay > 1:
+        budget_term = 'FLOW LOWER FACE'
+        matched_name = [s for s in rec_names if budget_term in s]
+        if not matched_name:
+            raise RuntimeError(budget_term + err_msg)
+        flf = cbf.get_data(idx=idx, kstpkper=kstpkper, totim=totim,
+                           text=budget_term)
+        Qz_ext[1:, :, :] = - flf[0]
+        # SWI2 package
+        budget_term_swi = 'SWIADDTOFLF'
+        matched_name_swi = [s for s in rec_names if budget_term_swi in s]
+        if matched_name_swi:
+            flf_swi = cbf.get_data(idx=idx, kstpkper=kstpkper, totim=totim,
+                                   text=budget_term_swi)
+            Qz_ext[1:, :, :] -= flf_swi[0]
+
+    # deal with boundary cells
+    if boundary_ifaces is not None:
+        # need calculated heads for some stresses and to check hnoflo and hdry
+        if hdsfile is None:
+            raise ValueError('hdsfile must be provided when using '
+                             'boundary_ifaces')
+        hds = bf.HeadFile(hdsfile, precision=precision)
+        head = hds.get_data(idx=idx, kstpkper=kstpkper, totim=totim)
+
+        # get hnoflo and hdry values
+        if model is None:
+            raise ValueError('model must be provided when using '
+                             'boundary_ifaces')
+        noflo_or_dry = np.logical_or(head==model.hnoflo, head==model.hdry)
+
+        for budget_term, iface_info in boundary_ifaces.items():
+            # look for budget term in budget file
+            matched_name = [s for s in rec_names if budget_term in s]
+            if not matched_name:
+                raise RuntimeError('Budget term ' + budget_term + ' not found'
+                                   ' in "' + cbcfile + '" file.')
+            if len(matched_name) > 1:
+                raise RuntimeError('Budget term ' + budget_term + ' found'
+                                   ' in several record names. Use a more '
+                                   ' precise name.')
+            Q_stress = cbf.get_data(idx=idx, kstpkper=kstpkper, totim=totim,
+                                    text=matched_name[0], full3D=True)[0]
+
+            # remove potential leading and trailing spaces
+            budget_term = budget_term.strip()
+
+            # weirdly, MODFLOW puts recharge in all potential recharge cells
+            # and not only the actual cells; thus, correct this by putting 0
+            # away from water table cells
+            if budget_term == 'RECHARGE':
+                # find the water table as the first active cell in each column
+                water_table = np.full((nlay, nrow, ncol), False)
+                water_table[0, :, :] = np.logical_not(noflo_or_dry[0, :, :])
+                already_found = water_table[0, :, :]
+                for lay in range(1, nlay):
+                    if np.sum(already_found) == nrow * ncol:
+                        break
+                    water_table[lay, :, :] = np.logical_and(
+                        np.logical_not(noflo_or_dry[lay, :, :]),
+                        np.logical_not(already_found))
+                    already_found = np.logical_or(already_found,
+                                                  water_table[lay, :, :])
+                Q_stress[np.logical_not(water_table)] = 0.
+
+            # case where the same iface is assigned to all cells
+            if isinstance(iface_info, int):
+                if iface_info == 1:
+                    Qx_ext[:, :, :-1] += Q_stress
+                elif iface_info == 2:
+                    Qx_ext[:, :, 1:] -= Q_stress
+                elif iface_info == 3:
+                    Qy_ext[:, 1:, :] += Q_stress
+                elif iface_info == 4:
+                    Qy_ext[:, :-1, :] -= Q_stress
+                elif iface_info == 5:
+                    Qz_ext[1:, :, :] += Q_stress
+                elif iface_info == 6:
+                    Qz_ext[:-1, :, :] -= Q_stress
+
+            # case where iface is assigned individually per cell
+            elif isinstance(iface_info, list):
+                # impose a unique iface (normally = 6) for some stresses
+                # (note: UZF RECHARGE, GW ET and SURFACE LEAKAGE are all
+                # related to the UZF package)
+                if budget_term == 'RECHARGE' or \
+                   budget_term == 'ET' or \
+                   budget_term == 'UZF RECHARGE' or \
+                   budget_term == 'GW ET' or \
+                   budget_term == 'SURFACE LEAKAGE':
+                    raise ValueError('This function imposes the use of a '
+                                     'unique iface (normally = 6) for the '
+                                     + budget_term + ' budget term.')
+
+                # loop through boundary cells
+                for cell_info in iface_info:
+                    lay, row, col = cell_info[0], cell_info[1], cell_info[2]
+                    if noflo_or_dry[lay, row, col]:
+                        continue
+                    iface = cell_info[-1]
+                    # Here, where appropriate, we recalculate Q_stress_cell
+                    # using package input. This gives more flexibility than
+                    # directly taking the value saved by MODFLOW. Indeed, it
+                    # allows for a same type of stress to be applied several
+                    # times to the same cell but to different faces
+                    # (whereas MODFLOW only saves one lumped  value per
+                    # stress type per cell).
+                    # Note: this flexibility is not supported for:
+                    # - FHB package (we would need to interpolate inputs
+                    #   across time steps as done in the package; complicated)
+                    # - RES package (we would need to interpolate inputs
+                    #   across time steps as done in the package; complicated)
+                    # - STR package (we would need first to retrieve river
+                    #   stage from model outputs; complicated)
+                    # - SFR1 package (we would need to retrieve river
+                    #   stage and conductance from model outputs; complicated)
+                    # - SFR2 package (even more complicated than SFR1)
+                    # - LAK3 package (we would need to retrieve lake
+                    #   stage and conductance from model outputs; complicated)
+                    # - MNW1 package (we would need to retrieve well head and
+                    #   conductance from model outputs; complicated)
+                    # - MNW2 package (even more complicated than MNW1)
+                    if budget_term == 'WELLS':
+                        Q_stress_cell = cell_info[3]
+                    elif budget_term == 'HEAD DEP BOUNDS':
+                        ghb_head = cell_info[3]
+                        ghb_cond = cell_info[4]
+                        model_head = head[lay, row, col]
+                        Q_stress_cell = ghb_cond * (ghb_head - model_head)
+                    elif budget_term == 'RIVER LEAKAGE':
+                        riv_stage = cell_info[3]
+                        riv_cond = cell_info[4]
+                        riv_rbot = cell_info[5]
+                        model_head = head[lay, row, col]
+                        if model_head > riv_rbot:
+                            Q_stress_cell = riv_cond * (riv_stage - model_head)
+                        else:
+                            Q_stress_cell = riv_cond * (riv_stage - riv_rbot)
+                    elif budget_term == 'DRAINS':
+                        drn_stage = cell_info[3]
+                        drn_cond = cell_info[4]
+                        model_head = head[lay, row, col]
+                        if model_head > drn_stage:
+                            Q_stress_cell = drn_cond * (drn_stage - model_head)
+                        else:
+                            continue
+                    # Else, take the value saved by MODFLOW.
+                    # This includes the budget terms:
+                    # - 'CONSTANT HEAD' for:
+                    #      * head specified through -1 in IBOUND
+                    #      * head specified in CHD package
+                    #      * head specified in FHB package
+                    # - 'SPECIFIED FLOWS' for flow specified in FHB package
+                    # - 'RESERV. LEAKAGE' for RES package
+                    # - 'STREAM LEAKAGE' for:
+                    #      * STR package
+                    #      * SFR1 package
+                    #      * SFR2 package
+                    #  - 'LAKE SEEPAGE' for LAK3 package
+                    #  - 'MNW' for MNW1 package
+                    #  - 'MNW2' for MNW2 package
+                    #  - 'SWIADDTOCH' for SWI2 package
+                    else:
+                        Q_stress_cell = Q_stress[lay, row, col]
+
+                    if iface == 1:
+                        Qx_ext[lay, row, col] += Q_stress_cell
+                    elif iface == 2:
+                        Qx_ext[lay, row, col+1] -= Q_stress_cell
+                    elif iface == 3:
+                        Qy_ext[lay, row+1, col] += Q_stress_cell
+                    elif iface == 4:
+                        Qy_ext[lay, row, col] -= Q_stress_cell
+                    elif iface == 5:
+                        Qz_ext[lay+1, row, col] += Q_stress_cell
+                    elif iface == 6:
+                        Qz_ext[lay, row, col] -= Q_stress_cell
+            else:
+                raise TypeError('boundary_ifaces value must be either '\
+                                'int or list.')
+
+    return Qx_ext, Qy_ext, Qz_ext
+
+def get_specific_discharge(model, cbcfile, precision='single', idx=None,
+                           kstpkper=None, totim=None, boundary_ifaces=None,
+                           hdsfile=None):
+    """
+    Get the discharge vector at cell centers at a given time. For "classical"
+    MODFLOW versions, we calculate it from the flow rate across cell faces.
+    For MODFLOW 6, we directly take it from MODFLOW output (this requires
+    setting the option "save_specific_discharge" in the NPF package).
+
+    Parameters
+    ----------
+    model : flopy.modflow.Modflow object
+        Modflow model instance.
+    cbcfile : str
+        Cell by cell file produced by Modflow.
+    precision : str
+        Binary file precision, default is 'single'.
+    idx : int or list
+            The zero-based record number.
+    kstpkper : tuple of ints
+        A tuple containing the time step and stress period (kstp, kper).
+        The kstp and kper values are zero based.
+    totim : float
+        The simulation time.
+    boundary_ifaces : dictionary {str: int or list}
+        A dictionary defining how to treat stress flows at boundary cells.
+        Only implemented for "classical" MODFLOW versions where the budget is
+        recorded as FLOW RIGHT FACE, FLOW FRONT FACE and FLOW LOWER FACE
+        arrays.
+        The keys are budget terms corresponding to stress packages (same term
+        as in the overall volumetric budget printed in the listing file).
+        The values are either a single iface number to be applied to all cells
+        for the stress package, or a list of lists describing individual
+        boundary cells in the same way as in the package input plus the iface
+        number appended. The iface number indicates the face to which the
+        stress flow is assigned, following the MODPATH convention (see MODPATH
+        user guide).
+        Example:
+        boundary_ifaces = {
+        'RECHARGE': 6,
+        'RIVER LEAKAGE': 6,
+        'WELLS': [[lay, row, col, flux, iface], ...],
+        'HEAD DEP BOUNDS': [[lay, row, col, head, cond, iface], ...]}.
+        Note: stresses that are not informed in boundary_ifaces are implicitly
+        treated as internally-distributed sinks/sources.
+    hdsfile : str
+        Head file produced by MODFLOW. Head is used to calculate saturated
+        thickness and to determine if a cell is inactive or dry. If not
+        provided, all cells are considered fully saturated.
+        hdsfile is also required if the budget term 'HEAD DEP BOUNDS',
+        'RIVER LEAKAGE' or 'DRAINS' is present in boundary_ifaces and that the
+        corresponding value is a list.
+
+    Returns
+    -------
+    (qx, qy, qz) : tuple
+        Discharge vector.
+        qx, qy, qz are ndarrays of size (nlay, nrow, ncol) for a structured
+        grid or size (nlay, ncpl) for an unstructured grid.
+        The sign of qy is such that the y axis is considered to increase
+        in the north direction.
+        The sign of qz is such that the z axis is considered to increase
+        in the upward direction.
+        Note: if hdsfile is provided, inactive and dry cells are set to NaN.
+    """
+    import flopy.utils.binaryfile as bf
+
+    # check if budget file has classical budget terms
+    cbf = bf.CellBudgetFile(cbcfile, precision=precision)
+    rec_names = cbf.get_unique_record_names(decode=True)
+    classical_budget_terms = ['FLOW RIGHT FACE', 'FLOW FRONT FACE',
+                         'FLOW RIGHT FACE']
+    classical_budget = False
+    for budget_term in classical_budget_terms:
+        matched_name = [s for s in rec_names if budget_term in s]
+        if matched_name:
+            classical_budget = True
+            break
+
+    if hdsfile is not None:
+        hds = bf.HeadFile(hdsfile, precision=precision)
+        head = hds.get_data(idx=idx, kstpkper=kstpkper, totim=totim)
+
+    if classical_budget:
+        # get extended budget
+        Qx_ext, Qy_ext, Qz_ext = get_extended_budget(cbcfile,
+                               precision=precision, idx=idx, kstpkper=kstpkper,
+                               totim=totim, boundary_ifaces=boundary_ifaces,
+                               hdsfile=hdsfile, model=model)
+
+        # get saturated thickness (head - bottom elev for unconfined layer)
+        if hdsfile is None:
+            sat_thk = model.dis.thickness.array
+        else:
+            sat_thk = get_saturated_thickness(head, model, model.hdry)
+
+        # calculate qx at cell center
+        delc = np.reshape(model.modelgrid.delc, (1, model.modelgrid.nrow, 1))
+        cross_area_x = np.empty(model.modelgrid.shape, dtype=float)
+        cross_area_x = delc * sat_thk
+        qx = 0.5 * (Qx_ext[:, :, 1:] + Qx_ext[:, :, :-1]) / cross_area_x
+
+        # calculate qy at cell center
+        delr = np.reshape(model.modelgrid.delr, (1, 1, model.modelgrid.ncol))
+        cross_area_y = np.empty(model.modelgrid.shape, dtype=float)
+        cross_area_y = delr * sat_thk
+        qy = 0.5 * (Qy_ext[:, 1:, :] + Qy_ext[:, :-1, :]) / cross_area_y
+
+        # calculate qz at cell center
+        cross_area_z = np.empty(model.modelgrid.shape, dtype=float)
+        cross_area_z = delc * delr
+        qz = 0.5 * (Qz_ext[1:, :, :] + Qz_ext[:-1, :, :]) / cross_area_z
+
+    else:
+        if boundary_ifaces is not None:
+            import warnings
+            warnings.warn('the boundary_ifaces option is not implemented '
+                          'for "non-classical" MODFLOW versions where the '
+                          'budget is not recorded as FLOW RIGHT FACE, '
+                          'FLOW FRONT FACE and FLOW LOWER FACE; it will be '
+                          'ignored', UserWarning)
+
+        is_spdis = [s for s in rec_names if 'DATA-SPDIS' in s]
+        if not is_spdis:
+            err_msg = 'Could not find suitable records in the budget file ' \
+                      'to construct the discharge vector.'
+            raise RuntimeError(err_msg)
+        spdis = cbf.get_data(text='DATA-SPDIS', idx=idx, kstpkper=kstpkper,
+                             totim=totim)[0]
+        nnodes = model.modelgrid.nnodes
+        qx = np.full((nnodes), np.nan)
+        qy = np.full((nnodes), np.nan)
+        qz = np.full((nnodes), np.nan)
+        idx = np.array(spdis['node']) - 1
+        qx[idx] = spdis['qx']
+        qy[idx] = spdis['qy']
+        qz[idx] = spdis['qz']
+        shape = model.modelgrid.shape
+        qx.shape = shape
+        qy.shape = shape
+        qz.shape = shape
+
+    # set no-flow and dry cells to NaN
+    if hdsfile is not None:
+        noflo_or_dry = np.logical_or(head==model.hnoflo, head==model.hdry)
+        qx[noflo_or_dry] = np.nan
+        qy[noflo_or_dry] = np.nan
+        qz[noflo_or_dry] = np.nan
+
+    return qx, qy, qz


### PR DESCRIPTION
One may want to allow flow through boundaries instead of treating boundary stresses as an internal source/sink (behavior until now). This is made possible by new post-processing and plotting functions.

The idea is best illustrated with a simple example from tutorial 1. Until now, plotting the specific discharge would give:
<img src="https://raw.githubusercontent.com/etiennebresciani/share/master/tutorial1_old.png" width=400 height=400>
Notice that the arrows in the first and last columns are half of the other ones; this is because boundary faces are implicitly always treated as no flow. With what I developed, we can assign the flow from/to constant head cells to boundary faces, and thus get:
<img src="https://raw.githubusercontent.com/etiennebresciani/share/master/tutorial1_new.png" width=400 height=400>
The essential lines to get the latter figure with the new functions are:
```python
# generate boundary faces information
consthead_ifaces = []
xlow_iface = 1
xhigh_iface = 2
for row in range(nrow):
    consthead_ifaces.append([0, row, 0, xlow_iface])
    consthead_ifaces.append([0, row, ncol-1, xhigh_iface])
boundary_ifaces = {'CONSTANT HEAD': consthead_ifaces}

# get specific discharge
qx, qy, qz = flopy.utils.postprocessing.get_specific_discharge(mf, 
                                    cbcfile, boundary_ifaces=boundary_ifaces, 
                                    hdsfile=hdsfile)

# plot
modelmap.plot_vector(qx, qy, color='white')
```
I tried my best to account for all possible stress packages and MODFLOW versions. However, the new functionality is not available for MODFLOW 6. It would be quite complicated since the cell faces can be arbitrary. Thus, for MODFLOW 6, I simply take the DATA-SPDIS vector from the budget file.

PS1: In line with the proposed developments, I am suggesting the two-steps workflow 1) get_specific_discharge() and 2) plot_vector() as the new workflow for plotting specific discharge in all cases. This is better in line with the existing workflow for heads (i.e., 1) get_data() and 2) plot_array()), and so I think this is an improvement.

PS2: As a consequence, I deprecated a few functions which are now redundant since the new functions are just more flexible. In fact, the previous functionalities are now coded more concisely and generically. In particular, `plot_specific_discharge()` (for “classical” MODFLOW versions) and `plot_discharge()` (for MODFLOW 6) are replaced by a generic `plot_vector()` function (in both `PlotMapView` and `PlotCrossSection` classes).

PS3: A few commits in this PR relate to various fixes that I made along the way but are in fact independent of the above-stated intention. I tried my best for writing explicit commit messages.

PS4: Hope you will find it useful! Please let me know if you have any question or concern.
