### PR TITLE
feat(netcdf): use modern features from pyproj>=2.2.0

### DIFF
--- a/flopy/export/netcdf.py
+++ b/flopy/export/netcdf.py
@@ -624,24 +624,25 @@ class NetCdf(object):
             needed for the netcdf file
         """
         try:
-            from pyproj import Proj, transform
-        except Exception as e:
-            raise Exception("NetCdf error importing pyproj module:\n" + str(e))
+            import pyproj
+        except ImportError as e:
+            raise ImportError(
+                "NetCdf error importing pyproj module:\n" + str(e))
+        from distutils.version import LooseVersion
+
+        # Check if using newer pyproj version conventions
+        pyproj220 = LooseVersion(pyproj.__version__) >= LooseVersion('2.2.0')
 
         proj4_str = self.proj4_str
         print('initialize_geometry::proj4_str = {}'.format(proj4_str))
 
         self.log("building grid crs using proj4 string: {}".format(proj4_str))
-        try:
-            self.grid_crs = Proj(proj4_str, preserve_units=True)
-
-        except Exception as e:
-            self.log("error building grid crs:\n{0}".format(str(e)))
-            raise Exception("error building grid crs:\n{0}".format(str(e)))
+        if pyproj220:
+            self.grid_crs = pyproj.CRS(proj4_str)
+        else:
+            self.grid_crs = pyproj.Proj(proj4_str, preserve_units=True)
 
         print('initialize_geometry::self.grid_crs = {}'.format(self.grid_crs))
-
-        self.log("building grid crs using proj4 string: {}".format(proj4_str))
 
         vmin, vmax = self.model_grid.botm.min(), \
                      self.model_grid.top.max()
@@ -654,21 +655,25 @@ class NetCdf(object):
         xs = self.model_grid.xyzcellcenters[0].copy()
 
         # Transform to a known CRS
-        nc_crs = Proj(self.nc_epsg_str)
+        if pyproj220:
+            nc_crs = pyproj.CRS(self.nc_epsg_str)
+            self.transformer = pyproj.Transformer.from_crs(
+                self.grid_crs, nc_crs, always_xy=True)
+        else:
+            nc_crs = pyproj.Proj(self.nc_epsg_str)
+            self.transformer = None
+
         print('initialize_geometry::nc_crs = {}'.format(nc_crs))
 
-        self.log("projecting grid cell center arrays " + \
-                 "from {} to {}".format(str(self.grid_crs.srs),
-                                        str(nc_crs.srs)))
-        try:
-            self.xs, self.ys = transform(self.grid_crs, nc_crs, xs, ys)
-        except Exception as e:
-            self.log("error projecting:\n{0}".format(str(e)))
-            raise Exception("error projecting:\n{0}".format(str(e)))
+        if pyproj220:
+            print('transforming coordinates using = {}'
+                  .format(self.transformer))
 
-        self.log("projecting grid cell center arrays " + \
-                 "from {0} to {1}".format(str(self.grid_crs),
-                                          str(nc_crs)))
+        self.log("projecting grid cell center arrays")
+        if pyproj220:
+            self.xs, self.ys = self.transformer.transform(xs, ys)
+        else:
+            self.xs, self.ys = pyproj.transform(self.grid_crs, nc_crs, xs, ys)
 
         # get transformed bounds and record to check against ScienceBase later
         xmin, xmax, ymin, ymax = self.model_grid.extent
@@ -676,10 +681,12 @@ class NetCdf(object):
                          [xmin, ymax],
                          [xmax, ymax],
                          [xmax, ymin]])
-        x, y = transform(self.grid_crs, nc_crs, *bbox.transpose())
+        if pyproj220:
+            x, y = self.transformer.transform(*bbox.transpose())
+        else:
+            x, y = pyproj.transform(self.grid_crs, nc_crs, *bbox.transpose())
         self.bounds = x.min(), y.min(), x.max(), y.max()
         self.vbounds = vmin, vmax
-        pass
 
     def initialize_file(self, time_values=None):
         """


### PR DESCRIPTION
This was mentioned in #837 to use some modern features of pyproj versions, which I've declared as version 2.2.0 when the parameter `always_xy` was added.

With older pyproj versions, continue to use the older Proj class, which has limitations best described with the [PROJ docs](https://proj.org/development/migration.html#background). This may result in some coordinate transformation discrepancies between versions, but probably too small to discern with most groundwater models.

Currently, pyproj is only used for netcdf exports. More integration with pyproj should be done in flopy/utils/reference.py which can be done later.