### PR TITLE
Python3 classes does not need to inherit from object

### DIFF
--- a/flopy/datbase.py
+++ b/flopy/datbase.py
@@ -13,7 +13,7 @@ class DataType(Enum):
     transientscalar = 8
 
 
-class DataInterface(object):
+class DataInterface:
     @property
     @abc.abstractmethod
     def data_type(self):
@@ -58,7 +58,7 @@ class DataInterface(object):
         )
 
 
-class DataListInterface(object):
+class DataListInterface:
     @property
     @abc.abstractmethod
     def package(self):

--- a/flopy/discretization/grid.py
+++ b/flopy/discretization/grid.py
@@ -4,7 +4,7 @@ import warnings
 from ..utils import geometry
 
 
-class CachedData(object):
+class CachedData:
     def __init__(self, data):
         self._data = data
         self.out_of_date = False
@@ -22,7 +22,7 @@ class CachedData(object):
         self.out_of_date = False
 
 
-class Grid(object):
+class Grid:
     """
     Base class for a structured or unstructured model grid
 

--- a/flopy/export/netcdf.py
+++ b/flopy/export/netcdf.py
@@ -28,7 +28,7 @@ with open(path + "/longnames.json") as f:
     NC_LONG_NAMES = json.load(f)
 
 
-class Logger(object):
+class Logger:
     """
     Basic class for logging events during the linear analysis calculations
     if filename is passed, then an file handle is opened
@@ -121,7 +121,7 @@ class Logger(object):
         return
 
 
-class NetCdf(object):
+class NetCdf:
     """
     Support for writing a netCDF4 compliant file from a flopy model
 

--- a/flopy/export/shapefile_utils.py
+++ b/flopy/export/shapefile_utils.py
@@ -659,7 +659,7 @@ def write_prj(shpname, mg=None, epsg=None, prj=None, wkt_string=None):
             output.write(prjtxt)
 
 
-class CRS(object):
+class CRS:
     """
     Container to parse and store coordinate reference system parameters,
     and translate between different formats.

--- a/flopy/export/vtk.py
+++ b/flopy/export/vtk.py
@@ -331,7 +331,7 @@ class XmlWriterBinary(XmlWriterInterface):
         super().final()
 
 
-class _Array(object):
+class _Array:
     # class to store array and tell if array is 2d
     def __init__(self, array, array2d):
         self.array = array
@@ -347,7 +347,7 @@ def _get_basic_modeltime(perlen_list):
     return totim
 
 
-class Vtk(object):
+class Vtk:
     """
     Class to build VTK object for exporting flopy vtk
 

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -31,7 +31,7 @@ iprn = (
 )  # Printout flag. If >= 0 then array values read are printed in listing file.
 
 
-class FileDataEntry(object):
+class FileDataEntry:
     def __init__(self, fname, unit, binflag=False, output=False, package=None):
         self.fname = fname
         self.unit = unit
@@ -40,7 +40,7 @@ class FileDataEntry(object):
         self.package = package
 
 
-class FileData(object):
+class FileData:
     def __init__(self):
         self.file_data = []
         return
@@ -59,7 +59,7 @@ class FileData(object):
         return
 
 
-class ModelInterface(object):
+class ModelInterface:
     def __init__(self):
         self._mg_resync = True
         self._modelgrid = None
@@ -1077,7 +1077,7 @@ class BaseModel(ModelInterface):
         #     if ptype in pak.name:
         #         print("BaseModel.add_existing_package() warning: " +\
         #               "replacing existing package {0}".format(ptype))
-        class Obj(object):
+        class Obj:
             pass
 
         fake_package = Obj()

--- a/flopy/mf6/coordinates/modeldimensions.py
+++ b/flopy/mf6/coordinates/modeldimensions.py
@@ -13,7 +13,7 @@ from ..utils.mfenums import DiscretizationType
 from ...utils.datautil import DatumUtil, NameIter
 
 
-class DataDimensions(object):
+class DataDimensions:
     """
     Resolves dimension information for model data using information contained
     in the model files
@@ -121,7 +121,7 @@ class DataDimensions(object):
                 return self.package_dim.model_dim[int(model_num)]
 
 
-class PackageDimensions(object):
+class PackageDimensions:
     """
     Resolves dimension information for common parts of a package
 
@@ -286,7 +286,7 @@ class PackageDimensions(object):
         return names_dict
 
 
-class ModelDimensions(object):
+class ModelDimensions:
     """
     Contains model dimension information and helper methods
 

