### PR TITLE
vtk export: .vti and .vtr formats (#833), code improvements and fixes

### DIFF
--- a/autotest/t050_test.py
+++ b/autotest/t050_test.py
@@ -215,6 +215,13 @@ def test_vtk_mf6():
             m = loaded_sim.get_model(mname)
             m.export(os.path.join(cpth, m.name), fmt='vtk')
 
+    # check one
+    filetocheck = os.path.join(cpth, 'twrihfb2015', 'npf.vtr')
+    # totalbytes = os.path.getsize(filetocheck)
+    # assert(totalbytes==21609)
+    nlines = count_lines_in_file(filetocheck)
+    assert(nlines==76)
+
     return
 
 
@@ -334,6 +341,101 @@ def test_vtk_cbc():
 
     return
 
+def test_vtk_vti():
+    # test mf 2005 ibs2k
+    mpth = os.path.join('..', 'examples', 'data', 'mf2005_test')
+    namfile = 'ibs2k.nam'
+    m = flopy.modflow.Modflow.load(namfile, model_ws=mpth, verbose=False)
+    output_dir = os.path.join(cpth, m.name)
+    filenametocheck = 'DIS.vti'
+
+    # export and check
+    m.export(output_dir, fmt='vtk')
+    filetocheck = os.path.join(output_dir, filenametocheck)
+    # totalbytes = os.path.getsize(filetocheck)
+    # assert(totalbytes==6322)
+    nlines = count_lines_in_file(filetocheck)
+    assert(nlines==21)
+
+    # with point scalar
+    m.export(output_dir + '_points', fmt='vtk', point_scalars=True)
+    filetocheck = os.path.join(output_dir + '_points', filenametocheck)
+    # totalbytes1 = os.path.getsize(filetocheck)
+    # assert(totalbytes1==16382)
+    nlines1 = count_lines_in_file(filetocheck)
+    assert(nlines1==38)
+
+    # with binary
+    m.export(output_dir + '_bin', fmt='vtk', binary=True)
+    filetocheck = os.path.join(output_dir + '_bin', filenametocheck)
+    # totalbytes2 = os.path.getsize(filetocheck)
+    # assert(totalbytes2==6537)
+    nlines2 = count_lines_in_file_bin(filetocheck)
+    assert(nlines2==18)
+
+    # force .vtr
+    filenametocheck = 'DIS.vtr'
+    m.export(output_dir, fmt='vtk', vtk_grid_type='RectilinearGrid')
+    filetocheck = os.path.join(output_dir, filenametocheck)
+    # totalbytes3 = os.path.getsize(filetocheck)
+    # assert(totalbytes3==7146)
+    nlines3 = count_lines_in_file(filetocheck)
+    assert(nlines3==56)
+
+    # force .vtu
+    filenametocheck = 'DIS.vtu'
+    m.export(output_dir, fmt='vtk', vtk_grid_type='UnstructuredGrid')
+    filetocheck = os.path.join(output_dir, filenametocheck)
+    # totalbytes4 = os.path.getsize(filetocheck)
+    # assert(totalbytes4==67065)
+    nlines4 = count_lines_in_file(filetocheck)
+    assert(nlines4==993)
+
+    return
+
+def test_vtk_vtr():
+    # test mf 2005 l1a2k
+    mpth = os.path.join('..', 'examples', 'data', 'mf2005_test')
+    namfile = 'l1a2k.nam'
+    m = flopy.modflow.Modflow.load(namfile, model_ws=mpth, verbose=False)
+    output_dir = os.path.join(cpth, m.name)
+    filenametocheck = 'EVT_01.vtr'
+
+    # export and check
+    m.export(output_dir, fmt='vtk')
+    filetocheck = os.path.join(output_dir, filenametocheck)
+    # totalbytes = os.path.getsize(filetocheck)
+    # assert(totalbytes==79953)
+    nlines = count_lines_in_file(filetocheck)
+    assert(nlines==87)
+
+    # with point scalar
+    m.export(output_dir + '_points', fmt='vtk', point_scalars=True)
+    filetocheck = os.path.join(output_dir + '_points', filenametocheck)
+    # totalbytes1 = os.path.getsize(filetocheck)
+    # assert(totalbytes1==182472)
+    nlines1 = count_lines_in_file(filetocheck)
+    assert(nlines1==121)
+
+    # with binary
+    m.export(output_dir + '_bin', fmt='vtk', binary=True)
+    filetocheck = os.path.join(output_dir + '_bin', filenametocheck)
+    # totalbytes2 = os.path.getsize(filetocheck)
+    # assert(totalbytes2==47778)
+    nlines2 = count_lines_in_file_bin(filetocheck)
+    assert(nlines2==28)
+
+    # force .vtu
+    filenametocheck = 'EVT_01.vtu'
+    m.export(output_dir, fmt='vtk', vtk_grid_type='UnstructuredGrid')
+    filetocheck = os.path.join(output_dir, filenametocheck)
+    # totalbytes3 = os.path.getsize(filetocheck)
+    # assert(totalbytes3==78762)
+    nlines3 = count_lines_in_file(filetocheck)
+    assert(nlines3==1105)
+
+    return
+
 if __name__ == '__main__':
     test_vtk_export_array2d()
     test_vtk_export_array3d()
@@ -342,3 +444,5 @@ if __name__ == '__main__':
     test_vtk_mf6()
     test_vtk_binary_head_export()
     test_vtk_cbc()
+    test_vtk_vti()
+    test_vtk_vtr()

--- a/autotest/t050_test.py
+++ b/autotest/t050_test.py
@@ -1,8 +1,13 @@
 import shutil
 import os
-import numpy as np
 import flopy
 from flopy.export import vtk
+
+# Test vtk export
+# Note: initially thought about asserting that exported file size in bytes is
+# unchanged, but this seems to be sensitive to the running environment.
+# Thus, only asserting that the number of lines is unchanged.
+# Still keeping the file size check commented for now.
 
 # create output directory
 cpth = os.path.join('temp', 't050')
@@ -10,107 +15,193 @@ if os.path.isdir(cpth):
     shutil.rmtree(cpth)
 os.makedirs(cpth)
 
-# binary output directory
-binot = os.path.join(cpth, 'bin')
-if os.path.isdir(binot):
-    shutil.rmtree(binot)
-os.makedirs(binot)
+def count_lines_in_file(filepath):
+    f = open(filepath, 'r')
+    n = len(f.readlines())
+    return n
 
+def count_lines_in_file_bin(filepath):
+    f = open(filepath, 'rb')
+    n = len(f.readlines())
+    return n
 
 def test_vtk_export_array2d():
-    """Export 2d array"""
+    # test mf 2005 freyberg
     mpath = os.path.join('..', 'examples', 'data',
                          'freyberg_multilayer_transient')
     namfile = 'freyberg.nam'
-    m = flopy.modflow.Modflow.load(namfile, model_ws=mpath, verbose=False)
-    m.dis.top.export(os.path.join(cpth, 'array_2d_test'), fmt='vtk')
-    # with smoothing
-    m.dis.top.export(os.path.join(cpth, 'array_2d_test'), fmt='vtk',
-                     name='top_smooth', smooth=True)
+    m = flopy.modflow.Modflow.load(namfile, model_ws=mpath, verbose=False,
+                                   load_only=['dis', 'bas6'])
+    output_dir = os.path.join(cpth, 'array_2d_test')
 
+    # export and check
+    m.dis.top.export(output_dir, name='top', fmt='vtk')
+    filetocheck = os.path.join(output_dir, 'top.vtu')
+    # totalbytes = os.path.getsize(filetocheck)
+    # assert(totalbytes==352026)
+    nlines = count_lines_in_file(filetocheck)
+    assert(nlines==2846)
+
+    # with smoothing
+    m.dis.top.export(output_dir, fmt='vtk', name='top_smooth', smooth=True)
+    filetocheck = os.path.join(output_dir, 'top_smooth.vtu')
+    # totalbytes1 = os.path.getsize(filetocheck)
+    # assert(totalbytes1==351829)
+    nlines1 = count_lines_in_file(filetocheck)
+    assert(nlines1==2846)
+
+    return
 
 def test_vtk_export_array3d():
-    """Vtk export 3d array"""
+    # test mf 2005 freyberg
     mpath = os.path.join('..', 'examples', 'data',
                          'freyberg_multilayer_transient')
     namfile = 'freyberg.nam'
-    m = flopy.modflow.Modflow.load(namfile, model_ws=mpath, verbose=False)
-    m.upw.hk.export(os.path.join(cpth, 'array_3d_test'), fmt='vtk')
+    m = flopy.modflow.Modflow.load(namfile, model_ws=mpath, verbose=False,
+                                   load_only=['dis', 'bas6', 'upw'])
+    output_dir = os.path.join(cpth, 'array_3d_test')
+
+    # export and check
+    m.upw.hk.export(output_dir, fmt='vtk', name='hk')
+    filetocheck = os.path.join(output_dir, 'hk.vtu')
+    # totalbytes = os.path.getsize(filetocheck)
+    # assert(totalbytes==992576)
+    nlines = count_lines_in_file(filetocheck)
+    assert(nlines==8486)
+
     # with point scalars
-    m.upw.hk.export(os.path.join(cpth, 'array_3d_test'), fmt='vtk',
-                    name='hk_points', point_scalars=True)
-    # binary test
-    m.upw.hk.export(os.path.join(binot, 'array_3d_test'), fmt='vtk',
-                    name='hk_points', point_scalars=True, binary=True)
+    m.upw.hk.export(output_dir, fmt='vtk', name='hk_points',
+                    point_scalars=True)
+    filetocheck = os.path.join(output_dir, 'hk_points.vtu')
+    # totalbytes1 = os.path.getsize(filetocheck)
+    # assert(totalbytes1==1321292)
+    nlines1 = count_lines_in_file(filetocheck)
+    assert(nlines1==10605)
+
+    # with point scalars and binary
+    m.upw.hk.export(output_dir, fmt='vtk', name='hk_points_bin',
+                    point_scalars=True, binary=True)
+    filetocheck = os.path.join(output_dir, 'hk_points_bin.vtu')
+    # totalbytes2 = os.path.getsize(filetocheck)
+    # assert(totalbytes2==637861)
+    nlines2 = count_lines_in_file_bin(filetocheck)
+    assert(nlines2==1848)
 
     return
-
 
 def test_vtk_transient_array_2d():
-    """VTK export transient 2d array"""
+    # test mf 2005 freyberg
     mpath = os.path.join('..', 'examples', 'data',
                          'freyberg_multilayer_transient')
     namfile = 'freyberg.nam'
-    m = flopy.modflow.Modflow.load(namfile, model_ws=mpath, verbose=False)
-    m.rch.rech.export(os.path.join(cpth, 'transient_2d_test'), fmt='vtk')
+    m = flopy.modflow.Modflow.load(namfile, model_ws=mpath, verbose=False,
+                                   load_only=['dis', 'bas6', 'rch'])
+    output_dir = os.path.join(cpth, 'transient_2d_test')
+    output_dir_bin = os.path.join(cpth, 'transient_2d_test_bin')
 
-    # binary test
-    m.rch.rech.export(os.path.join(binot, 'transient_2d_test'), fmt='vtk',
-                      binary=True)
+    # export and check
+    r = m.rch.rech
+    m.rch.rech.export(output_dir, fmt='vtk')
+    filetocheck = os.path.join(output_dir, 'rech_01.vtu')
+    # totalbytes = os.path.getsize(filetocheck)
+    # assert(totalbytes==355324)
+    nlines = count_lines_in_file(filetocheck)
+    assert(nlines==2851)
+    filetocheck = os.path.join(output_dir, 'rech_01097.vtu')
+    # totalbytes1 = os.path.getsize(filetocheck)
+    # assert(totalbytes1==354622)
+    nlines1 = count_lines_in_file(filetocheck)
+    assert(nlines1==2851)
+
+    # with binary
+    m.rch.rech.export(output_dir_bin, fmt='vtk', binary=True)
+    filetocheck = os.path.join(output_dir_bin, 'rech_01.vtu')
+    # totalbytes2 = os.path.getsize(filetocheck)
+    # assert(totalbytes2==168339)
+    nlines2 = count_lines_in_file_bin(filetocheck)
+    assert(nlines2==762)
+    filetocheck = os.path.join(output_dir_bin, 'rech_01097.vtu')
+    # totalbytes3 = os.path.getsize(filetocheck)
+    # assert(totalbytes3==168339)
+    nlines3 = count_lines_in_file_bin(filetocheck)
+    assert(nlines3==762)
 
     return
-
 
 def test_vtk_export_packages():
-    """testing vtk package export"""
+    # test mf 2005 freyberg
     mpath = os.path.join('..', 'examples', 'data',
                          'freyberg_multilayer_transient')
     namfile = 'freyberg.nam'
-    m = flopy.modflow.Modflow.load(namfile, model_ws=mpath, verbose=False)
-    # test dis export
-    m.dis.export(os.path.join(cpth, 'DIS'), fmt='vtk')
+    m = flopy.modflow.Modflow.load(namfile, model_ws=mpath, verbose=False,
+                                   load_only=['dis', 'bas6', 'upw', 'DRN'])
+
+    # dis export and check
+    output_dir = os.path.join(cpth, 'DIS')
+    m.dis.export(output_dir, fmt='vtk')
+    filetocheck = os.path.join(output_dir, 'DIS.vtu')
+    # totalbytes = os.path.getsize(filetocheck)
+    # assert(totalbytes==1010527)
+    nlines = count_lines_in_file(filetocheck)
+    assert(nlines==8496)
+
     # upw with point scalar output
-    m.upw.export(os.path.join(cpth, 'UPW'), fmt='vtk', point_scalars=True)
+    output_dir = os.path.join(cpth, 'UPW')
+    m.upw.export(output_dir, fmt='vtk', point_scalars=True)
+    filetocheck = os.path.join(output_dir, 'UPW.vtu')
+    # totalbytes1 = os.path.getsize(filetocheck)
+    # assert(totalbytes1==2485295)
+    nlines1 = count_lines_in_file(filetocheck)
+    assert(nlines1==21215)
+
     # bas with smoothing on
-    m.bas6.export(os.path.join(cpth, 'BAS'), fmt='vtk', smooth=True)
+    output_dir = os.path.join(cpth, 'BAS')
+    m.bas6.export(output_dir, fmt='vtk', smooth=True)
+    filetocheck = os.path.join(output_dir, 'BAS6.vtu')
+    # totalbytes2 = os.path.getsize(filetocheck)
+    # assert(totalbytes2==1002054)
+    nlines2 = count_lines_in_file(filetocheck)
+    assert(nlines2==8491)
+
     # transient package drain
-    m.drn.export(os.path.join(cpth, 'DRN'), fmt='vtk')
-    # binary test
-    m.dis.export(os.path.join(binot, 'DIS'), fmt='vtk', binary=True)
-    # upw with point scalar output
-    m.upw.export(os.path.join(binot, 'UPW'), fmt='vtk', point_scalars=True,
-                 binary=True)
+    output_dir = os.path.join(cpth, 'DRN')
+    m.drn.export(output_dir, fmt='vtk')
+    filetocheck = os.path.join(output_dir, 'DRN_01.vtu')
+    # totalbytes3 = os.path.getsize(filetocheck)
+    # assert(totalbytes3==20702)
+    nlines3 = count_lines_in_file(filetocheck)
+    assert(nlines3==191)
+    filetocheck = os.path.join(output_dir, 'DRN_01097.vtu')
+    # totalbytes4 = os.path.getsize(filetocheck)
+    # assert(totalbytes4==20702)
+    nlines4 = count_lines_in_file(filetocheck)
+    assert(nlines4==191)
+
+    # dis with binary
+    output_dir = os.path.join(cpth, 'DIS_bin')
+    m.dis.export(output_dir, fmt='vtk', binary=True)
+    filetocheck = os.path.join(output_dir, 'DIS.vtu')
+    # totalbytes5 = os.path.getsize(filetocheck)
+    # assert(totalbytes5==536436)
+    nlines5 = count_lines_in_file_bin(filetocheck)
+    assert(nlines5==1545)
+
+    # upw with point scalars and binary
+    output_dir = os.path.join(cpth, 'UPW_bin')
+    m.upw.export(output_dir, fmt='vtk', point_scalars=True, binary=True)
+    filetocheck = os.path.join(output_dir, 'UPW.vtu')
+    # totalbytes6 = os.path.getsize(filetocheck)
+    # assert(totalbytes6==1400561)
+    nlines6 = count_lines_in_file_bin(filetocheck)
+    assert(nlines6==1868)
 
     return
-
-
-# add mf2005 model exports
-def test_export_mf2005_vtk():
-    """test vtk model export mf2005"""
-    pth = os.path.join('..', 'examples', 'data', 'mf2005_test')
-    namfiles = [namfile for namfile in os.listdir(pth) if
-                namfile.endswith('.nam')]
-    skip = ['bcf2ss.nam']
-    for namfile in namfiles:
-        if namfile in skip:
-            continue
-        print('testing namefile', namfile)
-        m = flopy.modflow.Modflow.load(namfile, model_ws=pth, verbose=False)
-        m.export(os.path.join(cpth, m.name), fmt='vtk')
-
-        # binary test
-        m.export(os.path.join(binot, m.name), fmt='vtk', binary=True)
-
-    return
-
 
 def test_vtk_mf6():
+    # test mf6
     mf6expth = os.path.join('..', 'examples', 'data', 'mf6')
-    # test vtk mf6 export
-    mf6sims = ['test045_lake1ss_table',
-               'test036_twrihfb', 'test045_lake2tr', 'test006_2models_mvr']
-    # mf6sims = ['test005_advgw_tidal']
-    # mf6sims = ['test036_twrihfb']
+    mf6sims = ['test045_lake1ss_table', 'test036_twrihfb', 'test045_lake2tr',
+               'test006_2models_mvr']
 
     for simnm in mf6sims:
         print(simnm)
@@ -128,87 +219,126 @@ def test_vtk_mf6():
 
 
 def test_vtk_binary_head_export():
+    # test mf 2005 freyberg
+    mpth = os.path.join('..', 'examples', 'data',
+                        'freyberg_multilayer_transient')
+    namfile = 'freyberg.nam'
+    hdsfile = os.path.join(mpth, 'freyberg.hds')
+    m = flopy.modflow.Modflow.load(namfile, model_ws=mpth, verbose=False,
+                                   load_only=['dis', 'bas6'])
+    filenametocheck = 'freyberg_Heads_KPER455_KSTP1.vtu'
 
-    """test vet export of heads"""
-
-    freyberg_pth = os.path.join('..', 'examples', 'data',
-                                'freyberg_multilayer_transient')
-
-    hdsfile = os.path.join(freyberg_pth, 'freyberg.hds')
-
-    m = flopy.modflow.Modflow.load('freyberg.nam', model_ws=freyberg_pth,
-                                   verbose=False)
+    # export and check
     otfolder = os.path.join(cpth, 'heads_test')
-
     vtk.export_heads(m, hdsfile, otfolder, nanval=-999.99, kstpkper=[(0, 0),
                                                                      (0, 199),
                                                                      (0, 354),
                                                                      (0, 454),
                                                                      (0,
                                                                       1089)])
-    # test with points
+    filetocheck = os.path.join(otfolder, filenametocheck)
+    # totalbytes = os.path.getsize(filetocheck)
+    # assert(totalbytes==993755)
+    nlines = count_lines_in_file(filetocheck)
+    assert(nlines==8486)
+
+    # with point scalars
     otfolder = os.path.join(cpth, 'heads_test_1')
     vtk.export_heads(m, hdsfile, otfolder,
                      kstpkper=[(0, 0), (0, 199), (0, 354), (0, 454), (0,
                                                                       1089)],
                      point_scalars=True, nanval=-999.99)
+    filetocheck = os.path.join(otfolder, filenametocheck)
+    # totalbytes1 = os.path.getsize(filetocheck)
+    # assert(totalbytes1==1332346)
+    nlines1 = count_lines_in_file(filetocheck)
+    assert(nlines1==10605)
 
-    # test vtk export heads with smoothing and no point scalars
+    # with smoothing
     otfolder = os.path.join(cpth, 'heads_test_2')
     vtk.export_heads(m, hdsfile, otfolder,
                      kstpkper=[(0, 0), (0, 199), (0, 354), (0, 454), (0,
                                                                       1089)],
-                     point_scalars=False, smooth=True, nanval=-999.99)
+                     smooth=True, nanval=-999.99)
+    filetocheck = os.path.join(otfolder, filenametocheck)
+    # totalbytes2 = os.path.getsize(filetocheck)
+    # assert(totalbytes2==993551)
+    nlines2 = count_lines_in_file(filetocheck)
+    assert(nlines2==8486)
 
