### PR TITLE
fix(get_active) include the cbd layers when checking layer thickness …

### DIFF
--- a/flopy/utils/check.py
+++ b/flopy/utils/check.py
@@ -436,7 +436,8 @@ class check:
         """
         mg = self.model.modelgrid
         if mg.grid_type == "structured":
-            inds = (mg.nlay, mg.nrow, mg.ncol)
+            nlaycbd = mg._StructuredGrid__laycbd.sum() if include_cbd else 0
+            inds = (mg.nlay + nlaycbd, mg.nrow, mg.ncol)
         elif mg.grid_type == "vertex":
             inds = (mg.nlay, mg.ncpl)
         else:


### PR DESCRIPTION
DIS uses this function before BAS is loaded. There will be an error when there is a quasi 3-D confining bed layer, which is `active.shape != thickness.shape` (Line 784 in `mfdis.py`).