### PR TITLE
vtk export: a few fixes and a new functionality (export vector)

### DIFF
--- a/autotest/t050_test.py
+++ b/autotest/t050_test.py
@@ -7,7 +7,7 @@ from flopy.export import vtk
 # Note: initially thought about asserting that exported file size in bytes is
 # unchanged, but this seems to be sensitive to the running environment.
 # Thus, only asserting that the number of lines is unchanged.
-# Still keeping the file size check commented for now.
+# Still keeping the file size check commented for development purposes.
 
 # create output directory
 cpth = os.path.join('temp', 't050')
@@ -15,14 +15,14 @@ if os.path.isdir(cpth):
     shutil.rmtree(cpth)
 os.makedirs(cpth)
 
-def count_lines_in_file(filepath):
-    f = open(filepath, 'r')
+def count_lines_in_file(filepath, binary=False):
+    if binary:
+        f = open(filepath, 'rb')
+    else:
+        f = open(filepath, 'r')
+    # note this does not mean much for a binary file but still allows for check
     n = len(f.readlines())
-    return n
-
-def count_lines_in_file_bin(filepath):
-    f = open(filepath, 'rb')
-    n = len(f.readlines())
+    f.close()
     return n
 
 def test_vtk_export_array2d():
@@ -37,7 +37,7 @@ def test_vtk_export_array2d():
     # export and check
     m.dis.top.export(output_dir, name='top', fmt='vtk')
     filetocheck = os.path.join(output_dir, 'top.vtu')
-    # totalbytes = os.path.getsize(filetocheck)
+    totalbytes = os.path.getsize(filetocheck)
     # assert(totalbytes==352026)
     nlines = count_lines_in_file(filetocheck)
     assert(nlines==2846)
@@ -45,7 +45,7 @@ def test_vtk_export_array2d():
     # with smoothing
     m.dis.top.export(output_dir, fmt='vtk', name='top_smooth', smooth=True)
     filetocheck = os.path.join(output_dir, 'top_smooth.vtu')
-    # totalbytes1 = os.path.getsize(filetocheck)
+    totalbytes1 = os.path.getsize(filetocheck)
     # assert(totalbytes1==351829)
     nlines1 = count_lines_in_file(filetocheck)
     assert(nlines1==2846)
@@ -64,7 +64,7 @@ def test_vtk_export_array3d():
     # export and check
     m.upw.hk.export(output_dir, fmt='vtk', name='hk')
     filetocheck = os.path.join(output_dir, 'hk.vtu')
-    # totalbytes = os.path.getsize(filetocheck)
+    totalbytes = os.path.getsize(filetocheck)
     # assert(totalbytes==992576)
     nlines = count_lines_in_file(filetocheck)
     assert(nlines==8486)
@@ -73,8 +73,8 @@ def test_vtk_export_array3d():
     m.upw.hk.export(output_dir, fmt='vtk', name='hk_points',
                     point_scalars=True)
     filetocheck = os.path.join(output_dir, 'hk_points.vtu')
-    # totalbytes1 = os.path.getsize(filetocheck)
-    # assert(totalbytes1==1321292)
+    totalbytes1 = os.path.getsize(filetocheck)
+    # assert(totalbytes1==1321502)
     nlines1 = count_lines_in_file(filetocheck)
     assert(nlines1==10605)
 
@@ -82,10 +82,10 @@ def test_vtk_export_array3d():
     m.upw.hk.export(output_dir, fmt='vtk', name='hk_points_bin',
                     point_scalars=True, binary=True)
     filetocheck = os.path.join(output_dir, 'hk_points_bin.vtu')
-    # totalbytes2 = os.path.getsize(filetocheck)
-    # assert(totalbytes2==637861)
-    nlines2 = count_lines_in_file_bin(filetocheck)
-    assert(nlines2==1848)
+    totalbytes2 = os.path.getsize(filetocheck)
+    # assert(totalbytes2==629401)
+    nlines2 = count_lines_in_file(filetocheck, binary=True)
+    assert(nlines2==1869)
 
     return
 
