### PR TITLE
refactor: replace OrderedDict with dict

### DIFF
--- a/examples/scripts/flopy_swi2_ex2.py
+++ b/examples/scripts/flopy_swi2_ex2.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import collections
 
 import numpy as np
 
@@ -48,7 +47,7 @@ def run():
     if cleanFiles:
         print("cleaning all files")
         print("excluding *.py files")
-        file_dict = collections.OrderedDict()
+        file_dict = {}
         file_dict[0] = os.listdir(dirs[0])
         file_dict[1] = os.listdir(dirs[1])
         file_dict[-1] = os.listdir(workspace)

--- a/examples/scripts/flopy_swi2_ex5.py
+++ b/examples/scripts/flopy_swi2_ex5.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import math
-import collections
 
 import numpy as np
 
@@ -49,7 +48,7 @@ def run(silent=False):
     if cleanFiles:
         print("cleaning all files")
         print("excluding *.py files")
-        file_dict = collections.OrderedDict()
+        file_dict = {}
         file_dict[0] = os.listdir(dirs[0])
         file_dict[1] = os.listdir(dirs[1])
         file_dict[-1] = os.listdir(workspace)

--- a/flopy/export/shapefile_utils.py
+++ b/flopy/export/shapefile_utils.py
@@ -9,7 +9,6 @@ import json
 import numpy as np
 import os
 import warnings
-from collections import OrderedDict
 
 from ..datbase import DataType, DataInterface
 from ..utils import Util3d
@@ -989,10 +988,10 @@ class EpsgReference:
         """
         returns dict with EPSG code integer key, and WKT CRS text
         """
-        data = OrderedDict()
+        data = {}
         if os.path.exists(self.location):
             with open(self.location, "r") as f:
-                loaded_data = json.load(f, object_pairs_hook=OrderedDict)
+                loaded_data = json.load(f)
             # convert JSON key from str to EPSG integer
             for key, value in loaded_data.items():
                 try:

--- a/flopy/mf6/data/mfdataarray.py
+++ b/flopy/mf6/data/mfdataarray.py
@@ -1,6 +1,5 @@
 import sys, inspect, copy, os
 import numpy as np
-from collections import OrderedDict
 from ..data.mfstructure import DatumType
 from .mfdatastorage import DataStorage, DataStructureType, DataStorageType
 from ...utils.datautil import MultiList, DatumUtil
@@ -1712,7 +1711,7 @@ class MFTransientArray(MFArray, MFTransient):
                 if `data` is a dictionary.
         """
 
-        if isinstance(data, dict) or isinstance(data, OrderedDict):
+        if isinstance(data, dict):
             # each item in the dictionary is a list for one stress period
             # the dictionary key is the stress period the list is for
             del_keys = []
@@ -1815,7 +1814,7 @@ class MFTransientArray(MFArray, MFTransient):
                 set_layers, base_storage, stress_period
             )
         else:
-            return OrderedDict()
+            return {}
 
     def _set_storage_obj(self, storage):
         self._data_storage[self._current_key] = storage

--- a/flopy/mf6/data/mfdatalist.py
+++ b/flopy/mf6/data/mfdatalist.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 import math
 import sys
 import os
@@ -1671,7 +1670,7 @@ class MFTransientList(MFList, mfdata.MFTransient, DataListInterface):
             Automatically correct data.
         """
         self._cache_model_grid = True
-        if isinstance(data, dict) or isinstance(data, OrderedDict):
+        if isinstance(data, dict):
             if "filename" not in data:
                 # each item in the dictionary is a list for one stress period
                 # the dictionary key is the stress period the list is for
@@ -1815,7 +1814,7 @@ class MFTransientList(MFList, mfdata.MFTransient, DataListInterface):
         super().update_record(record, key_index)
 
     def _new_storage(self, stress_period=0):
