### PR TITLE
fix(numpy): aliases of builtin types is deprecated

### DIFF
--- a/flopy/plot/crosssection.py
+++ b/flopy/plot/crosssection.py
@@ -631,7 +631,7 @@ class PlotCrossSection:
             else:
                 ibound = self.mg.idomain
 
-        plotarray = np.zeros(ibound.shape, dtype=np.int)
+        plotarray = np.zeros(ibound.shape, dtype=int)
         idx1 = ibound == 0
         plotarray[idx1] = 1
         plotarray = np.ma.masked_equal(plotarray, 0)
@@ -685,7 +685,7 @@ class PlotCrossSection:
 
             ibound = self.mg.idomain
 
-        plotarray = np.zeros(ibound.shape, dtype=np.int)
+        plotarray = np.zeros(ibound.shape, dtype=int)
         idx1 = ibound == 0
         idx2 = ibound < 0
         plotarray[idx1] = 1
@@ -823,11 +823,11 @@ class PlotCrossSection:
                     idx = mflist["node"]
 
         if len(self.mg.shape) != 3:
-            plotarray = np.zeros((self._nlay, self._ncpl), dtype=np.int)
+            plotarray = np.zeros((self._nlay, self._ncpl), dtype=int)
             plotarray[tuple(idx)] = 1
         else:
             plotarray = np.zeros(
-                (self.mg.nlay, self.mg.nrow, self.mg.ncol), dtype=np.int
+                (self.mg.nlay, self.mg.nrow, self.mg.ncol), dtype=int
             )
             plotarray[idx[0], idx[1], idx[2]] = 1
 
@@ -1155,7 +1155,7 @@ class PlotCrossSection:
             # thickness by setting laytyp to zeros
             if head is None or laytyp is None:
                 head = np.zeros(botm.shape, np.float32)
-                laytyp = np.zeros((nlay,), dtype=np.int)
+                laytyp = np.zeros((nlay,), dtype=int)
                 head[0, :, :] = top
                 if nlay > 1:
                     head[1:, :, :] = botm[:-1, :, :]
@@ -1170,7 +1170,7 @@ class PlotCrossSection:
             )
 
             if qz is None:
-                qz = np.zeros(qx.shape, dtype=np.float)
+                qz = np.zeros(qx.shape, dtype=float)
 
             qx = qx.ravel()
             qy = qy.ravel()

--- a/flopy/plot/map.py
+++ b/flopy/plot/map.py
@@ -485,9 +485,9 @@ class PlotMapView:
 
         nlay = self.mg.nlay
 
-        plotarray = np.zeros(self.mg.shape, dtype=np.int)
+        plotarray = np.zeros(self.mg.shape, dtype=int)
         if plotAll and len(self.mg.shape) > 1:
-            pa = np.zeros(self.mg.shape[1:], dtype=np.int)
+            pa = np.zeros(self.mg.shape[1:], dtype=int)
             pa[tuple(idx[1:])] = 1
             for k in range(nlay):
                 plotarray[k] = pa.copy()

--- a/flopy/utils/rasters.py
+++ b/flopy/utils/rasters.py
@@ -57,7 +57,7 @@ class Raster:
     FLOAT64 = (np.float64,)
     INT8 = (np.int8,)
     INT16 = (np.int16,)
-    INT32 = (int, np.int, np.int32, np.uint32)
+    INT32 = (int, np.int32, np.uint32)
     INT64 = (np.int64,)
 
     def __init__(


### PR DESCRIPTION
This is a re-do of #1052 for changes from #1078.