### PR TITLE
feat(data storage): Data automatically stored internally when simulation or model relative path changed (#1126)

### DIFF
--- a/autotest/t504_test.py
+++ b/autotest/t504_test.py
@@ -76,9 +76,12 @@ def test001a_tharmonic():
     sim.simulation_data.mfpath.set_sim_path(run_folder)
 
     # write simulation to new location
-    sim.set_all_data_external()
+    sim.set_all_data_external(external_data_folder="data")
     sim.write_simulation(silent=True)
-
+    # verify external data written to correct location
+    data_path = os.path.join(run_folder, "data", "flow15.dis_botm.txt")
+    assert os.path.exists(data_path)
+    # model export test
     model = sim.get_model(model_name)
     model.export("{}/tharmonic.nc".format(model.model_ws))
     model.export("{}/tharmonic.shp".format(model.model_ws))

--- a/flopy/mf6/data/mfdataarray.py
+++ b/flopy/mf6/data/mfdataarray.py
@@ -3,7 +3,7 @@ import numpy as np
 from collections import OrderedDict
 from ..data.mfstructure import DatumType
 from .mfdatastorage import DataStorage, DataStructureType, DataStorageType
-from ...utils.datautil import MultiList
+from ...utils.datautil import MultiList, DatumUtil
 from ..mfbase import ExtFileAction, MFDataException, VerbosityLevel
 from ..utils.mfenums import DiscretizationType
 from ...datbase import DataType
@@ -1567,31 +1567,29 @@ class MFTransientArray(MFArray, MFTransient):
             check_data : bool
                 Verify data prior to storing
         """
-        sim_time = self._data_dimensions.package_dim.model_dim[
-            0
-        ].simulation_time
-        num_sp = sim_time.get_num_stress_periods()
         # store each stress period in separate file(s)
-        for sp in range(0, num_sp):
-            if sp in self._data_storage:
-                self._current_key = sp
-                layer_storage = self._get_storage_obj().layer_storage
-                if (
-                    layer_storage.get_total_size() > 0
-                    and self._get_storage_obj()
-                    .layer_storage[0]
-                    .data_storage_type
-                    != DataStorageType.external_file
-                ):
-                    fname, ext = os.path.splitext(external_file_path)
+        for sp in self._data_storage.keys():
+            self._current_key = sp
+            layer_storage = self._get_storage_obj().layer_storage
+            if (
+                layer_storage.get_total_size() > 0
+                and self._get_storage_obj()
+                .layer_storage[0]
+                .data_storage_type
+                != DataStorageType.external_file
+            ):
+                fname, ext = os.path.splitext(external_file_path)
+                if DatumUtil.is_int(sp):
                     full_name = "{}_{}{}".format(fname, sp + 1, ext)
-                    super().store_as_external_file(
-                        full_name,
-                        layer,
-                        binary,
-                        replace_existing_external,
-                        check_data,
-                    )
+                else:
+                    full_name = "{}_{}{}".format(fname, sp, ext)
+                super().store_as_external_file(
+                    full_name,
+                    layer,
+                    binary,
+                    replace_existing_external,
+                    check_data,
+                )
 
     def store_internal(
         self,
@@ -1610,26 +1608,20 @@ class MFTransientArray(MFArray, MFTransient):
             check_data : bool
                 Verify data prior to storing
         """
-        sim_time = self._data_dimensions.package_dim.model_dim[
-            0
-        ].simulation_time
-        num_sp = sim_time.get_num_stress_periods()
-        # store each stress period in separate file(s)
-        for sp in range(0, num_sp):
-            if sp in self._data_storage:
-                self._current_key = sp
-                layer_storage = self._get_storage_obj().layer_storage
-                if (
-                    layer_storage.get_total_size() > 0
-                    and self._get_storage_obj()
-                    .layer_storage[0]
-                    .data_storage_type
-                    == DataStorageType.external_file
-                ):
-                    super().store_internal(
-                        layer,
-                        check_data,
-                    )
+        for sp in self._data_storage.keys():
+            self._current_key = sp
+            layer_storage = self._get_storage_obj().layer_storage
+            if (
+                layer_storage.get_total_size() > 0
+                and self._get_storage_obj()
+                .layer_storage[0]
+                .data_storage_type
+                == DataStorageType.external_file
+            ):
+                super().store_internal(
+                    layer,
+                    check_data,
+                )
 
     def get_data(self, layer=None, apply_mult=True, **kwargs):
         """Returns the data associated with stress period key `layer`.

--- a/flopy/mf6/data/mfdataarray.py
+++ b/flopy/mf6/data/mfdataarray.py
@@ -1573,9 +1573,7 @@ class MFTransientArray(MFArray, MFTransient):
             layer_storage = self._get_storage_obj().layer_storage
             if (
                 layer_storage.get_total_size() > 0
-                and self._get_storage_obj()
-                .layer_storage[0]
-                .data_storage_type
+                and self._get_storage_obj().layer_storage[0].data_storage_type
                 != DataStorageType.external_file
             ):
                 fname, ext = os.path.splitext(external_file_path)
@@ -1613,9 +1611,7 @@ class MFTransientArray(MFArray, MFTransient):
             layer_storage = self._get_storage_obj().layer_storage
             if (
                 layer_storage.get_total_size() > 0
-                and self._get_storage_obj()
-                .layer_storage[0]
-                .data_storage_type
+                and self._get_storage_obj().layer_storage[0].data_storage_type
                 == DataStorageType.external_file
             ):
                 super().store_internal(

--- a/flopy/mf6/data/mfdatalist.py
+++ b/flopy/mf6/data/mfdatalist.py
@@ -1569,9 +1569,7 @@ class MFTransientList(MFList, mfdata.MFTransient, DataListInterface):
             layer_storage = self._get_storage_obj().layer_storage
             if (
                 layer_storage.get_total_size() > 0
-                and self._get_storage_obj()
-                .layer_storage[0]
-                .data_storage_type
+                and self._get_storage_obj().layer_storage[0].data_storage_type
                 != DataStorageType.external_file
             ):
                 fname, ext = os.path.splitext(external_file_path)

--- a/flopy/mf6/data/mfdatalist.py
+++ b/flopy/mf6/data/mfdatalist.py
@@ -1564,29 +1564,28 @@ class MFTransientList(MFList, mfdata.MFTransient, DataListInterface):
 
         """
         self._cache_model_grid = True
-        sim_time = self._data_dimensions.package_dim.model_dim[
-            0
-        ].simulation_time
-        num_sp = sim_time.get_num_stress_periods()
-        for sp in range(0, num_sp):
-            if sp in self._data_storage:
-                self._current_key = sp
-                layer_storage = self._get_storage_obj().layer_storage
-                if (
-                    layer_storage.get_total_size() > 0
-                    and self._get_storage_obj()
-                    .layer_storage[0]
-                    .data_storage_type
-                    != DataStorageType.external_file
-                ):
-                    fname, ext = os.path.splitext(external_file_path)
+        for sp in self._data_storage.keys():
+            self._current_key = sp
+            layer_storage = self._get_storage_obj().layer_storage
+            if (
+                layer_storage.get_total_size() > 0
+                and self._get_storage_obj()
+                .layer_storage[0]
+                .data_storage_type
+                != DataStorageType.external_file
+            ):
+                fname, ext = os.path.splitext(external_file_path)
+                if datautil.DatumUtil.is_int(sp):
                     full_name = "{}_{}{}".format(fname, sp + 1, ext)
-                    super().store_as_external_file(
-                        full_name,
-                        binary,
-                        replace_existing_external,
-                        check_data,
-                    )
+                else:
+                    full_name = "{}_{}{}".format(fname, sp, ext)
+
+                super().store_as_external_file(
+                    full_name,
+                    binary,
+                    replace_existing_external,
+                    check_data,
+                )
         self._cache_model_grid = False
 
     def store_internal(
@@ -1602,20 +1601,15 @@ class MFTransientList(MFList, mfdata.MFTransient, DataListInterface):
 
         """
         self._cache_model_grid = True
-        sim_time = self._data_dimensions.package_dim.model_dim[
-            0
-        ].simulation_time
-        num_sp = sim_time.get_num_stress_periods()
-        for sp in range(0, num_sp):
-            if sp in self._data_storage:
-                self._current_key = sp
-                if (
-                    self._get_storage_obj().layer_storage[0].data_storage_type
-                    == DataStorageType.external_file
-                ):
-                    super().store_internal(
-                        check_data,
-                    )
+        for sp in self._data_storage.keys():
+            self._current_key = sp
+            if (
+                self._get_storage_obj().layer_storage[0].data_storage_type
+                == DataStorageType.external_file
+            ):
+                super().store_internal(
+                    check_data,
+                )
         self._cache_model_grid = False
 
     def get_data(self, key=None, apply_mult=False, **kwargs):

--- a/flopy/mf6/data/mfdatalist.py
+++ b/flopy/mf6/data/mfdatalist.py
@@ -13,7 +13,7 @@ from ...datbase import DataListInterface, DataType
 from ...mbase import ModelInterface
 from .mffileaccess import MFFileAccessList
 from .mfdatastorage import DataStorage, DataStorageType, DataStructureType
-from .mfdatautil import to_string, iterable
+from .mfdatautil import to_string
 
 
 class MFList(mfdata.MFMultiDimVar, DataListInterface):
@@ -284,6 +284,41 @@ class MFList(mfdata.MFMultiDimVar, DataListInterface):
                         "binary": binary,
                     }
                     self._set_data(external_data, check_data=check_data)
+
+    def store_internal(
+        self,
+        check_data=True,
+    ):
+        """Store all data internally.
+
+        Parameters
+        ----------
+            check_data : bool
+                Verify data prior to storing
+
+        """
+        storage = self._get_storage_obj()
+        # check if data is already stored external
+        if (
+            storage is None
+            or storage.layer_storage.first_item().data_storage_type
+            == DataStorageType.external_file
+        ):
+            data = self._get_data()
+            # if not empty dataset
+            if data is not None:
+                if (
+                    self._simulation_data.verbosity_level.value
+                    >= VerbosityLevel.verbose.value
+                ):
+                    print(
+                        "Storing {} internally.."
+                        ".".format(self.structure.name)
+                    )
+                internal_data = {
+                    "data": data,
+                }
+                self._set_data(internal_data, check_data=check_data)
 
     def has_data(self):
         """Returns whether this MFList has any data associated with it."""
@@ -1541,7 +1576,7 @@ class MFTransientList(MFList, mfdata.MFTransient, DataListInterface):
                     layer_storage.get_total_size() > 0
                     and self._get_storage_obj()
                     .layer_storage[0]
-                    .layer_storage_type
+                    .data_storage_type
                     != DataStorageType.external_file
                 ):
                     fname, ext = os.path.splitext(external_file_path)
@@ -1550,6 +1585,35 @@ class MFTransientList(MFList, mfdata.MFTransient, DataListInterface):
                         full_name,
                         binary,
                         replace_existing_external,
+                        check_data,
+                    )
+        self._cache_model_grid = False
+
+    def store_internal(
+        self,
+        check_data=True,
+    ):
+        """Store all data internally.
+
+        Parameters
+        ----------
+            check_data : bool
+                Verify data prior to storing
+
+        """
+        self._cache_model_grid = True
+        sim_time = self._data_dimensions.package_dim.model_dim[
+            0
+        ].simulation_time
+        num_sp = sim_time.get_num_stress_periods()
+        for sp in range(0, num_sp):
+            if sp in self._data_storage:
+                self._current_key = sp
+                if (
+                    self._get_storage_obj().layer_storage[0].data_storage_type
+                    == DataStorageType.external_file
+                ):
+                    super().store_internal(
                         check_data,
                     )
         self._cache_model_grid = False

--- a/flopy/mf6/data/mfdatastorage.py
+++ b/flopy/mf6/data/mfdatastorage.py
@@ -1753,7 +1753,6 @@ class DataStorage:
         read_file = self._simulation_data.mfpath.resolve_path(
             self.layer_storage[layer].fname, model_name
         )
-        # read_file = self.layer_storage[layer].fname
         # currently support files containing ndarrays or recarrays
         if self.data_structure_type == DataStructureType.ndarray:
             file_access = MFFileAccessArray(

--- a/flopy/mf6/data/mfdatastorage.py
+++ b/flopy/mf6/data/mfdatastorage.py
@@ -1373,6 +1373,9 @@ class DataStorage:
                 self._check_line_size(data_check, min_line_size)
 
     def _build_recarray(self, data, key, autofill):
+        if not mfdatautil.PyListUtil.is_iterable(data) or len(data) == 0:
+            # set data to build empty recarray
+            data = [()]
         self.build_type_list(data=data, key=key)
         if not self.tuple_cellids(data):
             # fix data so cellid is a single tuple
@@ -1514,7 +1517,6 @@ class DataStorage:
         # pathing to external file
         data_dim = self.data_dimensions
         model_name = data_dim.package_dim.model_dim[0].model_name
-        fp = self._simulation_data.mfpath.resolve_path(file_path, model_name)
         fp_relative = file_path
         if model_name is not None:
             rel_path = self._simulation_data.mfpath.model_relative_path[
@@ -1523,6 +1525,7 @@ class DataStorage:
             if rel_path is not None and len(rel_path) > 0 and rel_path != ".":
                 # include model relative path in external file path
                 fp_relative = os.path.join(rel_path, file_path)
+        fp = self._simulation_data.mfpath.resolve_path(fp_relative, model_name)
         if data is not None:
             if self.data_structure_type == DataStructureType.recarray:
                 # create external file and write file entry to the file

--- a/flopy/mf6/mfbase.py
+++ b/flopy/mf6/mfbase.py
@@ -230,9 +230,10 @@ class MFFileMgmt:
 
     """
 
-    def __init__(self, path):
+    def __init__(self, path, mfsim=None):
+        self.simulation = mfsim
         self._sim_path = ""
-        self.set_sim_path(path)
+        self.set_sim_path(path, True)
 
         # keys:fully pathed filenames, vals:FilePath instances
         self.existing_file_dict = {}
@@ -292,8 +293,11 @@ class MFFileMgmt:
     def get_updated_path(
         self, external_file_path, model_name, ext_file_action
     ):
+        return external_file_path
+
         """Get updated external file path information.  For internal
         FloPy use, not intended for end user."""
+        """
         external_file_path = self.string_to_file_path(external_file_path)
         if ext_file_action == ExtFileAction.copy_all:
             if os.path.isabs(external_file_path):
@@ -318,6 +322,7 @@ class MFFileMgmt:
                 )
         else:
             return None
+        """
 
     def _build_relative_path(self, model_name):
         old_abs_path = self.resolve_path("", model_name, True)
@@ -434,9 +439,10 @@ class MFFileMgmt:
             new_file_path = MFFilePath(file_path, model_name)
             self.existing_file_dict[file_path] = new_file_path
 
-    def set_sim_path(self, path):
+    def set_sim_path(self, path, internal_use=False):
         """
-        Set the file path to the simulation files
+        Set the file path to the simulation files.  Internal use only,
+        call MFSimulation's set_sim_path method instead.
 
         Parameters
         ----------
@@ -451,7 +457,14 @@ class MFFileMgmt:
         --------
         self.simulation_data.mfdata.set_sim_path('sim_folder')
         """
-
+        if not internal_use:
+            print(
+                "WARNING: MFFileMgt's set_sim_path has been deprecated.  "
+                "Please use MFSimulation's set_sim_path in the future."
+            )
+            if self.simulation is not None:
+                self.simulation.set_sim_path(path)
+                return
         # recalculate paths for everything
         # resolve path type
         path = self.string_to_file_path(path)
@@ -474,23 +487,21 @@ class MFFileMgmt:
         if os.path.isabs(file_path):
             # path is an absolute path
             if move_abs_paths:
-                if model_name is None:
-                    return self.get_sim_path(last_loaded_path)
-                else:
-                    return self.get_model_path(model_name, last_loaded_path)
+                # if model_name is None:
+                return self.get_sim_path(last_loaded_path)
+                # else:
+                #   return self.get_model_path(model_name, last_loaded_path)
             else:
                 return file_path
         else:
             # path is a relative path
-            if model_name is None:
-                return os.path.join(
-                    self.get_sim_path(last_loaded_path), file_path
-                )
-            else:
-                return os.path.join(
-                    self.get_model_path(model_name, last_loaded_path),
-                    file_path,
-                )
+            # if model_name is None:
+            return os.path.join(self.get_sim_path(last_loaded_path), file_path)
+            # else:
+            #    return os.path.join(
+            #        self.get_model_path(model_name, last_loaded_path),
+            #        file_path,
+            #    )
 
 
 class PackageContainer:

--- a/flopy/mf6/mfbase.py
+++ b/flopy/mf6/mfbase.py
@@ -167,10 +167,6 @@ class MFDataException(Exception):
             error_message_4,
             error_message_5,
         )
-        # if self.debug:
-        #    tb_string = ''.join(self.org_tb_string)
-        #    error_message = '{}\nCall Stack\n{}'.format(error_message,
-        #                                                tb_string)
         Exception.__init__(self, error_message)
 
 
@@ -293,36 +289,8 @@ class MFFileMgmt:
     def get_updated_path(
         self, external_file_path, model_name, ext_file_action
     ):
+        """For internal FloPy use, not intended for end user."""
         return external_file_path
-
-        """Get updated external file path information.  For internal
-        FloPy use, not intended for end user."""
-        """
-        external_file_path = self.string_to_file_path(external_file_path)
-        if ext_file_action == ExtFileAction.copy_all:
-            if os.path.isabs(external_file_path):
-                # move file path to local model or simulation path
-                file_name = os.path.split(external_file_path)[1]
-                if model_name:
-                    return os.path.join(
-                        self.get_model_path(model_name), file_name
-                    )
-                else:
-                    return os.path.join(self.get_sim_path(), file_name)
-            else:
-                return external_file_path
-        elif ext_file_action == ExtFileAction.copy_relative_paths:
-            return external_file_path
-        elif ext_file_action == ExtFileAction.copy_none:
-            if os.path.isabs(external_file_path):
-                return external_file_path
-            else:
-                return os.path.join(
-                    self._build_relative_path(model_name), external_file_path
-                )
-        else:
-            return None
-        """
 
     def _build_relative_path(self, model_name):
         old_abs_path = self.resolve_path("", model_name, True)
@@ -487,21 +455,12 @@ class MFFileMgmt:
         if os.path.isabs(file_path):
             # path is an absolute path
             if move_abs_paths:
-                # if model_name is None:
                 return self.get_sim_path(last_loaded_path)
-                # else:
-                #   return self.get_model_path(model_name, last_loaded_path)
             else:
                 return file_path
         else:
             # path is a relative path
-            # if model_name is None:
             return os.path.join(self.get_sim_path(last_loaded_path), file_path)
-            # else:
-            #    return os.path.join(
-            #        self.get_model_path(model_name, last_loaded_path),
-            #        file_path,
-            #    )
 
 
 class PackageContainer:

--- a/flopy/mf6/mfmodel.py
+++ b/flopy/mf6/mfmodel.py
@@ -799,7 +799,14 @@ class MFModel(PackageContainer, ModelInterface):
                     print("    loading package {}...".format(ftype))
                 # load package
                 instance.load_package(ftype, fname, pname, strict, None)
-
+                sim_data = simulation.simulation_data
+                if ftype == "dis" and not sim_data.max_columns_user_set:
+                    # set column wrap to ncol
+                    dis = instance.get_package("dis")
+                    if dis is not None and hasattr(dis, "ncol"):
+                        sim_data.max_columns_of_data = dis.ncol.get_data()
+                        sim_data.max_columns_user_set = False
+                        sim_data.max_columns_auto_set = True
         # load referenced packages
         if modelname in instance.simulation_data.referenced_files:
             for ref_file in instance.simulation_data.referenced_files[
@@ -1178,7 +1185,9 @@ class MFModel(PackageContainer, ModelInterface):
                     package.package_type,
                 )
 
-    def set_all_data_external(self, check_data=True):
+    def set_all_data_external(
+        self, check_data=True, external_data_folder=None
+    ):
         """Sets the model's list and array data to be stored externally.
 
         Parameters
@@ -1186,10 +1195,14 @@ class MFModel(PackageContainer, ModelInterface):
             check_data : bool
                 Determines if data error checking is enabled during this
                 process.
+            external_data_folder
+                Folder, relative to the simulation path or model relative path
+                (see use_model_relative_path parameter), where external data
+                will be stored
 
         """
         for package in self.packagelist:
-            package.set_all_data_external(check_data)
+            package.set_all_data_external(check_data, external_data_folder)
 
     def set_all_data_internal(self, check_data=True):
         """Sets the model's list and array data to be stored externally.

--- a/flopy/mf6/mfmodel.py
+++ b/flopy/mf6/mfmodel.py
@@ -980,6 +980,9 @@ class MFModel(PackageContainer, ModelInterface):
             Model working folder relative to simulation working folder
 
         """
+        # set all data internal
+        self.set_all_data_internal(False)
+
         # update path in the file manager
         file_mgr = self.simulation_data.mfpath
         file_mgr.set_last_accessed_model_path()
@@ -991,6 +994,10 @@ class MFModel(PackageContainer, ModelInterface):
             and model_ws != "."
             and self.simulation.name_file is not None
         ):