@@ -100,15 +100,14 @@ def test_vtk_transient_array_2d():
     output_dir_bin = os.path.join(cpth, 'transient_2d_test_bin')
 
     # export and check
-    r = m.rch.rech
     m.rch.rech.export(output_dir, fmt='vtk')
     filetocheck = os.path.join(output_dir, 'rech_01.vtu')
-    # totalbytes = os.path.getsize(filetocheck)
+    totalbytes = os.path.getsize(filetocheck)
     # assert(totalbytes==355324)
     nlines = count_lines_in_file(filetocheck)
     assert(nlines==2851)
     filetocheck = os.path.join(output_dir, 'rech_01097.vtu')
-    # totalbytes1 = os.path.getsize(filetocheck)
+    totalbytes1 = os.path.getsize(filetocheck)
     # assert(totalbytes1==354622)
     nlines1 = count_lines_in_file(filetocheck)
     assert(nlines1==2851)
@@ -116,14 +115,14 @@ def test_vtk_transient_array_2d():
     # with binary
     m.rch.rech.export(output_dir_bin, fmt='vtk', binary=True)
     filetocheck = os.path.join(output_dir_bin, 'rech_01.vtu')
-    # totalbytes2 = os.path.getsize(filetocheck)
+    totalbytes2 = os.path.getsize(filetocheck)
     # assert(totalbytes2==168339)
-    nlines2 = count_lines_in_file_bin(filetocheck)
+    nlines2 = count_lines_in_file(filetocheck, binary=True)
     assert(nlines2==762)
     filetocheck = os.path.join(output_dir_bin, 'rech_01097.vtu')
-    # totalbytes3 = os.path.getsize(filetocheck)
+    totalbytes3 = os.path.getsize(filetocheck)
     # assert(totalbytes3==168339)
-    nlines3 = count_lines_in_file_bin(filetocheck)
+    nlines3 = count_lines_in_file(filetocheck, binary=True)
     assert(nlines3==762)
 
     return
@@ -140,8 +139,8 @@ def test_vtk_export_packages():
     output_dir = os.path.join(cpth, 'DIS')
     m.dis.export(output_dir, fmt='vtk')
     filetocheck = os.path.join(output_dir, 'DIS.vtu')
-    # totalbytes = os.path.getsize(filetocheck)
-    # assert(totalbytes==1010527)
+    totalbytes = os.path.getsize(filetocheck)
+    # assert(totalbytes==1020397)
     nlines = count_lines_in_file(filetocheck)
     assert(nlines==8496)
 
@@ -149,8 +148,8 @@ def test_vtk_export_packages():
     output_dir = os.path.join(cpth, 'UPW')
     m.upw.export(output_dir, fmt='vtk', point_scalars=True)
     filetocheck = os.path.join(output_dir, 'UPW.vtu')
-    # totalbytes1 = os.path.getsize(filetocheck)
-    # assert(totalbytes1==2485295)
+    totalbytes1 = os.path.getsize(filetocheck)
+    # assert(totalbytes1==2485991)
     nlines1 = count_lines_in_file(filetocheck)
     assert(nlines1==21215)
 
@@ -158,7 +157,7 @@ def test_vtk_export_packages():
     output_dir = os.path.join(cpth, 'BAS')
     m.bas6.export(output_dir, fmt='vtk', smooth=True)
     filetocheck = os.path.join(output_dir, 'BAS6.vtu')
-    # totalbytes2 = os.path.getsize(filetocheck)
+    totalbytes2 = os.path.getsize(filetocheck)
     # assert(totalbytes2==1002054)
     nlines2 = count_lines_in_file(filetocheck)
     assert(nlines2==8491)
@@ -167,12 +166,12 @@ def test_vtk_export_packages():
     output_dir = os.path.join(cpth, 'DRN')
     m.drn.export(output_dir, fmt='vtk')
     filetocheck = os.path.join(output_dir, 'DRN_01.vtu')
-    # totalbytes3 = os.path.getsize(filetocheck)
+    totalbytes3 = os.path.getsize(filetocheck)
     # assert(totalbytes3==20702)
     nlines3 = count_lines_in_file(filetocheck)
     assert(nlines3==191)
     filetocheck = os.path.join(output_dir, 'DRN_01097.vtu')
