### PR TITLE
Remove message "flopy is installed in ..."

### DIFF
--- a/flopy/mf6/utils/generate_classes.py
+++ b/flopy/mf6/utils/generate_classes.py
@@ -9,7 +9,6 @@ from .createpackages import create_packages
 thisfilepath = os.path.dirname(os.path.abspath( __file__ ))
 flopypth = os.path.join(thisfilepath, '..', '..')
 flopypth = os.path.abspath(flopypth)
-print('flopy is installed in {}'.format(flopypth))
 protected_dfns = ['flopy.dfn']
 
 


### PR DESCRIPTION
Currently when flopy is imported, a message is printed to stdout: `flopy is installed in /path/to/flopy`.

Normally, Python packages do not print messages to stdout when they are imported, so this PR removes this behaviour.

Anyone that would like to show this message in their workflow can use the following:
```python
import os
import flopy

print('flopy is installed in ' + os.path.dirname(flopy.__file__))
```