+            model_folder_path = file_mgr.get_model_path(self.name)
+            if not os.path.exists(model_folder_path):
+                # make new model folder
+                os.makedirs(model_folder_path)
             # update model name file location in simulation name file
             models = self.simulation.name_file.models
             models_data = models.get_data()
@@ -1183,6 +1190,19 @@ class MFModel(PackageContainer, ModelInterface):
         """
         for package in self.packagelist:
             package.set_all_data_external(check_data)
+
+    def set_all_data_internal(self, check_data=True):
+        """Sets the model's list and array data to be stored externally.
+
+        Parameters
+        ----------
+            check_data : bool
+                Determines if data error checking is enabled during this
+                process.
+
+        """
+        for package in self.packagelist:
+            package.set_all_data_internal(check_data)
 
     def register_package(
         self,

--- a/flopy/mf6/mfpackage.py
+++ b/flopy/mf6/mfpackage.py
@@ -24,6 +24,7 @@ from ..pakbase import PackageInterface
 from .data.mfdatautil import MFComment
 from ..utils.check import mf6check
 from .utils.output_util import MF6Output
+from ..mbase import ModelInterface
 from ..version import __version__
 
 
@@ -807,7 +808,7 @@ class MFBlock:
             if arr_line[0].lower() == "open/close":
                 # open block contents from external file
                 fd_block.readline()
-                fd_path = os.path.split(os.path.realpath(fd_block.name))[0]
+                root_path = self._simulation_data.mfpath.get_sim_path()
                 try:
                     file_name = os.path.split(arr_line[1])[-1]
                     if (
@@ -819,7 +820,7 @@ class MFBlock:
                             ".".format(file_name)
                         )
                     external_file_info = arr_line
-                    fd_block = open(os.path.join(fd_path, file_name), "r")
+                    fd_block = open(os.path.join(root_path, arr_line[1]), "r")
                     # read first line of external file
                     line = fd_block.readline()
                     arr_line = datautil.PyListUtil.split_data_line(line)
@@ -1188,7 +1189,9 @@ class MFBlock:
                     return True
         return False
 
-    def set_all_data_external(self, base_name, check_data=True):
+    def set_all_data_external(
+        self, base_name, check_data=True, external_data_folder=None
+    ):
         """Sets the block's list and array data to be stored externally,
         base_name is external file name's prefix, check_data determines
         if data error checking is enabled during this process.
