### PR TITLE
fix(utils/check) file checking for unstructured mfusg models

### DIFF
--- a/autotest/t038_test.py
+++ b/autotest/t038_test.py
@@ -28,7 +28,7 @@ def test_load_usg():
 # function to load a MODFLOW-USG model and then write it back out
 def load_model(namfile, model_ws):
     m = flopy.modflow.Modflow.load(namfile, model_ws=model_ws,
-                                   version='mfusg', verbose=True, check=False)
+                                   version='mfusg', verbose=True, check=True)
     assert m, 'Could not load namefile {}'.format(namfile)
     assert m.load_fail is False
     m.change_model_ws(tpth)

--- a/flopy/modflow/mf.py
+++ b/flopy/modflow/mf.py
@@ -841,12 +841,6 @@ class Modflow(BaseModel):
         )
         files_successfully_loaded.append(disnamdata.filename)
 
-        # make unstructured modelgrid so checker will work
-        # if 'DISU' in ml.get_package_list():
-        #    dis = ml.get_package("disu")
-        #    ncpl = dis.nodelay.array
-        #    return UnstructuredGrid(ncpl=ncpl)
-
         if ml.verbose:
             print("   {:4s} package load...success".format(dis.name[0]))
         assert ml.pop_key_list.pop() == dis_key

--- a/flopy/modflow/mf.py
+++ b/flopy/modflow/mf.py
@@ -840,7 +840,6 @@ class Modflow(BaseModel):
             disnamdata.filehandle, ml, ext_unit_dict=ext_unit_dict, check=False
         )
         files_successfully_loaded.append(disnamdata.filename)
-
         if ml.verbose:
             print("   {:4s} package load...success".format(dis.name[0]))
         assert ml.pop_key_list.pop() == dis_key

--- a/flopy/utils/__init__.py
+++ b/flopy/utils/__init__.py
@@ -53,7 +53,7 @@ from .mflistfile import (
     SwrListBudget,
     Mf6ListBudget,
 )
-from .check import check, get_neighbors
+from .check import check, get_neighbors, get_neighbors_u
 from .utils_def import FlopyBinaryData, totim_to_datetime
 from .flopy_io import read_fixed_var, write_fixed_var
 from .zonbud import (

--- a/flopy/utils/check.py
+++ b/flopy/utils/check.py
@@ -792,12 +792,14 @@ def get_neighbors_u(a, disu):
     ja = disu.ja.array - 1
     iac_sum = np.cumsum(disu.iac.array)
     ja_slices = np.asarray(
-        [np.s_[iac_sum[i - 1] + 1:x] if i > 0 else np.s_[1:x]
-         for i, x in enumerate(iac_sum)]
-        )  # note: this removes the diagonal - neighbors only
+        [
+            np.s_[iac_sum[i - 1] + 1 : x] if i > 0 else np.s_[1:x]
+            for i, x in enumerate(iac_sum)
+        ]
+    )  # note: this removes the diagonal - neighbors only
     neighbors = [ja[sl] for sl in ja_slices]
     a_neighbors = [a[n] for n in neighbors]
-    
+
     return a_neighbors
 
 

--- a/flopy/utils/check.py
+++ b/flopy/utils/check.py
@@ -435,7 +435,23 @@ class check:
             True where active.
         """
         mg = self.model.modelgrid
-        if mg.grid_type == "structured":
+        if not mg:  # if no modelgrid defined, use disu/dis to define inds
+            if "DIS" in self.model.get_package_list():
+                if include_cbd and dis.laycbd.sum() > 0:
+                    inds = (
+                        self.model.dis.nlay + dis.laycbd.sum(),
+                        self.model.dis.nrow,
+                        self.model.dis.ncol,
+                    )
+                else:
+                    inds = (
+                        self.model.dis.nlay,
+                        self.model.dis.nrow,
+                        self.model.dis.ncol,
+                    )
+            else:
+                inds = self.model.disu.nodes
+        elif mg.grid_type == "structured":
             nlaycbd = mg._StructuredGrid__laycbd.sum() if include_cbd else 0
             inds = (mg.nlay + nlaycbd, mg.nrow, mg.ncol)
         elif mg.grid_type == "vertex":
@@ -770,6 +786,37 @@ def get_neighbors(a):
         ]
     )  # j+1
     return neighbors.reshape(6, nk, ni, nj)
+
+
+def get_neighbors_u(a, disu):
+    """
+    Returns the n neighboring values for each value in a.
+
+    Parameters
+    ----------
+    a : 1-D numpy array of values for all nodes in the model
+        Model array in node order.
+    disu : flopy mfusg disu package
+
+
+    Returns
+    -------
+    neighbors : jagged list for each node in a, containing numpy arrays of
+        neighbouring values from a.
+    """
+
+    ja = disu.ja.array - 1
+    iac_sum = np.cumsum(disu.iac.array)
+    ja_slices = np.asarray(
+        [
+            np.s_[iac_sum[i - 1] + 1 : x] if i > 0 else np.s_[1:x]
+            for i, x in enumerate(iac_sum)
+        ]
+    )  # note: this removes the diagonal - neighbors only
+    neighbors = [ja[sl] for sl in ja_slices]
+    a_neighbors = [a[n] for n in neighbors]
+
+    return a_neighbors
 
 
 class mf6check(check):

--- a/flopy/utils/check.py
+++ b/flopy/utils/check.py
@@ -435,23 +435,7 @@ class check:
             True where active.
         """
         mg = self.model.modelgrid
-        if not mg:  # if no modelgrid defined, use disu/dis to define inds
-            if "DIS" in self.model.get_package_list():
-                if include_cbd and dis.laycbd.sum() > 0:
-                    inds = (
-                        self.model.dis.nlay + dis.laycbd.sum(),
-                        self.model.dis.nrow,
-                        self.model.dis.ncol,
-                    )
-                else:
-                    inds = (
-                        self.model.dis.nlay,
-                        self.model.dis.nrow,
-                        self.model.dis.ncol,
-                    )
-            else:
-                inds = self.model.disu.nodes
-        elif mg.grid_type == "structured":
+        if mg.grid_type == "structured":
             nlaycbd = mg._StructuredGrid__laycbd.sum() if include_cbd else 0
             inds = (mg.nlay + nlaycbd, mg.nrow, mg.ncol)
         elif mg.grid_type == "vertex":
@@ -808,14 +792,12 @@ def get_neighbors_u(a, disu):
     ja = disu.ja.array - 1
     iac_sum = np.cumsum(disu.iac.array)
     ja_slices = np.asarray(
-        [
-            np.s_[iac_sum[i - 1] + 1 : x] if i > 0 else np.s_[1:x]
-            for i, x in enumerate(iac_sum)
-        ]
-    )  # note: this removes the diagonal - neighbors only
+        [np.s_[iac_sum[i - 1] + 1:x] if i > 0 else np.s_[1:x]
+         for i, x in enumerate(iac_sum)]
+        )  # note: this removes the diagonal - neighbors only
     neighbors = [ja[sl] for sl in ja_slices]
     a_neighbors = [a[n] for n in neighbors]
-
+    
     return a_neighbors
 
 


### PR DESCRIPTION
Resolves #1072. Issues still need to be addressed to enable loading RCH and EVT, so users will still need to use "load_only=[]" to avoid trying to load those. E.g. m = flopy.modflow.Modflow.load(nam, model_ws = model_ws, version = 'mfusg', load_only = ['DISU', 'BAS6', 'LPF']).