### PR TITLE
fix(rcha and evta): irch and ievt arrays now zero based

### DIFF
--- a/flopy/mf6/data/dfn/gwf-evta.dfn
+++ b/flopy/mf6/data/dfn/gwf-evta.dfn
@@ -157,6 +157,7 @@ name ievt
 type integer
 shape (ncol*nrow; ncpl)
 reader readarray
+numeric_index true
 optional true
 longname layer number for evapotranspiration
 description IEVT is the layer number that defines the layer in each vertical column where evapotranspiration is applied. If IEVT is omitted, evapotranspiration by default is applied to cells in layer 1.  If IEVT is specified, it must be specified as the first variable in the PERIOD block or MODFLOW will terminate with an error.

--- a/flopy/mf6/data/dfn/gwf-rcha.dfn
+++ b/flopy/mf6/data/dfn/gwf-rcha.dfn
@@ -157,6 +157,7 @@ name irch
 type integer
 shape (ncol*nrow; ncpl)
 reader readarray
+numeric_index true
 optional true
 longname layer number for recharge
 description IRCH is the layer number that defines the layer in each vertical column where recharge is applied. If IRCH is omitted, recharge by default is applied to cells in layer 1.  IRCH can only be used if READASARRAYS is specified in the OPTIONS block.  If IRCH is specified, it must be specified as the first variable in the PERIOD block or MODFLOW will terminate with an error.

--- a/flopy/mf6/data/mfdata.py
+++ b/flopy/mf6/data/mfdata.py
@@ -408,6 +408,11 @@ class MFData(DataInterface):
 
     def _get_constant_formatting_string(self, const_val, layer, data_type,
                                         suffix='\n'):
+        if self.structure.data_item_structures[0].numeric_index or \
+                self.structure.data_item_structures[0].is_cellid:
+            # for cellid and numeric indices convert from 0 base to 1 based
+            const_val = abs(const_val) + 1
+
         sim_data = self._simulation_data
         const_format = list(sim_data.constant_formatting)
         const_format[1] = to_string(const_val, data_type, self._simulation_data,

--- a/flopy/mf6/modflow/mfgwfevta.py
+++ b/flopy/mf6/modflow/mfgwfevta.py
@@ -69,7 +69,11 @@ class ModflowGwfevta(mfpackage.MFPackage):
           each vertical column where evapotranspiration is applied. If IEVT is
           omitted, evapotranspiration by default is applied to cells in layer
           1. If IEVT is specified, it must be specified as the first variable
-          in the PERIOD block or MODFLOW will terminate with an error.
+          in the PERIOD block or MODFLOW will terminate with an error. This
+          argument is an index variable, which means that it should be treated
+          as zero-based when working with FloPy and Python. Flopy will
+          automatically subtract one when loading index variables and add one
+          when writing index variables.
     surface : [double]
         * surface (double) is the elevation of the ET surface (:math:`L`).
     rate : [double]
@@ -153,7 +157,8 @@ class ModflowGwfevta(mfpackage.MFPackage):
             "block_variable True", "in_record true", "tagged false", "shape",
             "valid", "reader urword", "optional false"],
            ["block period", "name ievt", "type integer",
-            "shape (ncol*nrow; ncpl)", "reader readarray", "optional true"],
+            "shape (ncol*nrow; ncpl)", "reader readarray",
+            "numeric_index true", "optional true"],
            ["block period", "name surface", "type double precision",
             "shape (ncol*nrow; ncpl)", "reader readarray", "default_value 0."],
            ["block period", "name rate", "type double precision",

--- a/flopy/mf6/modflow/mfgwfrcha.py
+++ b/flopy/mf6/modflow/mfgwfrcha.py
@@ -70,7 +70,11 @@ class ModflowGwfrcha(mfpackage.MFPackage):
           recharge by default is applied to cells in layer 1. IRCH can only be
           used if READASARRAYS is specified in the OPTIONS block. If IRCH is
           specified, it must be specified as the first variable in the PERIOD
-          block or MODFLOW will terminate with an error.
+          block or MODFLOW will terminate with an error. This argument is an
+          index variable, which means that it should be treated as zero-based
+          when working with FloPy and Python. Flopy will automatically subtract
+          one when loading index variables and add one when writing index
+          variables.
     recharge : [double]
         * recharge (double) is the recharge flux rate (:math:`LT^{-1}`). This
           rate is multiplied inside the program by the surface area of the cell
@@ -150,7 +154,8 @@ class ModflowGwfrcha(mfpackage.MFPackage):
             "block_variable True", "in_record true", "tagged false", "shape",
             "valid", "reader urword", "optional false"],
            ["block period", "name irch", "type integer",
-            "shape (ncol*nrow; ncpl)", "reader readarray", "optional true"],
+            "shape (ncol*nrow; ncpl)", "reader readarray",
+            "numeric_index true", "optional true"],
            ["block period", "name recharge", "type double precision",
             "shape (ncol*nrow; ncpl)", "reader readarray",
             "default_value 1.e-3"],

--- a/flopy/mf6/utils/createpackages.py
+++ b/flopy/mf6/utils/createpackages.py
@@ -1,4 +1,5 @@
 import os
+import io
 import textwrap
 from enum import Enum
 from flopy.mf6.data import mfstructure, mfdatautil
@@ -334,8 +335,9 @@ def create_packages():
                                  package.file_type))
 
     util_path, tail = os.path.split(os.path.realpath(__file__))
-    init_file = open(os.path.join(util_path, '..', 'modflow', '__init__.py'),
-                     'w')
+    init_file = io.open(os.path.join(util_path, '..', 'modflow',
+                                     '__init__.py'),
+                        'w', newline='\n')
     init_file.write('# imports\n')
     init_file.write('from .mfsimulation import MFSimulation\n')
 
@@ -499,8 +501,9 @@ def create_packages():
             init_string_full, parent_init_string, init_vars)
 
         # open new Packages file
-        pb_file = open(os.path.join(util_path, '..', 'modflow',
-                                    'mf{}.py'.format(package_name)), 'w')
+        pb_file = io.open(os.path.join(util_path, '..', 'modflow',
+                                       'mf{}.py'.format(package_name)), 'w',
+                          newline='\n')
         pb_file.write(package_string)
 
         if package[2] == 'utl' and package_abbr != 'utltab':
@@ -616,9 +619,9 @@ def create_packages():
                 comment_string, nam_import_string, class_def_string,
                 doc_string.get_doc_string(True), doc_text, class_var_string,
                 init_string_model, mparent_init_string, init_vars, load_txt)
-            md_file = open(os.path.join(util_path, '..', 'modflow',
-                           'mf{}.py'.format(model_name)),
-                           'w')
+            md_file = io.open(os.path.join(util_path, '..', 'modflow',
+                                           'mf{}.py'.format(model_name)),
+                              'w', newline='\n')
             md_file.write(package_string)
             md_file.close()
             init_file.write('from .mf{} import '


### PR DESCRIPTION
fix for issue #941.  also changed createpackages.py to always produce python scripts with unix-style line endings.