### PR TITLE
fix(setup.py): read package name, version, etc. from version.py

### DIFF
--- a/flopy/__init__.py
+++ b/flopy/__init__.py
@@ -20,7 +20,7 @@ contribute.
 
 """
 
-from .version import __version__
+from .version import __version__, __author__, __author_email__
 
 # imports
 from . import modflow

--- a/flopy/__init__.py
+++ b/flopy/__init__.py
@@ -20,13 +20,6 @@ contribute.
 
 """
 
-__name__ = 'flopy'
-__author__ = 'Mark Bakker, Vincent Post, Christian D. Langevin, ' + \
-             'Joseph D. Hughes, Jeremy T. White, Andrew T. Leaf, ' + \
-             'Scott R. Paulinski, Joshua D. Larsen, Michael W. Toews, ' + \
-             'Eric D. Morway, Jason C. Bellino, Jeffrey Starn, ' + \
-             'and Michael N. Fienen'
-
 from .version import __version__
 
 # imports

--- a/flopy/utils/gridintersect.py
+++ b/flopy/utils/gridintersect.py
@@ -1,18 +1,26 @@
-import matplotlib.pyplot as plt
 import numpy as np
+
+try:
+    import matplotlib.pyplot as plt
+except ModuleNotFoundError:
+    plt = None
+    print("matplotlib is needed for grid intersect operations! Please " +
+          "matplotlib if you need to use grid intersect functionality.")
 from .geometry import transform
+
 try:
     from shapely.geometry import (MultiPoint, Point, Polygon, box,
                                   GeometryCollection)
     from shapely.strtree import STRtree
     from shapely.affinity import translate, rotate
 except ModuleNotFoundError:
-    print("Shapely is needed for grid intersect operations!"
-          "Please install shapely.")
+    print("Shapely is needed for grid intersect operations! Please install " +
+          "shapely if you need to use grid intersect functionality.")
 
 
 def parse_shapely_ix_result(collection, ix_result, shptyps=None):
-    """Recursive function for parsing shapely intersection results.
+    """
+    Recursive function for parsing shapely intersection results.
     Returns a list of shapely shapes matching shptyp
 
     Parameters
@@ -209,8 +217,10 @@ class GridIntersect:
             sorted list of Polygons
 
         """
+
         def sort_key(o):
             return o.name
+
         shapelist.sort(key=sort_key)
         return shapelist
 
@@ -1041,8 +1051,15 @@ class GridIntersect:
         try:
             from descartes import PolygonPatch
         except ModuleNotFoundError:
-            raise ModuleNotFoundError(
-                "descartes module needed for plotting polygons")
+            msg = 'descartes package needed for plotting polygons'
+            if plt is None:
+                msg = 'matplotlib and descartes packages needed for ' + \
+                      'plotting polygons'
+            raise ModuleNotFoundError(msg)
+
+        if plt is None:
+            msg = 'matplotlib package needed for plotting polygons'
+            raise ModuleNotFoundError(msg)
 
         if ax is None:
             _, ax = plt.subplots()
@@ -1077,6 +1094,10 @@ class GridIntersect:
             returns the axes handle
 
         """
+        if plt is None:
+            msg = 'matplotlib package needed for plotting polygons'
+            raise ModuleNotFoundError(msg)
+
         if ax is None:
             _, ax = plt.subplots()
 