@@ -1199,6 +1202,8 @@ class MFBlock:
                 Base file name of external files where data will be written to.
             check_data : bool
                 Whether to do data error checking.
+            external_data_folder
+                Folder where external data will be stored
 
         """
         for key, dataset in self.datasets.items():
@@ -1210,8 +1215,29 @@ class MFBlock:
                 )
                 and dataset.enabled
             ):
+                file_path = "{}_{}.txt".format(
+                    base_name, dataset.structure.name
+                )
+                if external_data_folder is not None:
+                    # get simulation root path
+                    root_path = self._simulation_data.mfpath.get_sim_path()
+                    # get model relative path, if it exists
+                    if isinstance(self._model_or_sim, ModelInterface):
+                        name = self._model_or_sim.name
+                        rel_path = (
+                            self._simulation_data.mfpath.model_relative_path[
+                                name
+                            ]
+                        )
+                        if rel_path is not None:
+                            root_path = os.path.join(root_path, rel_path)
+                    full_path = os.path.join(root_path, external_data_folder)
+                    if not os.path.exists(full_path):
+                        # create new external data folder
+                        os.makedirs(full_path)
+                    file_path = os.path.join(external_data_folder, file_path)
                 dataset.store_as_external_file(
-                    "{}_{}.txt".format(base_name, dataset.structure.name),
+                    file_path,
                     replace_existing_external=False,
                     check_data=check_data,
                 )
@@ -2009,22 +2035,27 @@ class MFPackage(PackageContainer, PackageInterface):
         for package in self._packagelist:
             package.set_model_relative_path(model_ws)
 
-    def set_all_data_external(self, check_data=True):
+    def set_all_data_external(
+        self, check_data=True, external_data_folder=None
+    ):
         """Sets the package's list and array data to be stored externally.
 
         Parameters
         ----------
             check_data : bool
                 Determine if data error checking is enabled