--- a/flopy/mf6/coordinates/modelgrid.py
+++ b/flopy/mf6/coordinates/modelgrid.py
@@ -12,7 +12,7 @@ class MFGridException(Exception):
         Exception.__init__(self, "MFGridException: {}".format(error))
 
 
-class ModelCell(object):
+class ModelCell:
     """
     Represents a model cell
 
@@ -328,7 +328,7 @@ class UnstructuredModelCell(ModelCell):
                 fahl[connecting_cell - 1][rev_con_number] *= con_area_mult
 
 
-class ModelGrid(object):
+class ModelGrid:
     """
     Base class for a structured or unstructured model grid
 

--- a/flopy/mf6/coordinates/simulationtime.py
+++ b/flopy/mf6/coordinates/simulationtime.py
@@ -6,7 +6,7 @@ stress period classes
 """
 
 
-class StressPeriod(object):
+class StressPeriod:
     """
     Represents a stress period
 
@@ -62,7 +62,7 @@ class StressPeriod(object):
     # def get_ts_length(self, timestep):
 
 
-class SimulationTime(object):
+class SimulationTime:
     """
     Represents a block in a MF6 input file
 

--- a/flopy/mf6/data/mfdata.py
+++ b/flopy/mf6/data/mfdata.py
@@ -14,7 +14,7 @@ from .mfdatastorage import DataStructureType
 from .mfdatautil import to_string
 
 
-class MFTransient(object):
+class MFTransient:
     """
     Parent class for transient data.  This class contains internal objects and
     methods that most end users will not need to access directly.

--- a/flopy/mf6/data/mfdatastorage.py
+++ b/flopy/mf6/data/mfdatastorage.py
@@ -40,7 +40,7 @@ class DataStructureType(Enum):
     scalar = 3
 
 
-class LayerStorage(object):
+class LayerStorage:
     """
     Stores a single layer of data.
 
@@ -160,7 +160,7 @@ class LayerStorage(object):
             return self.data_const_value
 
 
-class DataStorage(object):
+class DataStorage:
     """
     Stores and retrieves data.
 

--- a/flopy/mf6/data/mfdatautil.py
+++ b/flopy/mf6/data/mfdatautil.py
@@ -222,7 +222,7 @@ def to_string(
         return str(val)
 
 
-class MFComment(object):
+class MFComment:
     """
     Represents a variable in a MF6 input file
 
@@ -428,7 +428,7 @@ class MFComment(object):
                     fd.write(" {}".format(item))
 
 
-class TemplateGenerator(object):
+class TemplateGenerator:
     """
     Abstract base class for building a data template for different data types.
     This is a generic class that is initialized with a path that identifies
@@ -805,7 +805,7 @@ class ListTemplateGenerator(TemplateGenerator):
             return rec_array
 
 
-class MFDocString(object):
+class MFDocString:
     """
     Helps build a python class doc string
 

--- a/flopy/mf6/data/mffileaccess.py
+++ b/flopy/mf6/data/mffileaccess.py
@@ -14,7 +14,7 @@ from ...utils import datautil
 from ..data.mfstructure import DatumType, MFDataStructure, DataType
 
 
-class MFFileAccess(object):
+class MFFileAccess:
     def __init__(
         self, structure, data_dimensions, simulation_data, path, current_key
     ):

--- a/flopy/mf6/data/mfstructure.py
+++ b/flopy/mf6/data/mfstructure.py
@@ -37,7 +37,7 @@ class DfnType(Enum):
     unknown = 999
 
 
-class Dfn(object):
+class Dfn:
     """
     Base class for package file definitions
 
@@ -799,7 +799,7 @@ class BlockType(Enum):
     transient = 3
 
 
-class MFDataItemStructure(object):
+class MFDataItemStructure:
     """
     Defines the structure of a single MF6 data item in a dfn file
 
@@ -1283,7 +1283,7 @@ class MFDataItemStructure(object):
         return item_type
 
 
-class MFDataStructure(object):
+class MFDataStructure:
     """
     Defines the structure of a single MF6 data item in a dfn file
 
@@ -1917,7 +1917,7 @@ class MFDataStructure(object):
         return ""
 
 
-class MFBlockStructure(object):
+class MFBlockStructure:
     """
     Defines the structure of a MF6 block.
 
@@ -2030,7 +2030,7 @@ class MFBlockStructure(object):
         return recarray_list
 
 
-class MFInputFileStructure(object):
+class MFInputFileStructure:
     """
     MODFLOW Input File Stucture class.  Loads file
     structure information for individual input file
@@ -2115,7 +2115,7 @@ class MFInputFileStructure(object):
             return None
 
 
-class MFModelStructure(object):
+class MFModelStructure:
     """
     Defines the structure of a MF6 model and its packages
 
@@ -2205,7 +2205,7 @@ class MFModelStructure(object):
             return None
 
 
-class MFSimulationStructure(object):
+class MFSimulationStructure:
     """
     Defines the structure of a MF6 simulation and its packages
     and models.
@@ -2399,7 +2399,7 @@ class MFSimulationStructure(object):
                     package_struct.read_as_arrays = True
 
 
-class MFStructure(object):
+class MFStructure:
     """
     Singleton class for accessing the contents of the json structure file
     (only one instance of this class can exist, which loads the json file on

--- a/flopy/mf6/mfbase.py
+++ b/flopy/mf6/mfbase.py
@@ -190,7 +190,7 @@ class ExtFileAction(Enum):
     copy_relative_paths = 3
 
 
-class MFFilePath(object):
+class MFFilePath:
     def __init__(self, file_path, model_name):
         self.file_path = file_path
         self.model_name = {model_name: 0}
@@ -199,7 +199,7 @@ class MFFilePath(object):
         return os.path.isabs(self.file_path)
 
 
-class MFFileMgmt(object):
+class MFFileMgmt:
     """
     Class containing MODFLOW path data
 
@@ -451,7 +451,7 @@ class MFFileMgmt(object):
                 )
 
 
