### PR TITLE
update(python): set python 3.7 as minimum supported version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
       run: |
         pip install https://github.com/modflowpy/pymake/zipball/master
         pip install xmipy
-        pip install .
+        pip install . --use-feature=in-tree-build
 
     - name: Setup symbolic link to gfortran on Linux
       if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,10 @@ jobs:
     - name: Checkout flopy repo
       uses: actions/checkout@v2.3.4
 
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v2
+    - name: Setup Python 3.9
+      uses: actions/setup-python@v2.2.2
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Upgrade pip
       run: |
@@ -66,15 +66,15 @@ jobs:
     # standard python here since only linting on linux.
     # Use standard bash shell with standard python
     - name: Setup Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v2.2.2
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Print python version
       run: |
         python --version
 
-    - name: Install Python 3.8 packages
+    - name: Install Python 3.9 packages
       run: |
         python -m pip install --upgrade pip
         pip install -r etc/requirements.pip.txt
@@ -102,16 +102,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.7, 3.6]
+        python-version: [3.9, 3.8, 3.7]
         run-type: [std]
         test-pth: [""]
         include:
           - os: ubuntu-latest
-            python-version: 3.8
+            python-version: 3.9
             run-type: nb
             test-path: autotest_notebooks.py
           - os: ubuntu-latest
-            python-version: 3.8
+            python-version: 3.9
             run-type: script
             test-path: autotest_scripts.py
     defaults:
@@ -130,7 +130,7 @@ jobs:
       uses: actions/cache@v2.1.0
       env:
         # Increase this value to reset cache if environment.yml has changed
-        CACHE_NUMBER: 0
+        CACHE_NUMBER: 1
       with:
         path: ~/conda_pkgs_dir
         key: ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.run-type }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('etc/environment.yml') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Base flopy installation
       run: |
-        pip install .
+        pip install . --use-feature=in-tree-build
 
     - name: Print flopy version
       run: |

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v2.1.1
         with:
-          python-version: 3.8
+          python-version: 3.9
           mamba-version: "*"
           channels: conda-forge
           auto-update-conda: true

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -24,5 +24,5 @@ dependencies:
   - descartes
   - pyproj
   - shapely
-  - geos>=3.9.2,<3.9.0  # required until 3.9.2 is available
+  - geos
   - geojson

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -2,6 +2,7 @@ name: flopy
 channels:
   - conda-forge
 dependencies:
+  - python>=3.7
   - pylint
   - flake8
   - black
@@ -10,7 +11,7 @@ dependencies:
   - coverage
   - appdirs
   - requests
-  - numpy
+  - numpy>=1.15
   - matplotlib
   - bmipy
   - affine
@@ -23,5 +24,5 @@ dependencies:
   - descartes
   - pyproj
   - shapely
-  - geos=3.8.1  # required until 3.9.2 is available
+  - geos>3.9.1, <3.9.1  # required until 3.9.2 is available
   - geojson

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -24,5 +24,5 @@ dependencies:
   - descartes
   - pyproj
   - shapely
-  - geos>3.9.1, <3.9.1  # required until 3.9.2 is available
+  - geos>=3.9.2,<3.9.0  # required until 3.9.2 is available
   - geojson

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ import sys
 from setuptools import setup
 
 # ensure minimum version of Python is running
-if sys.version_info[0:2] < (3, 5):
-    raise RuntimeError("Flopy requires Python >= 3.5")
+if sys.version_info[0:2] < (3, 7):
+    raise RuntimeError("Flopy requires Python >= 3.7")
 
 # local import of package variables in flopy/version.py
 # imports __version__, __pakname__, __author__, __author_email__
@@ -28,7 +28,9 @@ setup(
     url="https://github.com/modflowpy/flopy/",
     license="CC0",
     platforms="Windows, Mac OS-X, Linux",
-    install_requires=["numpy"],
+    install_requires=[
+        "numpy >=1.15",
+    ],
     packages=[
         "flopy",
         "flopy.modflow",


### PR DESCRIPTION
Also set minimum NumPy version to >= 1.15. Add python 3.9 to
GitHub action workflows and remove python 3.6.

Closes #1176 Closes #1177