### PR TITLE
fix(pyproj): pyproj.Proj's errcheck keyword option not reliable

### DIFF
--- a/flopy/export/netcdf.py
+++ b/flopy/export/netcdf.py
@@ -633,7 +633,7 @@ class NetCdf(object):
 
         self.log("building grid crs using proj4 string: {}".format(proj4_str))
         try:
-            self.grid_crs = Proj(proj4_str, preserve_units=True, errcheck=True)
+            self.grid_crs = Proj(proj4_str, preserve_units=True)
 
         except Exception as e:
             self.log("error building grid crs:\n{0}".format(str(e)))

--- a/flopy/utils/reference.py
+++ b/flopy/utils/reference.py
@@ -261,9 +261,7 @@ class SpatialReference(object):
             if "EPSG" in self.proj4_str.upper():
                 import pyproj
 
-                crs = pyproj.Proj(self.proj4_str,
-                                  preserve_units=True,
-                                  errcheck=True)
+                crs = pyproj.Proj(self.proj4_str, preserve_units=True)
                 proj_str = crs.srs
             else:
                 proj_str = self.proj4_str


### PR DESCRIPTION
Fixes a pyproj regression that appeared in version 2.6.0 (spotted in #836). It seems that the `errcheck` keyword option is not used, despite being documented. It is probably best left out.

Note this is a basic patch to get past the new error. There are several other improvements that could be implemented using pyproj versions >= 2.2.0, which support a CRS class, better transformation pipelines, among other improvements. The old `Proj` class is getting stale.