### PR TITLE
perf(util_array.util2d) write_txt string += performance slow for large…

### DIFF
--- a/flopy/utils/util_array.py
+++ b/flopy/utils/util_array.py
@@ -2808,28 +2808,17 @@ class Util2d(DataInterface):
                     + "   [column_length, fmt]\n"
                     + "    e.g., [10, {0:10.2e}]"
                 )
-        if ncol % column_length == 0:
-            linereturnflag = False
-        else:
-            linereturnflag = True
         # write the array to a string
-        s = ""
-        for i in range(nrow):
-            icol = 0
-            for j in range(ncol):
-                try:
-                    s = s + output_fmt.format(data[i, j])
-                except Exception as e:
-                    raise Exception(
-                        "error writing array value"
-                        + "{0} at r,c [{1},{2}]\n{3}".format(
-                            data[i, j], i, j, str(e)
-                        )
-                    )
-                if (j + 1) % column_length == 0.0 and (j != 0 or ncol == 1):
-                    s += "\n"
-            if linereturnflag:
-                s += "\n"
+        len_data = len(data.flatten())
+        str_fmt_data = [
+            output_fmt.format(d) + "\n"
+            if (((i + 1) % column_length == 0.0) and (i != 0 or ncol == 1))
+            or ((i + 1 == ncol) and (ncol != 1))
+            or (i + 1 == len_data)
+            else output_fmt.format(d)
+            for i, d in enumerate(data.flatten())
+        ]
+        s = "".join(str_fmt_data)
         return s
 
     @staticmethod

--- a/flopy/utils/util_array.py
+++ b/flopy/utils/util_array.py
@@ -2809,7 +2809,7 @@ class Util2d(DataInterface):
                     + "    e.g., [10, {0:10.2e}]"
                 )
         # write the array to a string
-        len_data = len(data.flatten())
+        len_data = data.size
         str_fmt_data = [
             output_fmt.format(d) + "\n"
             if (((i + 1) % column_length == 0.0) and (i != 0 or ncol == 1))

--- a/flopy/utils/util_array.py
+++ b/flopy/utils/util_array.py
@@ -2816,7 +2816,7 @@ class Util2d(DataInterface):
             or ((i + 1 == ncol) and (ncol != 1))
             or (i + 1 == len_data)
             else output_fmt.format(d)
-            for i, d in enumerate(data.flatten())
+            for i, d in enumerate(data.flat)
         ]
         s = "".join(str_fmt_data)
         return s

--- a/flopy/utils/util_array.py
+++ b/flopy/utils/util_array.py
@@ -2816,7 +2816,7 @@ class Util2d(DataInterface):
             or ((i + 1 == ncol) and (ncol != 1))
             or (i + 1 == len_data)
             else output_fmt.format(d)
-            for i, d in enumerate(data.flat)
+            for i, d in enumerate(data.flatten())
         ]
         s = "".join(str_fmt_data)
         return s


### PR DESCRIPTION
… arrays.

Writing large arrays (like JA in a disu file) using package_object.write_file() is
too slow (hours for a JA of size ~10M). Experimentation suggests the bottleneck is
in utils/util_array.py() in function array2string, which uses the string += "more"
and string = string + "more" methods, which scale badly with size.
Implement solution: Change string += loop to "".join(iterable) method.

Fixes #961