### PR TITLE
fix(mfsfr2.check): make "reach_connection_gaps.chk.csv" a normal CSV file

### DIFF
--- a/flopy/modflow/mfsfr2.py
+++ b/flopy/modflow/mfsfr2.py
@@ -2582,12 +2582,14 @@ class check:
                     txt += "At segments:\n"
                     txt += " ".join(map(str, segments_with_breaks)) + "\n"
                 else:
-                    f = os.path.join(
+                    fpath = os.path.join(
                         self.sfr.parent._model_ws,
                         "reach_connection_gaps.chk.csv",
                     )
-                    rd.tofile(f, sep="\t")
-                    txt += "See {} for details.".format(f)
+                    with open(fpath, "w") as fp:
+                        fp.write(",".join(rd.dtype.names) + "\n")
+                        np.savetxt(fp, rd, "%s", ",")
+                    txt += "See {} for details.".format(fpath)
                 if self.verbose:
                     print(txt)
             self._txt_footer(


### PR DESCRIPTION
While the previous format of "reach_connection_gaps.chk.csv" was a text file, it was not well formatted.

This PR writes the numpy recarray as a conventional CSV file.