-    # totalbytes4 = os.path.getsize(filetocheck)
+    totalbytes4 = os.path.getsize(filetocheck)
     # assert(totalbytes4==20702)
     nlines4 = count_lines_in_file(filetocheck)
     assert(nlines4==191)
@@ -181,19 +180,19 @@ def test_vtk_export_packages():
     output_dir = os.path.join(cpth, 'DIS_bin')
     m.dis.export(output_dir, fmt='vtk', binary=True)
     filetocheck = os.path.join(output_dir, 'DIS.vtu')
-    # totalbytes5 = os.path.getsize(filetocheck)
-    # assert(totalbytes5==536436)
-    nlines5 = count_lines_in_file_bin(filetocheck)
+    totalbytes5 = os.path.getsize(filetocheck)
+    # assert(totalbytes5==519516)
+    nlines5 = count_lines_in_file(filetocheck, binary=True)
     assert(nlines5==1545)
 
     # upw with point scalars and binary
     output_dir = os.path.join(cpth, 'UPW_bin')
     m.upw.export(output_dir, fmt='vtk', point_scalars=True, binary=True)
     filetocheck = os.path.join(output_dir, 'UPW.vtu')
-    # totalbytes6 = os.path.getsize(filetocheck)
-    # assert(totalbytes6==1400561)
-    nlines6 = count_lines_in_file_bin(filetocheck)
-    assert(nlines6==1868)
+    totalbytes6 = os.path.getsize(filetocheck)
+    # assert(totalbytes6==1349801)
+    nlines6 = count_lines_in_file(filetocheck, binary=True)
+    assert(nlines6==4004)
 
     return
 
@@ -217,7 +216,7 @@ def test_vtk_mf6():
 
     # check one
     filetocheck = os.path.join(cpth, 'twrihfb2015', 'npf.vtr')
-    # totalbytes = os.path.getsize(filetocheck)
+    totalbytes = os.path.getsize(filetocheck)
     # assert(totalbytes==21609)
     nlines = count_lines_in_file(filetocheck)
     assert(nlines==76)
@@ -244,7 +243,7 @@ def test_vtk_binary_head_export():
                                                                      (0,
                                                                       1089)])
     filetocheck = os.path.join(otfolder, filenametocheck)
-    # totalbytes = os.path.getsize(filetocheck)
+    totalbytes = os.path.getsize(filetocheck)
     # assert(totalbytes==993755)
     nlines = count_lines_in_file(filetocheck)
     assert(nlines==8486)
@@ -256,8 +255,8 @@ def test_vtk_binary_head_export():
                                                                       1089)],
                      point_scalars=True, nanval=-999.99)
     filetocheck = os.path.join(otfolder, filenametocheck)
-    # totalbytes1 = os.path.getsize(filetocheck)
-    # assert(totalbytes1==1332346)
+    totalbytes1 = os.path.getsize(filetocheck)
+    # assert(totalbytes1==1332153)
     nlines1 = count_lines_in_file(filetocheck)
     assert(nlines1==10605)
 
@@ -268,7 +267,7 @@ def test_vtk_binary_head_export():
                                                                       1089)],
                      smooth=True, nanval=-999.99)
     filetocheck = os.path.join(otfolder, filenametocheck)
-    # totalbytes2 = os.path.getsize(filetocheck)
+    totalbytes2 = os.path.getsize(filetocheck)
     # assert(totalbytes2==993551)
     nlines2 = count_lines_in_file(filetocheck)
     assert(nlines2==8486)
@@ -280,10 +279,10 @@ def test_vtk_binary_head_export():
                                                                       1089)],
                      smooth=True, binary=True, nanval=-999.99)
     filetocheck = os.path.join(otfolder, filenametocheck)
-    # totalbytes3 = os.path.getsize(filetocheck)
-    # assert(totalbytes3==502313)
-    nlines3 = count_lines_in_file_bin(filetocheck)
-    assert(nlines3==1538)
+    totalbytes3 = os.path.getsize(filetocheck)
+    # assert(totalbytes3==493853)
+    nlines3 = count_lines_in_file(filetocheck, binary=True)
+    assert(nlines3==1529)
 
     # with smoothing and binary, single time
     otfolder = os.path.join(cpth, 'heads_test_4')