-
+            external_data_folder
+                Folder where external data will be stored
         """
         # set blocks
         for key, block in self.blocks.items():
             file_name = os.path.split(self.filename)[1]
-            block.set_all_data_external(file_name, check_data=check_data)
+            block.set_all_data_external(
+                file_name, check_data, external_data_folder
+            )
         # set sub-packages
         for package in self._packagelist:
-            package.set_all_data_external(check_data)
+            package.set_all_data_external(check_data, external_data_folder)
 
     def set_all_data_internal(self, check_data=True):
         """Sets the package's list and array data to be stored internally.

--- a/flopy/utils/datautil.py
+++ b/flopy/utils/datautil.py
@@ -83,6 +83,8 @@ class PyListUtil:
 
     Methods
     -------
+    is_iterable : (obj : unknown) : boolean
+        determines if obj is iterable
     is_empty_list : (current_list : list) : boolean
         determines if an n-dimensional list is empty
     con_convert : (data : string, data_type : type that has conversion
@@ -151,6 +153,14 @@ class PyListUtil:
             isinstance(current_list[0], list)
             or isinstance(current_list, np.ndarray)
         ) and len(current_list[0] != 0):
+            return False
+        return True
+
+    @staticmethod
+    def is_iterable(obj):
+        try:
+            iterator = iter(obj)
+        except TypeError:
             return False
         return True
 


### PR DESCRIPTION
WARNING: This PR may break existing flopy for MF6 scripts that change simulation or model paths.  Data is now automatically stored internally when simulation or model paths are changed.  This is to greatly simplify the code for handling paths.  Data can be set back to external after changing paths, either individually, or by using the "set_all_data_external" method.

New simulation and model method "set_all_data_internal" added that sets all data internal. This method is automatically called whenever the simulation or model path are changed. This greatly simplifies flopy's behavior since flopy no longer needs to keep track of former and new external file paths that can possibly change multiple times before write is called. 