### PR TITLE
fix(mp7particledata): update dtype comparison for unstructured partlocs

### DIFF
--- a/flopy/modpath/mp7particledata.py
+++ b/flopy/modpath/mp7particledata.py
@@ -173,7 +173,7 @@ class ParticleData(object):
             partlocs = np.array(partlocs, dtype=dtype)
         elif isinstance(partlocs, np.ndarray):
             dtypein = partlocs.dtype
-            if dtypein != partlocs.dtype:
+            if dtypein != dtype:
                 partlocs = np.array(partlocs, dtype=dtype)
         else:
             msg = (


### PR DESCRIPTION
change dtypein comparison against dtype variable. dtypein was being compared against itself thus partlocs dtype didn't update