@@ -291,10 +290,10 @@ def test_vtk_binary_head_export():
                      point_scalars=False, smooth=True, binary=True,
                      nanval=-999.99)
     filetocheck = os.path.join(otfolder, 'freyberg_Heads_KPER1_KSTP1.vtu')
-    # totalbytes4 = os.path.getsize(filetocheck)
-    # assert(totalbytes4==502313)
-    nlines4 = count_lines_in_file_bin(filetocheck)
-    assert(nlines4==1528)
+    totalbytes4 = os.path.getsize(filetocheck)
+    # assert(totalbytes4==493853)
+    nlines4 = count_lines_in_file(filetocheck, binary=True)
+    assert(nlines4==1535)
 
     return
 
@@ -304,7 +303,8 @@ def test_vtk_cbc():
                         'freyberg_multilayer_transient')
     namfile = 'freyberg.nam'
     cbcfile = os.path.join(mpth, 'freyberg.cbc')
-    m = flopy.modflow.Modflow.load(namfile, model_ws=mpth, verbose=False)
+    m = flopy.modflow.Modflow.load(namfile, model_ws=mpth, verbose=False,
+                                   load_only=['dis', 'bas6'])
     filenametocheck = 'freyberg_CBC_KPER1_KSTP1.vtu'
 
     # export and check with point scalar
@@ -312,8 +312,8 @@ def test_vtk_cbc():
     vtk.export_cbc(m, cbcfile, otfolder,
                    kstpkper=[(0, 0), (0, 1), (0, 2)], point_scalars=True)
     filetocheck = os.path.join(otfolder, filenametocheck)
-    # totalbytes = os.path.getsize(filetocheck)
-    # assert(totalbytes==2496132)
+    totalbytes = os.path.getsize(filetocheck)
+    # assert(totalbytes==2626880)
     nlines = count_lines_in_file(filetocheck)
     assert(nlines==19093)
 
@@ -323,10 +323,10 @@ def test_vtk_cbc():
                    kstpkper=[(0, 0), (0, 1), (0, 2)], point_scalars=True,
                    binary=True)
     filetocheck = os.path.join(otfolder, filenametocheck)
-    # totalbytes1 = os.path.getsize(filetocheck)
-    # assert(totalbytes1==1248118)
-    nlines1 = count_lines_in_file_bin(filetocheck)
-    assert(nlines1==2609)
+    totalbytes1 = os.path.getsize(filetocheck)
+    # assert(totalbytes1==1205818)
+    nlines1 = count_lines_in_file(filetocheck, binary=True)
+    assert(nlines1==2514)
 
     # with point scalars and binary, only one budget component
     otfolder = os.path.join(cpth, 'freyberg_CBCTEST_bin2')
@@ -334,10 +334,10 @@ def test_vtk_cbc():
                    kstpkper=(0, 0), text='CONSTANT HEAD',
                    point_scalars=True,  binary=True)
     filetocheck = os.path.join(otfolder, filenametocheck)
-    # totalbytes2 = os.path.getsize(filetocheck)
-    # assert(totalbytes2==10262)
-    nlines2 = count_lines_in_file_bin(filetocheck)
-    assert(nlines2==61)
+    totalbytes2 = os.path.getsize(filetocheck)
+    # assert(totalbytes2==10142)
+    nlines2 = count_lines_in_file(filetocheck, binary=True)
+    assert(nlines2==62)
 
     return
 
@@ -352,7 +352,7 @@ def test_vtk_vti():
     # export and check
     m.export(output_dir, fmt='vtk')
     filetocheck = os.path.join(output_dir, filenametocheck)
-    # totalbytes = os.path.getsize(filetocheck)
+    totalbytes = os.path.getsize(filetocheck)
     # assert(totalbytes==6322)
     nlines = count_lines_in_file(filetocheck)
     assert(nlines==21)