-        return OrderedDict()
+        return {}
 
     def _get_storage_obj(self):
         if (

--- a/flopy/mf6/data/mfdatascalar.py
+++ b/flopy/mf6/data/mfdatascalar.py
@@ -2,7 +2,6 @@ import sys, inspect
 import numpy as np
 from ..data.mfstructure import DatumType
 from ..data import mfdata
-from collections import OrderedDict
 from ..mfbase import ExtFileAction, MFDataException
 from ...datbase import DataType
 from .mfdatautil import convert_data, to_string
@@ -820,7 +819,7 @@ class MFScalarTransient(MFScalar, mfdata.MFTransient):
             if `data` is a dictionary.
 
         """
-        if isinstance(data, dict) or isinstance(data, OrderedDict):
+        if isinstance(data, dict):
             # each item in the dictionary is a list for one stress period
             # the dictionary key is the stress period the list is for
             for key, list_item in data.items():
@@ -902,7 +901,7 @@ class MFScalarTransient(MFScalar, mfdata.MFTransient):
         )
 
     def _new_storage(self, stress_period=0):
-        return OrderedDict()
+        return {}
 
     def _get_storage_obj(self):
         if (

--- a/flopy/mf6/data/mfdatastorage.py
+++ b/flopy/mf6/data/mfdatastorage.py
@@ -3,7 +3,6 @@ import sys
 import os
 import inspect
 from shutil import copyfile
-from collections import OrderedDict
 from enum import Enum
 import numpy as np
 from ..mfbase import MFDataException, VerbosityLevel
@@ -205,7 +204,7 @@ class DataStorage:
         is the data layered
     pre_data_comments : string
         any comments before the start of the data
-    comments : OrderedDict
+    comments : dict
         any comments mixed in with the data, dictionary keys are data lines
     post_data_comments : string
         any comments after the end of the data
@@ -331,7 +330,7 @@ class DataStorage:
 
         # initialize comments
         self.pre_data_comments = None
-        self.comments = OrderedDict()
+        self.comments = {}
 
     def __repr__(self):
         return self.get_data_str(True)

--- a/flopy/mf6/data/mfstructure.py
+++ b/flopy/mf6/data/mfstructure.py
@@ -9,7 +9,6 @@ import ast
 import keyword
 from enum import Enum
 from textwrap import TextWrapper
-from collections import OrderedDict
 import numpy as np
 from ..mfbase import PackageContainer, StructException
 
@@ -228,7 +227,7 @@ class DfnPackage(Dfn):
         return self.package.package_abbr in self.multi_package
 
     def get_block_structure_dict(self, path, common, model_file):
-        block_dict = OrderedDict()
+        block_dict = {}
         dataset_items_in_block = {}
         self.dataset_items_needed_dict = {}
         keystring_items_needed_dict = {}
@@ -497,7 +496,7 @@ class DfnFile(Dfn):
         return base_file in self.multi_package
 
     def dict_by_name(self):
-        name_dict = OrderedDict()
+        name_dict = {}
         name = None
         dfn_fp = open(self._file_path, "r")
         for line in dfn_fp:
@@ -512,7 +511,7 @@ class DfnFile(Dfn):
 
     def get_block_structure_dict(self, path, common, model_file):
         self.dfn_list = []
-        block_dict = OrderedDict()
+        block_dict = {}
         dataset_items_in_block = {}
         self.dataset_items_needed_dict = {}
         keystring_items_needed_dict = {}
@@ -1430,9 +1429,9 @@ class MFDataStructure:
         self.parameter_name = data_item.parameter_name
         self.one_per_pkg = data_item.one_per_pkg
 
-        # self.data_item_structures_dict = OrderedDict()
+        # self.data_item_structures_dict = {}
         self.data_item_structures = []
-        self.expected_data_items = OrderedDict()
+        self.expected_data_items = {}
         self.shape = data_item.shape
         if (
             self.type == DatumType.recarray
@@ -1941,7 +1940,7 @@ class MFBlockStructure:
         (<model>, <package>, <block>)
     model_block : bool
         true if this block is part of a model
-    data_structures : OrderedDict
+    data_structures : dict
         dictionary of data items in this block, with the data item name as
         the key
     block_header_structure : list
@@ -1982,7 +1981,7 @@ class MFBlockStructure:
 
     def __init__(self, name, path, model_block):
         # initialize
-        self.data_structures = OrderedDict()
+        self.data_structures = {}
         self.block_header_structure = []
         self.name = name
         self.path = path + (self.name,)
@@ -2130,7 +2129,7 @@ class MFModelStructure:
         simulation structure validity
     name_file_struct_obj : MFInputFileStructure
         describes the structure of the simulation name file
-    package_struct_objs : OrderedDict
+    package_struct_objs : dict
         describes the structure of the simulation packages
     model_type : string
         dictionary containing simulation package structure
@@ -2161,7 +2160,7 @@ class MFModelStructure:
         # add name file structure
         self.model_type = model_type
         self.name_file_struct_obj = None
-        self.package_struct_objs = OrderedDict()
+        self.package_struct_objs = {}
         self.utl_struct_objs = utl_struct_objs
 
     def add_namefile(self, dfn_file, common):
@@ -2217,13 +2216,13 @@ class MFSimulationStructure:
     ----------
     name_file_struct_obj : MFInputFileStructure
         describes the structure of the simulation name file
-    package_struct_objs : OrderedDict
+    package_struct_objs : dict
         describes the structure of the simulation packages
-    model_struct_objs : OrderedDict
+    model_struct_objs : dict
         describes the structure of the supported model types
-    utl_struct_objs : OrderedDict
+    utl_struct_objs : dict
         describes the structure of the supported utility packages
-    common : OrderedDict
+    common : dict
         common file information
     model_type : string
         placeholder
@@ -2265,9 +2264,9 @@ class MFSimulationStructure:
     def __init__(self):
         # initialize
         self.name_file_struct_obj = None
-        self.package_struct_objs = OrderedDict()
-        self.utl_struct_objs = OrderedDict()
-        self.model_struct_objs = OrderedDict()
+        self.package_struct_objs = {}
+        self.utl_struct_objs = {}
+        self.model_struct_objs = {}
         self.common = None
         self.model_type = ""
 

--- a/flopy/mf6/mfbase.py
+++ b/flopy/mf6/mfbase.py
@@ -2,7 +2,6 @@ import glob
 import importlib
 import inspect, sys, traceback
 import os, copy
-from collections import OrderedDict
 from collections.abc import Iterable
 from shutil import copyfile
 from enum import Enum
@@ -221,7 +220,7 @@ class MFFileMgmt:
     Attributes
     ----------
 
-    model_relative_path : OrderedDict
+    model_relative_path : dict
         Dictionary of relative paths to each model folder
 
     """
@@ -235,10 +234,10 @@ class MFFileMgmt:
         self.existing_file_dict = {}
         # keys:filenames,vals:instance name
 
-        self.model_relative_path = OrderedDict()
+        self.model_relative_path = {}
 
         self._last_loaded_sim_path = None
-        self._last_loaded_model_relative_path = OrderedDict()
+        self._last_loaded_model_relative_path = {}
 
     def copy_files(self, copy_relative_only=True):
         """Copy files external to updated path.

--- a/flopy/mf6/mfmodel.py
+++ b/flopy/mf6/mfmodel.py
@@ -57,7 +57,7 @@ class MFModel(PackageContainer, ModelInterface):
         Name of the model
     exe_name : str
         Model executable name
-    packages : OrderedDict(MFPackage)
+    packages : dict of MFPackage
         Dictionary of model packages
 
     """

--- a/flopy/mf6/mfpackage.py
+++ b/flopy/mf6/mfpackage.py
@@ -4,7 +4,6 @@ import errno
 import inspect
 import datetime
 import numpy as np
-from collections import OrderedDict
 
 from .mfbase import PackageContainer, ExtFileAction, PackageContainerType
 from .mfbase import (
@@ -347,7 +346,7 @@ class MFBlock:
         ]
         self.structure = structure
         self.path = path
-        self.datasets = OrderedDict()
+        self.datasets = {}
         self.datasets_keyword = {}
         # initially disable if optional
         self.enabled = structure.number_non_optional_data() > 0
@@ -1475,7 +1474,7 @@ class MFPackage(PackageContainer, PackageInterface):
 
     Attributes
     ----------
-    blocks : OrderedDict
+    blocks : dict
         Dictionary of blocks contained in this package by block name
     path : tuple
         Data dictionary path to this package
@@ -1530,7 +1529,7 @@ class MFPackage(PackageContainer, PackageInterface):
         self.parent = model_or_sim
         self._simulation_data = model_or_sim.simulation_data
         self.parent_file = parent_file
-        self.blocks = OrderedDict()
+        self.blocks = {}
         self.container_type = []
         self.loading_package = loading_package
         if pname is not None:

--- a/flopy/mf6/modflow/mfsimulation.py
+++ b/flopy/mf6/modflow/mfsimulation.py
@@ -219,7 +219,7 @@ class MFSimulationData:
         Numbers less than this threshold are written in scientific notation
     mfpath : MFFileMgmt
         File path location information for the simulation
-    model_dimensions : OrderedDict
+    model_dimensions : dict
         Dictionary containing discretization information for each model
     mfdata : SimulationDict
         Custom dictionary containing all model data for the simulation
@@ -254,14 +254,14 @@ class MFSimulationData:
 
         # --- ease of use variables to make working with modflow input and
         # output data easier --- model dimension class for each model
-        self.model_dimensions = collections.OrderedDict()
+        self.model_dimensions = {}
 
         # --- model data ---
         self.mfdata = SimulationDict(self.mfpath)
 
         # --- temporary variables ---
         # other external files referenced
-        self.referenced_files = collections.OrderedDict()
+        self.referenced_files = {}
 
     @property
     def max_columns_of_data(self):
@@ -402,13 +402,13 @@ class MFSimulation(PackageContainer):
 
         self.version = version
         self.exe_name = exe_name
-        self._models = collections.OrderedDict()
+        self._models = {}
         self._tdis_file = None
-        self._exchange_files = collections.OrderedDict()
-        self._ims_files = collections.OrderedDict()
+        self._exchange_files = {}
+        self._ims_files = {}
         self._ghost_node_files = {}
         self._mover_files = {}
-        self._other_files = collections.OrderedDict()
+        self._other_files = {}
         self.structure = fpdata.sim_struct
         self.model_type = None
 

--- a/flopy/mf6/utils/binaryfile_utils.py
+++ b/flopy/mf6/utils/binaryfile_utils.py
@@ -13,7 +13,7 @@ class MFOutput:
     ----------
     path: binary file path location
     mfdict: SimulationDict() object
-    key: OrderedDictionary key ex. ('flow15','CBC','FLOW RIGHT FACE')
+    key: dict key ex. ('flow15','CBC','FLOW RIGHT FACE')
 
     Returns
     -------
@@ -55,7 +55,7 @@ class MFOutputRequester:
 
     Parameters:
     ----------
-    mfdict: OrderedDict
+    mfdict: dict
         local instance of the SimulationDict() object
     path:
         pointer to the MFSimulationPath object

--- a/flopy/mf6/utils/binarygrid_util.py
+++ b/flopy/mf6/utils/binarygrid_util.py
@@ -6,7 +6,6 @@ be accessed by the user.
 """
 
 import numpy as np
-import collections
 
 from ...utils.utils_def import FlopyBinaryData
 import warnings
@@ -62,8 +61,8 @@ class MfGrdFile(FlopyBinaryData):
         self.set_float(precision=precision)
         self.verbose = verbose
         self._initial_len = 50
-        self._recorddict = collections.OrderedDict()
-        self._datadict = collections.OrderedDict()
+        self._recorddict = {}
+        self._datadict = {}
         self._recordkeys = []
         self.filename = filename
 

--- a/flopy/modflow/mfag.py
+++ b/flopy/modflow/mfag.py
@@ -14,7 +14,6 @@ from ..utils.flopy_io import multi_line_strip
 from ..pakbase import Package
 from ..utils.recarray_utils import create_empty_recarray
 from ..utils.optionblock import OptionBlock
-from collections import OrderedDict
 
 
 class ModflowAg(Package):
@@ -58,7 +57,7 @@ class ModflowAg(Package):
 
     """
 
-    _options = OrderedDict(
+    _options = dict(
         [
             ("noprint", OptionBlock.simple_flag),
             (
@@ -67,7 +66,7 @@ class ModflowAg(Package):
                     OptionBlock.dtype: np.bool_,
                     OptionBlock.nested: True,
                     OptionBlock.n_nested: 2,
-                    OptionBlock.vars: OrderedDict(
+                    OptionBlock.vars: dict(
                         [
                             ("numirrdiversions", OptionBlock.simple_int),
                             ("maxcellsdiversion", OptionBlock.simple_int),
@@ -81,7 +80,7 @@ class ModflowAg(Package):
                     OptionBlock.dtype: np.bool_,
                     OptionBlock.nested: True,
                     OptionBlock.n_nested: 2,
-                    OptionBlock.vars: OrderedDict(
+                    OptionBlock.vars: dict(
                         [
                             ("numirrwells", OptionBlock.simple_int),
                             ("maxcellswell", OptionBlock.simple_int),
@@ -95,7 +94,7 @@ class ModflowAg(Package):
                     OptionBlock.dtype: np.bool_,
                     OptionBlock.nested: True,
                     OptionBlock.n_nested: 2,
-                    OptionBlock.vars: OrderedDict(
+                    OptionBlock.vars: dict(
                         [
                             ("numsupwells", OptionBlock.simple_int),
                             ("maxdiversions", OptionBlock.simple_int),
@@ -109,7 +108,7 @@ class ModflowAg(Package):
                     OptionBlock.dtype: np.bool_,
                     OptionBlock.nested: True,
                     OptionBlock.n_nested: 1,
-                    OptionBlock.vars: OrderedDict(
+                    OptionBlock.vars: dict(
                         [("nummaxwell", OptionBlock.simple_int)]
                     ),
                 },
@@ -128,7 +127,7 @@ class ModflowAg(Package):
                     OptionBlock.dtype: np.bool_,
                     OptionBlock.nested: True,
                     OptionBlock.n_nested: 1,
-                    OptionBlock.vars: OrderedDict(
+                    OptionBlock.vars: dict(
                         [("unit_diversionlist", OptionBlock.simple_int)]
                     ),
                 },
@@ -139,7 +138,7 @@ class ModflowAg(Package):
                     OptionBlock.dtype: np.bool_,
                     OptionBlock.nested: True,
                     OptionBlock.n_nested: 1,
-                    OptionBlock.vars: OrderedDict(
+                    OptionBlock.vars: dict(
                         [("unit_welllist", OptionBlock.simple_int)]
                     ),
                 },
@@ -150,7 +149,7 @@ class ModflowAg(Package):
                     OptionBlock.dtype: np.bool_,
                     OptionBlock.nested: True,
                     OptionBlock.n_nested: 1,
-                    OptionBlock.vars: OrderedDict(
+                    OptionBlock.vars: dict(
                         [("unit_wellirrlist", OptionBlock.simple_int)]
                     ),
                 },
@@ -161,7 +160,7 @@ class ModflowAg(Package):
                     OptionBlock.dtype: np.bool_,
                     OptionBlock.nested: True,
                     OptionBlock.n_nested: 1,
-                    OptionBlock.vars: OrderedDict(
+                    OptionBlock.vars: dict(
                         [("unit_diversionirrlist", OptionBlock.simple_int)]
                     ),
                 },
@@ -172,7 +171,7 @@ class ModflowAg(Package):
                     OptionBlock.dtype: np.bool_,
                     OptionBlock.nested: True,
                     OptionBlock.n_nested: 1,
-                    OptionBlock.vars: OrderedDict(
+                    OptionBlock.vars: dict(
                         [("unitcbc", OptionBlock.simple_int)]
                     ),
                 },

--- a/flopy/modflow/mfhob.py
+++ b/flopy/modflow/mfhob.py
@@ -1,5 +1,4 @@
 import sys
-import collections
 import numpy as np
 from ..pakbase import Package
 from ..utils.recarray_utils import create_empty_recarray
@@ -397,7 +396,7 @@ class ModflowHob(Package):
             else:
                 line = f.readline()
                 t = line.strip().split()
-                mlay = collections.OrderedDict()
+                mlay = {}
                 if len(t) >= abs(layer) * 2:
                     for j in range(0, abs(layer) * 2, 2):
                         k = int(t[j]) - 1

--- a/flopy/modflow/mfmlt.py
+++ b/flopy/modflow/mfmlt.py
@@ -7,7 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow-nwt/MODFLOW-NWT-Guide/mult.htm>`_.
 
 """
-import collections
 import sys
 
 import numpy as np
@@ -184,7 +183,7 @@ class ModflowMlt(Package):
             nrow, ncol, nlay, nper = model.get_nrow_ncol_nlay_nper()
 
         # read zone data
-        mult_dict = collections.OrderedDict()
+        mult_dict = {}
         for n in range(nml):
             line = f.readline()
             t = line.strip().split()

--- a/flopy/modflow/mfnwt.py
+++ b/flopy/modflow/mfnwt.py
@@ -404,8 +404,6 @@ class ModflowNwt(Package):
         >>> nwt = flopy.modflow.ModflowPcg.load('test.nwt', m)
 
         """
-        import collections
-
         if model.verbose:
             sys.stdout.write("loading nwt package file...\n")
 
@@ -436,18 +434,17 @@ class ModflowNwt(Package):
         # dataset 1
         ifrfm = True  # model.free_format_input
 
-        vars = (
-            ("headtol", float),
-            ("fluxtol", float),
-            ("maxiterout", int),
-            ("thickfact", float),
-            ("linmeth", int),
-            ("iprnwt", int),
-            ("ibotav", int),
-            ("options", str),
-            ("Continue", str),
-        )
-        vars = collections.OrderedDict(vars)
+        vars = {
+            "headtol": float,
+            "fluxtol": float,
+            "maxiterout": int,
+            "thickfact": float,
+            "linmeth": int,
+            "iprnwt": int,
+            "ibotav": int,
+            "options": str,
+            "Continue": str,
+        }
         kwargs = {}
         if ifrfm:
             t = line.split()
@@ -472,17 +469,16 @@ class ModflowNwt(Package):
             else:
                 kwargs.pop("Continue")
 
-        specdict = (
-            ("dbdtheta", float),
-            ("dbdkappa", float),
-            ("dbdgamma", float),
-            ("momfact", float),
-            ("backflag", int),
-            ("maxbackiter", int),
-            ("backtol", float),
-            ("backreduce", float),
-        )
-        specdict = collections.OrderedDict(specdict)
+        specdict = {
+            "dbdtheta": float,
+            "dbdkappa": float,
+            "dbdgamma": float,
+            "momfact": float,
+            "backflag": int,
+            "maxbackiter": int,
+            "backtol": float,
+            "backreduce": float,
+        }
         ipos = len(kwargs)
         if kwargs["options"].lower().strip() == "specified":
             for (k, c) in specdict.items():
@@ -504,27 +500,26 @@ class ModflowNwt(Package):
 
             lindict = {}
             if kwargs["linmeth"] == 1:
-                lindict = (
-                    ("maxitinner", int),
-                    ("ilumethod", int),
-                    ("levfill", int),
-                    ("stoptol", float),
-                    ("msdr", int),
-                )
+                lindict = {
+                    "maxitinner": int,
+                    "ilumethod": int,
+                    "levfill": int,
+                    "stoptol": float,
+                    "msdr": int,
+                }
             elif kwargs["linmeth"] == 2:
-                lindict = (
-                    ("iacl", int),
-                    ("norder", int),
-                    ("level", int),
-                    ("north", int),
-                    ("iredsys", int),
-                    ("rrctols", float),
-                    ("idroptol", int),
-                    ("epsrn", float),
-                    ("hclosexmd", float),
-                    ("mxiterxmd", int),
-                )
-            lindict = collections.OrderedDict(lindict)
+                lindict = {
+                    "iacl": int,
+                    "norder": int,
+                    "level": int,
+                    "north": int,
+                    "iredsys": int,
+                    "rrctols": float,
+                    "idroptol": int,
+                    "epsrn": float,
+                    "hclosexmd": float,
+                    "mxiterxmd": int,
+                }
             if ifrfm:
                 t = line.split()
             else:

--- a/flopy/modflow/mfsfr2.py
+++ b/flopy/modflow/mfsfr2.py
@@ -11,7 +11,6 @@ from ..utils import MfList
 from ..utils.flopy_io import line_parse
 from ..utils.recarray_utils import create_empty_recarray
 from ..utils.optionblock import OptionBlock
-from collections import OrderedDict
 
 try:
     import pandas as pd
@@ -268,7 +267,7 @@ class ModflowSfr2(Package):
 
     """
 
-    _options = OrderedDict(
+    _options = dict(
         [
             ("reachinput", OptionBlock.simple_flag),
             ("transroute", OptionBlock.simple_flag),

--- a/flopy/modflow/mfuzf1.py
+++ b/flopy/modflow/mfuzf1.py
@@ -14,7 +14,6 @@ from ..utils.flopy_io import pop_item, line_parse
 from ..pakbase import Package
 from ..utils import Util2d, Transient2d
 from ..utils.optionblock import OptionBlock
-from collections import OrderedDict
 import warnings
 
 
@@ -318,7 +317,7 @@ class ModflowUzf1(Package):
 
     """
 
-    _options = OrderedDict(
+    _options = dict(
         [
             ("specifythtr", OptionBlock.simple_flag),
             ("specifythti", OptionBlock.simple_flag),
@@ -342,7 +341,7 @@ class ModflowUzf1(Package):
                     OptionBlock.dtype: np.bool_,
                     OptionBlock.nested: True,
                     OptionBlock.n_nested: 2,
-                    OptionBlock.vars: OrderedDict(
+                    OptionBlock.vars: dict(
                         [
                             ("unitrech", OptionBlock.simple_int),
                             ("unitdis", OptionBlock.simple_int),

--- a/flopy/modflow/mfwel.py
+++ b/flopy/modflow/mfwel.py
@@ -14,7 +14,6 @@ from ..utils import MfList
 from ..pakbase import Package
 from ..utils.recarray_utils import create_empty_recarray
 from ..utils.optionblock import OptionBlock
-from collections import OrderedDict
 import warnings
 
 
@@ -111,7 +110,7 @@ class ModflowWel(Package):
 
     """
 
-    _options = OrderedDict(
+    _options = dict(
         [
             (
                 "specify",
@@ -119,12 +118,12 @@ class ModflowWel(Package):
                     OptionBlock.dtype: np.bool_,
                     OptionBlock.nested: True,
                     OptionBlock.n_nested: 2,
-                    OptionBlock.vars: OrderedDict(
+                    OptionBlock.vars: dict(
                         [
                             ("phiramp", OptionBlock.simple_float),
                             (
                                 "iunitramp",
-                                OrderedDict(
+                                dict(
                                     [
                                         (OptionBlock.dtype, int),
                                         (OptionBlock.nested, False),

--- a/flopy/modflow/mfzon.py
+++ b/flopy/modflow/mfzon.py
@@ -8,7 +8,6 @@ MODFLOW Guide
 
 """
 import sys
-import collections
 import numpy as np
 from ..pakbase import Package
 from ..utils import Util2d
@@ -187,7 +186,7 @@ class ModflowZon(Package):
             nrow, ncol, nlay, nper = model.get_nrow_ncol_nlay_nper()
 
         # read zone data
-        zone_dict = collections.OrderedDict()
+        zone_dict = {}
         for n in range(nzn):
             line = f.readline()
             t = line.strip().split()

--- a/flopy/utils/binaryfile.py
+++ b/flopy/utils/binaryfile.py
@@ -10,7 +10,6 @@ important classes that can be accessed by the user.
 """
 import numpy as np
 import warnings
-from collections import OrderedDict
 from ..utils.datafile import Header, LayerFile
 
 
@@ -806,7 +805,7 @@ class CellBudgetFile:
         self.file.seek(0, 2)
         self.totalbytes = self.file.tell()
         self.file.seek(0, 0)
-        self.recorddict = OrderedDict()
+        self.recorddict = {}
         ipos = 0
         while ipos < self.totalbytes:
             self.iposheader.append(ipos)

--- a/flopy/utils/cvfdutil.py
+++ b/flopy/utils/cvfdutil.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 import numpy as np
 
 
@@ -174,7 +173,7 @@ def to_cvfd(
     # First create vertexdict {(x1, y1): ivert1, (x2, y2): ivert2, ...} and
     # vertexlist [[ivert1, ivert2, ...], [ivert9, ivert10, ...], ...]
     # In the process, filter out any duplicate vertices
-    vertexdict = OrderedDict()
+    vertexdict = {}
     vertexlist = []
     xcyc = np.empty((ncells, 2), dtype=float)
     iv = 0
@@ -217,7 +216,7 @@ def to_cvfd(
             "Reduced total number of vertices by {}".format(nvertstart - nvert)
         )
         print("Creating dict of vertices with their associated cells")
-    vertex_cell_dict = OrderedDict()
+    vertex_cell_dict = {}
     for icell in range(nodestart, nodestop):
         ivertlist = vertexlist[icell]
         for ivert in ivertlist:

--- a/flopy/utils/mflistfile.py
+++ b/flopy/utils/mflistfile.py
@@ -5,7 +5,6 @@ recarrays, which can then be easily plotted.
 
 """
 
-import collections
 import os
 import re
 import numpy as np
@@ -688,9 +687,9 @@ class ListBudget:
                 "entry in list file"
             )
         self.entries = incdict.keys()
-        null_entries = collections.OrderedDict()
-        incdict = collections.OrderedDict()
-        cumdict = collections.OrderedDict()
+        null_entries = {}
+        incdict = {}
+        cumdict = {}
         for entry in self.entries:
             incdict[entry] = []
             cumdict[entry] = []
@@ -767,8 +766,8 @@ class ListBudget:
                 break
 
         tag = "IN"
-        incdict = collections.OrderedDict()
-        cumdict = collections.OrderedDict()
+        incdict = {}
+        cumdict = {}
         entrydict = {}
         while True:
 

--- a/flopy/utils/mfreadnam.py
+++ b/flopy/utils/mfreadnam.py
@@ -8,12 +8,6 @@ MODFLOW Guide
 
 """
 import os
-import sys
-
-if sys.version_info < (3, 6):
-    from collections import OrderedDict
-
-    dict = OrderedDict
 
 
 class NamData:
@@ -113,12 +107,10 @@ def parsenamefile(namfilename, packages, verbose=True):
 
     Returns
     -------
-    dict or OrderedDict
+    dict
         For each file listed in the name file, a
         :class:`flopy.utils.mfreadnam.NamData` instance
-        is stored in the returned dict keyed by unit number. Prior to Python
-        version 3.6 the return object is an OrderedDict to retain the order
-        of items in the nam file.
+        is stored in the returned dict keyed by unit number.
 
     Raises
     ------
@@ -127,8 +119,8 @@ def parsenamefile(namfilename, packages, verbose=True):
     ValueError:
         For lines that cannot be parsed.
     """
-    # initiate the ext_unit_dict ordered dictionary
-    ext_unit_dict = dict()
+    # initiate the ext_unit_dict dictionary
+    ext_unit_dict = {}
 
     if verbose:
         print("Parsing the namefile --> {0:s}".format(namfilename))

--- a/flopy/utils/modpathfile.py
+++ b/flopy/utils/modpathfile.py
@@ -8,7 +8,6 @@ important classes that can be accessed by the user.
 """
 
 import itertools
-import collections
 import numpy as np
 
 from numpy.lib.recfunctions import append_fields, stack_arrays
@@ -560,7 +559,7 @@ class PathlineFile(_ModpathSeries):
             ]
         )
         idx = 0
-        part_dict = collections.OrderedDict()
+        part_dict = {}
         ndata = 0
         while True:
             if idx == 0:

--- a/flopy/utils/optionblock.py
+++ b/flopy/utils/optionblock.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 import numpy as np
 from ..utils import flopy_io
 
@@ -27,27 +26,19 @@ class OptionBlock:
     vars = "vars"
     optional = "optional"
 
-    simple_flag = OrderedDict(
-        [(dtype, np.bool_), (nested, False), (optional, False)]
-    )
-    simple_str = OrderedDict(
-        [(dtype, str), (nested, False), (optional, False)]
-    )
-    simple_float = OrderedDict(
-        [(dtype, float), (nested, False), (optional, False)]
-    )
-    simple_int = OrderedDict(
-        [(dtype, int), (nested, False), (optional, False)]
-    )
+    simple_flag = dict([(dtype, np.bool_), (nested, False), (optional, False)])
+    simple_str = dict([(dtype, str), (nested, False), (optional, False)])
+    simple_float = dict([(dtype, float), (nested, False), (optional, False)])
+    simple_int = dict([(dtype, int), (nested, False), (optional, False)])
 
-    simple_tabfile = OrderedDict(
+    simple_tabfile = dict(
         [
             (dtype, np.bool_),
             (nested, True),
             (n_nested, 2),
             (
                 vars,
-                OrderedDict([("numtab", simple_int), ("maxval", simple_int)]),
+                dict([("numtab", simple_int), ("maxval", simple_int)]),
             ),
         ]
     )

--- a/flopy/utils/swroutputfile.py
+++ b/flopy/utils/swroutputfile.py
@@ -1,6 +1,5 @@
 import sys
 import numpy as np
-from collections import OrderedDict
 
 from ..utils.utils_def import FlopyBinaryData
 
@@ -604,7 +603,7 @@ class SwrFile(FlopyBinaryData):
         self._ntimes = 0
         self._times = []
         self._kswrkstpkper = []
-        self.recorddict = OrderedDict()
+        self.recorddict = {}
 
         idx = 0
         while True:

--- a/flopy/utils/zonbud.py
+++ b/flopy/utils/zonbud.py
@@ -2,7 +2,6 @@ import os
 import copy
 import numpy as np
 from itertools import groupby
-from collections import OrderedDict
 from .utils_def import totim_to_datetime
 import warnings
 
@@ -158,7 +157,7 @@ class ZoneBudget:
 
         self.izone = izone
         self.allzones = np.unique(izone)
-        self._zonenamedict = OrderedDict(
+        self._zonenamedict = dict(
             [(z, "ZONE_{}".format(z)) for z in self.allzones]
         )
 
@@ -2138,7 +2137,7 @@ class ZoneFile6:
         self.filename = self._parent.name + extension
         self.aliases = aliases
         self.allzones = [int(zn) for zn in np.unique(izone) if zn != 0]
-        self._zonenamedict = OrderedDict(
+        self._zonenamedict = dict(
             [(zn, "ZONE_{}".format(zn)) for zn in self.allzones]
         )
 

--- a/release/make-release.py
+++ b/release/make-release.py
@@ -5,7 +5,6 @@ import os
 import sys
 import datetime
 import json
-from collections import OrderedDict
 
 # file_paths dictionary has file names and the path to the file. Enter '.'
 # as the path if the file is in the root repository directory
@@ -237,7 +236,7 @@ def update_codejson(vmajor, vminor, vmicro):
 
     # load and modify json file
     with open(json_fname, "r") as f:
-        data = json.load(f, object_pairs_hook=OrderedDict)
+        data = json.load(f)
 
     # modify the json file data
     now = datetime.datetime.now()


### PR DESCRIPTION
A significant highlight from [Python 3.7](https://docs.python.org/3/whatsnew/3.7.html) is that "the insertion-order preservation nature of dict objects has been declared to be an official part of the Python language spec". This means that `OrderedDict` can be replaced with the `dict` built-in for most cases. Things like `json.load` will preserve the order too.

The one exception is `SimulationDict` (in `flopy/mf6/modflow/mfsimulation.py`) is kept to be a subclass of `OrderedDict`.