-class PackageContainer(object):
+class PackageContainer:
     """
     Base class for any class containing packages.
 

--- a/flopy/mf6/mfpackage.py
+++ b/flopy/mf6/mfpackage.py
@@ -26,7 +26,7 @@ from ..utils.check import mf6check
 from ..version import __version__
 
 
-class MFBlockHeader(object):
+class MFBlockHeader:
     """
     Represents the header of a block in a MF6 input file
 
@@ -268,7 +268,7 @@ class MFBlockHeader(object):
         return transient_key
 
 
-class MFBlock(object):
+class MFBlock:
     """
     Represents a block in a MF6 input file
 
@@ -2389,7 +2389,7 @@ class MFPackage(PackageContainer, PackageInterface):
         return axes
 
 
-class MFChildPackages(object):
+class MFChildPackages:
     def __init__(
         self,
         model,

--- a/flopy/mf6/modflow/mfsimulation.py
+++ b/flopy/mf6/modflow/mfsimulation.py
@@ -193,7 +193,7 @@ class SimulationDict(collections.OrderedDict):
             pass
 
 
-class MFSimulationData(object):
+class MFSimulationData:
     """
     Class containing MODFLOW simulation data and file formatting data.
 

--- a/flopy/mf6/utils/reference.py
+++ b/flopy/mf6/utils/reference.py
@@ -5,7 +5,7 @@ Module spatial referencing for flopy model objects
 import numpy as np
 
 
-class StructuredSpatialReference(object):
+class StructuredSpatialReference:
     """
     a simple class to locate the model grid in x-y space
 
@@ -547,7 +547,7 @@ class StructuredSpatialReference(object):
         return b
 
 
-class VertexSpatialReference(object):
+class VertexSpatialReference:
     """
     a simple class to locate the model grid in x-y space
 
@@ -858,7 +858,7 @@ class VertexSpatialReference(object):
             self._ycenter_array = np.append(self._ycenter_array, np.mean(cell))
 
 
-class SpatialReference(object):
+class SpatialReference:
     """
     A dynamic inheritance class that locates a gridded model in space
 

--- a/flopy/modflow/mfhob.py
+++ b/flopy/modflow/mfhob.py
@@ -510,7 +510,7 @@ class ModflowHob(Package):
         return 39
 
 
-class HeadObservation(object):
+class HeadObservation:
     """
     Create single HeadObservation instance from a time series array. A list of
     HeadObservation instances are passed to the ModflowHob package.

