### PR TITLE
Fix(mfsfr2.py): dataset 6b and 6c write routine, remove blank lines

### DIFF
--- a/autotest/t009_test.py
+++ b/autotest/t009_test.py
@@ -429,6 +429,16 @@ def test_no_ds_6bc():
         assert len(sfr.channel_geometry_data[0][1][i]) == 8
         assert sum(sfr.channel_geometry_data[0][1][i]) > 0.
 
+    sfrfile2 = os.path.join("temp", "junk.sfr")
+    sfr.write_file()
+    sfr = fm.ModflowSfr2.load(sfrfile2, model=m)
+    assert len(sfr.segment_data[0]) == 2
+    assert len(sfr.channel_geometry_data[0]) == 2
+    assert len(sfr.channel_geometry_data[0][1]) == 2
+    for i in range(2):
+        assert len(sfr.channel_geometry_data[0][1][i]) == 8
+        assert sum(sfr.channel_geometry_data[0][1][i]) > 0.
+
 
 def test_ds_6d_6e_disordered():
     path = os.path.join("..", "examples", "data", "hydmod_test")

--- a/flopy/modflow/mfsfr2.py
+++ b/flopy/modflow/mfsfr2.py
@@ -2023,11 +2023,11 @@ class ModflowSfr2(Package):
                 f_sfr.write(fmts[4].format(depth) + " ")
             elif icalc == 1:
                 if i > 0:
-                    pass
+                    return
                 else:
                     f_sfr.write(fmts[3].format(width) + " ")
             else:
-                pass
+                return
 
         else:
             return


### PR DESCRIPTION
* blank lines were previously written to file in the case of isfropt = 2 or 3 and icalc >= 2
* updated t009_test.py to check for this issue