@@ -360,7 +360,7 @@ def test_vtk_vti():
     # with point scalar
     m.export(output_dir + '_points', fmt='vtk', point_scalars=True)
     filetocheck = os.path.join(output_dir + '_points', filenametocheck)
-    # totalbytes1 = os.path.getsize(filetocheck)
+    totalbytes1 = os.path.getsize(filetocheck)
     # assert(totalbytes1==16382)
     nlines1 = count_lines_in_file(filetocheck)
     assert(nlines1==38)
@@ -368,16 +368,16 @@ def test_vtk_vti():
     # with binary
     m.export(output_dir + '_bin', fmt='vtk', binary=True)
     filetocheck = os.path.join(output_dir + '_bin', filenametocheck)
-    # totalbytes2 = os.path.getsize(filetocheck)
-    # assert(totalbytes2==6537)
-    nlines2 = count_lines_in_file_bin(filetocheck)
+    totalbytes2 = os.path.getsize(filetocheck)
+    # assert(totalbytes2==4617)
+    nlines2 = count_lines_in_file(filetocheck, binary=True)
     assert(nlines2==18)
 
     # force .vtr
     filenametocheck = 'DIS.vtr'
     m.export(output_dir, fmt='vtk', vtk_grid_type='RectilinearGrid')
     filetocheck = os.path.join(output_dir, filenametocheck)
-    # totalbytes3 = os.path.getsize(filetocheck)
+    totalbytes3 = os.path.getsize(filetocheck)
     # assert(totalbytes3==7146)
     nlines3 = count_lines_in_file(filetocheck)
     assert(nlines3==56)
@@ -386,8 +386,8 @@ def test_vtk_vti():
     filenametocheck = 'DIS.vtu'
     m.export(output_dir, fmt='vtk', vtk_grid_type='UnstructuredGrid')
     filetocheck = os.path.join(output_dir, filenametocheck)
-    # totalbytes4 = os.path.getsize(filetocheck)
-    # assert(totalbytes4==67065)
+    totalbytes4 = os.path.getsize(filetocheck)
+    # assert(totalbytes4==67905)
     nlines4 = count_lines_in_file(filetocheck)
     assert(nlines4==993)
 
@@ -404,7 +404,7 @@ def test_vtk_vtr():
     # export and check
     m.export(output_dir, fmt='vtk')
     filetocheck = os.path.join(output_dir, filenametocheck)
-    # totalbytes = os.path.getsize(filetocheck)
+    totalbytes = os.path.getsize(filetocheck)
     # assert(totalbytes==79953)
     nlines = count_lines_in_file(filetocheck)
     assert(nlines==87)
@@ -412,24 +412,24 @@ def test_vtk_vtr():
     # with point scalar
     m.export(output_dir + '_points', fmt='vtk', point_scalars=True)
     filetocheck = os.path.join(output_dir + '_points', filenametocheck)
-    # totalbytes1 = os.path.getsize(filetocheck)
-    # assert(totalbytes1==182472)
+    totalbytes1 = os.path.getsize(filetocheck)
+    # assert(totalbytes1==182168)
     nlines1 = count_lines_in_file(filetocheck)
     assert(nlines1==121)
 
     # with binary
     m.export(output_dir + '_bin', fmt='vtk', binary=True)
     filetocheck = os.path.join(output_dir + '_bin', filenametocheck)
-    # totalbytes2 = os.path.getsize(filetocheck)
+    totalbytes2 = os.path.getsize(filetocheck)
     # assert(totalbytes2==47778)
-    nlines2 = count_lines_in_file_bin(filetocheck)
+    nlines2 = count_lines_in_file(filetocheck, binary=True)
     assert(nlines2==28)
 
     # force .vtu
     filenametocheck = 'EVT_01.vtu'
     m.export(output_dir, fmt='vtk', vtk_grid_type='UnstructuredGrid')
     filetocheck = os.path.join(output_dir, filenametocheck)
-    # totalbytes3 = os.path.getsize(filetocheck)
+    totalbytes3 = os.path.getsize(filetocheck)
     # assert(totalbytes3==78762)
     nlines3 = count_lines_in_file(filetocheck)
     assert(nlines3==1105)

