### PR TITLE
refactor(super() function): use Python3 style described from PEP 3135

### DIFF
--- a/flopy/discretization/structuredgrid.py
+++ b/flopy/discretization/structuredgrid.py
@@ -154,7 +154,7 @@ class StructuredGrid(Grid):
         ncol=None,
         laycbd=None,
     ):
-        super(StructuredGrid, self).__init__(
+        super().__init__(
             "structured",
             top,
             botm,
@@ -211,7 +211,7 @@ class StructuredGrid(Grid):
         if (
             self.__delc is not None
             and self.__delr is not None
-            and super(StructuredGrid, self).is_complete
+            and super().is_complete
         ):
             return True
         return False
@@ -757,7 +757,7 @@ class StructuredGrid(Grid):
 
         """
         # transform x and y to local coordinates
-        x, y = super(StructuredGrid, self).intersect(x, y, local, forgive)
+        x, y = super().intersect(x, y, local, forgive)
 
         # get the cell edges in local coordinates
         xe, ye = self.xyedges

--- a/flopy/discretization/unstructuredgrid.py
+++ b/flopy/discretization/unstructuredgrid.py
@@ -91,7 +91,7 @@ class UnstructuredGrid(Grid):
         yoff=0.0,
         angrot=0.0,
     ):
-        super(UnstructuredGrid, self).__init__(
+        super().__init__(
             "unstructured",
             top,
             botm,
@@ -166,10 +166,7 @@ class UnstructuredGrid(Grid):
 
     @property
     def is_complete(self):
-        if (
-            self.is_valid is not None
-            and super(UnstructuredGrid, self).is_complete
-        ):
+        if self.is_valid is not None and super().is_complete:
             return True
         return False
 
@@ -347,7 +344,7 @@ class UnstructuredGrid(Grid):
         return copy.copy(self._polygons)
 
     def intersect(self, x, y, local=False, forgive=False):
-        x, y = super(UnstructuredGrid, self).intersect(x, y, local, forgive)
+        x, y = super().intersect(x, y, local, forgive)
         raise Exception("Not implemented yet")
 
     def get_cell_vertices(self, cellid):

--- a/flopy/discretization/vertexgrid.py
+++ b/flopy/discretization/vertexgrid.py
@@ -53,7 +53,7 @@ class VertexGrid(Grid):
         ncpl=None,
         cell1d=None,
     ):
-        super(VertexGrid, self).__init__(
+        super().__init__(
             "vertex",
             top,
             botm,
@@ -92,7 +92,7 @@ class VertexGrid(Grid):
         if (
             self._vertices is not None
             and (self._cell2d is not None or self._cell1d is not None)
-            and super(VertexGrid, self).is_complete
+            and super().is_complete
         ):
             return True
         return False
@@ -232,7 +232,7 @@ class VertexGrid(Grid):
 
         if local:
             # transform x and y to real-world coordinates
-            x, y = super(VertexGrid, self).get_coords(x, y)
+            x, y = super().get_coords(x, y)
         xv, yv, zv = self.xyzvertices
         for icell2d in range(self.ncpl):
             xa = np.array(xv[icell2d])

--- a/flopy/export/vtk.py
+++ b/flopy/export/vtk.py
@@ -159,7 +159,7 @@ class XmlWriterAscii(XmlWriterInterface):
     """
 
     def __init__(self, file_path):
-        super(XmlWriterAscii, self).__init__(file_path)
+        super().__init__(file_path)
 
     def _open_file(self, file_path):
         """
@@ -231,7 +231,7 @@ class XmlWriterBinary(XmlWriterInterface):
     """
 
     def __init__(self, file_path):
-        super(XmlWriterBinary, self).__init__(file_path)
+        super().__init__(file_path)
 
         if sys.byteorder == "little":
             self.byte_order = "<"
@@ -328,7 +328,7 @@ class XmlWriterBinary(XmlWriterInterface):
         self.close_element("AppendedData")
 
         # call super final
-        super(XmlWriterBinary, self).final()
+        super().final()
 
 
 class _Array(object):

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -1310,7 +1310,7 @@ class BaseModel(ModelInterface):
         if key == "free_format_input":
             # if self.bas6 is not None:
             #    self.bas6.ifrefm = value
-            super(BaseModel, self).__setattr__(key, value)
+            super().__setattr__(key, value)
         elif key == "name":
             self._set_name(value)
         elif key == "model_ws":
@@ -1346,7 +1346,7 @@ class BaseModel(ModelInterface):
                     "cannot set start_datetime -" "ModflowDis not found"
                 )
         else:
-            super(BaseModel, self).__setattr__(key, value)
+            super().__setattr__(key, value)
 
     def run_model(
         self,

--- a/flopy/mf6/coordinates/modelgrid.py
+++ b/flopy/mf6/coordinates/modelgrid.py
@@ -734,9 +734,7 @@ class UnstructuredModelGrid(ModelGrid):
     """
 
     def __init__(self, model_name, simulation_data):
-        super(UnstructuredModelGrid, self).__init__(
-            model_name, simulation_data, DiscretizationType.DISU
-        )
+        super().__init__(model_name, simulation_data, DiscretizationType.DISU)
 
     def __getitem__(self, index):
         return UnstructuredModelCell(

--- a/flopy/mf6/data/mfdata.py
+++ b/flopy/mf6/data/mfdata.py
@@ -489,7 +489,7 @@ class MFMultiDimVar(MFData):
         path=None,
         dimensions=None,
     ):
-        super(MFMultiDimVar, self).__init__(
+        super().__init__(
             sim_data, model_or_sim, structure, enable, path, dimensions
         )
 

--- a/flopy/mf6/data/mfdataarray.py
+++ b/flopy/mf6/data/mfdataarray.py
@@ -117,7 +117,7 @@ class MFArray(MFMultiDimVar):
         path=None,
         dimensions=None,
     ):
-        super(MFArray, self).__init__(
+        super().__init__(
             sim_data, model_or_sim, structure, enable, path, dimensions
         )
         if self.structure.layered:
@@ -204,7 +204,7 @@ class MFArray(MFMultiDimVar):
         elif name == "binary":
             self._get_storage_obj().layer_storage.first_item().binary = value
         else:
-            super(MFArray, self).__setattr__(name, value)
+            super().__setattr__(name, value)
 
     def __getitem__(self, k):
         if isinstance(k, int):
@@ -382,7 +382,7 @@ class MFArray(MFMultiDimVar):
             return True
 
     def new_simulation(self, sim_data):
-        super(MFArray, self).new_simulation(sim_data)
+        super().new_simulation(sim_data)
         self._data_storage = self._new_storage(False)
         self._layer_shape = (1,)
 
@@ -785,7 +785,7 @@ class MFArray(MFMultiDimVar):
         pre_data_comments=None,
         external_file_info=None,
     ):
-        super(MFArray, self).load(
+        super().load(
             first_line,
             file_handle,
             block_header,
@@ -1358,7 +1358,7 @@ class MFTransientArray(MFArray, MFTransient):
         path=None,
         dimensions=None,
     ):
-        super(MFTransientArray, self).__init__(
+        super().__init__(
             sim_data=sim_data,
             model_or_sim=model_or_sim,
             structure=structure,
@@ -1379,10 +1379,10 @@ class MFTransientArray(MFArray, MFTransient):
             del self._data_storage[transient_key]
 
     def add_transient_key(self, transient_key):
-        super(MFTransientArray, self).add_transient_key(transient_key)
-        self._data_storage[transient_key] = super(
-            MFTransientArray, self
-        )._new_storage(stress_period=transient_key)
+        super().add_transient_key(transient_key)
+        self._data_storage[transient_key] = super()._new_storage(
+            stress_period=transient_key
+        )
 
     def store_as_external_file(
         self,
@@ -1410,7 +1410,7 @@ class MFTransientArray(MFArray, MFTransient):
                 ):
                     fname, ext = os.path.splitext(external_file_path)
                     full_name = "{}_{}{}".format(fname, sp + 1, ext)
-                    super(MFTransientArray, self).store_as_external_file(
+                    super().store_as_external_file(
                         full_name,
                         layer,
                         binary,
@@ -1431,7 +1431,7 @@ class MFTransientArray(MFArray, MFTransient):
                     for sp in range(0, num_sp):
                         if sp in self._data_storage:
                             self.get_data_prep(sp)
-                            data = super(MFTransientArray, self).get_data(
+                            data = super().get_data(
                                 apply_mult=apply_mult, **kwargs
                             )
                             data = np.expand_dims(data, 0)
@@ -1439,7 +1439,7 @@ class MFTransientArray(MFArray, MFTransient):
                             if data is None:
                                 # get any data
                                 self.get_data_prep(self._data_storage.key()[0])
-                                data = super(MFTransientArray, self).get_data(
+                                data = super().get_data(
                                     apply_mult=apply_mult, **kwargs
                                 )
                                 data = np.expand_dims(data, 0)
@@ -1457,7 +1457,7 @@ class MFTransientArray(MFArray, MFTransient):
                         data = None
                         if sp in self._data_storage:
                             self.get_data_prep(sp)
-                            data = super(MFTransientArray, self).get_data(
+                            data = super().get_data(
                                 apply_mult=apply_mult, **kwargs
                             )
                         if output is None:
@@ -1473,9 +1473,7 @@ class MFTransientArray(MFArray, MFTransient):
                     return output
             else:
                 self.get_data_prep(layer)
-                return super(MFTransientArray, self).get_data(
-                    apply_mult=apply_mult
-                )
+                return super().get_data(apply_mult=apply_mult)
         else:
             return None
 
@@ -1490,9 +1488,7 @@ class MFTransientArray(MFArray, MFTransient):
                     del_keys.append(key)
                 else:
                     self._set_data_prep(list_item, key)
-                    super(MFTransientArray, self).set_data(
-                        list_item, multiplier, layer
-                    )
+                    super().set_data(list_item, multiplier, layer)
             for key in del_keys:
                 del data[key]
         else:
@@ -1511,15 +1507,13 @@ class MFTransientArray(MFArray, MFTransient):
                 self.remove_transient_key(key)
             else:
                 self._set_data_prep(data, key)
-                super(MFTransientArray, self).set_data(data, multiplier, layer)
+                super().set_data(data, multiplier, layer)
 
     def get_file_entry(
         self, key=0, ext_file_action=ExtFileAction.copy_relative_paths
     ):
         self._get_file_entry_prep(key)
-        return super(MFTransientArray, self).get_file_entry(
-            ext_file_action=ext_file_action
-        )
+        return super().get_file_entry(ext_file_action=ext_file_action)
 
     def load(
         self,
@@ -1530,7 +1524,7 @@ class MFTransientArray(MFArray, MFTransient):
         external_file_info=None,
     ):
         self._load_prep(block_header)
-        return super(MFTransientArray, self).load(
+        return super().load(
             first_line, file_handle, pre_data_comments, external_file_info
         )
 
@@ -1540,7 +1534,7 @@ class MFTransientArray(MFArray, MFTransient):
         if base_storage:
             if not isinstance(stress_period, int):
                 stress_period = 1
-            return super(MFTransientArray, self)._new_storage(
+            return super()._new_storage(
                 set_layers, base_storage, stress_period
             )
         else:

--- a/flopy/mf6/data/mfdatalist.py
+++ b/flopy/mf6/data/mfdatalist.py
@@ -122,7 +122,7 @@ class MFList(mfdata.MFMultiDimVar, DataListInterface):
         dimensions=None,
         package=None,
     ):
-        super(MFList, self).__init__(
+        super().__init__(
             sim_data, model_or_sim, structure, enable, path, dimensions
         )
         try:
@@ -251,7 +251,7 @@ class MFList(mfdata.MFMultiDimVar, DataListInterface):
 
     def new_simulation(self, sim_data):
         try:
-            super(MFList, self).new_simulation(sim_data)
+            super().new_simulation(sim_data)
             self._data_storage = self._new_storage()
         except Exception as ex:
             type_, value_, traceback_ = sys.exc_info()
@@ -1124,7 +1124,7 @@ class MFList(mfdata.MFMultiDimVar, DataListInterface):
         pre_data_comments=None,
         external_file_info=None,
     ):
-        super(MFList, self).load(
+        super().load(
             first_line, file_handle, block_header, pre_data_comments=None
         )
         self._resync()
@@ -1309,7 +1309,7 @@ class MFTransientList(MFList, mfdata.MFTransient, DataListInterface):
         dimensions=None,
         package=None,
     ):
-        super(MFTransientList, self).__init__(
+        super().__init__(
             sim_data=sim_data,
             model_or_sim=model_or_sim,
             structure=structure,
@@ -1425,21 +1425,19 @@ class MFTransientList(MFList, mfdata.MFTransient, DataListInterface):
                     yield name, m3d
 
     def to_array(self, kper=0, mask=False):
-        return super(MFTransientList, self).to_array(kper, mask)
+        return super().to_array(kper, mask)
 
     def remove_transient_key(self, transient_key):
         if transient_key in self._data_storage:
             del self._data_storage[transient_key]
 
     def add_transient_key(self, transient_key):
-        super(MFTransientList, self).add_transient_key(transient_key)
+        super().add_transient_key(transient_key)
         if isinstance(transient_key, int):
             stress_period = transient_key
         else:
             stress_period = 1
-        self._data_storage[transient_key] = super(
-            MFTransientList, self
-        )._new_storage(stress_period)
+        self._data_storage[transient_key] = super()._new_storage(stress_period)
 
     @property
     def data(self):
@@ -1469,7 +1467,7 @@ class MFTransientList(MFList, mfdata.MFTransient, DataListInterface):
                 ):
                     fname, ext = os.path.splitext(external_file_path)
                     full_name = "{}_{}{}".format(fname, sp + 1, ext)
-                    super(MFTransientList, self).store_as_external_file(
+                    super().store_as_external_file(
                         full_name,
                         binary,
                         replace_existing_external,
@@ -1489,9 +1487,7 @@ class MFTransientList(MFList, mfdata.MFTransient, DataListInterface):
                         if sp in self._data_storage:
                             self.get_data_prep(sp)
                             output.append(
-                                super(MFTransientList, self).get_data(
-                                    apply_mult=apply_mult
-                                )
+                                super().get_data(apply_mult=apply_mult)
                             )
                         else:
                             output.append(None)
@@ -1500,12 +1496,10 @@ class MFTransientList(MFList, mfdata.MFTransient, DataListInterface):
                     output = {}
                     for key in self._data_storage.keys():
                         self.get_data_prep(key)
-                        output[key] = super(MFTransientList, self).get_data(
-                            apply_mult=apply_mult
-                        )
+                        output[key] = super().get_data(apply_mult=apply_mult)
                     return output
             self.get_data_prep(key)
-            return super(MFTransientList, self).get_data(apply_mult=apply_mult)
+            return super().get_data(apply_mult=apply_mult)
         else:
             return None
 
@@ -1521,14 +1515,12 @@ class MFTransientList(MFList, mfdata.MFTransient, DataListInterface):
                         del_keys.append(key)
                     else:
                         self._set_data_prep(list_item, key)
-                        super(MFTransientList, self).set_data(
-                            list_item, autofill=autofill
-                        )
+                        super().set_data(list_item, autofill=autofill)
                 for key in del_keys:
                     del data[key]
             else:
                 self._set_data_prep(data["data"], key)
-                super(MFTransientList, self).set_data(data, autofill)
+                super().set_data(data, autofill)
         else:
             if key is None:
                 # search for a key
@@ -1541,15 +1533,13 @@ class MFTransientList(MFList, mfdata.MFTransient, DataListInterface):
                 self.remove_transient_key(key)
             else:
                 self._set_data_prep(data, key)
-                super(MFTransientList, self).set_data(data, autofill)
+                super().set_data(data, autofill)
 
     def get_file_entry(
         self, key=0, ext_file_action=ExtFileAction.copy_relative_paths
     ):
         self._get_file_entry_prep(key)
-        return super(MFTransientList, self).get_file_entry(
-            ext_file_action=ext_file_action
-        )
+        return super().get_file_entry(ext_file_action=ext_file_action)
 
     def load(
         self,
@@ -1560,7 +1550,7 @@ class MFTransientList(MFList, mfdata.MFTransient, DataListInterface):
         external_file_info=None,
     ):
         self._load_prep(block_header)
-        return super(MFTransientList, self).load(
+        return super().load(
             first_line,
             file_handle,
             block_header,
@@ -1570,11 +1560,11 @@ class MFTransientList(MFList, mfdata.MFTransient, DataListInterface):
 
     def append_list_as_record(self, record, key=0):
         self._append_list_as_record_prep(record, key)
-        super(MFTransientList, self).append_list_as_record(record)
+        super().append_list_as_record(record)
 
     def update_record(self, record, key_index, key=0):
         self._update_record_prep(key)
-        super(MFTransientList, self).update_record(record, key_index)
+        super().update_record(record, key_index)
 
     def _new_storage(self, stress_period=0):
         return OrderedDict()
@@ -1721,7 +1711,7 @@ class MFMultipleList(MFTransientList):
         dimensions=None,
         package=None,
     ):
-        super(MFMultipleList, self).__init__(
+        super().__init__(
             sim_data=sim_data,
             model_or_sim=model_or_sim,
             structure=structure,
@@ -1732,6 +1722,4 @@ class MFMultipleList(MFTransientList):
         )
 
     def get_data(self, key=None, apply_mult=False, **kwargs):
-        return super(MFMultipleList, self).get_data(
-            key=key, apply_mult=apply_mult, **kwargs
-        )
+        return super().get_data(key=key, apply_mult=apply_mult, **kwargs)

--- a/flopy/mf6/data/mfdatascalar.py
+++ b/flopy/mf6/data/mfdatascalar.py
@@ -82,7 +82,7 @@ class MFScalar(mfdata.MFData):
         path=None,
         dimensions=None,
     ):
-        super(MFScalar, self).__init__(
+        super().__init__(
             sim_data, model_or_sim, structure, enable, path, dimensions
         )
         self._data_type = self.structure.data_item_structures[0].type
@@ -570,7 +570,7 @@ class MFScalar(mfdata.MFData):
         pre_data_comments=None,
         external_file_info=None,
     ):
-        super(MFScalar, self).load(
+        super().load(
             first_line,
             file_handle,
             block_header,
@@ -703,7 +703,7 @@ class MFScalarTransient(MFScalar, mfdata.MFTransient):
         path=None,
         dimensions=None,
     ):
-        super(MFScalarTransient, self).__init__(
+        super().__init__(
             sim_data=sim_data,
             model_or_sim=model_or_sim,
             structure=structure,
@@ -726,37 +726,33 @@ class MFScalarTransient(MFScalar, mfdata.MFTransient):
             return True
 
     def add_transient_key(self, key):
-        super(MFScalarTransient, self).add_transient_key(key)
+        super().add_transient_key(key)
         if isinstance(key, int):
             stress_period = key
         else:
             stress_period = 1
-        self._data_storage[key] = super(MFScalarTransient, self)._new_storage(
-            stress_period
-        )
+        self._data_storage[key] = super()._new_storage(stress_period)
 
     def add_one(self, key=0):
         self._update_record_prep(key)
-        super(MFScalarTransient, self).add_one()
+        super().add_one()
 
     def has_data(self, key=None):
         if key is None:
             data_found = False
             for sto_key in self._data_storage.keys():
                 self.get_data_prep(sto_key)
-                data_found = (
-                    data_found or super(MFScalarTransient, self).has_data()
-                )
+                data_found = data_found or super().has_data()
                 if data_found:
                     break
         else:
             self.get_data_prep(key)
-            data_found = super(MFScalarTransient, self).has_data()
+            data_found = super().has_data()
         return data_found
 
     def get_data(self, key=0, **kwargs):
         self.get_data_prep(key)
-        return super(MFScalarTransient, self).get_data()
+        return super().get_data()
 
     def set_data(self, data, key=None):
         if isinstance(data, dict) or isinstance(data, OrderedDict):
@@ -764,10 +760,10 @@ class MFScalarTransient(MFScalar, mfdata.MFTransient):
             # the dictionary key is the stress period the list is for
             for key, list_item in data.items():
                 self._set_data_prep(list_item, key)
-                super(MFScalarTransient, self).set_data(list_item)
+                super().set_data(list_item)
         else:
             self._set_data_prep(data, key)
-            super(MFScalarTransient, self).set_data(data)
+            super().set_data(data)
 
     def get_file_entry(
         self, key=None, ext_file_action=ExtFileAction.copy_relative_paths
@@ -777,7 +773,7 @@ class MFScalarTransient(MFScalar, mfdata.MFTransient):
             for sto_key in self._data_storage.keys():
                 if self.has_data(sto_key):
                     self._get_file_entry_prep(sto_key)
-                    text_entry = super(MFScalarTransient, self).get_file_entry(
+                    text_entry = super().get_file_entry(
                         ext_file_action=ext_file_action
                     )
                     file_entry.append(text_entry)
@@ -789,9 +785,7 @@ class MFScalarTransient(MFScalar, mfdata.MFTransient):
                 return ""
         else:
             self._get_file_entry_prep(key)
-            return super(MFScalarTransient, self).get_file_entry(
-                ext_file_action=ext_file_action
-            )
+            return super().get_file_entry(ext_file_action=ext_file_action)
 
     def load(
         self,
@@ -802,7 +796,7 @@ class MFScalarTransient(MFScalar, mfdata.MFTransient):
         external_file_info=None,
     ):
         self._load_prep(block_header)
-        return super(MFScalarTransient, self).load(
+        return super().load(
             first_line, file_handle, pre_data_comments, external_file_info
         )
 

--- a/flopy/mf6/data/mfdatautil.py
+++ b/flopy/mf6/data/mfdatautil.py
@@ -506,7 +506,7 @@ class ArrayTemplateGenerator(TemplateGenerator):
     """
 
     def __init__(self, path):
-        super(ArrayTemplateGenerator, self).__init__(path)
+        super().__init__(path)
 
     def empty(
         self,
@@ -670,7 +670,7 @@ class ListTemplateGenerator(TemplateGenerator):
     """
 
     def __init__(self, path):
-        super(ListTemplateGenerator, self).__init__(path)
+        super().__init__(path)
 
     def _build_template_data(self, type_list):
         template_data = []

--- a/flopy/mf6/data/mffileaccess.py
+++ b/flopy/mf6/data/mffileaccess.py
@@ -199,7 +199,7 @@ class MFFileAccessArray(MFFileAccess):
     def __init__(
         self, structure, data_dimensions, simulation_data, path, current_key
     ):
-        super(MFFileAccessArray, self).__init__(
+        super().__init__(
             structure, data_dimensions, simulation_data, path, current_key
         )
 
@@ -975,7 +975,7 @@ class MFFileAccessList(MFFileAccess):
     def __init__(
         self, structure, data_dimensions, simulation_data, path, current_key
     ):
-        super(MFFileAccessList, self).__init__(
+        super().__init__(
             structure, data_dimensions, simulation_data, path, current_key
         )
 
@@ -2161,7 +2161,7 @@ class MFFileAccessScalar(MFFileAccess):
     def __init__(
         self, structure, data_dimensions, simulation_data, path, current_key
     ):
-        super(MFFileAccessScalar, self).__init__(
+        super().__init__(
             structure, data_dimensions, simulation_data, path, current_key
         )
 

--- a/flopy/mf6/data/mfstructure.py
+++ b/flopy/mf6/data/mfstructure.py
@@ -206,7 +206,7 @@ class DfnPackage(Dfn):
     """
 
     def __init__(self, package):
-        super(DfnPackage, self).__init__()
+        super().__init__()
         self.package = package
         self.package_type = package._package_type
         self.dfn_file_name = package.dfn_file_name
@@ -468,7 +468,7 @@ class DfnFile(Dfn):
     """
 
     def __init__(self, file):
-        super(DfnFile, self).__init__()
+        super().__init__()
 
         dfn_path, tail = os.path.split(os.path.realpath(__file__))
         dfn_path = os.path.join(dfn_path, "dfn")
@@ -2422,7 +2422,7 @@ class MFStructure(object):
 
     def __new__(cls, internal_request=False, load_from_dfn_files=False):
         if cls._instance is None:
-            cls._instance = super(MFStructure, cls).__new__(cls)
+            cls._instance = super().__new__(cls)
 
             # Initialize variables
             cls._instance.mf_version = 6

--- a/flopy/mf6/mfmodel.py
+++ b/flopy/mf6/mfmodel.py
@@ -114,7 +114,7 @@ class MFModel(PackageContainer, ModelInterface):
         verbose=False,
         **kwargs
     ):
-        super(MFModel, self).__init__(simulation.simulation_data, modelname)
+        super().__init__(simulation.simulation_data, modelname)
         self.simulation = simulation
         self.simulation_data = simulation.simulation_data
         self.name = modelname

--- a/flopy/mf6/mfpackage.py
+++ b/flopy/mf6/mfpackage.py
@@ -1475,9 +1475,7 @@ class MFPackage(PackageContainer, PackageInterface):
                 model_or_sim.simulation_data.debug,
             )
 
-        super(MFPackage, self).__init__(
-            model_or_sim.simulation_data, self.model_name
-        )
+        super().__init__(model_or_sim.simulation_data, self.model_name)
 
         self.parent = model_or_sim
         self._simulation_data = model_or_sim.simulation_data
@@ -1578,7 +1576,7 @@ class MFPackage(PackageContainer, PackageInterface):
                         package=self._get_pname(),
                     )
                 return
-        super(MFPackage, self).__setattr__(name, value)
+        super().__setattr__(name, value)
 
     def __repr__(self):
         return self._get_data_str(True)
@@ -1644,7 +1642,7 @@ class MFPackage(PackageContainer, PackageInterface):
     def check(self, f=None, verbose=True, level=1, checktype=None):
         if checktype is None:
             checktype = mf6check
-        return super(MFPackage, self).check(f, verbose, level, checktype)
+        return super().check(f, verbose, level, checktype)
 
     def _get_nan_exclusion_list(self):
         excl_list = []
@@ -2453,7 +2451,7 @@ class MFChildPackages(object):
             package = self._packages[0]
             setattr(package, key, value)
             return
-        super(MFChildPackages, self).__setattr__(key, value)
+        super().__setattr__(key, value)
 
     def __default_file_path_base(self, file_path, suffix=""):
         stem = os.path.split(file_path)[1]

--- a/flopy/mf6/modflow/mfgnc.py
+++ b/flopy/mf6/modflow/mfgnc.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -202,7 +202,7 @@ class ModflowGnc(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGnc, self).__init__(
+        super().__init__(
             simulation, "gnc", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwf.py
+++ b/flopy/mf6/modflow/mfgwf.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfmodel
 from ..data.mfdatautil import ListTemplateGenerator, ArrayTemplateGenerator
 
@@ -93,7 +93,7 @@ class ModflowGwf(mfmodel.MFModel):
         packages=None,
         **kwargs
     ):
-        super(ModflowGwf, self).__init__(
+        super().__init__(
             simulation,
             model_type="gwf6",
             modelname=modelname,

--- a/flopy/mf6/modflow/mfgwfbuy.py
+++ b/flopy/mf6/modflow/mfgwfbuy.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -234,7 +234,7 @@ class ModflowGwfbuy(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwfbuy, self).__init__(
+        super().__init__(
             model, "buy", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwfchd.py
+++ b/flopy/mf6/modflow/mfgwfchd.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -322,7 +322,7 @@ class ModflowGwfchd(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwfchd, self).__init__(
+        super().__init__(
             model, "chd", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwfcsub.py
+++ b/flopy/mf6/modflow/mfgwfcsub.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator, ArrayTemplateGenerator
 
@@ -1038,7 +1038,7 @@ class ModflowGwfcsub(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwfcsub, self).__init__(
+        super().__init__(
             model, "csub", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwfdis.py
+++ b/flopy/mf6/modflow/mfgwfdis.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator
 
@@ -214,7 +214,7 @@ class ModflowGwfdis(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwfdis, self).__init__(
+        super().__init__(
             model, "dis", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwfdisu.py
+++ b/flopy/mf6/modflow/mfgwfdisu.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -452,7 +452,7 @@ class ModflowGwfdisu(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwfdisu, self).__init__(
+        super().__init__(
             model, "disu", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwfdisv.py
+++ b/flopy/mf6/modflow/mfgwfdisv.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -311,7 +311,7 @@ class ModflowGwfdisv(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwfdisv, self).__init__(
+        super().__init__(
             model, "disv", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwfdrn.py
+++ b/flopy/mf6/modflow/mfgwfdrn.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -372,7 +372,7 @@ class ModflowGwfdrn(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwfdrn, self).__init__(
+        super().__init__(
             model, "drn", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwfevt.py
+++ b/flopy/mf6/modflow/mfgwfevt.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -439,7 +439,7 @@ class ModflowGwfevt(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwfevt, self).__init__(
+        super().__init__(
             model, "evt", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwfevta.py
+++ b/flopy/mf6/modflow/mfgwfevta.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator, ArrayTemplateGenerator
 
@@ -322,7 +322,7 @@ class ModflowGwfevta(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwfevta, self).__init__(
+        super().__init__(
             model, "evta", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwfghb.py
+++ b/flopy/mf6/modflow/mfgwfghb.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -352,7 +352,7 @@ class ModflowGwfghb(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwfghb, self).__init__(
+        super().__init__(
             model, "ghb", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwfgnc.py
+++ b/flopy/mf6/modflow/mfgwfgnc.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -202,7 +202,7 @@ class ModflowGwfgnc(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwfgnc, self).__init__(
+        super().__init__(
             model, "gnc", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwfgwf.py
+++ b/flopy/mf6/modflow/mfgwfgwf.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -438,7 +438,7 @@ class ModflowGwfgwf(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwfgwf, self).__init__(
+        super().__init__(
             simulation, "gwfgwf", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwfgwt.py
+++ b/flopy/mf6/modflow/mfgwfgwt.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 
 
@@ -50,7 +50,7 @@ class ModflowGwfgwt(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwfgwt, self).__init__(
+        super().__init__(
             simulation, "gwfgwt", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwfhfb.py
+++ b/flopy/mf6/modflow/mfgwfhfb.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -147,7 +147,7 @@ class ModflowGwfhfb(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwfhfb, self).__init__(
+        super().__init__(
             model, "hfb", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwfic.py
+++ b/flopy/mf6/modflow/mfgwfic.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator
 
@@ -65,7 +65,7 @@ class ModflowGwfic(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwfic, self).__init__(
+        super().__init__(
             model, "ic", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwflak.py
+++ b/flopy/mf6/modflow/mfgwflak.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -1220,7 +1220,7 @@ class ModflowGwflak(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwflak, self).__init__(
+        super().__init__(
             model, "lak", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwfmaw.py
+++ b/flopy/mf6/modflow/mfgwfmaw.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -1031,7 +1031,7 @@ class ModflowGwfmaw(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwfmaw, self).__init__(
+        super().__init__(
             model, "maw", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwfmvr.py
+++ b/flopy/mf6/modflow/mfgwfmvr.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -334,7 +334,7 @@ class ModflowGwfmvr(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwfmvr, self).__init__(
+        super().__init__(
             model, "mvr", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwfnam.py
+++ b/flopy/mf6/modflow/mfgwfnam.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -175,7 +175,7 @@ class ModflowGwfnam(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwfnam, self).__init__(
+        super().__init__(
             model, "nam", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwfnpf.py
+++ b/flopy/mf6/modflow/mfgwfnpf.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator, ArrayTemplateGenerator
 
@@ -462,7 +462,7 @@ class ModflowGwfnpf(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwfnpf, self).__init__(
+        super().__init__(
             model, "npf", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwfoc.py
+++ b/flopy/mf6/modflow/mfgwfoc.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -369,7 +369,7 @@ class ModflowGwfoc(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwfoc, self).__init__(
+        super().__init__(
             model, "oc", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwfrch.py
+++ b/flopy/mf6/modflow/mfgwfrch.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -337,7 +337,7 @@ class ModflowGwfrch(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwfrch, self).__init__(
+        super().__init__(
             model, "rch", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwfrcha.py
+++ b/flopy/mf6/modflow/mfgwfrcha.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator, ArrayTemplateGenerator
 
@@ -303,7 +303,7 @@ class ModflowGwfrcha(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwfrcha, self).__init__(
+        super().__init__(
             model, "rcha", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwfriv.py
+++ b/flopy/mf6/modflow/mfgwfriv.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -363,7 +363,7 @@ class ModflowGwfriv(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwfriv, self).__init__(
+        super().__init__(
             model, "riv", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwfsfr.py
+++ b/flopy/mf6/modflow/mfgwfsfr.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -1105,7 +1105,7 @@ class ModflowGwfsfr(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwfsfr, self).__init__(
+        super().__init__(
             model, "sfr", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwfsto.py
+++ b/flopy/mf6/modflow/mfgwfsto.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator
 
@@ -163,7 +163,7 @@ class ModflowGwfsto(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwfsto, self).__init__(
+        super().__init__(
             model, "sto", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwfuzf.py
+++ b/flopy/mf6/modflow/mfgwfuzf.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -783,7 +783,7 @@ class ModflowGwfuzf(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwfuzf, self).__init__(
+        super().__init__(
             model, "uzf", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwfwel.py
+++ b/flopy/mf6/modflow/mfgwfwel.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -355,7 +355,7 @@ class ModflowGwfwel(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwfwel, self).__init__(
+        super().__init__(
             model, "wel", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwt.py
+++ b/flopy/mf6/modflow/mfgwt.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfmodel
 from ..data.mfdatautil import ListTemplateGenerator, ArrayTemplateGenerator
 
@@ -87,7 +87,7 @@ class ModflowGwt(mfmodel.MFModel):
         packages=None,
         **kwargs
     ):
-        super(ModflowGwt, self).__init__(
+        super().__init__(
             simulation,
             model_type="gwt6",
             modelname=modelname,

--- a/flopy/mf6/modflow/mfgwtadv.py
+++ b/flopy/mf6/modflow/mfgwtadv.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 
 
@@ -55,7 +55,7 @@ class ModflowGwtadv(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwtadv, self).__init__(
+        super().__init__(
             model, "adv", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwtcnc.py
+++ b/flopy/mf6/modflow/mfgwtcnc.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -322,7 +322,7 @@ class ModflowGwtcnc(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwtcnc, self).__init__(
+        super().__init__(
             model, "cnc", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwtdis.py
+++ b/flopy/mf6/modflow/mfgwtdis.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator
 
@@ -214,7 +214,7 @@ class ModflowGwtdis(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwtdis, self).__init__(
+        super().__init__(
             model, "dis", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwtdisu.py
+++ b/flopy/mf6/modflow/mfgwtdisu.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -427,7 +427,7 @@ class ModflowGwtdisu(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwtdisu, self).__init__(
+        super().__init__(
             model, "disu", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwtdisv.py
+++ b/flopy/mf6/modflow/mfgwtdisv.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -311,7 +311,7 @@ class ModflowGwtdisv(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwtdisv, self).__init__(
+        super().__init__(
             model, "disv", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwtdsp.py
+++ b/flopy/mf6/modflow/mfgwtdsp.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator
 
@@ -174,7 +174,7 @@ class ModflowGwtdsp(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwtdsp, self).__init__(
+        super().__init__(
             model, "dsp", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwtfmi.py
+++ b/flopy/mf6/modflow/mfgwtfmi.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -109,7 +109,7 @@ class ModflowGwtfmi(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwtfmi, self).__init__(
+        super().__init__(
             model, "fmi", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwtic.py
+++ b/flopy/mf6/modflow/mfgwtic.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator
 
@@ -59,7 +59,7 @@ class ModflowGwtic(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwtic, self).__init__(
+        super().__init__(
             model, "ic", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwtist.py
+++ b/flopy/mf6/modflow/mfgwtist.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator, ArrayTemplateGenerator
 
@@ -339,7 +339,7 @@ class ModflowGwtist(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwtist, self).__init__(
+        super().__init__(
             model, "ist", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwtlkt.py
+++ b/flopy/mf6/modflow/mfgwtlkt.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -630,7 +630,7 @@ class ModflowGwtlkt(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwtlkt, self).__init__(
+        super().__init__(
             model, "lkt", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwtmst.py
+++ b/flopy/mf6/modflow/mfgwtmst.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator
 
@@ -199,7 +199,7 @@ class ModflowGwtmst(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwtmst, self).__init__(
+        super().__init__(
             model, "mst", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwtmvt.py
+++ b/flopy/mf6/modflow/mfgwtmvt.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -129,7 +129,7 @@ class ModflowGwtmvt(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwtmvt, self).__init__(
+        super().__init__(
             model, "mvt", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwtmwt.py
+++ b/flopy/mf6/modflow/mfgwtmwt.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -574,7 +574,7 @@ class ModflowGwtmwt(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwtmwt, self).__init__(
+        super().__init__(
             model, "mwt", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwtnam.py
+++ b/flopy/mf6/modflow/mfgwtnam.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -147,7 +147,7 @@ class ModflowGwtnam(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwtnam, self).__init__(
+        super().__init__(
             model, "nam", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwtoc.py
+++ b/flopy/mf6/modflow/mfgwtoc.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -370,7 +370,7 @@ class ModflowGwtoc(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwtoc, self).__init__(
+        super().__init__(
             model, "oc", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwtsft.py
+++ b/flopy/mf6/modflow/mfgwtsft.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -627,7 +627,7 @@ class ModflowGwtsft(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwtsft, self).__init__(
+        super().__init__(
             model, "sft", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwtsrc.py
+++ b/flopy/mf6/modflow/mfgwtsrc.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -324,7 +324,7 @@ class ModflowGwtsrc(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwtsrc, self).__init__(
+        super().__init__(
             model, "src", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwtssm.py
+++ b/flopy/mf6/modflow/mfgwtssm.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -133,7 +133,7 @@ class ModflowGwtssm(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwtssm, self).__init__(
+        super().__init__(
             model, "ssm", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfgwtuzt.py
+++ b/flopy/mf6/modflow/mfgwtuzt.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -594,7 +594,7 @@ class ModflowGwtuzt(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowGwtuzt, self).__init__(
+        super().__init__(
             model, "uzt", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfims.py
+++ b/flopy/mf6/modflow/mfims.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -734,7 +734,7 @@ class ModflowIms(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowIms, self).__init__(
+        super().__init__(
             simulation, "ims", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfmvr.py
+++ b/flopy/mf6/modflow/mfmvr.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -334,7 +334,7 @@ class ModflowMvr(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowMvr, self).__init__(
+        super().__init__(
             simulation, "mvr", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfnam.py
+++ b/flopy/mf6/modflow/mfnam.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -260,7 +260,7 @@ class ModflowNam(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowNam, self).__init__(
+        super().__init__(
             simulation, "nam", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfsimulation.py
+++ b/flopy/mf6/modflow/mfsimulation.py
@@ -423,7 +423,7 @@ class MFSimulation(PackageContainer):
         memory_print_option=None,
         write_headers=True,
     ):
-        super(MFSimulation, self).__init__(MFSimulationData(sim_ws), sim_name)
+        super().__init__(MFSimulationData(sim_ws), sim_name)
         self.simulation_data.verbosity_level = self._resolve_verbosity_level(
             verbosity_level
         )

--- a/flopy/mf6/modflow/mftdis.py
+++ b/flopy/mf6/modflow/mftdis.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -127,7 +127,7 @@ class ModflowTdis(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowTdis, self).__init__(
+        super().__init__(
             simulation, "tdis", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfutllaktab.py
+++ b/flopy/mf6/modflow/mfutllaktab.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -124,7 +124,7 @@ class ModflowUtllaktab(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowUtllaktab, self).__init__(
+        super().__init__(
             model, "tab", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfutlobs.py
+++ b/flopy/mf6/modflow/mfutlobs.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -188,7 +188,7 @@ class ModflowUtlobs(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowUtlobs, self).__init__(
+        super().__init__(
             model, "obs", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfutltas.py
+++ b/flopy/mf6/modflow/mfutltas.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator, ArrayTemplateGenerator
 
@@ -171,7 +171,7 @@ class ModflowUtltas(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowUtltas, self).__init__(
+        super().__init__(
             model, "tas", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/modflow/mfutlts.py
+++ b/flopy/mf6/modflow/mfutlts.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on February 18, 2021 16:23:05 UTC
+# FILE created on March 19, 2021 03:08:37 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -240,7 +240,7 @@ class ModflowUtlts(mfpackage.MFPackage):
         pname=None,
         parent_file=None,
     ):
-        super(ModflowUtlts, self).__init__(
+        super().__init__(
             model, "ts", filename, pname, loading_package, parent_file
         )
 

--- a/flopy/mf6/utils/createpackages.py
+++ b/flopy/mf6/utils/createpackages.py
@@ -659,10 +659,7 @@ def create_packages():
             init_var = "simulation"
         else:
             init_var = "model"
-        parent_init_string = (
-            "        super(Modflow{}, self)"
-            ".__init__(".format(package_name.title())
-        )
+        parent_init_string = "        super().__init__("
         spaces = " " * len(parent_init_string)
         parent_init_string = (
             '{}{}, "{}", filename, pname,\n{}'
@@ -826,10 +823,7 @@ def create_packages():
                 model_name, model_name
             )
             class_var_string = "    model_type = '{}'\n".format(model_name)
-            mparent_init_string = (
-                "        super(Modflow{}, self)"
-                ".__init__(".format(model_name.capitalize())
-            )
+            mparent_init_string = "        super().__init__("
             spaces = " " * len(mparent_init_string)
             mparent_init_string = (
                 "{}simulation, model_type='{}6',\n{}"

--- a/flopy/mf6/utils/reference.py
+++ b/flopy/mf6/utils/reference.py
@@ -139,35 +139,21 @@ class StructuredSpatialReference(object):
     def __setattr__(self, key, value):
         reset = True
         if key == "delr":
-            super(StructuredSpatialReference, self).__setattr__(
-                "delr", np.atleast_1d(np.array(value))
-            )
+            super().__setattr__("delr", np.atleast_1d(np.array(value)))
         elif key == "delc":
-            super(StructuredSpatialReference, self).__setattr__(
-                "delc", np.atleast_1d(np.array(value))
-            )
+            super().__setattr__("delc", np.atleast_1d(np.array(value)))
         elif key == "xul":
-            super(StructuredSpatialReference, self).__setattr__(
-                "xul", float(value)
-            )
+            super().__setattr__("xul", float(value))
         elif key == "yul":
-            super(StructuredSpatialReference, self).__setattr__(
-                "yul", float(value)
-            )
+            super().__setattr__("yul", float(value))
         elif key == "rotation":
-            super(StructuredSpatialReference, self).__setattr__(
-                "rotation", float(value)
-            )
+            super().__setattr__("rotation", float(value))
         elif key == "lenuni":
-            super(StructuredSpatialReference, self).__setattr__(
-                "lenuni", int(value)
-            )
+            super().__setattr__("lenuni", int(value))
         elif key == "nlay":
-            super(StructuredSpatialReference, self).__setattr__(
-                "nlay", int(value)
-            )
+            super().__setattr__("nlay", int(value))
         else:
-            super(StructuredSpatialReference, self).__setattr__(key, value)
+            super().__setattr__(key, value)
             reset = False
         if reset:
             self._reset()
@@ -687,33 +673,21 @@ class VertexSpatialReference(object):
     def __setattr__(self, key, value):
         reset = True
         if key == "xvdict":
-            super(VertexSpatialReference, self).__setattr__(
-                "xvdict", dict(value)
-            )
+            super().__setattr__("xvdict", dict(value))
         elif key == "yvdict":
-            super(VertexSpatialReference, self).__setattr__(
-                "yvdict", dict(value)
-            )
+            super().__setattr__("yvdict", dict(value))
         elif key == "xyvdict":
-            super(VertexSpatialReference, self).__setattr__("xyvdict", value)
+            super().__setattr__("xyvdict", value)
         elif key == "xadj":
-            super(VertexSpatialReference, self).__setattr__(
-                "xadj", float(value)
-            )
+            super().__setattr__("xadj", float(value))
         elif key == "yadj":
-            super(VertexSpatialReference, self).__setattr__(
-                "yadj", float(value)
-            )
+            super().__setattr__("yadj", float(value))
         elif key == "rotation":
-            super(VertexSpatialReference, self).__setattr__(
-                "rotation", float(value)
-            )
+            super().__setattr__("rotation", float(value))
         elif key == "lenuni":
-            super(VertexSpatialReference, self).__setattr__(
-                "lenuni", int(value)
-            )
+            super().__setattr__("lenuni", int(value))
         else:
-            super(VertexSpatialReference, self).__setattr__(key, value)
+            super().__setattr__(key, value)
             reset = False
         if reset:
             self._reset()

--- a/flopy/modflow/mfag.py
+++ b/flopy/modflow/mfag.py
@@ -216,7 +216,7 @@ class ModflowAg(Package):
         # set package name
         fname = [filenames[0]]
 
-        super(ModflowAg, self).__init__(
+        super().__init__(
             model,
             extension=extension,
             name=name,

--- a/flopy/modflow/mfbas.py
+++ b/flopy/modflow/mfbas.py
@@ -181,7 +181,7 @@ class ModflowBas(Package):
         if key == "ifrefm":
             self.parent.free_format_input = value
         else:
-            super(ModflowBas, self).__setattr__(key, value)
+            super().__setattr__(key, value)
 
     def check(self, f=None, verbose=True, level=1, checktype=None):
         """

--- a/flopy/modflow/mfmnw2.py
+++ b/flopy/modflow/mfmnw2.py
@@ -1753,7 +1753,7 @@ class ModflowMnw2(Package):
         self.stress_period_data = MfList(self, spd, dtype=dtype)
         """
 
-        return super(ModflowMnw2, self).export(f, **kwargs)
+        return super().export(f, **kwargs)
 
     def _write_1(self, f_mnw):
         """

--- a/flopy/modflow/mfriv.py
+++ b/flopy/modflow/mfriv.py
@@ -223,9 +223,7 @@ class ModflowRiv(Package):
         >>> m.riv.check()
 
         """
-        basechk = super(ModflowRiv, self).check(
-            verbose=False, checktype=checktype
-        )
+        basechk = super().check(verbose=False, checktype=checktype)
         chk = self._get_check(f, verbose, level, checktype)
         chk.summary_array = basechk.summary_array
 

--- a/flopy/modflow/mfsfr2.py
+++ b/flopy/modflow/mfsfr2.py
@@ -609,16 +609,16 @@ class ModflowSfr2(Package):
 
     def __setattr__(self, key, value):
         if key == "nstrm":
-            super(ModflowSfr2, self).__setattr__("_nstrm", value)
+            super().__setattr__("_nstrm", value)
         elif key == "dataset_5":
-            super(ModflowSfr2, self).__setattr__("_dataset_5", value)
+            super().__setattr__("_dataset_5", value)
         elif key == "segment_data":
-            super(ModflowSfr2, self).__setattr__("segment_data", value)
+            super().__setattr__("segment_data", value)
             self._dataset_5 = None
         elif key == "const":
-            super(ModflowSfr2, self).__setattr__("_const", value)
+            super().__setattr__("_const", value)
         else:  # return to default behavior of pakbase
-            super(ModflowSfr2, self).__setattr__(key, value)
+            super().__setattr__(key, value)
 
     @property
     def const(self):

--- a/flopy/modflow/mfuzf1.py
+++ b/flopy/modflow/mfuzf1.py
@@ -672,7 +672,7 @@ class ModflowUzf1(Package):
             )
             print(msg)
         else:
-            super(ModflowUzf1, self).__setattr__(key, value)
+            super().__setattr__(key, value)
 
     @property
     def nuzgag(self):

--- a/flopy/pakbase.py
+++ b/flopy/pakbase.py
@@ -585,7 +585,7 @@ class Package(PackageInterface):
                             )
                         value = new_list
 
-        super(Package, self).__setattr__(key, value)
+        super().__setattr__(key, value)
 
     @property
     def name(self):

--- a/flopy/plot/crosssection.py
+++ b/flopy/plot/crosssection.py
@@ -1732,7 +1732,7 @@ class DeprecatedCrossSection(PlotCrossSection):
     def __init__(
         self, ax=None, model=None, modelgrid=None, line=None, extent=None
     ):
-        super(DeprecatedCrossSection, self).__init__(
+        super().__init__(
             ax=ax, model=model, modelgrid=modelgrid, line=line, extent=extent
         )
 

--- a/flopy/plot/map.py
+++ b/flopy/plot/map.py
@@ -1138,7 +1138,7 @@ class DeprecatedMapView(PlotMapView):
     def __init__(
         self, model=None, modelgrid=None, ax=None, layer=0, extent=None
     ):
-        super(DeprecatedMapView, self).__init__(
+        super().__init__(
             model=model, modelgrid=modelgrid, ax=ax, layer=layer, extent=extent
         )
 
@@ -1194,7 +1194,7 @@ class DeprecatedMapView(PlotMapView):
                 modelgrid=self.mg, dis=dis
             )
 
-        super(DeprecatedMapView, self).plot_discharge(
+        super().plot_discharge(
             frf=frf,
             fff=fff,
             flf=flf,

--- a/flopy/plot/plotutil.py
+++ b/flopy/plot/plotutil.py
@@ -41,7 +41,7 @@ bc_color_dict = {
 
 class PlotException(Exception):
     def __init__(self, message):
-        super(PlotException, self).__init__(message)
+        super().__init__(message)
 
 
 class PlotUtilities(object):

--- a/flopy/seawat/swt.py
+++ b/flopy/seawat/swt.py
@@ -313,9 +313,7 @@ class Seawat(BaseModel):
             self._mt.change_model_ws(
                 new_pth=new_pth, reset_external=reset_external
             )
-        super(Seawat, self).change_model_ws(
-            new_pth=new_pth, reset_external=reset_external
-        )
+        super().change_model_ws(new_pth=new_pth, reset_external=reset_external)
 
     def write_name_file(self):
         """

--- a/flopy/utils/binaryfile.py
+++ b/flopy/utils/binaryfile.py
@@ -31,7 +31,7 @@ class BinaryHeader(Header):
     """
 
     def __init__(self, bintype=None, precision="single"):
-        super(BinaryHeader, self).__init__(bintype, precision)
+        super().__init__(bintype, precision)
 
     def set_values(self, **kwargs):
         """
@@ -280,9 +280,7 @@ class BinaryLayerFile(LayerFile):
     """
 
     def __init__(self, filename, precision, verbose, kwargs):
-        super(BinaryLayerFile, self).__init__(
-            filename, precision, verbose, kwargs
-        )
+        super().__init__(filename, precision, verbose, kwargs)
         return
 
     def __enter__(self):
@@ -495,7 +493,7 @@ class HeadFile(BinaryLayerFile):
         self.header_dtype = BinaryHeader.set_dtype(
             bintype="Head", precision=precision
         )
-        super(HeadFile, self).__init__(filename, precision, verbose, kwargs)
+        super().__init__(filename, precision, verbose, kwargs)
         return
 
 
@@ -565,7 +563,7 @@ class UcnFile(BinaryLayerFile):
         self.header_dtype = BinaryHeader.set_dtype(
             bintype="Ucn", precision=precision
         )
-        super(UcnFile, self).__init__(filename, precision, verbose, kwargs)
+        super().__init__(filename, precision, verbose, kwargs)
         return
 
 
@@ -1893,7 +1891,7 @@ class HeadUFile(BinaryLayerFile):
         self.header_dtype = BinaryHeader.set_dtype(
             bintype="Head", precision=precision
         )
-        super(HeadUFile, self).__init__(filename, precision, verbose, kwargs)
+        super().__init__(filename, precision, verbose, kwargs)
         return
 
     def _get_data_array(self, totim=0.0):

--- a/flopy/utils/check.py
+++ b/flopy/utils/check.py
@@ -781,9 +781,7 @@ class mf6check(check):
         level=1,
         property_threshold_values={},
     ):
-        super(mf6check, self).__init__(
-            package, f, verbose, level, property_threshold_values
-        )
+        super().__init__(package, f, verbose, level, property_threshold_values)
         if hasattr(package, "model_or_sim"):
             self.model = package.model_or_sim
 

--- a/flopy/utils/formattedfile.py
+++ b/flopy/utils/formattedfile.py
@@ -109,9 +109,7 @@ class FormattedLayerFile(LayerFile):
     """
 
     def __init__(self, filename, precision, verbose, kwargs):
-        super(FormattedLayerFile, self).__init__(
-            filename, precision, verbose, kwargs
-        )
+        super().__init__(filename, precision, verbose, kwargs)
         return
 
     def _build_index(self):
@@ -374,9 +372,7 @@ class FormattedHeadFile(FormattedLayerFile):
         **kwargs
     ):
         self.text = text
-        super(FormattedHeadFile, self).__init__(
-            filename, precision, verbose, kwargs
-        )
+        super().__init__(filename, precision, verbose, kwargs)
         return
 
     def _get_text_header(self):

--- a/flopy/utils/geometry.py
+++ b/flopy/utils/geometry.py
@@ -170,7 +170,7 @@ class Collection(list):
     """
 
     def __init__(self, geometries=()):
-        super(Collection, self).__init__(geometries)
+        super().__init__(geometries)
 
     def __repr__(self):
         return "Shapes: {}".format(list(self))
@@ -235,7 +235,7 @@ class MultiPolygon(Collection):
         for p in polygons:
             if not isinstance(p, Polygon):
                 raise TypeError("Only Polygon instances are supported")
-            super(MultiPolygon, self).__init__(polygons)
+            super().__init__(polygons)
 
     def __repr__(self):
         return "MultiPolygon: {}".format(list(self))
@@ -263,7 +263,7 @@ class MultiLineString(Collection):
         for l in linestrings:
             if not isinstance(l, LineString):
                 raise TypeError("Only LineString instances are supported")
-            super(MultiLineString, self).__init__(linestrings)
+            super().__init__(linestrings)
 
     def __repr__(self):
         return "LineString: {}".format(list(self))
@@ -291,7 +291,7 @@ class MultiPoint(Collection):
         for p in points:
             if not isinstance(p, Point):
                 raise TypeError("Only Point instances are supported")
-            super(MultiPoint, self).__init__(points)
+            super().__init__(points)
 
     def __repr__(self):
         return "MultiPoint: {}".format(list(self))
@@ -348,7 +348,7 @@ class Polygon(Shape):
         Multi-polygons not yet supported.
         z information is only stored if it was entered.
         """
-        super(Polygon, self).__init__(
+        super().__init__(
             self.type,
             coordinates=None,
             exterior=exterior,
@@ -484,7 +484,7 @@ class LineString(Shape):
         z information is only stored if it was entered.
 
         """
-        super(LineString, self).__init__(self.type, coordinates)
+        super().__init__(self.type, coordinates)
 
     def __eq__(self, other):
         if not isinstance(other, LineString):
@@ -583,7 +583,7 @@ class Point(Shape):
         -----
         z information is only stored if it was entered.
         """
-        super(Point, self).__init__(self.type, coordinates)
+        super().__init__(self.type, coordinates)
 
     def __eq__(self, other):
         if not isinstance(other, Point):

--- a/flopy/utils/mfgrdfile.py
+++ b/flopy/utils/mfgrdfile.py
@@ -60,7 +60,7 @@ class MfGrdFile(FlopyBinaryData):
         """
 
         # Call base class init
-        super(MfGrdFile, self).__init__()
+        super().__init__()
 
         # set attributes
         self.set_float(precision=precision)

--- a/flopy/utils/observationfile.py
+++ b/flopy/utils/observationfile.py
@@ -5,7 +5,7 @@ from ..utils.utils_def import FlopyBinaryData
 
 class ObsFiles(FlopyBinaryData):
     def __init__(self):
-        super(ObsFiles, self).__init__()
+        super().__init__()
         return
 
     def get_times(self):
@@ -277,7 +277,7 @@ class Mf6Obs(ObsFiles):
         Class constructor.
 
         """
-        super(Mf6Obs, self).__init__()
+        super().__init__()
         # initialize class information
         self.verbose = verbose
         if isBinary:
@@ -386,7 +386,7 @@ class HydmodObs(ObsFiles):
         Class constructor.
 
         """
-        super(HydmodObs, self).__init__()
+        super().__init__()
         # initialize class information
         self.verbose = verbose
         # --open binary head file
@@ -477,7 +477,7 @@ class SwrObs(ObsFiles):
         Class constructor.
 
         """
-        super(SwrObs, self).__init__()
+        super().__init__()
         self.set_float(precision=precision)
         # initialize class information
         self.verbose = verbose

--- a/flopy/utils/optionblock.py
+++ b/flopy/utils/optionblock.py
@@ -163,7 +163,7 @@ class OptionBlock(object):
             self.__dict__[key] = value
 
         elif value is None:
-            super(OptionBlock, self).__setattr__(key, value)
+            super().__setattr__(key, value)
 
         elif isinstance(value, np.recarray):
             for name in value.dtype.names:
@@ -191,7 +191,7 @@ class OptionBlock(object):
             self.__dict__[key] = value
 
         else:
-            super(OptionBlock, self).__setattr__(key, value)
+            super().__setattr__(key, value)
 
     def __getattribute__(self, item):
         """

--- a/flopy/utils/reference.py
+++ b/flopy/utils/reference.py
@@ -515,63 +515,57 @@ class SpatialReference(object):
     def __setattr__(self, key, value):
         reset = True
         if key == "delr":
-            super(SpatialReference, self).__setattr__(
-                "delr", np.atleast_1d(np.array(value))
-            )
+            super().__setattr__("delr", np.atleast_1d(np.array(value)))
         elif key == "delc":
-            super(SpatialReference, self).__setattr__(
-                "delc", np.atleast_1d(np.array(value))
-            )
+            super().__setattr__("delc", np.atleast_1d(np.array(value)))
         elif key == "xul":
-            super(SpatialReference, self).__setattr__("_xul", float(value))
+            super().__setattr__("_xul", float(value))
             self.origin_loc = "ul"
         elif key == "yul":
-            super(SpatialReference, self).__setattr__("_yul", float(value))
+            super().__setattr__("_yul", float(value))
             self.origin_loc = "ul"
         elif key == "xll":
-            super(SpatialReference, self).__setattr__("_xll", float(value))
+            super().__setattr__("_xll", float(value))
             self.origin_loc = "ll"
         elif key == "yll":
-            super(SpatialReference, self).__setattr__("_yll", float(value))
+            super().__setattr__("_yll", float(value))
             self.origin_loc = "ll"
         elif key == "length_multiplier":
-            super(SpatialReference, self).__setattr__(
-                "_length_multiplier", float(value)
-            )
+            super().__setattr__("_length_multiplier", float(value))
             # self.set_origin(xul=self.xul, yul=self.yul, xll=self.xll,
             #                yll=self.yll)
         elif key == "rotation":
-            super(SpatialReference, self).__setattr__("rotation", float(value))
+            super().__setattr__("rotation", float(value))
             # self.set_origin(xul=self.xul, yul=self.yul, xll=self.xll,
             #                yll=self.yll)
         elif key == "lenuni":
-            super(SpatialReference, self).__setattr__("_lenuni", int(value))
+            super().__setattr__("_lenuni", int(value))
             # self.set_origin(xul=self.xul, yul=self.yul, xll=self.xll,
             #                yll=self.yll)
         elif key == "units":
             value = value.lower()
             assert value in self.supported_units
-            super(SpatialReference, self).__setattr__("_units", value)
+            super().__setattr__("_units", value)
         elif key == "proj4_str":
-            super(SpatialReference, self).__setattr__("_proj4_str", value)
+            super().__setattr__("_proj4_str", value)
             # reset the units and epsg
             units = self._parse_units_from_proj4()
             if units is not None:
                 self._units = units
             self._epsg = None
         elif key == "epsg":
-            super(SpatialReference, self).__setattr__("_epsg", value)
+            super().__setattr__("_epsg", value)
             # reset the units and proj4
             self._units = None
             self._proj4_str = getproj4(self._epsg)
             self.crs = crs(epsg=value)
         elif key == "prj":
-            super(SpatialReference, self).__setattr__("prj", value)
+            super().__setattr__("prj", value)
             # translation to proj4 strings in crs class not robust yet
             # leave units and proj4 alone for now.
             self.crs = crs(prj=value, epsg=self.epsg)
         else:
-            super(SpatialReference, self).__setattr__(key, value)
+            super().__setattr__(key, value)
             reset = False
         if reset:
             self._reset()

--- a/flopy/utils/swroutputfile.py
+++ b/flopy/utils/swroutputfile.py
@@ -50,7 +50,7 @@ class SwrFile(FlopyBinaryData):
         Class constructor.
 
         """
-        super(SwrFile, self).__init__()
+        super().__init__()
         self.set_float(precision=precision)
         self.header_dtype = np.dtype(
             [
@@ -680,7 +680,7 @@ class SwrStage(SwrFile):
     """
 
     def __init__(self, filename, precision="double", verbose=False):
-        super(SwrStage, self).__init__(
+        super().__init__(
             filename, swrtype="stage", precision=precision, verbose=verbose
         )
         return
@@ -720,7 +720,7 @@ class SwrBudget(SwrFile):
     """
 
     def __init__(self, filename, precision="double", verbose=False):
-        super(SwrBudget, self).__init__(
+        super().__init__(
             filename, swrtype="budget", precision=precision, verbose=verbose
         )
         return
@@ -760,7 +760,7 @@ class SwrFlow(SwrFile):
     """
 
     def __init__(self, filename, precision="double", verbose=False):
-        super(SwrFlow, self).__init__(
+        super().__init__(
             filename, swrtype="flow", precision=precision, verbose=verbose
         )
         return
@@ -800,7 +800,7 @@ class SwrExchange(SwrFile):
     """
 
     def __init__(self, filename, precision="double", verbose=False):
-        super(SwrExchange, self).__init__(
+        super().__init__(
             filename, swrtype="exchange", precision=precision, verbose=verbose
         )
         return
@@ -841,7 +841,7 @@ class SwrStructure(SwrFile):
     """
 
     def __init__(self, filename, precision="double", verbose=False):
-        super(SwrStructure, self).__init__(
+        super().__init__(
             filename, swrtype="structure", precision=precision, verbose=verbose
         )
         return

--- a/flopy/utils/util_array.py
+++ b/flopy/utils/util_array.py
@@ -184,7 +184,7 @@ class ArrayFormat(object):
             if other.lower() == "binary":
                 return self.binary
         else:
-            super(ArrayFormat, self).__eq__(other)
+            super().__eq__(other)
 
     @property
     def npl(self):
@@ -277,7 +277,7 @@ class ArrayFormat(object):
             self._parse_python_format(value)
 
         else:
-            super(ArrayFormat, self).__setattr__(key, value)
+            super().__setattr__(key, value)
 
     @property
     def py(self):
@@ -632,13 +632,13 @@ class Util3d(DataInterface):
                     fortran=value,
                     array_free_format=self.array_free_format,
                 )
-            super(Util3d, self).__setattr__("fmtin", value)
+            super().__setattr__("fmtin", value)
         elif hasattr(self, "util_2ds") and key == "how":
             for u2d in self.util_2ds:
                 u2d.how = value
         else:
             # set the attribute for u3d
-            super(Util3d, self).__setattr__(key, value)
+            super().__setattr__(key, value)
 
     @property
     def name(self):
@@ -1114,7 +1114,7 @@ class Transient3d(DataInterface):
 
     def __setattr__(self, key, value):
         # set the attribute for u3d, even for cnstnt
-        super(Transient3d, self).__setattr__(key, value)
+        super().__setattr__(key, value)
 
     @property
     def model(self):
@@ -1508,7 +1508,7 @@ class Transient2d(DataInterface):
             for kper, u2d in self.transient_2ds.items():
                 self.transient_2ds[kper].how = value
         # set the attribute for u3d, even for cnstnt
-        super(Transient2d, self).__setattr__(key, value)
+        super().__setattr__(key, value)
 
     def get_zero_2d(self, kper):
         name = self.name_base + str(kper + 1) + "(filled zero)"
@@ -2252,7 +2252,7 @@ class Util2d(DataInterface):
         elif key == "model":
             self._model = value
         else:
-            super(Util2d, self).__setattr__(key, value)
+            super().__setattr__(key, value)
 
     def all(self):
         return self.array.all()


### PR DESCRIPTION
This cleans up explicit passing of both the class and instance to `super`, which was required before Python 3.

See [PEP 3135](https://www.python.org/dev/peps/pep-3135/), which was adopted in 2007 for Python 3.0.