--- a/flopy/modflow/mfmnw2.py
+++ b/flopy/modflow/mfmnw2.py
@@ -12,7 +12,7 @@ from ..utils.recarray_utils import create_empty_recarray
 from ..pakbase import Package
 
 
-class Mnw(object):
+class Mnw:
     """
     Multi-Node Well object class
 

--- a/flopy/modflow/mfpar.py
+++ b/flopy/modflow/mfpar.py
@@ -12,7 +12,7 @@ from .mfpval import ModflowPval
 from .mfmlt import ModflowMlt
 
 
-class ModflowPar(object):
+class ModflowPar:
     """
     Class for loading mult, zone, pval, and parameter data for MODFLOW packages
     that use array data (LPF, UPW, RCH, EVT). Class also includes methods to

--- a/flopy/modflow/mfparbc.py
+++ b/flopy/modflow/mfparbc.py
@@ -8,7 +8,7 @@ import numpy as np
 from ..utils.flopy_io import line_strip, ulstrd
 
 
-class ModflowParBc(object):
+class ModflowParBc:
     """
     Class for loading boundary condition parameter data for MODFLOW packages
     that use list data (WEL, GHB, DRN, etc.). This Class is also used to

--- a/flopy/modpath/mp7particledata.py
+++ b/flopy/modpath/mp7particledata.py
@@ -11,7 +11,7 @@ from ..utils.util_array import Util2d
 from ..utils.recarray_utils import create_empty_recarray
 
 
-class ParticleData(object):
+class ParticleData:
     """
     Class to create the most basic particle data type (starting location
     input style 1). Input style 1 is the most general input style and
@@ -456,7 +456,7 @@ class ParticleData(object):
         return " " + " ".join(fmts)
 
 
-class FaceDataType(object):
+class FaceDataType:
     """
     Face data type class to create a MODPATH 7 particle location template for
     input style 2, 3, and 4 on cell faces (templatesubdivisiontype = 2).
@@ -597,7 +597,7 @@ class FaceDataType(object):
         return
 
 
-class CellDataType(object):
+class CellDataType:
     """
     Cell data type class to create a MODPATH 7 particle location template for
     input style 2, 3, and 4 in cells (templatesubdivisiontype = 2).
@@ -684,7 +684,7 @@ class CellDataType(object):
         return
 
 
-class LRCParticleData(object):
+class LRCParticleData:
     """
     Layer, row, column particle data template class to create MODPATH 7
     particle location input style 2 on cell faces (templatesubdivisiontype = 1)
@@ -851,7 +851,7 @@ class LRCParticleData(object):
         return
 
 
-class NodeParticleData(object):
+class NodeParticleData:
     """
     Node particle data template class to create MODPATH 7 particle location
     input style 3 on cell faces (templatesubdivisiontype = 1) and/or in cells

--- a/flopy/modpath/mp7particlegroup.py
+++ b/flopy/modpath/mp7particlegroup.py
@@ -11,7 +11,7 @@ from ..utils.util_array import Util2d
 from .mp7particledata import ParticleData, NodeParticleData
 
 
-class _Modpath7ParticleGroup(object):
+class _Modpath7ParticleGroup:
     """
     Base particle group class that defines common data to all particle
     input styles (MODPATH 7 simulation file items 26 through 32).

--- a/flopy/mt3d/mtssm.py
+++ b/flopy/mt3d/mtssm.py
@@ -8,7 +8,7 @@ from ..utils import Util2d, MfList, Transient2d
 SsmLabels = ["WEL", "DRN", "RCH", "EVT", "RIV", "GHB", "BAS6", "CHD", "PBC"]
 
 
-class SsmPackage(object):
+class SsmPackage:
     def __init__(self, label="", instance=None, needTFstr=False):
         self.label = label
         self.instance = instance

--- a/flopy/pakbase.py
+++ b/flopy/pakbase.py
@@ -20,7 +20,7 @@ from .utils import OptionBlock
 from .utils.flopy_io import ulstrd
 
 
-class PackageInterface(object):
+class PackageInterface:
     @property
     @abc.abstractmethod
     def name(self):

--- a/flopy/pest/params.py
+++ b/flopy/pest/params.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 import numpy as np
 
 
-class Params(object):
+class Params:
     """
     Class to define parameters that will be estimated using PEST.
 