--- a/flopy/export/vtk.py
+++ b/flopy/export/vtk.py
@@ -399,6 +399,7 @@ class Vtk(object):
 
         self.cell_type = 11
         self.arrays = {}
+        self.vectors = {}
 
         self.smooth = smooth
         self.point_scalars = point_scalars
@@ -499,9 +500,9 @@ class Vtk(object):
         # return vtk grid type and file extension
         return (vtk_grid_type, file_extension)
 
-    def add_array(self, name, a, array2d=False):
+    def _format_array(self, a, array2d=False):
         """
-        Adds an array to the vtk object
+        Format array for vtk output
 
         Parameters
         ----------
@@ -512,6 +513,10 @@ class Vtk(object):
             the array to be added to the vtk object
         array2d : bool
             True if the array is 2d
+
+        Return
+        ------
+        Formatted array (a copy is made)
         """
         # if array is 2d reformat to 3d array
         if array2d:
@@ -530,8 +535,55 @@ class Vtk(object):
         where_to_nan = np.logical_or(a==self.nanval, self.ibound==0)
         a = np.where(where_to_nan, np.nan, a)
 
+        return a
+
+    def add_array(self, name, a, array2d=False):
+        """
+        Adds an array to the vtk object
+
+        Parameters
+        ----------
+
+        name : str
+            name of the array
+        a : flopy array
+            the array to be added to the vtk object
+        array2d : bool
+            True if the array is 2d
+        """
+        # format array
+        a = self._format_array(a, array2d)
+
         # add to self.arrays
-        self.arrays[name] = a
+        if a is not None:
+            self.arrays[name] = a
+
+        return
+
+    def add_vector(self, name, v, array2d=False):
+        """
+        Adds a vector (i.e., a tuple of arrays) to the vtk object
+
+        Parameters
+        ----------
+
+        name : str
+            name of the vector
+        v : tuple of arrays
+            the vector to be added to the vtk object
+        array2d : bool
+            True if the vector components are 2d arrays
+        """
+        # format each component of the vector
+        vf = ()
+        for vcomp in v:
+            vcomp = self._format_array(vcomp, array2d=array2d)
+            if vcomp is None:
+                return
+            vf = vf + (vcomp,)
+
+        # add to self.vectors
+        self.vectors[name] = vf
 
         return
 
@@ -687,6 +739,23 @@ class Vtk(object):
                 a = np.flip(a, axis=1)
                 xml.write_array(a, Name=name, NumberOfComponents='1')
 
+        # loop through stored vectors
+        for name, v in self.vectors.items():
+            ncomp = len(v)
+            v_as_array = np.moveaxis(np.array(v), 0, -1)
+            if self.vtk_grid_type == 'UnstructuredGrid':
+                shape4d = actwcells3d.shape + (ncomp,)
+                actwcells4d = actwcells3d.reshape(actwcells3d.shape + (1,))
+                actwcells4d = np.broadcast_to(actwcells4d, shape4d)
+                xml.write_array(v_as_array, actwcells=actwcells4d, Name=name,
+                                NumberOfComponents=ncomp)
+            else:
+                # flip "v" so coordinates increase along with indices as in vtk
+                v_as_array = np.flip(v_as_array, axis=0)
+                v_as_array = np.flip(v_as_array, axis=1)
+                xml.write_array(v_as_array, Name=name,
+                                NumberOfComponents=ncomp)
+
         # end cell data
         xml.close_element('CellData')
 
@@ -707,7 +776,31 @@ class Vtk(object):
                     # vtk
                     a = np.flip(a, axis=0)
                     a = np.flip(a, axis=1)
+                # write to file
                 xml.write_array(a, Name=name, NumberOfComponents='1')
