### PR TITLE
fix(mfsimulation): repair change for case insensitive model names

### DIFF
--- a/flopy/mf6/modflow/mfsimulation.py
+++ b/flopy/mf6/modflow/mfsimulation.py
@@ -1793,7 +1793,7 @@ class MFSimulation(PackageContainer):
                 for index, item in enumerate(record):
                     if record[1] == ims_file or item not in new_models:
                         new_record.append(item)
-                        if index > 1:
+                        if index > 1 and item is not None:
                             rec_model_dict[item.lower()] = 1
 
                 if record[1] == ims_file:


### PR DESCRIPTION
A recent change was made to allow case insensitive model names to be added to IMS solutions.  This change broke some previous functionality.  This PR simply checks to make sure that .lower() is not applied to None.