### PR TITLE
Modified flopy/modflow/ load methods to allow better subclassing.

### DIFF
--- a/flopy/modflow/mf.py
+++ b/flopy/modflow/mf.py
@@ -670,8 +670,9 @@ class Modflow(BaseModel):
         else:
             return hdObj, ddObj, bdObj
 
-    @staticmethod
+    @classmethod
     def load(
+        cls,
         f,
         version="mf2005",
         exe_name="mf2005.exe",
@@ -746,7 +747,7 @@ class Modflow(BaseModel):
             os.path.join(model_ws, f)
         )
 
-        ml = Modflow(
+        ml = cls(
             modelname,
             version=version,
             exe_name=exe_name,

--- a/flopy/modflow/mfag.py
+++ b/flopy/modflow/mfag.py
@@ -685,8 +685,8 @@ class ModflowAg(Package):
 
         return np.dtype(dtype)
 
-    @staticmethod
-    def load(f, model, nper=0, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, nper=0, ext_unit_dict=None):
         """
         Method to load the AG package from file
 
@@ -891,7 +891,7 @@ class ModflowAg(Package):
                         "Something went wrong at: {}".format(line)
                     )
 
-        return ModflowAg(
+        return cls(
             model,
             options=options,
             time_series=time_series,

--- a/flopy/modflow/mfbas.py
+++ b/flopy/modflow/mfbas.py
@@ -286,8 +286,8 @@ class ModflowBas(Package):
         # Close file
         f_bas.close()
 
-    @staticmethod
-    def load(f, model, ext_unit_dict=None, check=True, **kwargs):
+    @classmethod
+    def load(cls, f, model, ext_unit_dict=None, check=True, **kwargs):
         """
         Load an existing package.
 
@@ -398,7 +398,7 @@ class ModflowBas(Package):
             )
 
         # create bas object and return
-        bas = ModflowBas(
+        bas = cls(
             model,
             ibound=ibound,
             strt=strt,

--- a/flopy/modflow/mfbcf.py
+++ b/flopy/modflow/mfbcf.py
@@ -320,8 +320,8 @@ class ModflowBcf(Package):
                 f_bcf.write(self.wetdry[k].get_file_entry())
         f_bcf.close()
 
-    @staticmethod
-    def load(f, model, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, ext_unit_dict=None):
         """
         Load an existing package.
 
@@ -529,7 +529,7 @@ class ModflowBcf(Package):
                 model.add_pop_key_list(ipakcb)
 
         # create instance of bcf object
-        bcf = ModflowBcf(
+        bcf = cls(
             model,
             ipakcb=ipakcb,
             intercellt=intercellt,

--- a/flopy/modflow/mfde4.py
+++ b/flopy/modflow/mfde4.py
@@ -227,8 +227,8 @@ class ModflowDe4(Package):
             f.write("\n")
         f.close()
 
-    @staticmethod
-    def load(f, model, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, ext_unit_dict=None):
         """
         Load an existing package.
 
@@ -313,7 +313,7 @@ class ModflowDe4(Package):
                 ext_unit_dict, filetype=ModflowDe4.ftype()
             )
 
-        de4 = ModflowDe4(
+        de4 = cls(
             model,
             itmx=itmx,
             mxup=mxup,

--- a/flopy/modflow/mfdis.py
+++ b/flopy/modflow/mfdis.py
@@ -848,8 +848,8 @@ class ModflowDis(Package):
         # if verbose:
         #     print(txt)
 
-    @staticmethod
-    def load(f, model, ext_unit_dict=None, check=True):
+    @classmethod
+    def load(cls, f, model, ext_unit_dict=None, check=True):
         """
         Load an existing package.
 
@@ -1067,7 +1067,7 @@ class ModflowDis(Package):
             )
 
         # create dis object instance
-        dis = ModflowDis(
+        dis = cls(
             model,
             nlay=nlay,
             nrow=nrow,

--- a/flopy/modflow/mfdisu.py
+++ b/flopy/modflow/mfdisu.py
@@ -529,8 +529,8 @@ class ModflowDisU(Package):
     def ncpl(self):
         return self.nodes / self.nlay
 
-    @staticmethod
-    def load(f, model, ext_unit_dict=None, check=False):
+    @classmethod
+    def load(cls, f, model, ext_unit_dict=None, check=False):
         """
         Load an existing package.
 
@@ -798,7 +798,7 @@ class ModflowDisU(Package):
             )
 
         # create dis object instance
-        disu = ModflowDisU(
+        disu = cls(
             model,
             nodes=nodes,
             nlay=nlay,

--- a/flopy/modflow/mfevt.py
+++ b/flopy/modflow/mfevt.py
@@ -215,8 +215,8 @@ class ModflowEvt(Package):
                 f_evt.write(ievt)
         f_evt.close()
 
-    @staticmethod
-    def load(f, model, nper=None, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, nper=None, ext_unit_dict=None):
         """
         Load an existing package.
 
@@ -417,7 +417,7 @@ class ModflowEvt(Package):
         args["unitnumber"] = unitnumber
         args["filenames"] = filenames
 
-        evt = ModflowEvt(model, **args)
+        evt = cls(model, **args)
 
         # return evt object
         return evt

--- a/flopy/modflow/mffhb.py
+++ b/flopy/modflow/mffhb.py
@@ -420,8 +420,8 @@ class ModflowFhb(Package):
 
         f.close()
 
-    @staticmethod
-    def load(f, model, nper=None, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, nper=None, ext_unit_dict=None):
         """
         Load an existing package.
 
@@ -756,7 +756,7 @@ class ModflowFhb(Package):
         nfhbx1 = 0
         nfhbx2 = 0
 
-        fhb = ModflowFhb(
+        fhb = cls(
             model,
             nbdtim=nbdtim,
             nflw=nflw,

--- a/flopy/modflow/mfflwob.py
+++ b/flopy/modflow/mfflwob.py
@@ -380,8 +380,8 @@ class ModflowFlwob(Package):
 
         return
 
-    @staticmethod
-    def load(f, model, ext_unit_dict=None, check=True):
+    @classmethod
+    def load(cls, f, model, ext_unit_dict=None, check=True):
         """
         Load an existing package.
 
@@ -537,7 +537,7 @@ class ModflowFlwob(Package):
                 model.add_pop_key_list(iufbobsv)
 
         # create ModflowFlwob object instance
-        flwob = ModflowFlwob(
+        flwob = cls(
             model,
             iufbobsv=iufbobsv,
             tomultfb=tomultfb,

--- a/flopy/modflow/mfgage.py
+++ b/flopy/modflow/mfgage.py
@@ -286,8 +286,8 @@ class ModflowGage(Package):
         # close the gage file
         f.close()
 
-    @staticmethod
-    def load(f, model, nper=None, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, nper=None, ext_unit_dict=None):
         """
         Load an existing package.
 
@@ -395,7 +395,7 @@ class ModflowGage(Package):
         for file in files:
             filenames.append(os.path.basename(file))
 
-        gagepak = ModflowGage(
+        gagepak = cls(
             model,
             numgage=numgage,
             gage_data=gage_data,

--- a/flopy/modflow/mfgmg.py
+++ b/flopy/modflow/mfgmg.py
@@ -318,8 +318,8 @@ class ModflowGmg(Package):
         f_gmg.write("{}\n".format(self.relax))
         f_gmg.close()
 
-    @staticmethod
-    def load(f, model, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, ext_unit_dict=None):
         """
         Load an existing package.
 
@@ -411,7 +411,7 @@ class ModflowGmg(Package):
                 model.add_pop_key_list(iunitmhc)
 
         # create the gmg object
-        gmg = ModflowGmg(
+        gmg = cls(
             model,
             mxiter=mxiter,
             iiter=iiter,

--- a/flopy/modflow/mfhfb.py
+++ b/flopy/modflow/mfhfb.py
@@ -253,8 +253,8 @@ class ModflowHfb(Package):
     def get_sfac_columns():
         return ["hydchr"]
 
-    @staticmethod
-    def load(f, model, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, ext_unit_dict=None):
         """
         Load an existing package.
 
@@ -412,7 +412,7 @@ class ModflowHfb(Package):
                 ext_unit_dict, filetype=ModflowHfb.ftype()
             )
 
-        hfb = ModflowHfb(
+        hfb = cls(
             model,
             nphfb=0,
             mxfb=0,

--- a/flopy/modflow/mfhob.py
+++ b/flopy/modflow/mfhob.py
@@ -308,8 +308,8 @@ class ModflowHob(Package):
 
         return
 
-    @staticmethod
-    def load(f, model, ext_unit_dict=None, check=True):
+    @classmethod
+    def load(cls, f, model, ext_unit_dict=None, check=True):
         """
         Load an existing package.
 
@@ -492,7 +492,7 @@ class ModflowHob(Package):
                     model.add_pop_key_list(iuhobsv)
 
         # create hob object instance
-        hob = ModflowHob(
+        hob = cls(
             model,
             iuhobsv=iuhobsv,
             hobdry=hobdry,

--- a/flopy/modflow/mfhyd.py
+++ b/flopy/modflow/mfhyd.py
@@ -286,8 +286,8 @@ class ModflowHyd(Package):
         )
         return dtype
 
-    @staticmethod
-    def load(f, model, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, ext_unit_dict=None):
         """
         Load an existing package.
 
@@ -367,7 +367,7 @@ class ModflowHyd(Package):
                 model.add_pop_key_list(ihydun)
 
         # create hyd instance
-        hyd = ModflowHyd(
+        hyd = cls(
             model,
             nhyd=nhyd,
             ihydun=ihydun,

--- a/flopy/modflow/mflak.py
+++ b/flopy/modflow/mflak.py
@@ -639,8 +639,8 @@ class ModflowLak(Package):
         # close the lak file
         f.close()
 
-    @staticmethod
-    def load(f, model, nper=None, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, nper=None, ext_unit_dict=None):
         """
         Load an existing package.
 
@@ -908,7 +908,7 @@ class ModflowLak(Package):
                     )
                     ipos += 1
 
-        lakpak = ModflowLak(
+        lakpak = cls(
             model,
             options=options,
             nlakes=nlakes,

--- a/flopy/modflow/mflmt.py
+++ b/flopy/modflow/mflmt.py
@@ -170,8 +170,8 @@ class ModflowLmt(Package):
 
         f.close()
 
-    @staticmethod
-    def load(f, model, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, ext_unit_dict=None):
         """
         Load an existing package.
 
@@ -257,7 +257,7 @@ class ModflowLmt(Package):
                 ext_unit_dict, filetype=ModflowLmt.ftype()
             )
 
-        lmt = ModflowLmt(
+        lmt = cls(
             model,
             output_file_name=output_file_name,
             output_file_unit=output_file_unit,

--- a/flopy/modflow/mflpf.py
+++ b/flopy/modflow/mflpf.py
@@ -437,8 +437,8 @@ class ModflowLpf(Package):
         f.close()
         return
 
-    @staticmethod
-    def load(f, model, ext_unit_dict=None, check=True):
+    @classmethod
+    def load(cls, f, model, ext_unit_dict=None, check=True):
         """
         Load an existing package.
 
@@ -723,7 +723,7 @@ class ModflowLpf(Package):
                 model.add_pop_key_list(ipakcb)
 
         # create instance of lpf class
-        lpf = ModflowLpf(
+        lpf = cls(
             model,
             ipakcb=ipakcb,
             laytyp=laytyp,

--- a/flopy/modflow/mfmlt.py
+++ b/flopy/modflow/mfmlt.py
@@ -128,8 +128,8 @@ class ModflowMlt(Package):
         """
         pass
 
-    @staticmethod
-    def load(f, model, nrow=None, ncol=None, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, nrow=None, ncol=None, ext_unit_dict=None):
         """
         Load an existing package.
 
@@ -233,7 +233,7 @@ class ModflowMlt(Package):
             )
 
         # create mlt dictionary
-        mlt = ModflowMlt(
+        mlt = cls(
             model,
             mult_dict=mult_dict,
             unitnumber=unitnumber,

--- a/flopy/modflow/mfmnw1.py
+++ b/flopy/modflow/mfmnw1.py
@@ -209,8 +209,8 @@ class ModflowMnw1(Package):
         else:
             pass
 
-    @staticmethod
-    def load(f, model, nper=None, gwt=False, nsol=1, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, nper=None, gwt=False, nsol=1, ext_unit_dict=None):
 
         if model.verbose:
             sys.stdout.write("loading mnw1 package file...\n")
@@ -278,7 +278,7 @@ class ModflowMnw1(Package):
         if openfile:
             f.close()
 
-        return ModflowMnw1(
+        return cls(
             model,
             mxmnw=mxmnw,
             ipakcb=ipakcb,

--- a/flopy/modflow/mfmnw2.py
+++ b/flopy/modflow/mfmnw2.py
@@ -1324,8 +1324,8 @@ class ModflowMnw2(Package):
             msg = "get_default_spd_dtype: unstructured model not supported"
             raise NotImplementedError(msg)
 
-    @staticmethod
-    def load(f, model, nper=None, gwt=False, nsol=1, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, nper=None, gwt=False, nsol=1, ext_unit_dict=None):
         """
 
         Parameters
@@ -1464,7 +1464,7 @@ class ModflowMnw2(Package):
                         filenames[1] = os.path.basename(value.filename)
                         model.add_pop_key_list(key)
 
-        return ModflowMnw2(
+        return cls(
             model,
             mnwmax=mnwmax,
             nodtot=nodtot,

--- a/flopy/modflow/mfmnwi.py
+++ b/flopy/modflow/mfmnwi.py
@@ -202,8 +202,8 @@ class ModflowMnwi(Package):
 
         self.parent.add_package(self)
 
-    @staticmethod
-    def load(f, model, nper=None, gwt=False, nsol=1, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, nper=None, gwt=False, nsol=1, ext_unit_dict=None):
 
         if model.verbose:
             sys.stdout.write("loading mnw2 package file...\n")
@@ -281,7 +281,7 @@ class ModflowMnwi(Package):
                 )
                 idx += 1
 
-        return ModflowMnwi(
+        return cls(
             model,
             wel1flag=wel1flag,
             qsumflag=qsumflag,

--- a/flopy/modflow/mfnwt.py
+++ b/flopy/modflow/mfnwt.py
@@ -377,8 +377,8 @@ class ModflowNwt(Package):
 
         f.close()
 
-    @staticmethod
-    def load(f, model, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, ext_unit_dict=None):
         """
         Load an existing package.
 
@@ -556,7 +556,7 @@ class ModflowNwt(Package):
         kwargs["filenames"] = filenames
 
         # create and return an instance of the nwt class
-        return ModflowNwt(model, **kwargs)
+        return cls(model, **kwargs)
 
     @staticmethod
     def ftype():

--- a/flopy/modflow/mfoc.py
+++ b/flopy/modflow/mfoc.py
@@ -733,8 +733,8 @@ class ModflowOc(Package):
         # return
         return ihedun, fhead, iddnun, fddn
 
-    @staticmethod
-    def load(f, model, nper=None, nstp=None, nlay=None, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, nper=None, nstp=None, nlay=None, ext_unit_dict=None):
         """
         Load an existing package.
 
@@ -1103,7 +1103,7 @@ class ModflowOc(Package):
             model.add_pop_key_list(u)
 
         # create instance of oc class
-        oc = ModflowOc(
+        oc = cls(
             model,
             ihedfm=ihedfm,
             iddnfm=iddnfm,

--- a/flopy/modflow/mfparbc.py
+++ b/flopy/modflow/mfparbc.py
@@ -41,8 +41,8 @@ class ModflowParBc(object):
                 return self.bc_parms[key]
         return None
 
-    @staticmethod
-    def load(f, npar, dt, model, ext_unit_dict=None, verbose=False):
+    @classmethod
+    def load(cls, f, npar, dt, model, ext_unit_dict=None, verbose=False):
         """
         Load bc property parameters from an existing bc package
         that uses list data (e.g. WEL, RIV, etc.).
@@ -119,7 +119,7 @@ class ModflowParBc(object):
                 ]
 
         # print bc_parms
-        bcpar = ModflowParBc(bc_parms)
+        bcpar = cls(bc_parms)
         return bcpar
 
     @staticmethod

--- a/flopy/modflow/mfpcg.py
+++ b/flopy/modflow/mfpcg.py
@@ -219,8 +219,8 @@ class ModflowPcg(Package):
             f.write("\n")
         f.close()
 
-    @staticmethod
-    def load(f, model, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, ext_unit_dict=None):
         """
         Load an existing package.
 
@@ -343,7 +343,7 @@ class ModflowPcg(Package):
             )
 
         # create instance of pcg class
-        pcg = ModflowPcg(
+        pcg = cls(
             model,
             mxiter=mxiter,
             iter1=iter1,

--- a/flopy/modflow/mfpcgn.py
+++ b/flopy/modflow/mfpcgn.py
@@ -393,8 +393,8 @@ class ModflowPcgn(Package):
             f.write(line)
         f.close()
 
-    @staticmethod
-    def load(f, model, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, ext_unit_dict=None):
         """
         Load an existing package.
 
@@ -558,7 +558,7 @@ class ModflowPcgn(Package):
                     ext_unit_dict, unit=ipunit
                 )
 
-        pcgn = ModflowPcgn(
+        pcgn = cls(
             model,
             iter_mo=iter_mo,
             iter_mi=iter_mi,

--- a/flopy/modflow/mfpks.py
+++ b/flopy/modflow/mfpks.py
@@ -228,8 +228,8 @@ class ModflowPks(Package):
         f.write("END\n")
         f.close()
 
-    @staticmethod
-    def load(f, model, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, ext_unit_dict=None):
         """
         Load an existing package.
 
@@ -287,7 +287,7 @@ class ModflowPks(Package):
                 ext_unit_dict, filetype=ModflowPks.ftype()
             )
 
-        pks = ModflowPks(model, unitnumber=unitnumber, filenames=filenames)
+        pks = cls(model, unitnumber=unitnumber, filenames=filenames)
         return pks
 
     @staticmethod

--- a/flopy/modflow/mfpval.py
+++ b/flopy/modflow/mfpval.py
@@ -139,8 +139,8 @@ class ModflowPval(Package):
         else:
             return None
 
-    @staticmethod
-    def load(f, model, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, ext_unit_dict=None):
         """
         Load an existing package.
 
@@ -218,7 +218,7 @@ class ModflowPval(Package):
                 ext_unit_dict, filetype=ModflowPval.ftype()
             )
 
-        pval = ModflowPval(
+        pval = cls(
             model,
             pval_dict=pval_dict,
             unitnumber=unitnumber,

--- a/flopy/modflow/mfrch.py
+++ b/flopy/modflow/mfrch.py
@@ -366,8 +366,8 @@ class ModflowRch(Package):
                     f_rch.write(file_entry_irch)
         f_rch.close()
 
-    @staticmethod
-    def load(f, model, nper=None, ext_unit_dict=None, check=True):
+    @classmethod
+    def load(cls, f, model, nper=None, ext_unit_dict=None, check=True):
         """
         Load an existing package.
 
@@ -527,7 +527,7 @@ class ModflowRch(Package):
                 model.add_pop_key_list(ipakcb)
 
         # create recharge package instance
-        rch = ModflowRch(
+        rch = cls(
             model,
             nrchop=nrchop,
             ipakcb=ipakcb,

--- a/flopy/modflow/mfsfr2.py
+++ b/flopy/modflow/mfsfr2.py
@@ -834,8 +834,8 @@ class ModflowSfr2(Package):
             ]
         )
 
-    @staticmethod
-    def load(f, model, nper=None, gwt=False, nsol=1, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, nper=None, gwt=False, nsol=1, ext_unit_dict=None):
 
         if model.verbose:
             sys.stdout.write("loading sfr2 package file...\n")
@@ -1070,7 +1070,7 @@ class ModflowSfr2(Package):
                         filenames[2] = os.path.basename(value.filename)
                         model.add_pop_key_list(key)
 
-        return ModflowSfr2(
+        return cls(
             model,
             nstrm=nstrm,
             nss=nss,

--- a/flopy/modflow/mfsip.py
+++ b/flopy/modflow/mfsip.py
@@ -190,8 +190,8 @@ class ModflowSip(Package):
             )
         f.close()
 
-    @staticmethod
-    def load(f, model, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, ext_unit_dict=None):
         """
         Load an existing package.
 
@@ -271,7 +271,7 @@ class ModflowSip(Package):
                 ext_unit_dict, filetype=ModflowSip.ftype()
             )
 
-        sip = ModflowSip(
+        sip = cls(
             model,
             mxiter=mxiter,
             nparm=nparm,

--- a/flopy/modflow/mfsms.py
+++ b/flopy/modflow/mfsms.py
@@ -412,8 +412,8 @@ class ModflowSms(Package):
         f.write("\n")
         f.close()
 
-    @staticmethod
-    def load(f, model, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, ext_unit_dict=None):
         """
         Load an existing package.
 
@@ -629,7 +629,7 @@ class ModflowSms(Package):
                 ext_unit_dict, filetype=ModflowSms.ftype()
             )
 
-        sms = ModflowSms(
+        sms = cls(
             model,
             hclose=hclose,
             hiclose=hiclose,

--- a/flopy/modflow/mfsor.py
+++ b/flopy/modflow/mfsor.py
@@ -152,8 +152,8 @@ class ModflowSor(Package):
         f.write(line)
         f.close()
 
-    @staticmethod
-    def load(f, model, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, ext_unit_dict=None):
         """
         Load an existing package.
 
@@ -213,7 +213,7 @@ class ModflowSor(Package):
             )
 
         # create sor object
-        sor = ModflowSor(model, unitnumber=unitnumber, filenames=filenames)
+        sor = cls(model, unitnumber=unitnumber, filenames=filenames)
 
         # return sor object
         return sor

--- a/flopy/modflow/mfstr.py
+++ b/flopy/modflow/mfstr.py
@@ -681,8 +681,8 @@ class ModflowStr(Package):
         # close the str file
         f_str.close()
 
-    @staticmethod
-    def load(f, model, nper=None, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, nper=None, ext_unit_dict=None):
         """
         Load an existing package.
 
@@ -994,7 +994,7 @@ class ModflowStr(Package):
                     ext_unit_dict, unit=abs(istcb2)
                 )
 
-        strpak = ModflowStr(
+        strpak = cls(
             model,
             mxacts=mxacts,
             nss=nss,

--- a/flopy/modflow/mfsub.py
+++ b/flopy/modflow/mfsub.py
@@ -586,8 +586,8 @@ class ModflowSub(Package):
         # close sub file
         f.close()
 
-    @staticmethod
-    def load(f, model, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, ext_unit_dict=None):
         """
         Load an existing package.
 
@@ -929,7 +929,7 @@ class ModflowSub(Package):
                     ipos += 1
 
         # create sub instance
-        sub = ModflowSub(
+        sub = cls(
             model,
             ipakcb=ipakcb,
             isuboc=isuboc,

--- a/flopy/modflow/mfswi2.py
+++ b/flopy/modflow/mfswi2.py
@@ -531,8 +531,8 @@ class ModflowSwi2(Package):
         # close swi2 file
         f.close()
 
-    @staticmethod
-    def load(f, model, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, ext_unit_dict=None):
         """Load an existing package.
 
         Parameters
@@ -783,7 +783,7 @@ class ModflowSwi2(Package):
                 )
 
         # create swi2 instance
-        swi2 = ModflowSwi2(
+        swi2 = cls(
             model,
             nsrf=nsrf,
             istrat=istrat,

--- a/flopy/modflow/mfswr1.py
+++ b/flopy/modflow/mfswr1.py
@@ -122,8 +122,8 @@ class ModflowSwr1(Package):
         # f.write('{0}\n'.format(self.heading))
         # f.close()
 
-    @staticmethod
-    def load(f, model, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, ext_unit_dict=None):
         """
         Load an existing package.
 
@@ -185,7 +185,7 @@ class ModflowSwr1(Package):
             )
 
         # create swr1 object instance
-        swr1 = ModflowSwr1(model, unitnumber=unitnumber, filenames=filenames)
+        swr1 = cls(model, unitnumber=unitnumber, filenames=filenames)
 
         # return swr object
         return swr1

--- a/flopy/modflow/mfswt.py
+++ b/flopy/modflow/mfswt.py
@@ -599,8 +599,8 @@ class ModflowSwt(Package):
         # add package to model
         self.parent.add_package(self)
 
-    @staticmethod
-    def load(f, model, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, ext_unit_dict=None):
         """
         Load an existing package.
 
@@ -932,7 +932,7 @@ class ModflowSwt(Package):
                     ipos += 1
 
         # create sub-wt instance
-        swt = ModflowSwt(
+        swt = cls(
             model,
             ipakcb=ipakcb,
             iswtoc=iswtoc,

--- a/flopy/modflow/mfupw.py
+++ b/flopy/modflow/mfupw.py
@@ -355,8 +355,8 @@ class ModflowUpw(Package):
                 f_upw.write(self.laywet[k].get_file_entry())
         f_upw.close()
 
-    @staticmethod
-    def load(f, model, ext_unit_dict=None, check=True):
+    @classmethod
+    def load(cls, f, model, ext_unit_dict=None, check=True):
         """
         Load an existing package.
 
@@ -609,7 +609,7 @@ class ModflowUpw(Package):
                 model.add_pop_key_list(ipakcb)
 
         # create upw object
-        upw = ModflowUpw(
+        upw = cls(
             model,
             ipakcb=ipakcb,
             iphdry=iphdry,

--- a/flopy/modflow/mfuzf1.py
+++ b/flopy/modflow/mfuzf1.py
@@ -873,8 +873,8 @@ class ModflowUzf1(Package):
 
         f_uzf.close()
 
-    @staticmethod
-    def load(f, model, ext_unit_dict=None, check=False):
+    @classmethod
+    def load(cls, f, model, ext_unit_dict=None, check=False):
         """
         Load an existing package.
 
@@ -1131,7 +1131,7 @@ class ModflowUzf1(Package):
                     ipos += 1
 
         # create uzf object
-        return ModflowUzf1(
+        return cls(
             model,
             nuztop=nuztop,
             iuzfopt=iuzfopt,

--- a/flopy/modflow/mfzon.py
+++ b/flopy/modflow/mfzon.py
@@ -131,8 +131,8 @@ class ModflowZon(Package):
         """
         return
 
-    @staticmethod
-    def load(f, model, nrow=None, ncol=None, ext_unit_dict=None):
+    @classmethod
+    def load(cls, f, model, nrow=None, ncol=None, ext_unit_dict=None):
         """
         Load an existing package.
 
@@ -224,7 +224,7 @@ class ModflowZon(Package):
                 ext_unit_dict, filetype=ModflowZon.ftype()
             )
 
-        zon = ModflowZon(
+        zon = cls(
             model,
             zone_dict=zone_dict,
             unitnumber=unitnumber,


### PR DESCRIPTION
In realtion to issue  #984
Modified almost every load method in the flopy/modflow/ classes, changing hard coded references to the class in a ```@staticmethod def load(f, ...)``` to ```@classmethod def load(cls, f, ...)```. This will allow for better subclassing and it's a more pythonic way to write alternative constructors, even if it's unlikely that many people will go that deep into subclassing the library.

The following files ```[mfchd, mfdrn, mfdrt, mfghb, mfriv, mfwel]``` didn't have their load methods altered because they used Package.load as an alternative constructor. Changing those to classmethod and replacing the class passed as a parameter to cls should acomplish the same as the applied changes.

```mfpar.py``` load method was not modified as it doesn't return an instance of the object (which seems weird).