+
+            # loop through stored vectors
+            for name, v in self.vectors.items():
+                # get the vector values onto vertices
+                v_ext = ()
+                for vcomp in v:
+                    if self.vtk_grid_type == 'UnstructuredGrid':
+                        _, _, zverts = self.get_3d_vertex_connectivity(
+                                     actwcells=actwcells3d, zvalues=vcomp)
+                        vcomp = np.array(list(zverts.values()))
+                    else:
+                        vcomp = self.extendedDataArray(vcomp)
+                    v_ext = v_ext + (vcomp,)
+                # write to file
+                ncomp = len(v_ext)
+                v_ext_as_array = np.moveaxis(np.array(v_ext), 0, -1)
+                if self.vtk_grid_type != 'UnstructuredGrid':
+                    # flip "v" so coordinates increase along with indices as in
+                    # vtk
+                    v_ext_as_array = np.flip(v_ext_as_array, axis=0)
+                    v_ext_as_array = np.flip(v_ext_as_array, axis=1)
+                xml.write_array(v_ext_as_array, Name=name,
+                                NumberOfComponents=ncomp)
 
             # end point data
             xml.close_element('PointData')
@@ -723,6 +816,7 @@ class Vtk(object):
 
         # clear arrays
         self.arrays.clear()
+        self.vectors.clear()
 
     def _configure_data_arrays(self):
         """
@@ -744,6 +838,16 @@ class Vtk(object):
             idxs = np.argwhere(np.logical_not(np.isnan(a)))
             # set the active array to 1
             ot_idx_array[idxs] = 1
+
+        # loop through vectors
+        for name in self.vectors:
+            for vcomp in self.vectors[name]:
+                # make array 1d
+                a = vcomp.ravel()
+                # get the indexes where there is data
+                idxs = np.argwhere(np.logical_not(np.isnan(a)))
+                # set the active array to 1
+                ot_idx_array[idxs] = 1
 
         # reset the shape of the active data array
         ot_idx_array = ot_idx_array.reshape(self.shape)
@@ -1197,6 +1301,60 @@ def export_array(model, array, output_folder, name, nanval=-1e+20,
     vtk = Vtk(model, nanval=nanval, smooth=smooth, point_scalars=point_scalars,
               vtk_grid_type=vtk_grid_type, binary=binary)
     vtk.add_array(name, array, array2d=array2d)
+    otfile = os.path.join(output_folder, '{}'.format(name))
+    vtk.write(otfile)
+
+    return
+
+
+def export_vector(model, vector, output_folder, name, nanval=-1e+20,
+                 array2d=False, smooth=False, point_scalars=False,
+                 vtk_grid_type='auto', binary=False):
+
+    """
+
+    Export vector (i.e., a tuple of arrays) to vtk
+
+    Parameters
+    ----------
+
+    model : flopy model instance
+        the flopy model instance
+    vector : tuple of arrays
+        vector to be exported
+    output_folder : str
+        output folder to write the data
+    name : str
+        name of vector
+    nanval : scalar
+        no data value, default value is -1e20
+    array2d : bool
+            True if the vector components are 2d arrays, default is False
+    smooth : bool
+        if True, will create smooth layer elevations, default is False
+    point_scalars : bool
+        if True, will also output array values at cell vertices, default is
+        False; note this automatically sets smooth to True
+    vtk_grid_type : str
+            Specific vtk_grid_type or 'auto'. Possible specific values are
+            'ImageData', 'RectilinearGrid', and 'UnstructuredGrid'.
+            If 'auto', the grid type is automatically determined. Namely:
+                * A regular grid (in all three directions) will be saved as an
+                  'ImageData'.
+                * A rectilinear (in all three directions), non-regular grid
+                  will be saved as a 'RectilinearGrid'.
+                * Other grids will be saved as 'UnstructuredGrid'.
+    binary : bool
+        if True the output file will be binary, default is False
+
+    """
+
+    if not os.path.exists(output_folder):
+        os.mkdir(output_folder)
+
+    vtk = Vtk(model, nanval=nanval, smooth=smooth, point_scalars=point_scalars,
+              vtk_grid_type=vtk_grid_type, binary=binary)
+    vtk.add_vector(name, vector, array2d=array2d)
     otfile = os.path.join(output_folder, '{}'.format(name))
     vtk.write(otfile)
 


### PR DESCRIPTION
This PR contains two commits.

The first commit fixes a few issues related to nan values and type cast.

The second commit implements the possibility to export vectors (e.g. hydraulic gradient, groundwater velocity...) to vtk (new function vtk.export_vector).