--- a/flopy/pest/templatewriter.py
+++ b/flopy/pest/templatewriter.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 from ..pest import tplarray as tplarray
 
 
-class TemplateWriter(object):
+class TemplateWriter:
     """
     Class for writing PEST template files.
 

--- a/flopy/pest/tplarray.py
+++ b/flopy/pest/tplarray.py
@@ -83,7 +83,7 @@ class Transient2dTpl:
             return self.transient2d.get_kper_entry(kper)
 
 
-class Util3dTpl(object):
+class Util3dTpl:
     """
     Class to define a three-dimensional template array for use with parameter
     estimation.
@@ -144,7 +144,7 @@ class Util3dTpl(object):
         return
 
 
-class Util2dTpl(object):
+class Util2dTpl:
     """
     Class to define a two-dimensional template array for use with parameter
     estimation.

--- a/flopy/plot/crosssection.py
+++ b/flopy/plot/crosssection.py
@@ -15,7 +15,7 @@ import warnings
 warnings.simplefilter("always", PendingDeprecationWarning)
 
 
-class PlotCrossSection(object):
+class PlotCrossSection:
     """
     Class to create a cross sectional plot of a model.
 
@@ -1732,7 +1732,7 @@ class DeprecatedCrossSection(PlotCrossSection):
         )
 
 
-class ModelCrossSection(object):
+class ModelCrossSection:
     """
     DEPRECATED. Class to create a cross section of the model.
 

--- a/flopy/plot/map.py
+++ b/flopy/plot/map.py
@@ -16,7 +16,7 @@ import warnings
 warnings.simplefilter("always", PendingDeprecationWarning)
 
 
-class PlotMapView(object):
+class PlotMapView:
     """
     Class to create a map of the model. Delegates plotting
     functionality based on model grid type.
@@ -1206,7 +1206,7 @@ class DeprecatedMapView(PlotMapView):
         )
 
 
-class ModelMap(object):
+class ModelMap:
     """
     DEPRECATED. ModelMap acts as a PlotMapView factory
     object. Please migrate to PlotMapView for plotting

--- a/flopy/plot/plotutil.py
+++ b/flopy/plot/plotutil.py
@@ -44,7 +44,7 @@ class PlotException(Exception):
         super().__init__(message)
 
 
-class PlotUtilities(object):
+class PlotUtilities:
     """
     Class which groups a collection of plotting utilities
     which Flopy and Flopy6 can use to generate map based plots
@@ -1700,7 +1700,7 @@ class PlotUtilities(object):
         return (qx, qy, qz)
 
 
-class UnstructuredPlotUtilities(object):
+class UnstructuredPlotUtilities:
     """
     Collection of unstructured grid and vertex grid compatible
     plotting helper functions

--- a/flopy/plot/styles.py
+++ b/flopy/plot/styles.py
@@ -8,7 +8,7 @@ import os
 import platform
 
 
-class styles(object):
+class styles:
     """Styles class for custom matplotlib styling
 
     The class contains both custom styles and plotting methods

--- a/flopy/utils/binaryfile.py
+++ b/flopy/utils/binaryfile.py
@@ -571,7 +571,7 @@ class BudgetIndexError(Exception):
     pass
 
 
-class CellBudgetFile(object):
+class CellBudgetFile:
     """
     CellBudgetFile Class.
 

--- a/flopy/utils/cvfdutil.py
+++ b/flopy/utils/cvfdutil.py
@@ -36,7 +36,7 @@ def centroid_of_polygon(points):
     return (result_x, result_y)
 
 
-class Point(object):
+class Point:
     def __init__(self, x, y):
         self.x = x
         self.y = y

--- a/flopy/utils/datafile.py
+++ b/flopy/utils/datafile.py
@@ -9,7 +9,7 @@ import flopy.utils
 from ..discretization.structuredgrid import StructuredGrid
 
 
-class Header(object):
+class Header:
     """
     The header class is an abstract base class to create headers for MODFLOW files
     """
@@ -147,7 +147,7 @@ class Header(object):
             return self.header[0]
 
 
-class LayerFile(object):
+class LayerFile:
     """
     The LayerFile class is the abstract base class from which specific derived
     classes are formed.  LayerFile This class should not be instantiated

--- a/flopy/utils/datautil.py
+++ b/flopy/utils/datautil.py
@@ -38,7 +38,7 @@ def max_tuple_abs_size(some_tuple):
     return max_size
 
 