-    # test binary output
+    # with smoothing and binary
     otfolder = os.path.join(cpth, 'heads_test_3')
     vtk.export_heads(m, hdsfile, otfolder,
                      kstpkper=[(0, 0), (0, 199), (0, 354), (0, 454), (0,
                                                                       1089)],
-                     point_scalars=False, smooth=True, binary=True,
-                     nanval=-999.99)
+                     smooth=True, binary=True, nanval=-999.99)
+    filetocheck = os.path.join(otfolder, filenametocheck)
+    # totalbytes3 = os.path.getsize(filetocheck)
+    # assert(totalbytes3==502313)
+    nlines3 = count_lines_in_file_bin(filetocheck)
+    assert(nlines3==1538)
 
+    # with smoothing and binary, single time
     otfolder = os.path.join(cpth, 'heads_test_4')
     vtk.export_heads(m, hdsfile, otfolder, kstpkper=(0, 0),
-                     point_scalars=False,
-                     smooth=True, binary=True, nanval=-999.99)
+                     point_scalars=False, smooth=True, binary=True,
+                     nanval=-999.99)
+    filetocheck = os.path.join(otfolder, 'freyberg_Heads_KPER1_KSTP1.vtu')
+    # totalbytes4 = os.path.getsize(filetocheck)
+    # assert(totalbytes4==502313)
+    nlines4 = count_lines_in_file_bin(filetocheck)
+    assert(nlines4==1528)
 
     return
