### PR TITLE
fix(get_file_entry): "None" text removed from empty stress period data with aux variable (#1080)

### DIFF
--- a/flopy/mf6/data/mfdatalist.py
+++ b/flopy/mf6/data/mfdatalist.py
@@ -797,17 +797,18 @@ class MFList(mfdata.MFMultiDimVar, DataListInterface):
                             for aux_var_name in aux_var_names[0]:
                                 if aux_var_name.lower() != "auxiliary":
                                     data_val = data_line[index]
-                                    text_line.append(
-                                        to_string(
-                                            data_val,
-                                            data_item.type,
-                                            self._simulation_data,
-                                            self._data_dimensions,
-                                            data_item.is_cellid,
-                                            data_item.possible_cellid,
-                                            data_item,
+                                    if data_val is not None:
+                                        text_line.append(
+                                            to_string(
+                                                data_val,
+                                                data_item.type,
+                                                self._simulation_data,
+                                                self._data_dimensions,
+                                                data_item.is_cellid,
+                                                data_item.possible_cellid,
+                                                data_item,
+                                            )
                                         )
-                                    )
                                     index += 1
                     except Exception as ex:
                         type_, value_, traceback_ = sys.exc_info()


### PR DESCRIPTION
Fix for issue #1080.  MFList's get_file_entry no longer includes "None" text for empty stress periods when an aux variable is present.