-class DatumUtil(object):
+class DatumUtil:
     @staticmethod
     def is_int(str):
         try:
@@ -70,7 +70,7 @@ class DatumUtil(object):
         return False
 
 
-class PyListUtil(object):
+class PyListUtil:
     """
     Class contains miscellaneous methods to work with and compare python lists
 
@@ -600,7 +600,7 @@ class MultiList:
         return MultiListIter(self.multi_dim_list, False)
 
 
-class ArrayIndexIter(object):
+class ArrayIndexIter:
     def __init__(self, array_shape, index_as_tuple=False):
         self.array_shape = array_shape
         self.current_location = []
@@ -643,7 +643,7 @@ class ArrayIndexIter(object):
     next = __next__  # Python 2 support
 
 
-class MultiListIter(object):
+class MultiListIter:
     def __init__(self, multi_list, detailed_info=False, iter_leaf_lists=False):
         self.multi_list = multi_list
         self.detailed_info = detailed_info
@@ -665,7 +665,7 @@ class MultiListIter(object):
     next = __next__  # Python 2 support
 
 
-class ConstIter(object):
+class ConstIter:
     def __init__(self, value):
         self.value = value
 
@@ -678,7 +678,7 @@ class ConstIter(object):
     next = __next__  # Python 2 support
 
 
-class FileIter(object):
+class FileIter:
     def __init__(self, file_path):
         self.eof = False
         try:
@@ -721,7 +721,7 @@ class FileIter(object):
     next = __next__  # Python 2 support
 
 
-class NameIter(object):
+class NameIter:
     def __init__(self, name, first_not_numbered=True):
         self.name = name
         self.iter_num = -1
@@ -740,7 +740,7 @@ class NameIter(object):
     next = __next__  # Python 2 support
 
 
-class PathIter(object):
+class PathIter:
     def __init__(self, path, first_not_numbered=True):
         self.path = path
         self.name_iter = NameIter(path[-1], first_not_numbered)

--- a/flopy/utils/geometry.py
+++ b/flopy/utils/geometry.py
@@ -4,7 +4,7 @@ Container objects for working with geometric information
 import numpy as np
 
 
-class Shape(object):
+class Shape:
     """
     Parent class for handling geo interfacing, do not instantiate directly
 

--- a/flopy/utils/geospatial_utils.py
+++ b/flopy/utils/geospatial_utils.py
@@ -41,7 +41,7 @@ shape_types = {
 }
 
 
-class GeoSpatialUtil(object):
+class GeoSpatialUtil:
     """
     Geospatial utils are a unifying method to provide conversion between
     commonly used geospatial input types
@@ -237,7 +237,7 @@ class GeoSpatialUtil(object):
         return self._flopy_geometry
 
 
-class GeoSpatialCollection(object):
+class GeoSpatialCollection:
     """
     The GeoSpatialCollection class allows a user to convert between
     Collection objects from common geospatial libraries.

--- a/flopy/utils/gridgen.py
+++ b/flopy/utils/gridgen.py
@@ -167,7 +167,7 @@ def repair_array_asymmetry(isym, a, atol=0):
     return a
 
 
-class Gridgen(object):
+class Gridgen:
     """
     Class to work with the gridgen program to create layered quadtree grids.
 

--- a/flopy/utils/lgrutil.py
+++ b/flopy/utils/lgrutil.py
@@ -3,7 +3,7 @@ from ..modflow import Modflow
 from .util_array import Util2d, Util3d
 
 
-class Lgr(object):
+class Lgr:
     def __init__(
         self,
         nlayp,

--- a/flopy/utils/mflistfile.py
+++ b/flopy/utils/mflistfile.py
@@ -15,7 +15,7 @@ import errno
 from ..utils.utils_def import totim_to_datetime
 
 
-class ListBudget(object):
+class ListBudget:
     """
     MODFLOW family list file handling
 

--- a/flopy/utils/mfreadnam.py
+++ b/flopy/utils/mfreadnam.py
@@ -16,7 +16,7 @@ if sys.version_info < (3, 6):
     dict = OrderedDict
 
 
-class NamData(object):
+class NamData:
     """
     MODFLOW Namefile Class.
 

--- a/flopy/utils/mtlistfile.py
+++ b/flopy/utils/mtlistfile.py
@@ -12,7 +12,7 @@ import numpy as np
 from ..utils.utils_def import totim_to_datetime
 
 
-class MtListBudget(object):
+class MtListBudget:
     """
     MT3D mass budget reader
 