-
 
 def test_vtk_cbc():
     # test mf 2005 freyberg
-    freyberg_cbc = os.path.join('..', 'examples', 'data',
-                                'freyberg_multilayer_transient',
-                                'freyberg.cbc')
+    mpth = os.path.join('..', 'examples', 'data',
+                        'freyberg_multilayer_transient')
+    namfile = 'freyberg.nam'
+    cbcfile = os.path.join(mpth, 'freyberg.cbc')
+    m = flopy.modflow.Modflow.load(namfile, model_ws=mpth, verbose=False)
+    filenametocheck = 'freyberg_CBC_KPER1_KSTP1.vtu'
 
-    freyberg_mpth = os.path.join('..', 'examples', 'data',
-                                 'freyberg_multilayer_transient')
-
-    m = flopy.modflow.Modflow.load('freyberg.nam', model_ws=freyberg_mpth,
-                                   verbose=False)
-
-    vtk.export_cbc(m, freyberg_cbc, os.path.join(cpth, 'freyberg_CBCTEST'),
+    # export and check with point scalar
+    otfolder = os.path.join(cpth, 'freyberg_CBCTEST')
+    vtk.export_cbc(m, cbcfile, otfolder,
                    kstpkper=[(0, 0), (0, 1), (0, 2)], point_scalars=True)
+    filetocheck = os.path.join(otfolder, filenametocheck)
+    # totalbytes = os.path.getsize(filetocheck)
+    # assert(totalbytes==2496132)
+    nlines = count_lines_in_file(filetocheck)
+    assert(nlines==19093)
 
-    vtk.export_cbc(m, freyberg_cbc, os.path.join(cpth, 'freyberg_CBCTEST_bin'),
+    # with point scalars and binary
+    otfolder = os.path.join(cpth, 'freyberg_CBCTEST_bin')
+    vtk.export_cbc(m, cbcfile, otfolder,
                    kstpkper=[(0, 0), (0, 1), (0, 2)], point_scalars=True,
                    binary=True)
+    filetocheck = os.path.join(otfolder, filenametocheck)
+    # totalbytes1 = os.path.getsize(filetocheck)
+    # assert(totalbytes1==1248118)
+    nlines1 = count_lines_in_file_bin(filetocheck)
+    assert(nlines1==2609)
 
-    vtk.export_cbc(m, freyberg_cbc, os.path.join(cpth,
-                                                 'freyberg_CBCTEST_bin2'),
+    # with point scalars and binary, only one budget component
+    otfolder = os.path.join(cpth, 'freyberg_CBCTEST_bin2')
+    vtk.export_cbc(m, cbcfile, otfolder,
                    kstpkper=(0, 0), text='CONSTANT HEAD',
                    point_scalars=True,  binary=True)
+    filetocheck = os.path.join(otfolder, filenametocheck)
+    # totalbytes2 = os.path.getsize(filetocheck)
+    # assert(totalbytes2==10262)
+    nlines2 = count_lines_in_file_bin(filetocheck)
+    assert(nlines2==61)
 
     return
-
 
 if __name__ == '__main__':
     test_vtk_export_array2d()
     test_vtk_export_array3d()
     test_vtk_transient_array_2d()
     test_vtk_export_packages()
-    test_export_mf2005_vtk()
     test_vtk_mf6()
     test_vtk_binary_head_export()
     test_vtk_cbc()

--- a/flopy/discretization/grid.py
+++ b/flopy/discretization/grid.py
@@ -285,6 +285,12 @@ class Grid(object):
             'must define extent in child class')
 
     @property
+    def xyzextent(self):
+        return (np.min(self.xyzvertices[0]), np.max(self.xyzvertices[0]),
+                np.min(self.xyzvertices[1]), np.max(self.xyzvertices[1]),
+                np.min(self.xyzvertices[2]), np.max(self.xyzvertices[2]))
+
+    @property
     def grid_lines(self):
         raise NotImplementedError(
             'must define grid_lines in child class')

--- a/flopy/export/utils.py
+++ b/flopy/export/utils.py
@@ -512,32 +512,17 @@ def model_export(f, ml, fmt=None, **kwargs):
         or dictionary of ....
     ml : flopy.modflow.mbase.ModelInterface object
         flopy model object
-    fmt: str
-        output format flag. set to 'vtk' to export to vtk .vtu file
-
+    fmt : str
+        output format flag. 'vtk' will export to vtk
     **kwargs : keyword arguments
-         modelgrid: flopy.discretization.Grid
+        modelgrid: flopy.discretization.Grid
             user supplied modelgrid object which will supercede the built
             in modelgrid object
         epsg : int
             epsg projection code
         prj : str
             prj file name
-
-        smooth: bool
-            For vtk, if set to True will output smooth surface
-
-        point_scalars: bool
-            For vtk, if set to True will create point scalar values along
-            with cell values.
-
-        binary: bool
-            For vtk, if set to Ture will output binary .vtu files. Default
-            is False which exports standard text xml .vtu files.
-
-        nanval: For vtk, no data value
-
-
+        if fmt is set to 'vtk', parameters of vtk.export_model
 
     """
     assert isinstance(ml, ModelInterface)
@@ -567,13 +552,13 @@ def model_export(f, ml, fmt=None, **kwargs):
 
     elif fmt == 'vtk':
         # call vtk model export
+        nanval = kwargs.get('nanval', -1e20)
         smooth = kwargs.get('smooth', False)
         point_scalars = kwargs.get('point_scalars', False)
         binary = kwargs.get('binary', False)
-        nanval = kwargs.get('nanval', -1e20)
-        vtk.export_model(ml, f, package_names=package_names, smooth=smooth,
-                         point_scalars=point_scalars, binary=binary,
-                         nanval=nanval)
+        vtk.export_model(ml, f, package_names=package_names, nanval=nanval,
+                         smooth=smooth, point_scalars=point_scalars,
+                         binary=binary)
 
     else:
         raise NotImplementedError("unrecognized export argument:{0}".format(f))
@@ -591,8 +576,8 @@ def package_export(f, pak, fmt=None, **kwargs):
         output file name (ends in .shp for shapefile or .nc for netcdf)
     pak : flopy.pakbase.Package object
         package to export
-    fmt: str
-        output format flag. set to 'vtk' to export to vtk .vtu file
+    fmt : str
+        output format flag. 'vtk' will export to vtk
     ** kwargs : keword arguments
         modelgrid: flopy.discretization.Grid
             user supplied modelgrid object which will supercede the built
@@ -601,19 +586,7 @@ def package_export(f, pak, fmt=None, **kwargs):
             epsg projection code
         prj : str
             prj file name
-
-        smooth: bool
-            For vtk, if set to True will output smooth surface
-
-        point_scalars: bool
-            For vtk, if set to True will create point scalar values along
-            with cell values.
-
-        binary: bool
-            For vtk, if set to Ture will output binary .vtu files. Default
-            is False which exports standard text xml .vtu files.
-
-        nanval: For vtk, no data value
+        if fmt is set to 'vtk', parameters of vtk.export_package
 
     Returns
     -------
@@ -656,14 +629,13 @@ def package_export(f, pak, fmt=None, **kwargs):
 
     elif fmt == 'vtk':
         # call vtk array export to folder
+        nanval = kwargs.get('nanval', -1e20)
         smooth = kwargs.get('smooth', False)
         point_scalars = kwargs.get('point_scalars', False)
         binary = kwargs.get('binary', False)
-        nanval = kwargs.get('nanval', -1e20)
-        vtk.export_package(pak.parent, pak.name, f, smooth=smooth,
-                           point_scalars=point_scalars, binary=binary,
-                           nanval=nanval)
-
+        vtk.export_package(pak.parent, pak.name, f, nanval=nanval,
+                           smooth=smooth, point_scalars=point_scalars,
+                           binary=binary)
 
     else:
         raise NotImplementedError("unrecognized export argument:{0}".format(f))
@@ -874,18 +846,14 @@ def transient2d_export(f, t2d, fmt=None, **kwargs):
     f : str
         filename or existing export instance type (NetCdf only for now)
     u2d : Transient2d instance
-    fmt: set to 'vtk' to export a .vtu file
+    fmt : str
+        output format flag. 'vtk' will export to vtk
     **kwargs : keyword arguments
         min_valid : minimum valid value
         max_valid : maximum valid value
         modelgrid : flopy.discretization.Grid
             model grid instance which will supercede the flopy.model.modelgrid
-        smooth: for vtk to output a smooth represenation of the model
-        point_scalars: for vtk to output point value scalars as well as cell
-        name: for vtk to set a specific name for array and output file
-        binary: bool
-            For vtk, if set to True will output binary .vtu files. Default
-            is False which exports standard text xml .vtu files.
+        if fmt is set to 'vtk', parameters of vtk.export_transient
 
     """
 
@@ -986,13 +954,14 @@ def transient2d_export(f, t2d, fmt=None, **kwargs):
         return f
 
     elif fmt == 'vtk':
-        smooth = kwargs.get('smooth', False)
-        point_scalars = kwargs.get('point_scalars', False)
         name = kwargs.get('name', t2d.name)
         nanval = kwargs.get('nanval', -1e20)
-        vtk.export_transient(t2d.model, t2d.array, f, name, smooth=smooth,
-                             point_scalars=point_scalars, array2d=True,
-                             nanval=nanval)
+        smooth = kwargs.get('smooth', False)
+        point_scalars = kwargs.get('point_scalars', False)
+        binary = kwargs.get('binary', False)
+        vtk.export_transient(t2d.model, t2d.array, f, name, nanval=nanval,
+                             smooth=smooth, point_scalars=point_scalars,
+                             array2d=True, binary=binary)
     else:
         raise NotImplementedError("unrecognized export argument:{0}".format(f))
 
@@ -1006,18 +975,14 @@ def array3d_export(f, u3d, fmt=None, **kwargs):
     f : str
         filename or existing export instance type (NetCdf only for now)
     u2d : Util3d instance
-    fmt: set to 'vtk' to export a .vtu file
+    fmt : str
+        output format flag. 'vtk' will export to vtk
     **kwargs : keyword arguments
         min_valid : minimum valid value
         max_valid : maximum valid value
         modelgrid : flopy.discretization.Grid
             model grid instance which will supercede the flopy.model.modelgrid
-        smooth: for vtk to output a smooth represenation of the model
-        point_scalars: for vtk to output point value scalars as well as cell
-        name: for vtk to set a specific name for array and output file
-        binary: bool
-            For vtk, if set to Ture will output binary .vtu files. Default
-            is False which exports standard text xml .vtu files.
+        if fmt is set to 'vtk', parameters of vtk.export_array
 
     """
 
@@ -1137,17 +1102,17 @@ def array3d_export(f, u3d, fmt=None, **kwargs):
 
     elif fmt == 'vtk':
         # call vtk array export to folder
+        name = kwargs.get('name', u3d.name)
+        nanval = kwargs.get('nanval', -1e20)
         smooth = kwargs.get('smooth', False)
         point_scalars = kwargs.get('point_scalars', False)
-        name = kwargs.get('name', u3d.name)
         binary = kwargs.get('binary', False)
-        nanval = kwargs.get('nanval', -1e20)
         if isinstance(name, list) or isinstance(name, tuple):
             name = name[0]
 
-        vtk.export_array(u3d.model, u3d.array, f, name, smooth=smooth,
-                         point_scalars=point_scalars, binary=binary,
-                         nanval=nanval)
+        vtk.export_array(u3d.model, u3d.array, f, name, nanval=nanval,
+                         smooth=smooth, point_scalars=point_scalars,
+                         binary=binary)
 
     else:
         raise NotImplementedError("unrecognized export argument:{0}".format(f))
@@ -1162,18 +1127,14 @@ def array2d_export(f, u2d, fmt=None, **kwargs):
     f : str
         filename or existing export instance type (NetCdf only for now)
     u2d : Util2d instance
-    fmt: set to 'vtk' to export a .vtu file
+    fmt : str
+        output format flag. 'vtk' will export to vtk
     **kwargs : keyword arguments
         min_valid : minimum valid value
         max_valid : maximum valid value
         modelgrid : flopy.discretization.Grid
             model grid instance which will supercede the flopy.model.modelgrid
-        smooth: for vtk to output a smooth represenation of the model
-        point_scalars: for vtk to output point value scalars as well as cell
-        name: for vtk to set a specific name for array and output file
-        binary: bool
-            For vtk, if set to Ture will output binary .vtu files. Default
-            is False which exports standard text xml .vtu files.
+        if fmt is set to 'vtk', parameters of vtk.export_array
 
     """
     assert isinstance(u2d, DataInterface), "util2d_helper only helps " \
@@ -1269,14 +1230,14 @@ def array2d_export(f, u2d, fmt=None, **kwargs):
     elif fmt == 'vtk':
 
         # call vtk array export to folder
+        name = kwargs.get('name', u2d.name)
+        nanval = kwargs.get('nanval', -1e20)
         smooth = kwargs.get('smooth', False)
         point_scalars = kwargs.get('point_scalars', False)
-        name = kwargs.get('name', u2d.name)
         binary = kwargs.get('binary', False)
-        nanval = kwargs.get('nanval', -1e20)
-        vtk.export_array(u2d.model, u2d.array, f, name, smooth=smooth,
-                         point_scalars=point_scalars, array2d=True,
-                         binary=binary, nanval=nanval)
+        vtk.export_array(u2d.model, u2d.array, f, name, nanval=nanval,
+                         smooth=smooth, point_scalars=point_scalars,
+                         array2d=True, binary=binary)
 
     else:
         raise NotImplementedError("unrecognized export argument:{0}".format(f))

--- a/flopy/export/utils.py
+++ b/flopy/export/utils.py
@@ -555,10 +555,11 @@ def model_export(f, ml, fmt=None, **kwargs):
         nanval = kwargs.get('nanval', -1e20)
         smooth = kwargs.get('smooth', False)
         point_scalars = kwargs.get('point_scalars', False)
+        vtk_grid_type = kwargs.get('vtk_grid_type', 'auto')
         binary = kwargs.get('binary', False)
         vtk.export_model(ml, f, package_names=package_names, nanval=nanval,
                          smooth=smooth, point_scalars=point_scalars,
-                         binary=binary)
+                         vtk_grid_type=vtk_grid_type, binary=binary)
 
     else:
         raise NotImplementedError("unrecognized export argument:{0}".format(f))
@@ -632,10 +633,11 @@ def package_export(f, pak, fmt=None, **kwargs):
         nanval = kwargs.get('nanval', -1e20)
         smooth = kwargs.get('smooth', False)
         point_scalars = kwargs.get('point_scalars', False)
+        vtk_grid_type = kwargs.get('vtk_grid_type', 'auto')
         binary = kwargs.get('binary', False)
         vtk.export_package(pak.parent, pak.name, f, nanval=nanval,
                            smooth=smooth, point_scalars=point_scalars,
-                           binary=binary)
+                           vtk_grid_type=vtk_grid_type, binary=binary)
 
     else:
         raise NotImplementedError("unrecognized export argument:{0}".format(f))
