### PR TITLE
fix building in clean env

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ if sys.version_info[0:2] < (3, 5):
 
 # local import of package variables in flopy/version.py
 # imports __version__, __pakname__, __author__, __author_email__
-exec(open("flopy/version.py").read())
+exec(open(os.path.join("flopy", "version.py")).read())
 
 try:
     import pypandoc

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,8 @@ if sys.version_info[0:2] < (3, 5):
     raise RuntimeError('Flopy requires Python >= 3.5')
 
 # local import of package variables in flopy/version.py
-sys.path.append('flopy')
-from version import __version__, __pakname__, __author__, __author_email__
-print(__version__, __pakname__, __author__, __author_email__)
+# imports __version__, __pakname__, __author__, __author_email__
+exec(open("flopy/version.py").read())
 
 try:
     import pypandoc


### PR DESCRIPTION
Make installable in a clean environment. Before `flopy.__init__.py` was implicitly loaded and leads to an import of numpy (which could be not installed before installation) See #892