### PR TITLE
Update mfchd.py, prevent write chk-file always

### DIFF
--- a/flopy/modflow/mfchd.py
+++ b/flopy/modflow/mfchd.py
@@ -197,7 +197,7 @@ class ModflowChd(Package):
         return ['shead', 'ehead']
 
     @staticmethod
-    def load(f, model, nper=None, ext_unit_dict=None):
+    def load(f, model, nper=None, ext_unit_dict=None, check=True):
         """
         Load an existing package.
 
@@ -235,7 +235,7 @@ class ModflowChd(Package):
         if model.verbose:
             sys.stdout.write('loading chd package file...\n')
 
-        return Package.load(f, model, ModflowChd, nper=nper,
+        return Package.load(f, model, ModflowChd, nper=nper, check=check,
                             ext_unit_dict=ext_unit_dict)
 
     @staticmethod


### PR DESCRIPTION
Loading a mf-model, the CHD.chk file was always written, also wich the check-variable set to false.
For this reason the check-parameter is now added to the mfchd.load method and passed to the Package.load method.