@@ -1114,6 +1135,10 @@ class GridIntersect:
             returns the axes handle
 
         """
+        if plt is None:
+            msg = 'matplotlib package needed for plotting polygons'
+            raise ModuleNotFoundError(msg)
+
         if ax is None:
             _, ax = plt.subplots()
 

--- a/flopy/version.py
+++ b/flopy/version.py
@@ -1,7 +1,20 @@
 # flopy version file automatically created using...make-release.py
-# created on...December 15, 2019 09:55:43
+# created on...May 26, 2020 14:30:24
 
 major = 3
 minor = 3
 micro = 1
 __version__ = '{:d}.{:d}.{:d}'.format(major, minor, micro)
+__name__ = 'flopy'
+__author__ = 'Mark Bakker, Vincent Post, Christian D. Langevin, ' + \
+             'Joseph D. Hughes, Jeremy T. White, Andrew T. Leaf, ' + \
+             'Scott R. Paulinski, Joshua D. Larsen, Michael W. Toews, ' + \
+             'Eric D. Morway, Jason C. Bellino, Jeffrey Starn, ' + \
+             'and Michael N. Fienen'
+__author_email__ = 'mark.bakker@tudelft.nl, Vincent.Post@bgr.de, ' + \
+                   'langevin@usgs.gov, jdhughes@usgs.gov, ' + \
+                   'j.white@gns.cri.nz, aleaf@usgs.gov, ' + \
+                   'spaulinski@usgs.gov, jlarsen@usgs.gov,' + \
+                   'M.Toews@gns.cri.nz, emorway@usgs.gov, ' + \
+                   'jbellino@usgs.gov, jjstarn@usgs.gov, ' + \
+                   'mnfienen@usgs.gov'

--- a/flopy/version.py
+++ b/flopy/version.py
@@ -1,20 +1,28 @@
 # flopy version file automatically created using...make-release.py
-# created on...May 26, 2020 14:30:24
+# created on...May 26, 2020 17:16:58
 
 major = 3
 minor = 3
 micro = 1
 __version__ = '{:d}.{:d}.{:d}'.format(major, minor, micro)
-__name__ = 'flopy'
-__author__ = 'Mark Bakker, Vincent Post, Christian D. Langevin, ' + \
-             'Joseph D. Hughes, Jeremy T. White, Andrew T. Leaf, ' + \
-             'Scott R. Paulinski, Joshua D. Larsen, Michael W. Toews, ' + \
-             'Eric D. Morway, Jason C. Bellino, Jeffrey Starn, ' + \
-             'and Michael N. Fienen'
-__author_email__ = 'mark.bakker@tudelft.nl, Vincent.Post@bgr.de, ' + \
-                   'langevin@usgs.gov, jdhughes@usgs.gov, ' + \
-                   'j.white@gns.cri.nz, aleaf@usgs.gov, ' + \
-                   'spaulinski@usgs.gov, jlarsen@usgs.gov,' + \
-                   'M.Toews@gns.cri.nz, emorway@usgs.gov, ' + \
-                   'jbellino@usgs.gov, jjstarn@usgs.gov, ' + \
-                   'mnfienen@usgs.gov'
+
+__pakname__ = 'flopy'
+
+# edit author dictionary as necessary
+author_dict = {
+    'Mark Bakker': 'mark.bakker@tudelft.nl',
+    'Vincent Post': 'Vincent.Post@bgr.de',
+    'Christian D. Langevin': 'langevin@usgs.gov',
+    'Joseph D. Hughes': 'jdhughes@usgs.gov',
+    'Jeremy T. White': 'jwhite@usgs.gov',
+    'Andrew T. Leaf': 'aleaf@usgs.gov',
+    'Scott R. Paulinski': 'spaulinski@usgs.gov',
+    'Joshua D. Larsen': 'jlarsen@usgs.gov',
+    'Michael W. Toews': 'M.Toews@gns.cri.nz',
+    'Eric D. Morway': 'emorway@usgs.gov',
+    'Jason C. Bellino': 'jbellino@usgs.gov',
+    'Jeffrey Starn': 'jjstarn@usgs.gov',
+    'Michael N. Fienen': 'mnfienen@usgs.gov',
+}
+__author__ = ', '.join(author_dict.keys())
+__author_email__ = ', '.join(s for _, s in author_dict.items())

--- a/release/make-release.py
+++ b/release/make-release.py
@@ -168,8 +168,8 @@ def update_version():
                 vminor = int(t[2])
             elif 'micro =' in line:
                 vmicro = int(t[2])
-            elif '__name__' in line:
-                name_pos = idx
+            elif '__version__' in line:
+                name_pos = idx + 1
 
     except:
         msg = 'There was a problem updating the version file'

--- a/release/make-release.py
+++ b/release/make-release.py
@@ -152,6 +152,7 @@ def get_software_citation(version, is_approved):
 
 
 def update_version():
+    name_pos = None
     try:
         fpth = os.path.join(paths[0], files[0])
 
@@ -159,7 +160,7 @@ def update_version():
         vminor = 0
         vmicro = 0
         lines = [line.rstrip('\n') for line in open(fpth, 'r')]
-        for line in lines:
+        for idx, line in enumerate(lines):
             t = line.split()
             if 'major =' in line:
                 vmajor = int(t[2])
@@ -167,6 +168,9 @@ def update_version():
                 vminor = int(t[2])
             elif 'micro =' in line:
                 vmicro = int(t[2])
+            elif '__name__' in line:
+                name_pos = idx
+
     except:
         msg = 'There was a problem updating the version file'
         raise IOError(msg)
@@ -184,6 +188,11 @@ def update_version():
         f.write('minor = {}\n'.format(vminor))
         f.write('micro = {}\n'.format(vmicro))
         f.write("__version__ = '{:d}.{:d}.{:d}'.format(major, minor, micro)\n")
+
+        # write the remainder of the version file
+        if name_pos is not None:
+            for line in lines[name_pos:]:
+                f.write('{}\n'.format(line))
         f.close()
         print('Successfully updated version.py')
     except:

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,18 @@ import os
 import sys
 from setuptools import setup
 
-from flopy import __version__, __name__, __author__
-
 # ensure minimum version of Python is running
 if sys.version_info[0:2] < (3, 5):
     raise RuntimeError('Flopy requires Python >= 3.5')
+
+# read package variables in flopy/version.py into a dictionary
+# dictionary is created rather than using an import so that numpy and
+# matplotlib imports in flopy do not cause pip install failures with
+# python environments that do not have numpy and matplotlib
+# already installed
+pak_vars = {}
+with open(os.path.join('flopy', 'version.py')) as vfile:
+    exec(vfile.read(), pak_vars)
 
 try:
     import pypandoc
@@ -16,18 +23,12 @@ try:
 except ImportError:
     long_description = ''
 
-setup(name=__name__,
+setup(name=pak_vars['__name__'],
       description='FloPy is a Python package to create, run, and ' +
                   'post-process MODFLOW-based models.',
       long_description=long_description,
-      author=__author__,
-      author_email='mark.bakker@tudelft.nl, Vincent.Post@bgr.de, ' +
-                   'langevin@usgs.gov, jdhughes@usgs.gov, ' +
-                   'j.white@gns.cri.nz, aleaf@usgs.gov, ' +
-                   'spaulinski@usgs.gov, jlarsen@usgs.gov,' +
-                   'M.Toews@gns.cri.nz, emorway@usgs.gov, ' +
-                   'jbellino@usgs.gov, jjstarn@usgs.gov, ' +
-                   'mnfienen@usgs.gov',
+      author=pak_vars['__author__'],
+      author_email=pak_vars['__author_email__'],
       url='https://github.com/modflowpy/flopy/',
       license='CC0',
       platforms='Windows, Mac OS-X, Linux',
@@ -39,5 +40,5 @@ setup(name=__name__,
                 'flopy.mf6.modflow', 'flopy.mf6.utils'],
       include_package_data=True,  # includes files listed in MANIFEST.in
       # use this version ID if .svn data cannot be found
-      version=__version__,
+      version=pak_vars['__version__'],
       classifiers=['Topic :: Scientific/Engineering :: Hydrology'])

--- a/setup.py
+++ b/setup.py
@@ -6,14 +6,10 @@ from setuptools import setup
 if sys.version_info[0:2] < (3, 5):
     raise RuntimeError('Flopy requires Python >= 3.5')
 
-# read package variables in flopy/version.py into a dictionary
-# dictionary is created rather than using an import so that numpy and
-# matplotlib imports in flopy do not cause pip install failures with
-# python environments that do not have numpy and matplotlib
-# already installed
-pak_vars = {}
-with open(os.path.join('flopy', 'version.py')) as vfile:
-    exec(vfile.read(), pak_vars)
+# local import of package variables in flopy/version.py
+sys.path.append('flopy')
+from version import __version__, __pakname__, __author__, __author_email__
+print(__version__, __pakname__, __author__, __author_email__)
 
 try:
     import pypandoc
@@ -23,12 +19,12 @@ try:
 except ImportError:
     long_description = ''
 
-setup(name=pak_vars['__name__'],
+setup(name=__pakname__,
       description='FloPy is a Python package to create, run, and ' +
                   'post-process MODFLOW-based models.',
       long_description=long_description,
-      author=pak_vars['__author__'],
-      author_email=pak_vars['__author_email__'],
+      author=__author__,
+      author_email=__author_email__,
       url='https://github.com/modflowpy/flopy/',
       license='CC0',
       platforms='Windows, Mac OS-X, Linux',
@@ -40,5 +36,5 @@ setup(name=pak_vars['__name__'],
                 'flopy.mf6.modflow', 'flopy.mf6.utils'],
       include_package_data=True,  # includes files listed in MANIFEST.in
       # use this version ID if .svn data cannot be found
-      version=pak_vars['__version__'],
+      version=__version__,
       classifiers=['Topic :: Scientific/Engineering :: Hydrology'])


### PR DESCRIPTION
Import of __version__, __name__, and __author__ from flopy caused
failure of setup.py because of dependency of flopy on numpy with
python installations that did not already have numpy installed. Moved
all information needed by setup.py to version.py and update
make-release.py to retain __name__, __author__, and __author_email__
information in file after updating version numbers. Removed unintended
unmanaged dependency on matplotlib in gridintersect.py by wrapping
import in a try and except. In the case that matplotlib is not installed
and methods that depend on matplotlib are called then a
ModuleNotFoundError exception is issued.

Closes #892