@@ -958,10 +960,12 @@ def transient2d_export(f, t2d, fmt=None, **kwargs):
         nanval = kwargs.get('nanval', -1e20)
         smooth = kwargs.get('smooth', False)
         point_scalars = kwargs.get('point_scalars', False)
+        vtk_grid_type = kwargs.get('vtk_grid_type', 'auto')
         binary = kwargs.get('binary', False)
         vtk.export_transient(t2d.model, t2d.array, f, name, nanval=nanval,
                              smooth=smooth, point_scalars=point_scalars,
-                             array2d=True, binary=binary)
+                             array2d=True, vtk_grid_type=vtk_grid_type,
+                             binary=binary)
     else:
         raise NotImplementedError("unrecognized export argument:{0}".format(f))
 
@@ -1106,13 +1110,14 @@ def array3d_export(f, u3d, fmt=None, **kwargs):
         nanval = kwargs.get('nanval', -1e20)
         smooth = kwargs.get('smooth', False)
         point_scalars = kwargs.get('point_scalars', False)
+        vtk_grid_type = kwargs.get('vtk_grid_type', 'auto')
         binary = kwargs.get('binary', False)
         if isinstance(name, list) or isinstance(name, tuple):
             name = name[0]
 
         vtk.export_array(u3d.model, u3d.array, f, name, nanval=nanval,
                          smooth=smooth, point_scalars=point_scalars,
-                         binary=binary)
+                         vtk_grid_type=vtk_grid_type, binary=binary)
 
     else:
         raise NotImplementedError("unrecognized export argument:{0}".format(f))
