### PR TITLE
refactor(numpy): patch modern flip function for versions older than 1.15.0

### DIFF
--- a/flopy/discretization/structuredgrid.py
+++ b/flopy/discretization/structuredgrid.py
@@ -2,6 +2,34 @@ import copy
 import numpy as np
 from .grid import Grid, CachedData
 
+try:
+    from numpy.lib import NumpyVersion
+
+    numpy115 = NumpyVersion(np.__version__) >= "1.15.0"
+except ImportError:
+    numpy115 = False
+
+if not numpy115:
+
+    def flip_numpy115(m, axis=None):
+        """Provide same behavior for np.flip since numpy 1.15.0."""
+        import numpy.core.numeric as _nx
+        from numpy.core.numeric import asarray
+
+        if not hasattr(m, "ndim"):
+            m = asarray(m)
+        if axis is None:
+            indexer = (np.s_[::-1],) * m.ndim
+        else:
+            axis = _nx.normalize_axis_tuple(axis, m.ndim)
+            indexer = [np.s_[:]] * m.ndim
+            for ax in axis:
+                indexer[ax] = np.s_[::-1]
+            indexer = tuple(indexer)
+        return m[indexer]
+
+    np.flip = flip_numpy115
+
 
 def array_at_verts_basic2d(a):
     """


### PR DESCRIPTION
This patches the flip function for numpy versions before 1.15.0 (released 24 Jul 2018). The modern `np.flip(m, axis=None)` function signature is used in a few recent flopy modules, which raise 13 errors in the autotest suite with older numpy releases (either "TypeError: flip() missing 1 required positional argument: 'axis'" or "TypeError: list indices must be integers or slices, not list"). These errors are resolved with the patched function.

For reference, compare `np.flip` when it was changed:

 * https://github.com/numpy/numpy/blob/v1.14.6/numpy/lib/function_base.py#L202-L210
 * https://github.com/numpy/numpy/blob/v1.15.0/numpy/lib/function_base.py#L228-L238
