### PR TITLE
refactor: clean-up python 2 'next' and redundant '__future__' imports

### DIFF
--- a/autotest/autotest_scripts.py
+++ b/autotest/autotest_scripts.py
@@ -1,5 +1,4 @@
 # Remove the temp directory and then create a fresh one
-from __future__ import print_function
 import os
 import sys
 import shutil

--- a/examples/Testing/flopy3_plotdata.py
+++ b/examples/Testing/flopy3_plotdata.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 
 import numpy as np

--- a/examples/scripts/flopy_swi2_ex1.py
+++ b/examples/scripts/flopy_swi2_ex1.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import sys
 import math

--- a/examples/scripts/flopy_swi2_ex2.py
+++ b/examples/scripts/flopy_swi2_ex2.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import sys
 import collections

--- a/examples/scripts/flopy_swi2_ex3.py
+++ b/examples/scripts/flopy_swi2_ex3.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import sys
 

--- a/examples/scripts/flopy_swi2_ex4.py
+++ b/examples/scripts/flopy_swi2_ex4.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import platform
 import sys

--- a/examples/scripts/flopy_swi2_ex5.py
+++ b/examples/scripts/flopy_swi2_ex5.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import sys
 import math

--- a/flopy/export/utils.py
+++ b/flopy/export/utils.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import json
 import os
 import numpy as np

--- a/flopy/export/vtk.py
+++ b/flopy/export/vtk.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, division
 import os
 import numpy as np
 from ..discretization import StructuredGrid

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -4,8 +4,6 @@ mbase module
   all of the other models inherit from.
 
 """
-
-from __future__ import print_function
 import abc
 import sys
 import os

--- a/flopy/mf6/data/mfdatastorage.py
+++ b/flopy/mf6/data/mfdatastorage.py
@@ -2423,10 +2423,10 @@ class DataStorage:
             data_array = np.ndarray(shape=dimensions, dtype=np_dtype)
             # fill array
             for index in ArrayIndexIter(dimensions):
-                data_array.itemset(index, data_iter.__next__())
+                data_array.itemset(index, next(data_iter))
             return data_array
         elif self.data_structure_type == DataStructureType.scalar:
-            return data_iter.__next__()
+            return next(data_iter)
         else:
             data_array = None
             data_line = ()
@@ -2471,7 +2471,7 @@ class DataStorage:
                         )
                     current_col = 0
                     data_line = ()
-                data_array[index] = data_iter.next()
+                data_array[index] = next(data_iter)
             return data_array
 
     def set_tas(self, tas_name, tas_label, current_key, check_name=True):

--- a/flopy/pakbase.py
+++ b/flopy/pakbase.py
@@ -4,9 +4,6 @@ pakbase module
   all of the other packages inherit from.
 
 """
-
-from __future__ import print_function
-
 import abc
 import os
 import webbrowser as wb

--- a/flopy/pest/params.py
+++ b/flopy/pest/params.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import numpy as np
 
 

--- a/flopy/pest/templatewriter.py
+++ b/flopy/pest/templatewriter.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from ..pest import tplarray as tplarray
 
 

--- a/flopy/pest/tplarray.py
+++ b/flopy/pest/tplarray.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import numpy as np
 from ..utils.util_array import Util3d as Util3d
 from ..utils.util_array import Transient2d as Transient2d

--- a/flopy/plot/plotutil.py
+++ b/flopy/plot/plotutil.py
@@ -4,7 +4,6 @@ using ModelMap and ModelCrossSection. Functions for plotting
 shapefiles are also included.
 
 """
-from __future__ import print_function
 import os
 import sys
 import math

--- a/flopy/utils/binaryfile.py
+++ b/flopy/utils/binaryfile.py
@@ -8,7 +8,6 @@ important classes that can be accessed by the user.
 *  CellBudgetFile (Binary cell-by-cell flow file)
 
 """
-from __future__ import print_function
 import numpy as np
 import warnings
 from collections import OrderedDict

--- a/flopy/utils/datafile.py
+++ b/flopy/utils/datafile.py
@@ -3,7 +3,6 @@ Module to read MODFLOW output files.  The module contains shared
 abstract classes that should not be directly accessed.
 
 """
-from __future__ import print_function
 import numpy as np
 import flopy.utils
 from ..discretization.structuredgrid import StructuredGrid

--- a/flopy/utils/datautil.py
+++ b/flopy/utils/datautil.py
@@ -594,7 +594,7 @@ class MultiList:
         aii = ArrayIndexIter(self.list_shape, True)
         index_num = 0
         while index_num <= n:
-            index = aii.next()
+            index = next(aii)
             index_num += 1
         return index
 
@@ -651,8 +651,6 @@ class ArrayIndexIter:
                 self.current_index -= 1
         raise StopIteration()
 
-    next = __next__  # Python 2 support
-
 
 class MultiListIter:
     def __init__(self, multi_list, detailed_info=False, iter_leaf_lists=False):
@@ -673,8 +671,6 @@ class MultiListIter:
         else:
             return next_val[0]
 
-    next = __next__  # Python 2 support
-
 
 class ConstIter:
     def __init__(self, value):
@@ -685,8 +681,6 @@ class ConstIter:
 
     def __next__(self):
         return self.value
-
-    next = __next__  # Python 2 support
 
 
 class FileIter:
@@ -729,8 +723,6 @@ class FileIter:
             return
         self._current_data = PyListUtil.split_data_line(data_line)
 
-    next = __next__  # Python 2 support
-
 
 class NameIter:
     def __init__(self, name, first_not_numbered=True):
@@ -748,8 +740,6 @@ class NameIter:
         else:
             return "{}_{}".format(self.name, self.iter_num)
 
-    next = __next__  # Python 2 support
-
 
 class PathIter:
     def __init__(self, path, first_not_numbered=True):
@@ -760,6 +750,4 @@ class PathIter:
         return self
 
     def __next__(self):
-        return self.path[0:-1] + (self.name_iter.__next__(),)
-
-    next = __next__  # Python 2 support
+        return self.path[0:-1] + (next(self.name_iter),)

--- a/flopy/utils/gridgen.py
+++ b/flopy/utils/gridgen.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import numpy as np
 import subprocess

--- a/flopy/utils/util_array.py
+++ b/flopy/utils/util_array.py
@@ -5,8 +5,6 @@ util_array module.  Contains the util_2d, util_3d and transient_2d classes.
  instantiate these classes directly.
 
 """
-from __future__ import division, print_function
-
 # from future.utils import with_metaclass
 
 import os

--- a/flopy/utils/util_list.py
+++ b/flopy/utils/util_list.py
@@ -7,8 +7,6 @@ util_list module.  Contains the mflist class.
     some more info
 
 """
-from __future__ import division, print_function
-
 import os
 import warnings
 import numpy as np


### PR DESCRIPTION
As flopy is Python 3-only code (with the exception of a few old examples), clean-up Python 2 code:

- Python 2 used `next`, replaced by `__next__` in Python 3 ([PEP 3114](https://www.python.org/dev/peps/pep-3114/)); use the [`next()` built-in function](https://docs.python.org/3/library/functions.html#next)
- Python 2 had several `from __future__ import` statements, including `print_function` and `division`, which are [redundant](https://docs.python.org/3/reference/simple_stmts.html#future-statements) in Python 3