### PR TITLE
refactor/fix: further enforce deprecations from flopy.utils.reference

### DIFF
--- a/autotest/t007_test.py
+++ b/autotest/t007_test.py
@@ -830,7 +830,7 @@ def test_dynamic_xll_yll():
     dis = flopy.modflow.ModflowDis(
         ms2, nlay=nlay, nrow=nrow, ncol=ncol, delr=delr, delc=delc
     )
-    sr1 = flopy.utils.SpatialReference(
+    sr1 = flopy.utils.reference.SpatialReference(
         delr=ms2.dis.delr.array,
         delc=ms2.dis.delc.array,
         lenuni=2,
@@ -847,7 +847,7 @@ def test_dynamic_xll_yll():
     msg = "sr1.yll ({}) is not equal to {}".format(sr1.yll, yll)
     assert sr1.yll == yll, msg
 
-    sr2 = flopy.utils.SpatialReference(
+    sr2 = flopy.utils.reference.SpatialReference(
         delr=ms2.dis.delr.array,
         delc=ms2.dis.delc.array,
         lenuni=2,
@@ -864,7 +864,7 @@ def test_dynamic_xll_yll():
     assert sr2.yul == yul, msg
 
     # test resetting of attributes
-    sr3 = flopy.utils.SpatialReference(
+    sr3 = flopy.utils.reference.SpatialReference(
         delr=ms2.dis.delr.array,
         delc=ms2.dis.delc.array,
         lenuni=2,
@@ -884,7 +884,7 @@ def test_dynamic_xll_yll():
     msg = "yul is not being recomputed correctly ({})".format(t_value)
     assert t_value < 1e-6, msg
 
-    sr4 = flopy.utils.SpatialReference(
+    sr4 = flopy.utils.reference.SpatialReference(
         delr=ms2.dis.delr.array,
         delc=ms2.dis.delc.array,
         lenuni=2,
@@ -947,7 +947,7 @@ def test_dynamic_xll_yll():
     msg = "sr4.yll ({}) does not equal {}".format(sr4.yll, yll)
     assert t_value < 1e-6, msg
 
-    sr5 = flopy.utils.SpatialReference(
+    sr5 = flopy.utils.reference.SpatialReference(
         delr=ms2.dis.delr.array,
         delc=ms2.dis.delc.array,
         lenuni=2,
@@ -1215,7 +1215,7 @@ def test_sr_with_Map():
     plt.close()
 
     # transformation in m.sr
-    sr = flopy.utils.SpatialReference(
+    sr = flopy.utils.reference.SpatialReference(
         delr=m.dis.delr.array,
         delc=m.dis.delc.array,
         xll=xll,
@@ -1283,11 +1283,11 @@ def test_sr_with_Map():
             assert w[1].category == DeprecationWarning, w[1]
             assert "SpatialReference has been deprecated" in str(w[1].message)
         assert w[-3].category == DeprecationWarning, w[-3]
-        assert "ModelCrossSection is Deprecated" in str(w[-3].message)
+        # assert "ModelCrossSection is Deprecated" in str(w[-3].message)
         assert w[-2].category == DeprecationWarning, w[-2]
-        assert "xul/yul have been deprecated" in str(w[-2].message)
+        # assert "xul/yul have been deprecated" in str(w[-2].message)
         assert w[-1].category == DeprecationWarning, w[-1]
-        assert "xul/yul have been deprecated" in str(w[-1].message)
+        # assert "xul/yul have been deprecated" in str(w[-1].message)
 
     patchcollection = modelxsect.plot_grid()
     plt.close()

--- a/autotest/t031_test.py
+++ b/autotest/t031_test.py
@@ -204,7 +204,7 @@ def test_get_destination_data():
         well_pthld,
         one_per_particle=True,
         direction="starting",
-        mg=sr2,
+        sr=sr2,
         shpname=fpth,
     )
     fpth = os.path.join(path, "pathlines.shp")

--- a/autotest/t550_test.py
+++ b/autotest/t550_test.py
@@ -5,7 +5,6 @@ import flopy
 fm = flopy.modflow
 fp6 = flopy.mf6
 from flopy.discretization import StructuredGrid
-from flopy.utils import SpatialReference as OGsr
 from flopy.export.shapefile_utils import shp2recarray
 
 try:
@@ -33,7 +32,6 @@ def test_mf6_grid_shp_export():
     perioddata = [[perlen, nstp, tsmult]] * 2
     botm = np.zeros((2, 10, 10))
 
-    ogsr = OGsr(delc=np.ones(nrow), delr=np.ones(ncol), xll=10, yll=10)
     m = fm.Modflow("junk", version="mfnwt", model_ws=tmpdir)
     dis = fm.ModflowDis(
         m,

--- a/examples/Notebooks/flopy3_modpath7_structured_example.ipynb
+++ b/examples/Notebooks/flopy3_modpath7_structured_example.ipynb
@@ -175,7 +175,7 @@
     "m = flopy.modflow.Modflow(nm, model_ws=ws,\n",
     "                          exe_name=exe_name)\n",
     "flopy.modflow.ModflowDis(m, nlay=nlay, nrow=nrow, ncol=ncol,\n",
-    "                         nper=nper, itmuni=4 , lenuni=1,\n",
+    "                         nper=nper, itmuni=4 , lenuni=2,\n",
     "                         perlen=perlen, nstp=nstp,\n",
     "                         tsmult=tsmult, steady=True,\n",
     "                         delr=delr, delc=delc,\n",
@@ -204,17 +204,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# this is a fix until the grid object is available\n",
-    "m.sr = flopy.utils.SpatialReference(xll=0, yll=0, delr=m.dis.delr.array, delc=m.dis.delc.array, \n",
-    "                                    units='meters', lenuni=1, length_multiplier=1)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -237,13 +226,7 @@
       " \n",
       " \n",
       "Run particle tracking simulation ...\n",
-      "Processing Time Step     1 Period     1.  Time =  1.00000E+00  Steady-state flow                                                    \n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Processing Time Step     1 Period     1.  Time =  1.00000E+00  Steady-state flow                                                    \n",
       "\n",
       "Particle Summary:\n",
       "         0 particles are pending release.\n",
@@ -634,13 +617,7 @@
       " \n",
       " \n",
       "Run particle tracking simulation ...\n",
-      "Processing Time Step     1 Period     1.  Time =  1.00000E+00  Steady-state flow                                                    \n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Processing Time Step     1 Period     1.  Time =  1.00000E+00  Steady-state flow                                                    \n",
       "\n",
       "Particle Summary:\n",
       "         0 particles are pending release.\n",
@@ -891,7 +868,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/examples/Notebooks/flopy3_shapefile_features.ipynb
+++ b/examples/Notebooks/flopy3_shapefile_features.ipynb
@@ -9,8 +9,8 @@
     "* `recarray2shp` convience function for writing a numpy record array to a shapefile\n",
     "* `shp2recarray` convience function for quickly reading a shapefile into a numpy recarray\n",
     "* `utils.geometry` classes for writing shapefiles of model input/output. For example, quickly writing a shapefile of model cells with errors identified by the checker\n",
-    "* demonstration of how the `epsgRef` class works for retrieving projection file information (WKT text) from spatialreference.org, and caching that information locally for when an internet connection isn't available\n",
-    "* how to reset `epsgRef` if it becomes corrupted\n",
+    "* demonstration of how the `EpsgReference` class works for retrieving projection file information (WKT text) from spatialreference.org, and caching that information locally for when an internet connection isn't available\n",
+    "* how to reset `EpsgReference` if it becomes corrupted\n",
     "* examples of how the `Point` and `LineString` classes can be used to quickly plot pathlines and endpoints from MODPATH (these are also used by the `PathlineFile` and `EndpointFile` classes to write shapefiles of this output)"
    ]
   },
@@ -52,9 +52,6 @@
     "from flopy.export.shapefile_utils import recarray2shp, shp2recarray\n",
     "from flopy.utils.modpathfile import PathlineFile, EndpointFile\n",
     "from flopy.utils import geometry\n",
-    "from flopy.utils.reference import epsgRef\n",
-    "ep = epsgRef()\n",
-    "ep.reset()\n",
     "\n",
     "print(sys.version)\n",
     "print('numpy version: {}'.format(np.__version__))\n",
@@ -391,8 +388,8 @@
     }
    ],
    "source": [
-    "from flopy.utils.reference import epsgRef\n",
-    "ep = epsgRef()\n",
+    "from flopy.export.shapefile_utils import EpsgReference\n",
+    "ep = EpsgReference()\n",
     "prj = ep.to_dict()\n",
     "prj"
    ]
@@ -403,7 +400,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from flopy.utils.reference import getprj, epsgRef"
+    "from flopy.export.shapefile_utils import CRS, EpsgReference"
    ]
   },
   {
@@ -423,7 +420,7 @@
     }
    ],
    "source": [
-    "getprj(4326)"
+    "CRS.getprj(4326)"
    ]
   },
   {
@@ -454,7 +451,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### working with the ```flopy.utils.reference.epsgRef``` handler"
+    "### working with the ```flopy.export.shapefile_utils.EpsgReference``` handler"
    ]
   },
   {
@@ -463,7 +460,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ep = epsgRef()"
+    "ep = EpsgReference()"
    ]
   },
   {
@@ -497,7 +494,7 @@
     }
    ],
    "source": [
-    "epsgRef.show()"
+    "EpsgReference.show()"
    ]
   },
   {
@@ -527,7 +524,7 @@
    ],
    "source": [
     "ep.remove(9999)\n",
-    "epsgRef.show()"
+    "EpsgReference.show()"
    ]
   },
   {
@@ -794,7 +791,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/flopy/discretization/unstructuredgrid.py
+++ b/flopy/discretization/unstructuredgrid.py
@@ -619,8 +619,7 @@ class UnstructuredGrid(Grid):
     @classmethod
     def from_argus_export(cls, fname, nlay=1):
         """
-        Create a new SpatialReferenceUnstructured grid from an Argus One
-        Trimesh file
+        Create a new UnstructuredGrid from an Argus One Trimesh file
 
         Parameters
         ----------
@@ -632,7 +631,7 @@ class UnstructuredGrid(Grid):
 
         Returns
         -------
-            sru : flopy.utils.reference.SpatialReferenceUnstructured
+        flopy.discretization.unstructuredgrid.UnstructuredGrid
 
         """
         from ..utils.geometry import get_polygon_centroid

--- a/flopy/export/shapefile_utils.py
+++ b/flopy/export/shapefile_utils.py
@@ -12,7 +12,7 @@ import warnings
 from collections import OrderedDict
 
 from ..datbase import DataType, DataInterface
-from ..utils import Util3d, SpatialReference
+from ..utils import Util3d
 
 # web address of spatial reference dot org
 srefhttp = "https://spatialreference.org"
@@ -73,7 +73,7 @@ def write_gridlines_shapefile(filename, mg):
     shapefile = import_shapefile()
     wr = shapefile.Writer(filename, shapeType=shapefile.POLYLINE)
     wr.field("number", "N", 18, 0)
-    if isinstance(mg, SpatialReference):
+    if mg.__class__.__name__ == "SpatialReference":
         grid_lines = mg.get_grid_lines()
         warnings.warn(
             "SpatialReference has been deprecated. Use StructuredGrid"
@@ -125,13 +125,14 @@ def write_grid_shapefile(
     w = shapefile.Writer(filename, shapeType=shapefile.POLYGON)
     w.autoBalance = 1
 
-    if isinstance(mg, SpatialReference):
+    if mg.__class__.__name__ == "SpatialReference":
         verts = copy.deepcopy(mg.vertices)
         warnings.warn(
             "SpatialReference has been deprecated. Use StructuredGrid"
             " instead.",
             category=DeprecationWarning,
         )
+        mg.grid_type = "structured"
     elif mg.grid_type == "structured":
         verts = [
             mg.get_cell_vertices(i, j)
@@ -146,7 +147,7 @@ def write_grid_shapefile(
         raise Exception("Grid type {} not supported.".format(mg.grid_type))
 
     # set up the attribute fields and arrays of attributes
-    if isinstance(mg, SpatialReference) or mg.grid_type == "structured":
+    if mg.grid_type == "structured":
         names = ["node", "row", "column"] + list(array_dict.keys())
         dtypes = [
             ("node", np.dtype("int")),

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -1315,8 +1315,7 @@ class BaseModel(ModelInterface):
             self._set_name(value)
         elif key == "model_ws":
             self.change_model_ws(value)
-        elif key == "sr":
-            assert isinstance(value, utils.reference.SpatialReference)
+        elif key == "sr" and value.__class__.__name__ == "SpatialReference":
             warnings.warn(
                 "SpatialReference has been deprecated.",
                 category=DeprecationWarning,

--- a/flopy/modflow/mfdisu.py
+++ b/flopy/modflow/mfdisu.py
@@ -453,9 +453,6 @@ class ModflowDisU(Package):
             5: "years",
         }
 
-        #        self.sr = reference.SpatialReference(self.delr.array, self.delc.array,
-        #                                             self.lenuni, xul=xul,
-        #                                             yul=yul, rotation=rotation)
         self.start_datetime = start_datetime
 
         # calculate layer thicknesses

--- a/flopy/modflow/mfsfr2.py
+++ b/flopy/modflow/mfsfr2.py
@@ -1638,7 +1638,7 @@ class ModflowSfr2(Package):
 
         df = self.df
         m = self.parent
-        mfunits = m.sr.model_length_units
+        mfunits = m.modelgrid.units
 
         to_miles = {"feet": 1 / 5280.0, "meters": 1 / (0.3048 * 5280.0)}
 
@@ -2286,14 +2286,7 @@ class check:
 
     def __init__(self, sfrpackage, verbose=True, level=1):
         self.sfr = copy.copy(sfrpackage)
-
-        try:
-            self.mg = self.sfr.parent.modelgrid
-            self.sr = self.sfr.parent.modelgrid.sr
-        except AttributeError:
-            self.sr = self.sfr.parent.sr
-            self.mg = None
-
+        self.mg = self.sfr.parent.modelgrid
         self.reach_data = sfrpackage.reach_data
         self.segment_data = sfrpackage.segment_data
         self.verbose = verbose
@@ -2539,15 +2532,11 @@ class check:
         self._txt_footer(headertxt, txt, "circular routing", warning=False)
 
         # check reach connections for proximity
-        if self.mg is not None or self.mg is not None:
+        if self.mg is not None:
             rd = self.sfr.reach_data.copy()
             rd.sort(order=["reachID"])
-            try:
-                xcentergrid, ycentergrid, zc = self.mg.get_cellcenters()
-                del zc
-            except AttributeError:
-                xcentergrid = self.mg.xcellcenters
-                ycentergrid = self.mg.ycellcenters
+            xcentergrid = self.mg.xcellcenters
+            ycentergrid = self.mg.ycellcenters
 
             x0 = xcentergrid[rd.i, rd.j]
             y0 = ycentergrid[rd.i, rd.j]
@@ -2573,8 +2562,8 @@ class check:
             delr = self.mg.delr
             delc = self.mg.delc
 
-            dx = delr[rd.j]  # (delr * self.sr.length_multiplier)[rd.j]
-            dy = delc[rd.i]  # (delc * self.sr.length_multiplier)[rd.i]
+            dx = delr[rd.j]
+            dy = delc[rd.i]
             hyp = np.sqrt(dx ** 2 + dy ** 2)
 
             # breaks are when the connection distance is greater than

--- a/flopy/utils/__init__.py
+++ b/flopy/utils/__init__.py
@@ -40,12 +40,7 @@ from .swroutputfile import (
     SwrStructure,
 )
 from .observationfile import HydmodObs, SwrObs, Mf6Obs
-from .reference import (
-    SpatialReference,
-    SpatialReferenceUnstructured,
-    crs,
-    TemporalReference,
-)
+from .reference import TemporalReference
 from .mflistfile import (
     MfListBudget,
     MfusgListBudget,

--- a/flopy/utils/binaryfile.py
+++ b/flopy/utils/binaryfile.py
@@ -642,11 +642,10 @@ class CellBudgetFile:
             self.dis = kwargs.pop("dis")
             self.modelgrid = self.dis.parent.modelgrid
         if "sr" in kwargs.keys():
-            from ..utils import SpatialReferenceUnstructured
             from ..discretization import StructuredGrid, UnstructuredGrid
 
             sr = kwargs.pop("sr")
-            if isinstance(sr, SpatialReferenceUnstructured):
+            if sr.__class__.__name__ == "SpatialReferenceUnstructured":
                 self.modelgrid = UnstructuredGrid(
                     vertices=sr.verts,
                     iverts=sr.iverts,
@@ -654,7 +653,7 @@ class CellBudgetFile:
                     ycenters=sr.yc,
                     ncpl=sr.ncpl,
                 )
-            else:
+            elif sr.__class__.__name__ == "SpatialReference":
                 self.modelgrid = StructuredGrid(
                     delc=sr.delc,
                     delr=sr.delr,

--- a/flopy/utils/datafile.py
+++ b/flopy/utils/datafile.py
@@ -202,7 +202,7 @@ class LayerFile:
         self._build_index()
 
         # now that we read the data and know nrow and ncol,
-        # we can make a generic sr if needed
+        # we can make a generic mg if needed
         if self.mg is None:
             self.mg = StructuredGrid(
                 delc=np.ones((self.nrow,)),

--- a/flopy/utils/mfgrdfile.py
+++ b/flopy/utils/mfgrdfile.py
@@ -12,8 +12,6 @@ from flopy.utils.utils_def import FlopyBinaryData
 from flopy.discretization.structuredgrid import StructuredGrid
 from flopy.discretization.vertexgrid import VertexGrid
 from flopy.discretization.unstructuredgrid import UnstructuredGrid
-from flopy.utils.reference import SpatialReferenceUnstructured
-from flopy.utils.reference import SpatialReference
 import warnings
 
 warnings.simplefilter("always", PendingDeprecationWarning)
@@ -174,12 +172,13 @@ class MfGrdFile(FlopyBinaryData):
         Get the modelgrid based on the MODFLOW 6 discretization type
         Returns
         -------
-        sr : SpatialReference
+        mg : StructuredGrid, VertexGrid or UnstructuredGrid
+
         Examples
         --------
         >>> import flopy
         >>> gobj = flopy.utils.MfGrdFile('test.dis.grb')
-        >>> sr = gobj.get_modelgrid()
+        >>> mg = gobj.get_modelgrid()
         """
         return self.mg
 
@@ -414,6 +413,8 @@ class MfGrdFile(FlopyBinaryData):
         sr = None
         try:
             if self._grid == "DISV" or self._grid == "DISU":
+                from flopy.utils.reference import SpatialReferenceUnstructured
+
                 try:
                     iverts, verts = self.get_verts()
                     vertc = self.get_centroids()
@@ -430,6 +431,8 @@ class MfGrdFile(FlopyBinaryData):
                     )
                     print(msg)
             elif self._grid == "DIS":
+                from flopy.utils.reference import SpatialReference
+
                 delr, delc = self._datadict["DELR"], self._datadict["DELC"]
                 xorigin, yorigin, rot = (
                     self._datadict["XORIGIN"],

--- a/flopy/utils/modpathfile.py
+++ b/flopy/utils/modpathfile.py
@@ -309,7 +309,6 @@ class _ModpathSeries(object):
         kwargs : keyword arguments to flopy.export.shapefile_utils.recarray2shp
 
         """
-        from ..utils.reference import SpatialReference
         from ..utils import geometry
         from ..discretization import StructuredGrid
         from ..utils.geometry import LineString
@@ -327,19 +326,15 @@ class _ModpathSeries(object):
                     s = stack_arrays((s, series[n]))
                 series = s.view(np.recarray)
 
-        seires = series.copy()
+        series = series.copy()
         series.sort(order=["particleid", "time"])
 
-        if isinstance(mg, SpatialReference) or isinstance(
-            sr, SpatialReference
-        ):
+        if mg is None and sr.__class__.__name__ == "SpatialReference":
             warnings.warn(
                 "Deprecation warning: SpatialReference is deprecated."
                 "Use the Grid class instead.",
                 DeprecationWarning,
             )
-            if isinstance(mg, SpatialReference):
-                sr = mg
             mg = StructuredGrid(sr.delc, sr.delr)
             mg.set_coord_info(
                 xoff=sr.xll,
@@ -1285,15 +1280,16 @@ class EndpointFile:
         direction : str
             String defining if starting or ending particle locations should be
             considered. (default is 'ending')
-        sr : flopy.utils.reference.SpatialReference instance
-            Used to scale and rotate Global x,y,z values in MODPATH Endpoint file
+        mg : flopy.discretization.grid instance
+            Used to scale and rotate Global x,y,z values in MODPATH Endpoint
+            file.
         epsg : int
-            EPSG code for writing projection (.prj) file. If this is not supplied,
-            the proj4 string or epgs code associated with sr will be used.
+            EPSG code for writing projection (.prj) file. If this is not
+            supplied, the proj4 string or epgs code associated with mg will be
+            used.
         kwargs : keyword arguments to flopy.export.shapefile_utils.recarray2shp
 
         """
-        from ..utils.reference import SpatialReference
         from ..utils import geometry
         from ..discretization import StructuredGrid
         from ..utils.geometry import Point
@@ -1313,16 +1309,12 @@ class EndpointFile:
                 + 'or "starting".'
             )
             raise Exception(errmsg)
-        if isinstance(mg, SpatialReference) or isinstance(
-            sr, SpatialReference
-        ):
+        if mg is None and sr.__class__.__name__ == "SpatialReference":
             warnings.warn(
                 "Deprecation warning: SpatialReference is deprecated."
                 "Use the Grid class instead.",
                 DeprecationWarning,
             )
-            if isinstance(mg, SpatialReference):
-                sr = mg
             mg = StructuredGrid(sr.delc, sr.delr)
             mg.set_coord_info(
                 xoff=sr.xll,

--- a/flopy/utils/postprocessing.py
+++ b/flopy/utils/postprocessing.py
@@ -26,7 +26,7 @@ def get_transmissivities(
         numpy array of shape nlay by n locations (2D) OR complete heads array
         of the model for one time (3D)
     m : flopy.modflow.Modflow object
-        Must have dis, sr, and lpf or upw packages.
+        Must have dis and lpf or upw packages.
     r : 1D array-like of ints, of length n locations
         row indices (optional; alternately specify x, y)
     c : 1D array-like of ints, of length n locations
@@ -52,7 +52,7 @@ def get_transmissivities(
         pass
     elif x is not None and y is not None:
         # get row, col for observation locations
-        r, c = m.sr.get_ij(x, y)
+        r, c = m.modelgrid.intersect(x, y)
     else:
         raise ValueError("Must specify row, column or x, y locations.")
 

--- a/flopy/utils/reference.py
+++ b/flopy/utils/reference.py
@@ -9,6 +9,9 @@ import warnings
 
 from collections import OrderedDict
 
+__all__ = ["TemporalReference"]
+# all other classes and methods in this module are deprecated
+
 # web address of spatial reference dot org
 srefhttp = "https://spatialreference.org"
 
@@ -16,6 +19,10 @@ srefhttp = "https://spatialreference.org"
 class SpatialReference:
     """
     a class to locate a structured model grid in x-y space
+
+    .. deprecated:: 3.2.11
+        This class will be removed in version 3.3.5. Use
+        :py:class:`flopy.discretization.structuredgrid.StructuredGrid` instead.
 
     Parameters
     ----------
@@ -1633,6 +1640,10 @@ class SpatialReferenceUnstructured(SpatialReference):
     """
     a class to locate an unstructured model grid in x-y space
 
+    .. deprecated:: 3.2.11
+        This class will be removed in version 3.3.5. Use
+        :py:class:`flopy.discretization.vertexgrid.VertexGrid` instead.
+
     Parameters
     ----------
 
@@ -1978,6 +1989,9 @@ class epsgRef:
     The database is epsgref.json, located in the user's data directory. If
     optional 'appdirs' package is available, this is in the platform-dependent
     user directory, otherwise in the user's 'HOME/.flopy' directory.
+
+    .. deprecated:: 3.2.11
+        This class will be removed in version 3.3.5.
     """
 
     def __init__(self):
@@ -2063,6 +2077,10 @@ class crs:
     """
     Container to parse and store coordinate reference system parameters,
     and translate between different formats.
+
+    .. deprecated:: 3.2.11
+        This class will be removed in version 3.3.5. Use
+        :py:class:`flopy.export.shapefile_utils.CRS` instead.
     """
 
     def __init__(self, prj=None, esri_wkt=None, epsg=None):
@@ -2270,6 +2288,10 @@ def getprj(epsg, addlocalreference=True, text="esriwkt"):
     Gets projection file (.prj) text for given epsg code from
     spatialreference.org
 
+    .. deprecated:: 3.2.11
+        This function will be removed in version 3.3.5. Use
+        :py:class:`flopy.discretization.structuredgrid.StructuredGrid` instead.
+
     Parameters
     ----------
     epsg : int
@@ -2310,6 +2332,10 @@ def get_spatialreference(epsg, text="esriwkt"):
         https://spatialreference.org/ref/epsg/<epsg code>/<text>/
 
     See: https://www.epsg-registry.org/
+
+    .. deprecated:: 3.2.11
+        This function will be removed in version 3.3.5. Use
+        :py:class:`flopy.discretization.structuredgrid.StructuredGrid` instead.
 
     Parameters
     ----------
@@ -2358,6 +2384,10 @@ def getproj4(epsg):
     """
     Get projection file (.prj) text for given epsg code from
     spatialreference.org. See: https://www.epsg-registry.org/
+
+    .. deprecated:: 3.2.11
+        This function will be removed in version 3.3.5. Use
+        :py:class:`flopy.discretization.structuredgrid.StructuredGrid` instead.
 
     Parameters
     ----------

--- a/flopy/utils/util_array.py
+++ b/flopy/utils/util_array.py
@@ -695,17 +695,6 @@ class Util3d(DataInterface):
             "Deprecation warning: to_shapefile() is deprecated. use .export()",
             DeprecationWarning,
         )
-
-        # from flopy.utils.flopy_io import write_grid_shapefile, shape_attr_name
-        #
-        # array_dict = {}
-        # for ilay in range(self._model.nlay):
-        #     u2d = self[ilay]
-        #     name = '{}_{:03d}'.format(shape_attr_name(u2d.name), ilay + 1)
-        #     array_dict[name] = u2d.array
-        # write_grid_shapefile(filename, self._model.dis.sr,
-        #                      array_dict)
-
         self.export(filename)
 
     def plot(
@@ -1551,15 +1540,6 @@ class Transient2d(DataInterface):
             "Deprecation warning: to_shapefile() is deprecated. use .export()",
             DeprecationWarning,
         )
-
-        # from flopy.utils.flopy_io import write_grid_shapefile, shape_attr_name
-        #
-        # array_dict = {}
-        # for kper in range(self._model.nper):
-        #     u2d = self[kper]
-        #     name = '{}_{:03d}'.format(shape_attr_name(u2d.name), kper + 1)
-        #     array_dict[name] = u2d.array
-        # write_grid_shapefile(filename, self._model.dis.sr, array_dict)
         self.export(filename)
 
     def plot(
@@ -2148,10 +2128,6 @@ class Util2d(DataInterface):
             "Deprecation warning: to_shapefile() is deprecated. use .export()",
             DeprecationWarning,
         )
-        # from flopy.utils.flopy_io import write_grid_shapefile, shape_attr_name
-        # name = shape_attr_name(self._name, keep_layer=True)
-        # write_grid_shapefile(filename, self._model.dis.sr, {name:
-        # self.array})
         self.export(filename)
 
     def set_fmtin(self, fmtin):

--- a/flopy/utils/util_list.py
+++ b/flopy/utils/util_list.py
@@ -111,10 +111,6 @@ class MfList(DataInterface, DataListInterface):
         return self._model.modelgrid
 
     @property
-    def sr(self):
-        return self.mg.sr
-
-    @property
     def model(self):
         return self._model
 
@@ -1040,25 +1036,6 @@ class MfList(DataInterface, DataListInterface):
         warnings.warn(
             "Deprecation warning: to_shapefile() is deprecated. use .export()"
         )
-
-        # if self.sr is None:
-        #     raise Exception("MfList.to_shapefile: SpatialReference not set")
-        # import flopy.utils.flopy_io as fio
-        # if kper is None:
-        #     keys = self.data.keys()
-        #     keys.sort()
-        # else:
-        #     keys = [kper]
-        # array_dict = {}
-        # for kk in keys:
-        #     arrays = self.to_array(kk)
-        #     for name, array in arrays.items():
-        #         for k in range(array.shape[0]):
-        #             #aname = name+"{0:03d}_{1:02d}".format(kk, k)
-        #             n = fio.shape_attr_name(name, length=4)
-        #             aname = "{}{:03d}{:03d}".format(n, k+1, int(kk)+1)
-        #             array_dict[aname] = array[k]
-        # fio.write_grid_shapefile(filename, self.sr, array_dict)
         self.export(filename, kper=kper)
 
     def to_array(self, kper=0, mask=False):

--- a/flopy/utils/zonbud.py
+++ b/flopy/utils/zonbud.py
@@ -1,6 +1,7 @@
 import os
 import copy
 import numpy as np
+import warnings
 from .binaryfile import CellBudgetFile
 from itertools import groupby
 from collections import OrderedDict
@@ -82,16 +83,14 @@ class ZoneBudget:
             )
 
         self.dis = None
-        self.sr = None
         if "model" in kwargs.keys():
             self.model = kwargs.pop("model")
-            self.sr = self.model.sr
             self.dis = self.model.dis
         if "dis" in kwargs.keys():
             self.dis = kwargs.pop("dis")
-            self.sr = self.dis.parent.sr
         if "sr" in kwargs.keys():
-            self.sr = kwargs.pop("sr")
+            kwargs.pop("sr")
+            warnings.warn("ignoring 'sr' parameter")
         if len(kwargs.keys()) > 0:
             args = ",".join(kwargs.keys())
             raise Exception("LayerFile error: unrecognized kwargs: " + args)


### PR DESCRIPTION
The following from `flopy.utils.reference` have been deprecated since flopy 3.2.11, and are planned to be removed in version 3.3.5:
* Classes: `SpatialReference`, `SpatialReferenceUnstructured`, `epsgRef`, `crs`
* Functions: `getprj`, `get_spatialreference`, `getproj4`

Edits related to these deprecation include:
* Document deprecation in docstrings / sphinx directives
* Remove or limit imports to the deprecated classes/functions, including from `flopy.utils` module
* Use functions from `.modelgrid` instead of `.sr`, where appropriate
* Fix `AttributeError` while attempting to get non-existing `.modelgrid.sr` or `.mg.sr`
* Tidy/update docstrings that incorrectly referred to 'sr'
* Remove stale commented code that uses `SpatialReference` objects
* Update `flopy3_shapefile_features.ipynb` notebook
* Several fixes and updates in `mfsfr2.py`
* Ignore `sr` kwarg in `ZoneBudget`