### PR TITLE
fix(DeprecationWarning): related to numpy

### DIFF
--- a/flopy/discretization/structuredgrid.py
+++ b/flopy/discretization/structuredgrid.py
@@ -195,7 +195,7 @@ class StructuredGrid(Grid):
         if laycbd is not None:
             self.__laycbd = laycbd
         else:
-            self.__laycbd = np.zeros(self.__nlay, dtype=int)
+            self.__laycbd = np.zeros(self.__nlay or (), dtype=int)
 
     ####################
     # Properties

--- a/flopy/utils/utils_def.py
+++ b/flopy/utils/utils_def.py
@@ -38,12 +38,8 @@ class FlopyBinaryData(object):
         return
 
     def read_text(self, nchar=20):
-        textvalue = self._read_values(self.character, nchar).tostring()
-        if not isinstance(textvalue, str):
-            textvalue = textvalue.decode().strip()
-        else:
-            textvalue = textvalue.strip()
-        return textvalue
+        bytesvalue = self._read_values(self.character, nchar).tobytes()
+        return bytesvalue.decode().strip()
 
     def read_integer(self):
         return self._read_values(self.integer, 1)[0]


### PR DESCRIPTION
Two unrelated NumPy DeprecationWarnings are fixed in this PR:
* Passing None into shape arguments as an alias for () is deprecated. See [NumPy 1.20.0 Release Notes](https://numpy.org/devdocs/release/1.20.0-notes.html#passing-shape-none-to-functions-with-a-non-optional-shape-argument-is-deprecated).
* tostring() is deprecated. Use tobytes() instead. See [NumPy 1.19.0 Release Notes](https://numpy.org/devdocs/release/1.19.0-notes.html#numpy-ndarray-tostring-is-deprecated-in-favor-of-tobytes).