### PR TITLE
refactor(exceptions): reduce redundancy, simplify message generation

### DIFF
--- a/flopy/mf6/coordinates/modelgrid.py
+++ b/flopy/mf6/coordinates/modelgrid.py
@@ -8,9 +8,6 @@ class MFGridException(Exception):
     Model grid related exception
     """
 
-    def __init__(self, error):
-        Exception.__init__(self, f"MFGridException: {error}")
-
 
 class ModelCell:
     """

--- a/flopy/mf6/mfbase.py
+++ b/flopy/mf6/mfbase.py
@@ -13,20 +13,12 @@ class MFInvalidTransientBlockHeaderException(Exception):
     Exception occurs when parsing a transient block header
     """
 
-    def __init__(self, error):
-        Exception.__init__(
-            self, f"MFInvalidTransientBlockHeaderException: {error}"
-        )
-
 
 class ReadAsArraysException(Exception):
     """
     Exception occurs when loading ReadAsArrays package as non-ReadAsArrays
     package.
     """
-
-    def __init__(self, error):
-        Exception.__init__(self, f"ReadAsArraysException: {error}")
 
 
 # external exceptions for users
@@ -37,7 +29,7 @@ class FlopyException(Exception):
 
     def __init__(self, error, location=""):
         self.message = error
-        Exception.__init__(self, f"FlopyException: {error} ({location})")
+        super().__init__(f"{error} ({location})")
 
 
 class StructException(Exception):
@@ -47,7 +39,7 @@ class StructException(Exception):
 
     def __init__(self, error, location):
         self.message = error
-        Exception.__init__(self, f"StructException: {error} ({location})")
+        super().__init__(f"{error} ({location})")
 
 
 class MFDataException(Exception):
@@ -132,35 +124,21 @@ class MFDataException(Exception):
             self.org_type, self.org_value, self.org_traceback
         )
         # build error string
-        error_message_0 = "An error occurred in "
+        error_message = "An error occurred in "
         if self.data_element is not None and self.data_element != "":
-            error_message_1 = f'data element "{self.data_element}" '
-        else:
-            error_message_1 = ""
+            error_message += f'data element "{self.data_element}" '
         if self.model is not None and self.model != "":
-            error_message_2 = f'model "{self.model}" '
-        else:
-            error_message_2 = ""
-        error_message_3 = f'package "{self.package}".'
-        error_message_4 = (
-            ' The error occurred while {} in the "{}" method'
-            ".".format(self.current_process, self.method_caught_in)
+            error_message += f'model "{self.model}" '
+        error_message += (
+            f'package "{self.package}". The error occurred while '
+            f'{self.current_process} in the "{self.method_caught_in}" method.'
         )
         if len(self.messages) > 0:
-            error_message_5 = "\nAdditional Information:\n"
-            for index, message in enumerate(self.messages):
-                error_message_5 = f"{error_message_5}({index + 1}) {message}\n"
-        else:
-            error_message_5 = ""
-        error_message = "{}{}{}{}{}{}".format(
-            error_message_0,
-            error_message_1,
-            error_message_2,
-            error_message_3,
-            error_message_4,
-            error_message_5,
-        )
-        Exception.__init__(self, error_message)
+            error_message += "\nAdditional Information:\n"
+            error_message += "\n".join(
+                f"({idx}) {msg}" for (idx, msg) in enumerate(self.messages, 1)
+            )
+        super().__init__(error_message)
 
 
 class VerbosityLevel(Enum):

--- a/flopy/plot/plotutil.py
+++ b/flopy/plot/plotutil.py
@@ -39,8 +39,7 @@ bc_color_dict = {
 
 
 class PlotException(Exception):
-    def __init__(self, message):
-        super().__init__(message)
+    pass
 
 
 class PlotUtilities:

--- a/flopy/plot/plotutil.py
+++ b/flopy/plot/plotutil.py
@@ -38,10 +38,6 @@ bc_color_dict = {
 }
 
 
-class PlotException(Exception):
-    pass
-
-
 class PlotUtilities:
     """
     Class which groups a collection of plotting utilities
@@ -661,13 +657,10 @@ class PlotUtilities:
 
             try:
                 arr = arr_dict[key]
-            except:
-                err_msg = "Cannot find key to plot\n"
-                err_msg += f"  Provided key={key}\n  Available keys="
-                for name, arr in arr_dict.items():
-                    err_msg += f"{name}, "
-                err_msg += "\n"
-                raise PlotException(err_msg)
+            except KeyError:
+                err_msg = f'Cannot find key "{key}" to plot\n  Available keys='
+                err_msg += ", ".join(str(k) for k in arr_dict.keys())
+                raise KeyError(err_msg)
 
             axes = PlotUtilities._plot_array_helper(
                 arr,
@@ -1118,7 +1111,7 @@ class PlotUtilities:
 
         # check that matplotlib is installed
         if plt is None:
-            raise PlotException(
+            raise ImportError(
                 "Could not import matplotlib.  Must install matplotlib "
                 "in order to plot LayerFile data."
             )
@@ -1269,7 +1262,7 @@ class PlotUtilities:
         from .map import PlotMapView
 
         if plt is None:
-            raise PlotException(
+            raise ImportError(
                 "Could not import matplotlib.  Must install matplotlib "
                 "in order to plot boundary condition data."
             )
@@ -2030,8 +2023,10 @@ def shapefile_extents(shp):
 
     """
     if shapefile is None:
-        s = "Could not import shapefile.  Must install pyshp in order to plot shapefiles."
-        raise PlotException(s)
+        raise ImportError(
+            "Could not import shapefile.  "
+            "Must install pyshp in order to plot shapefiles."
+        )
 
     sf = shapefile.Reader(shp)
     shapes = sf.shapes()
@@ -2072,8 +2067,10 @@ def shapefile_get_vertices(shp):
 
     """
     if shapefile is None:
-        s = "Could not import shapefile.  Must install pyshp in order to plot shapefiles."
-        raise PlotException(s)
+        raise ImportError(
+            "Could not import shapefile.  "
+            "Must install pyshp in order to plot shapefiles."
+        )
 
     sf = shapefile.Reader(shp)
     shapes = sf.shapes()
@@ -2123,9 +2120,9 @@ def shapefile_to_patch_collection(shp, radius=500.0, idx=None):
 
     """
     if shapefile is None:
-        raise PlotException(
-            "Could not import shapefile.  Must install pyshp "
-            "in order to plot shapefiles."
+        raise ImportError(
+            "Could not import shapefile.  "
+            "Must install pyshp in order to plot shapefiles."
         )
     if plt is None:
         raise ImportError(
@@ -2271,11 +2268,10 @@ def plot_shapefile(
     """
 
     if shapefile is None:
-        s = (
-            "Could not import shapefile.  Must install pyshp in "
-            "order to plot shapefiles."
+        raise ImportError(
+            "Could not import shapefile.  "
+            "Must install pyshp in order to plot shapefiles."
         )
-        raise PlotException(s)
 
     vmin = kwargs.pop("vmin", None)
     vmax = kwargs.pop("vmax", None)


### PR DESCRIPTION
This PR removes some unnecessary `Exception.__init__` calls when only a simple message is used. But where it is overloaded, use `super()` instead of directly calling the superclass.

The error message generation in MFDataException is simplified, and should generate the same information, but without a trailing `\n`.