### PR TITLE
fix(shapely): handle deprecation warnings from shapely 1.8

### DIFF
--- a/flopy/utils/geospatial_utils.py
+++ b/flopy/utils/geospatial_utils.py
@@ -330,7 +330,7 @@ class GeoSpatialCollection(object):
                     MultiPolygon,
                 ),
             ):
-                for geom in list(obj):
+                for geom in obj.geoms:
                     self.__collection.append(GeoSpatialUtil(geom))
 
     def __iter__(self):


### PR DESCRIPTION
Shapely 1.8 is in the pre-release stage, and has several deprecation warning messages. Some of these are in preparation for shapely 2.0, which has some breaking changes.

This PR aims to fix the ones that are revealed from the autotest suite. The context manager `ignore_shapely_warnings_for_object_array` is used to silence false-positive warnings when assigning shapely geometries to object arrays. It shouldn't be used for other legitimate deprecation warnings.