@@ -1234,10 +1239,12 @@ def array2d_export(f, u2d, fmt=None, **kwargs):
         nanval = kwargs.get('nanval', -1e20)
         smooth = kwargs.get('smooth', False)
         point_scalars = kwargs.get('point_scalars', False)
+        vtk_grid_type = kwargs.get('vtk_grid_type', 'auto')
         binary = kwargs.get('binary', False)
         vtk.export_array(u2d.model, u2d.array, f, name, nanval=nanval,
                          smooth=smooth, point_scalars=point_scalars,
-                         array2d=True, binary=binary)
+                         array2d=True, vtk_grid_type=vtk_grid_type,
+                         binary=binary)
 
     else:
         raise NotImplementedError("unrecognized export argument:{0}".format(f))


### PR DESCRIPTION
I implemented the export of data to ImageData (.vti) or RectilinearGrid (.vtr) formats when possible, instead of always UnstructuredGrid (.vtu), since this can greatly reduce file volume and speed up subsequent operations (e.g. in Paraview). The user can also choose to force an export to a specific format (e.g., .vtu) by using the new parameter vtk_grid_type (by default = 'auto').

I made significant improvements to the vtk export code and fixed a number of issues along the way. These are in fact beneficial regardless of my initial intention. For better readability, I arranged my contribution into two commits: the first one only contains independent code improvements and fixes, and the second one actually contains the new feature. If possible, I think it would be better to keep the two commits.

This PR addresses issue #833 (although in this issue I also mentioned two more new functionalities, but I’d rather keep those for later to facilitate integration).