--- a/flopy/utils/optionblock.py
+++ b/flopy/utils/optionblock.py
@@ -3,7 +3,7 @@ import numpy as np
 from ..utils import flopy_io
 
 
-class OptionBlock(object):
+class OptionBlock:
     """
     Parent class to for option blocks within
     Modflow-nwt models. This class contains base
@@ -413,7 +413,7 @@ class OptionBlock(object):
                 return cls(options_line=option_line, package=package)
 
 
-class OptionUtil(object):
+class OptionUtil:
     @staticmethod
     def isfloat(s):
         """

--- a/flopy/utils/rasters.py
+++ b/flopy/utils/rasters.py
@@ -18,7 +18,7 @@ except ImportError:
     scipy = None
 
 
-class Raster(object):
+class Raster:
     """
     The Raster object is used for cropping, sampling raster values,
     and re-sampling raster values to grids, and provides methods to

--- a/flopy/utils/reference.py
+++ b/flopy/utils/reference.py
@@ -13,7 +13,7 @@ from collections import OrderedDict
 srefhttp = "https://spatialreference.org"
 
 
-class SpatialReference(object):
+class SpatialReference:
     """
     a class to locate a structured model grid in x-y space
 
@@ -1942,7 +1942,7 @@ class SpatialReferenceUnstructured(SpatialReference):
         return contour_set
 
 
-class TemporalReference(object):
+class TemporalReference:
     """
     For now, just a container to hold start time and time units files
     outside of DIS package.
@@ -2059,7 +2059,7 @@ class epsgRef:
             print("{}:\n{}\n".format(k, v))
 
 
-class crs(object):
+class crs:
     """
     Container to parse and store coordinate reference system parameters,
     and translate between different formats.

--- a/flopy/utils/triangle.py
+++ b/flopy/utils/triangle.py
@@ -6,7 +6,7 @@ from ..utils.cvfdutil import centroid_of_polygon
 from ..utils.geospatial_utils import GeoSpatialUtil
 
 
-class Triangle(object):
+class Triangle:
     """
     Class to work with the triangle program to unstructured triangular grids.
     Information on the triangle program can be found at

--- a/flopy/utils/util_array.py
+++ b/flopy/utils/util_array.py
@@ -19,7 +19,7 @@ from ..utils.flopy_io import line_parse
 from ..datbase import DataType, DataInterface
 
 
-class ArrayFormat(object):
+class ArrayFormat:
     """
     ArrayFormat class for handling various output format types for both
     MODFLOW and flopy

--- a/flopy/utils/utils_def.py
+++ b/flopy/utils/utils_def.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 import numpy as np
 
 
-class FlopyBinaryData(object):
+class FlopyBinaryData:
     """
     The FlopyBinaryData class is a class to that defines the data types for
     integer, floating point, and character data in MODFLOW binary

--- a/flopy/utils/zonbud.py
+++ b/flopy/utils/zonbud.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 from ..utils.utils_def import totim_to_datetime
 
 
-class ZoneBudget(object):
+class ZoneBudget:
     """
     ZoneBudget class
 
@@ -1830,7 +1830,7 @@ def get_totim_modflow6(tdis):
     return totim
 
 
-class ZBNetOutput(object):
+class ZBNetOutput:
     """
     Class that holds zonebudget netcdf output and allows export utilities
     to recognize the output data type.
@@ -1859,7 +1859,7 @@ class ZBNetOutput(object):
         self.flux = flux
 
 
-class ZoneBudgetOutput(object):
+class ZoneBudgetOutput:
     """
     Class method to process zonebudget output into volumetric budgets
 


### PR DESCRIPTION
See this [Q/A](https://stackoverflow.com/questions/4015417/why-do-python-classes-inherit-object) for a background on `class Foo(object):` vs `class Foo:`.

In summary, only Python 2 required inheriting from `object`, but this is no longer necessary with Python 3 (and the docs don't use that style [here](https://docs.python.org/3/tutorial/classes.html) or [here](https://docs.python.org/3/howto/descriptor.html)). This PR keeps the base classes a bit tidier and quicker to identify.

Edits were automated using:

    git ls-files -z | xargs -0 sed -i -re 's/class (.*)\(object\):/class \1:/g'