### PR TITLE
refactor: use print() instead of sys.stdout.write()

### DIFF
--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -5,7 +5,6 @@ mbase module
 
 """
 import abc
-import sys
 import os
 import shutil
 import threading
@@ -1203,8 +1202,8 @@ class BaseModel(ModelInterface):
         # --reset the model workspace
         old_pth = self._model_ws
         self._model_ws = new_pth
-        line = f"\nchanging model workspace...\n   {new_pth}\n"
-        sys.stdout.write(line)
+        if self.verbose:
+            print(f"\nchanging model workspace...\n   {new_pth}")
         # reset the paths for each package
         for pp in self.packagelist:
             pp.fn_path = os.path.join(self.model_ws, pp.file_name[0])

--- a/flopy/modflow/mfbas.py
+++ b/flopy/modflow/mfbas.py
@@ -9,7 +9,6 @@ MODFLOW Guide
 """
 
 import re
-import sys
 import numpy as np
 from ..pakbase import Package
 from ..utils import Util3d
@@ -324,7 +323,7 @@ class ModflowBas(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading bas6 package file...\n")
+            print("loading bas6 package file...")
 
         # parse keywords
         if "nlay" in kwargs:

--- a/flopy/modflow/mfbcf.py
+++ b/flopy/modflow/mfbcf.py
@@ -1,5 +1,3 @@
-import sys
-
 import numpy as np
 
 from ..pakbase import Package
@@ -349,7 +347,7 @@ class ModflowBcf(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading bcf package file...\n")
+            print("loading bcf package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:

--- a/flopy/modflow/mfchd.py
+++ b/flopy/modflow/mfchd.py
@@ -8,7 +8,6 @@ MODFLOW Guide
 
 """
 
-import sys
 import numpy as np
 from ..pakbase import Package
 from ..utils import MfList
@@ -266,7 +265,7 @@ class ModflowChd(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading chd package file...\n")
+            print("loading chd package file...")
 
         return Package.load(
             f,

--- a/flopy/modflow/mfde4.py
+++ b/flopy/modflow/mfde4.py
@@ -7,7 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow-nwt/MODFLOW-NWT-Guide/de4.htm>`_.
 
 """
-import sys
 from ..pakbase import Package
 
 
@@ -256,7 +255,7 @@ class ModflowDe4(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading de4 package file...\n")
+            print("loading de4 package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:

--- a/flopy/modflow/mfdis.py
+++ b/flopy/modflow/mfdis.py
@@ -7,8 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow/MODFLOW-2005-Guide/index.html?dis.htm>`_.
 
 """
-
-import sys
 import warnings
 
 import numpy as np
@@ -763,7 +761,7 @@ class ModflowDis(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading dis package file...\n")
+            print("loading dis package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:

--- a/flopy/modflow/mfdisu.py
+++ b/flopy/modflow/mfdisu.py
@@ -3,9 +3,6 @@ mfdisu module.  Contains the ModflowDisU class. Note that the user can access
 the ModflowDisU class as `flopy.modflow.ModflowDisU`.
 
 """
-
-import sys
-import warnings
 import numpy as np
 from ..pakbase import Package
 from ..utils import Util2d, Util3d, read1d
@@ -552,7 +549,7 @@ class ModflowDisU(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading disu package file...\n")
+            print("loading disu package file...")
 
         if model.version != "mfusg":
             print(

--- a/flopy/modflow/mfdrn.py
+++ b/flopy/modflow/mfdrn.py
@@ -7,7 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow/MODFLOW-2005-Guide/index.html?drn.htm>`_.
 
 """
-import sys
 import numpy as np
 from ..pakbase import Package
 from ..utils.util_list import MfList
@@ -323,7 +322,7 @@ class ModflowDrn(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading drn package file...\n")
+            print("loading drn package file...")
 
         return Package.load(
             f,

--- a/flopy/modflow/mfdrt.py
+++ b/flopy/modflow/mfdrt.py
@@ -7,7 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow/MODFLOW-2005-Guide/index.html?drt.htm>`_.
 
 """
-import sys
 import numpy as np
 from ..pakbase import Package
 from ..utils.util_list import MfList
@@ -309,7 +308,7 @@ class ModflowDrt(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading drt package file...\n")
+            print("loading drt package file...")
 
         return Package.load(
             f,

--- a/flopy/modflow/mfevt.py
+++ b/flopy/modflow/mfevt.py
@@ -7,8 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow/MODFLOW-2005-Guide/index.html?evt.htm>`_.
 
 """
-import sys
-
 import numpy as np
 from .mfparbc import ModflowParBc as mfparbc
 from ..utils import Transient2d, Util2d
@@ -267,7 +265,7 @@ class ModflowEvt(Package):
 
         """
         if model.verbose:
-            sys.stdout.write("loading evt package file...\n")
+            print("loading evt package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:

--- a/flopy/modflow/mffhb.py
+++ b/flopy/modflow/mffhb.py
@@ -7,8 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow/MODFLOW-2005-Guide/index.html?fhb.htm>`_.
 
 """
-import sys
-
 import numpy as np
 
 from ..pakbase import Package
@@ -455,7 +453,7 @@ class ModflowFhb(Package):
 
         """
         if model.verbose:
-            sys.stdout.write("loading fhb package file...\n")
+            print("loading fhb package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:
@@ -477,7 +475,7 @@ class ModflowFhb(Package):
 
         # dataset 1
         if model.verbose:
-            sys.stdout.write("loading fhb dataset 1\n")
+            print("loading fhb dataset 1")
         raw = line.strip().split()
         nbdtim = int(raw[0])
         nflw = int(raw[1])
@@ -493,10 +491,8 @@ class ModflowFhb(Package):
         flow_aux = []
         if nfhbx1 > 0:
             if model.verbose:
-                sys.stdout.write("loading fhb dataset 2\n")
-            sys.stdout.write(
-                "dataset 2 will not be preserved in the created hfb object.\n"
-            )
+                print("loading fhb dataset 2")
+            print("dataset 2 will not be preserved in the created hfb object.")
             for idx in range(nfhbx1):
                 line = f.readline()
                 raw = line.strip().split()
@@ -510,10 +506,8 @@ class ModflowFhb(Package):
         head_aux = []
         if nfhbx2 > 0:
             if model.verbose:
-                sys.stdout.write("loading fhb dataset 3\n")
-            sys.stdout.write(
-                "dataset 3 will not be preserved in the created hfb object.\n"
-            )
+                print("loading fhb dataset 3")
+            print("dataset 3 will not be preserved in the created hfb object.")
             for idx in range(nfhbx2):
                 line = f.readline()
                 raw = line.strip().split()
@@ -525,7 +519,7 @@ class ModflowFhb(Package):
 
         # Dataset 4a IFHBUN CNSTM IFHBPT
         if model.verbose:
-            sys.stdout.write("loading fhb dataset 4a\n")
+            print("loading fhb dataset 4a")
         line = f.readline()
         raw = line.strip().split()
         ifhbun = int(raw[0])
@@ -539,7 +533,7 @@ class ModflowFhb(Package):
 
         # Dataset 4b
         if model.verbose:
-            sys.stdout.write("loading fhb dataset 4b\n")
+            print("loading fhb dataset 4b")
         line = f.readline()
         raw = line.strip().split()
         bdtime = []
@@ -553,7 +547,7 @@ class ModflowFhb(Package):
         ds6 = None
         if nflw > 0:
             if model.verbose:
-                sys.stdout.write("loading fhb dataset 5a\n")
+                print("loading fhb dataset 5a")
             # Dataset 5a IFHBUN CNSTM IFHBPT
             line = f.readline()
             raw = line.strip().split()
@@ -567,7 +561,7 @@ class ModflowFhb(Package):
             ifhbpt = max(ifhbpt, int(raw[2]))
 
             if model.verbose:
-                sys.stdout.write("loading fhb dataset 5b\n")
+                print("loading fhb dataset 5b")
             dtype = ModflowFhb.get_default_dtype(
                 nbdtim=nbdtim, head=False, structured=model.structured
             )
@@ -598,12 +592,10 @@ class ModflowFhb(Package):
                     dtype.append((name, np.float32))
                 for naux in range(nfhbx1):
                     if model.verbose:
-                        sys.stdout.write(
-                            f"loading fhb dataset 6a - aux {naux + 1}\n"
-                        )
-                    sys.stdout.write(
+                        print(f"loading fhb dataset 6a - aux {naux + 1}")
+                    print(
                         "dataset 6a will not be preserved in "
-                        "the created hfb object.\n"
+                        "the created hfb object."
                     )
                     # Dataset 6a IFHBUN CNSTM IFHBPT
                     line = f.readline()
@@ -619,12 +611,10 @@ class ModflowFhb(Package):
                     ifhbpt = max(ifhbpt, int(raw[2]))
 
                     if model.verbose:
-                        sys.stdout.write(
-                            f"loading fhb dataset 6b - aux {naux + 1}\n"
-                        )
-                    sys.stdout.write(
+                        print(f"loading fhb dataset 6b - aux {naux + 1}")
+                    print(
                         "dataset 6b will not be preserved in "
-                        "the created hfb object.\n"
+                        "the created hfb object."
                     )
                     current = np.recarray(nflw, dtype=dtype)
                     for n in range(nflw):
@@ -640,7 +630,7 @@ class ModflowFhb(Package):
         ds8 = None
         if nhed > 0:
             if model.verbose:
-                sys.stdout.write("loading fhb dataset 7a\n")
+                print("loading fhb dataset 7a")
             # Dataset 7a IFHBUN CNSTM IFHBPT
             line = f.readline()
             raw = line.strip().split()
@@ -654,7 +644,7 @@ class ModflowFhb(Package):
             ifhbpt = max(ifhbpt, int(raw[2]))
 
             if model.verbose:
-                sys.stdout.write("loading fhb dataset 7b\n")
+                print("loading fhb dataset 7b")
             dtype = ModflowFhb.get_default_dtype(
                 nbdtim=nbdtim, head=True, structured=model.structured
             )
@@ -685,12 +675,10 @@ class ModflowFhb(Package):
                     dtype.append((name, np.float32))
                 for naux in range(nfhbx1):
                     if model.verbose:
-                        sys.stdout.write(
-                            f"loading fhb dataset 8a - aux {naux + 1}\n"
-                        )
-                    sys.stdout.write(
+                        print(f"loading fhb dataset 8a - aux {naux + 1}")
+                    print(
                         "dataset 8a will not be preserved in "
-                        "the created hfb object.\n"
+                        "the created hfb object."
                     )
                     # Dataset 6a IFHBUN CNSTM IFHBPT
                     line = f.readline()
@@ -707,10 +695,8 @@ class ModflowFhb(Package):
                     ifhbpt = max(ifhbpt, ifhbpt6)
 
                     if model.verbose:
-                        sys.stdout.write(
-                            f"loading fhb dataset 8b - aux {naux + 1}\n"
-                        )
-                    sys.stdout.write(
+                        print(f"loading fhb dataset 8b - aux {naux + 1}")
+                    print(
                         "dataset 8b will not be preserved in "
                         "the created hfb object."
                     )

--- a/flopy/modflow/mfflwob.py
+++ b/flopy/modflow/mfflwob.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import numpy as np
 from ..pakbase import Package
 from ..utils import parsenamefile
@@ -414,7 +413,7 @@ class ModflowFlwob(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading flwob package file...\n")
+            print("loading flwob package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:

--- a/flopy/modflow/mfgage.py
+++ b/flopy/modflow/mfgage.py
@@ -8,7 +8,6 @@ MODFLOW Guide
 
 """
 import os
-import sys
 
 import numpy as np
 
@@ -318,7 +317,7 @@ class ModflowGage(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading gage package file...\n")
+            print("loading gage package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:

--- a/flopy/modflow/mfghb.py
+++ b/flopy/modflow/mfghb.py
@@ -7,7 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow/MODFLOW-2005-Guide/index.html?ghb.htm>`_.
 
 """
-import sys
 import numpy as np
 from ..pakbase import Package
 from ..utils import MfList
@@ -301,7 +300,7 @@ class ModflowGhb(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading ghb package file...\n")
+            print("loading ghb package file...")
 
         return Package.load(
             f,

--- a/flopy/modflow/mfgmg.py
+++ b/flopy/modflow/mfgmg.py
@@ -7,7 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow/MODFLOW-2005-Guide/gmg.htm>`_.
 
 """
-import sys
 from ..pakbase import Package
 
 
@@ -343,7 +342,7 @@ class ModflowGmg(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading gmg package file...\n")
+            print("loading gmg package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:

--- a/flopy/modflow/mfhfb.py
+++ b/flopy/modflow/mfhfb.py
@@ -7,7 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow/MODFLOW-2005-Guide/index.html?hfb6.htm>`_.
 
 """
-import sys
 import numpy as np
 from ..pakbase import Package
 from .mfparbc import ModflowParBc as mfparbc
@@ -285,7 +284,7 @@ class ModflowHfb(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading hfb6 package file...\n")
+            print("loading hfb6 package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:

--- a/flopy/modflow/mfhob.py
+++ b/flopy/modflow/mfhob.py
@@ -1,4 +1,3 @@
-import sys
 import numpy as np
 from ..pakbase import Package
 from ..utils.recarray_utils import create_empty_recarray
@@ -337,7 +336,7 @@ class ModflowHob(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading hob package file...\n")
+            print("loading hob package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:

--- a/flopy/modflow/mfhyd.py
+++ b/flopy/modflow/mfhyd.py
@@ -7,8 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow/MODFLOW-2005-Guide/hyd.htm>`_.
 
 """
-import sys
-
 import numpy as np
 
 from ..pakbase import Package
@@ -311,7 +309,7 @@ class ModflowHyd(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading hydmod package file...\n")
+            print("loading hydmod package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:
@@ -321,7 +319,7 @@ class ModflowHyd(Package):
         # --read dataset 1
         # NHYD IHYDUN HYDNOH
         if model.verbose:
-            sys.stdout.write("  loading hydmod dataset 1\n")
+            print("  loading hydmod dataset 1")
         line = f.readline()
         t = line.strip().split()
         nhyd = int(t[0])

--- a/flopy/modflow/mflak.py
+++ b/flopy/modflow/mflak.py
@@ -7,7 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow/MODFLOW-2005-Guide/lak.htm>`_.
 
 """
-import sys
 import numpy as np
 from ..pakbase import Package
 from ..utils.util_array import Transient3d
@@ -665,7 +664,7 @@ class ModflowLak(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading lak package file...\n")
+            print("loading lak package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:

--- a/flopy/modflow/mflmt.py
+++ b/flopy/modflow/mflmt.py
@@ -8,7 +8,7 @@ MODFLOW Guide
 
 """
 import os
-import sys
+
 from ..pakbase import Package
 
 
@@ -191,7 +191,7 @@ class ModflowLmt(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading lmt package file...\n")
+            print("loading lmt package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:

--- a/flopy/modflow/mflpf.py
+++ b/flopy/modflow/mflpf.py
@@ -7,9 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow/MODFLOW-2005-Guide/index.html?lpf.htm>`_.
 
 """
-
-import sys
-
 import numpy as np
 from .mfpar import ModflowPar as mfpar
 
@@ -475,7 +472,7 @@ class ModflowLpf(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading lpf package file...\n")
+            print("loading lpf package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:

--- a/flopy/modflow/mfmlt.py
+++ b/flopy/modflow/mfmlt.py
@@ -7,8 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow-nwt/MODFLOW-NWT-Guide/mult.htm>`_.
 
 """
-import sys
-
 import numpy as np
 
 from ..pakbase import Package
@@ -162,7 +160,7 @@ class ModflowMlt(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading mult package file...\n")
+            print("loading mult package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:
@@ -192,7 +190,7 @@ class ModflowMlt(Package):
             else:
                 mltnam = t[0].lower()
             if model.verbose:
-                sys.stdout.write(f'   reading data for "{mltnam:<10s}" mult\n')
+                print(f'   reading data for "{mltnam:<10s}" mult')
             readArray = True
             kwrd = None
             if len(t) > 1:

--- a/flopy/modflow/mfmnw1.py
+++ b/flopy/modflow/mfmnw1.py
@@ -1,4 +1,3 @@
-import sys
 import re
 import numpy as np
 from ..pakbase import Package
@@ -209,7 +208,7 @@ class ModflowMnw1(Package):
     def load(cls, f, model, nper=None, gwt=False, nsol=1, ext_unit_dict=None):
 
         if model.verbose:
-            sys.stdout.write("loading mnw1 package file...\n")
+            print("loading mnw1 package file...")
 
         structured = model.structured
         if nper is None:

--- a/flopy/modflow/mfmnw2.py
+++ b/flopy/modflow/mfmnw2.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import warnings
 
 import numpy as np
@@ -1346,7 +1345,7 @@ class ModflowMnw2(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading mnw2 package file...\n")
+            print("loading mnw2 package file...")
 
         structured = model.structured
         if nper is None:

--- a/flopy/modflow/mfmnwi.py
+++ b/flopy/modflow/mfmnwi.py
@@ -1,5 +1,3 @@
-import sys
-
 from ..utils.flopy_io import line_parse, pop_item
 from ..pakbase import Package
 
@@ -202,7 +200,7 @@ class ModflowMnwi(Package):
     def load(cls, f, model, nper=None, gwt=False, nsol=1, ext_unit_dict=None):
 
         if model.verbose:
-            sys.stdout.write("loading mnw2 package file...\n")
+            print("loading mnw2 package file...")
 
         structured = model.structured
         if nper is None:

--- a/flopy/modflow/mfnwt.py
+++ b/flopy/modflow/mfnwt.py
@@ -7,8 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow-nwt/MODFLOW-NWT-Guide/nwt_newton_solver.htm>`_.
 
 """
-
-import sys
 from ..pakbase import Package
 
 
@@ -405,7 +403,7 @@ class ModflowNwt(Package):
 
         """
         if model.verbose:
-            sys.stdout.write("loading nwt package file...\n")
+            print("loading nwt package file...")
 
         if model.version != "mfnwt":
             print(

--- a/flopy/modflow/mfoc.py
+++ b/flopy/modflow/mfoc.py
@@ -8,7 +8,6 @@ MODFLOW Guide
 
 """
 import os
-import sys
 
 from ..pakbase import Package
 
@@ -766,7 +765,7 @@ class ModflowOc(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading oc package file...\n")
+            print("loading oc package file...")
 
         # set nper
         if nper is None or nlay is None:

--- a/flopy/modflow/mfpar.py
+++ b/flopy/modflow/mfpar.py
@@ -4,8 +4,6 @@ the ModflowPar class as `flopy.modflow.ModflowPar`.
 
 
 """
-
-import sys
 import numpy as np
 from .mfzon import ModflowZon
 from .mfpval import ModflowPval
@@ -76,13 +74,11 @@ class ModflowPar:
                     zone.filename, model, ext_unit_dict=ext_unit_dict
                 )
                 if model.verbose:
-                    sys.stdout.write(
-                        f"   {self.zone.name[0]} package load...success\n"
-                    )
+                    print(f"   {self.zone.name[0]} package load...success")
                 ext_unit_dict.pop(zone_key)
                 model.remove_package("ZONE")
             except BaseException as o:
-                sys.stdout.write(f"   ZONE package load...failed\n      {o!s}")
+                print(f"   ZONE package load...failed\n      {o!s}")
         return
 
     def set_mult(self, model, ext_unit_dict):
@@ -123,13 +119,11 @@ class ModflowPar:
                     mult.filename, model, ext_unit_dict=ext_unit_dict
                 )
                 if model.verbose:
-                    sys.stdout.write(
-                        f"   {self.mult.name[0]} package load...success\n"
-                    )
+                    print(f"   {self.mult.name[0]} package load...success")
                 ext_unit_dict.pop(mult_key)
                 model.remove_package("MULT")
             except BaseException as o:
-                sys.stdout.write(f"   MULT package load...failed\n      {o!s}")
+                print(f"   MULT package load...failed\n      {o!s}")
 
         return
 
@@ -171,13 +165,11 @@ class ModflowPar:
                     pval.filename, model, ext_unit_dict=ext_unit_dict
                 )
                 if model.verbose:
-                    sys.stdout.write(
-                        f"   {self.pval.name[0]} package load...success\n"
-                    )
+                    print(f"   {self.pval.name[0]} package load...success")
                 ext_unit_dict.pop(pval_key)
                 model.remove_package("PVAL")
             except BaseException as o:
-                sys.stdout.write(f"   PVAL package load...failed\n      {o!s}")
+                print(f"   PVAL package load...failed\n      {o!s}")
 
         return
 

--- a/flopy/modflow/mfpcg.py
+++ b/flopy/modflow/mfpcg.py
@@ -7,8 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow-nwt/MODFLOW-NWT-Guide/pcg.htm>`_.
 
 """
-import sys
-
 from ..pakbase import Package
 from ..utils.flopy_io import line_parse
 
@@ -248,7 +246,7 @@ class ModflowPcg(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading pcg package file...\n")
+            print("loading pcg package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:

--- a/flopy/modflow/mfpcgn.py
+++ b/flopy/modflow/mfpcgn.py
@@ -7,8 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow/MODFLOW-2005-Guide/pcgn.htm>`_.
 
 """
-
-import sys
 from ..pakbase import Package
 
 
@@ -421,7 +419,7 @@ class ModflowPcgn(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading pcgn package file...\n")
+            print("loading pcgn package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:

--- a/flopy/modflow/mfpks.py
+++ b/flopy/modflow/mfpks.py
@@ -3,7 +3,6 @@ mfpks module.  Contains the ModflowPks class. Note that the user can access
 the ModflowPks class as `flopy.modflow.ModflowPks`.
 
 """
-import sys
 from ..pakbase import Package
 
 
@@ -257,7 +256,7 @@ class ModflowPks(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading pks package file...\n")
+            print("loading pks package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:

--- a/flopy/modflow/mfpval.py
+++ b/flopy/modflow/mfpval.py
@@ -7,7 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow-nwt/MODFLOW-NWT-Guide/parameter_value_file.htm>`_.
 
 """
-import sys
 from ..pakbase import Package
 
 
@@ -168,7 +167,7 @@ class ModflowPval(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading pval package file...\n")
+            print("loading pval package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:
@@ -187,9 +186,7 @@ class ModflowPval(Package):
         npval = int(t[0])
 
         if model.verbose:
-            sys.stdout.write(
-                f'   reading parameter values from "{filename:<10s}"\n'
-            )
+            print(f'   reading parameter values from "{filename}"')
 
         # read PVAL data
         pval_dict = dict()

--- a/flopy/modflow/mfrch.py
+++ b/flopy/modflow/mfrch.py
@@ -7,8 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow/MODFLOW-2005-Guide/index.html?rch.htm>`_.
 
 """
-
-import sys
 import numpy as np
 from ..pakbase import Package
 from ..utils import Util2d, Transient2d
@@ -423,7 +421,7 @@ class ModflowRch(Package):
 
         """
         if model.verbose:
-            sys.stdout.write("loading rch package file...\n")
+            print("loading rch package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:

--- a/flopy/modflow/mfriv.py
+++ b/flopy/modflow/mfriv.py
@@ -7,7 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow/MODFLOW-2005-Guide/index.html?riv.htm>`_.
 
 """
-import sys
 import numpy as np
 from ..pakbase import Package
 from ..utils import MfList
@@ -386,7 +385,7 @@ class ModflowRiv(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading riv package file...\n")
+            print("loading riv package file...")
 
         return Package.load(
             f,

--- a/flopy/modflow/mfsfr2.py
+++ b/flopy/modflow/mfsfr2.py
@@ -1,6 +1,5 @@
 __author__ = "aleaf"
 
-import sys
 import os
 import numpy as np
 import warnings
@@ -817,7 +816,7 @@ class ModflowSfr2(Package):
     def load(cls, f, model, nper=None, gwt=False, nsol=1, ext_unit_dict=None):
 
         if model.verbose:
-            sys.stdout.write("loading sfr2 package file...\n")
+            print("loading sfr2 package file...")
 
         tabfiles = False
         tabfiles_dict = {}

--- a/flopy/modflow/mfsip.py
+++ b/flopy/modflow/mfsip.py
@@ -7,9 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow/MODFLOW-2005-Guide/index.html?sip.htm>`_.
 
 """
-
-import sys
-
 from ..pakbase import Package
 
 
@@ -213,7 +210,7 @@ class ModflowSip(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading sip package file...\n")
+            print("loading sip package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:

--- a/flopy/modflow/mfsms.py
+++ b/flopy/modflow/mfsms.py
@@ -5,9 +5,6 @@ the ModflowSms class as `flopy.modflow.ModflowSms`.
 
 
 """
-
-import sys
-
 from ..pakbase import Package
 from ..utils.flopy_io import line_parse
 
@@ -441,7 +438,7 @@ class ModflowSms(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading sms package file...\n")
+            print("loading sms package file...")
 
         if model.version != "mfusg":
             print(

--- a/flopy/modflow/mfsor.py
+++ b/flopy/modflow/mfsor.py
@@ -7,9 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/nrp/gwsoftware/modflow2000/Guide/sor.htm>`_.
 
 """
-
-import sys
-
 from ..pakbase import Package
 
 
@@ -179,7 +176,7 @@ class ModflowSor(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading sor package file...\n")
+            print("loading sor package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:

--- a/flopy/modflow/mfstr.py
+++ b/flopy/modflow/mfstr.py
@@ -7,8 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow/MODFLOW-2005-Guide/str.htm>`_.
 
 """
-import sys
-
 import numpy as np
 from ..utils import MfList
 from ..pakbase import Package
@@ -713,7 +711,7 @@ class ModflowStr(Package):
         fmt9 = [5]
 
         if model.verbose:
-            sys.stdout.write("loading str package file...\n")
+            print("loading str package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:
@@ -731,7 +729,7 @@ class ModflowStr(Package):
         t = line.strip().split()
         if t[0].lower() == "parameter":
             if model.verbose:
-                sys.stdout.write("  loading str dataset 1\n")
+                print("  loading str dataset 1")
             npstr = np.int32(t[1])
             mxl = np.int32(t[2])
 
@@ -740,7 +738,7 @@ class ModflowStr(Package):
 
         # data set 2
         if model.verbose:
-            sys.stdout.write("  loading str dataset 2\n")
+            print("  loading str dataset 2")
         t = read_fixed_var(line, ipos=fmt2, free=free)
         mxacts = np.int32(t[0])
         nss = np.int32(t[1])

--- a/flopy/modflow/mfsub.py
+++ b/flopy/modflow/mfsub.py
@@ -7,8 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow/MODFLOW-2005-Guide/sub.htm>`_.
 
 """
-import sys
-
 import numpy as np
 
 from ..pakbase import Package
@@ -607,7 +605,7 @@ class ModflowSub(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading sub package file...\n")
+            print("loading sub package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:
@@ -624,7 +622,7 @@ class ModflowSub(Package):
 
         # read dataset 1
         if model.verbose:
-            sys.stdout.write("  loading sub dataset 1\n")
+            print("  loading sub dataset 1")
         t = line.strip().split()
         ipakcb, isuboc, nndb, ndb, nmz, nn = (
             int(t[0]),
@@ -648,19 +646,19 @@ class ModflowSub(Package):
         ln = None
         if nndb > 0:
             if model.verbose:
-                sys.stdout.write("  loading sub dataset 2\n")
+                print("  loading sub dataset 2")
             ln = np.empty((nndb), dtype=np.int32)
             ln = read1d(f, ln) - 1
         ldn = None
         if ndb > 0:
             if model.verbose:
-                sys.stdout.write("  loading sub dataset 3\n")
+                print("  loading sub dataset 3")
             ldn = np.empty((ndb), dtype=np.int32)
             ldn = read1d(f, ldn) - 1
         rnb = None
         if ndb > 0:
             if model.verbose:
-                sys.stdout.write("  loading sub dataset 4\n")
+                print("  loading sub dataset 4")
             rnb = [0] * ndb
             for k in range(ndb):
                 t = Util2d.load(
@@ -685,9 +683,7 @@ class ModflowSub(Package):
                 kk = ln[k] + 1
                 # hc
                 if model.verbose:
-                    sys.stdout.write(
-                        f"  loading sub dataset 5 for layer {kk}\n"
-                    )
+                    print(f"  loading sub dataset 5 for layer {kk}")
                 t = Util2d.load(
                     f,
                     model,
@@ -699,9 +695,7 @@ class ModflowSub(Package):
                 hc[k] = t
                 # sfe
                 if model.verbose:
-                    sys.stdout.write(
-                        f"  loading sub dataset 6 for layer {kk}\n"
-                    )
+                    print(f"  loading sub dataset 6 for layer {kk}")
                 t = Util2d.load(
                     f,
                     model,
@@ -713,9 +707,7 @@ class ModflowSub(Package):
                 sfe[k] = t
                 # sfv
                 if model.verbose:
-                    sys.stdout.write(
-                        f"  loading sub dataset 7 for layer {kk}\n"
-                    )
+                    print(f"  loading sub dataset 7 for layer {kk}")
                 t = Util2d.load(
                     f,
                     model,
@@ -727,9 +719,7 @@ class ModflowSub(Package):
                 sfv[k] = t
                 # com
                 if model.verbose:
-                    sys.stdout.write(
-                        f"  loading sub dataset 8 for layer {kk}\n"
-                    )
+                    print(f"  loading sub dataset 8 for layer {kk}")
                 t = Util2d.load(
                     f,
                     model,
@@ -746,9 +736,7 @@ class ModflowSub(Package):
             dp = np.zeros((nmz, 3), dtype=np.float32)
             for k in range(nmz):
                 if model.verbose:
-                    sys.stdout.write(
-                        f"  loading sub dataset 9 for material zone {k + 1}\n"
-                    )
+                    print(f"  loading sub dataset 9 for material zone {k + 1}")
                 line = f.readline()
                 t = line.strip().split()
                 dp[k, :] = float(t[0]), float(t[1]), float(t[2])
@@ -768,9 +756,7 @@ class ModflowSub(Package):
                 kk = ldn[k] + 1
                 # dstart
                 if model.verbose:
-                    sys.stdout.write(
-                        f"  loading sub dataset 10 for layer {kk}\n"
-                    )
+                    print(f"  loading sub dataset 10 for layer {kk}")
                 t = Util2d.load(
                     f,
                     model,
@@ -782,9 +768,7 @@ class ModflowSub(Package):
                 dstart[k] = t
                 # dhc
                 if model.verbose:
-                    sys.stdout.write(
-                        f"  loading sub dataset 11 for layer {kk}\n"
-                    )
+                    print(f"  loading sub dataset 11 for layer {kk}")
                 t = Util2d.load(
                     f,
                     model,
@@ -796,9 +780,7 @@ class ModflowSub(Package):
                 dhc[k] = t
                 # dcom
                 if model.verbose:
-                    sys.stdout.write(
-                        f"  loading sub dataset 12 for layer {kk}\n"
-                    )
+                    print(f"  loading sub dataset 12 for layer {kk}")
                 t = Util2d.load(
                     f,
                     model,
@@ -810,9 +792,7 @@ class ModflowSub(Package):
                 dcom[k] = t
                 # dz
                 if model.verbose:
-                    sys.stdout.write(
-                        f"  loading sub dataset 13 for layer {kk}\n"
-                    )
+                    print(f"  loading sub dataset 13 for layer {kk}")
                 t = Util2d.load(
                     f,
                     model,
@@ -824,9 +804,7 @@ class ModflowSub(Package):
                 dz[k] = t
                 # nz
                 if model.verbose:
-                    sys.stdout.write(
-                        f"  loading sub dataset 14 for layer {kk}\n"
-                    )
+                    print(f"  loading sub dataset 14 for layer {kk}")
                 t = Util2d.load(
                     f,
                     model,
@@ -842,16 +820,14 @@ class ModflowSub(Package):
         if isuboc > 0:
             # dataset 15
             if model.verbose:
-                sys.stdout.write(f"  loading sub dataset 15 for layer {kk}\n")
+                print(f"  loading sub dataset 15 for layer {kk}")
             ids15 = np.empty(12, dtype=np.int32)
             ids15 = read1d(f, ids15)
             # dataset 16
             ids16 = [0] * isuboc
             for k in range(isuboc):
                 if model.verbose:
-                    sys.stdout.write(
-                        f"  loading sub dataset 16 for isuboc {k + 1}\n"
-                    )
+                    print(f"  loading sub dataset 16 for isuboc {k + 1}")
                 t = np.empty(17, dtype=np.int32)
                 t = read1d(f, t)
                 t[0:4] -= 1

--- a/flopy/modflow/mfswi2.py
+++ b/flopy/modflow/mfswi2.py
@@ -5,8 +5,6 @@ Additional information for this MODFLOW package can be found at the `Online
 MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow-nwt/MODFLOW-NWT-Guide/swi2_seawater_intrusion_pack.htm>`_.
 """
-import sys
-
 import numpy as np
 
 from ..pakbase import Package
@@ -547,7 +545,7 @@ class ModflowSwi2(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading swi2 package file...\n")
+            print("loading swi2 package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:
@@ -564,7 +562,7 @@ class ModflowSwi2(Package):
 
         # --read dataset 1
         if model.verbose:
-            sys.stdout.write("  loading swi2 dataset 1\n")
+            print("  loading swi2 dataset 1")
         t = line.strip().split()
         nsrf = int(t[0])
         istrat = int(t[1])
@@ -592,7 +590,7 @@ class ModflowSwi2(Package):
 
         # read dataset 2a
         if model.verbose:
-            sys.stdout.write("  loading swi2 dataset 2a\n")
+            print("  loading swi2 dataset 2a")
         while True:
             line = f.readline()
             if line[0] != "#":
@@ -606,7 +604,7 @@ class ModflowSwi2(Package):
         solver2params = {}
         if nsolver == 2:
             if model.verbose:
-                sys.stdout.write("  loading swi2 dataset 2b\n")
+                print("  loading swi2 dataset 2b")
             while True:
                 line = f.readline()
                 if line[0] != "#":
@@ -624,7 +622,7 @@ class ModflowSwi2(Package):
 
         # read dataset 3a
         if model.verbose:
-            sys.stdout.write("  loading swi2 dataset 3a\n")
+            print("  loading swi2 dataset 3a")
         while True:
             line = f.readline()
             if line[0] != "#":
@@ -646,7 +644,7 @@ class ModflowSwi2(Package):
         nadptmx, nadptmn, adptfct = None, None, None
         if adaptive:
             if model.verbose:
-                sys.stdout.write("  loading swi2 dataset 3b\n")
+                print("  loading swi2 dataset 3b")
             while True:
                 line = f.readline()
                 if line[0] != "#":

--- a/flopy/modflow/mfswr1.py
+++ b/flopy/modflow/mfswr1.py
@@ -7,7 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow-nwt/MODFLOW-NWT-Guide/swr.htm>`_.
 
 """
-import sys
 from ..pakbase import Package
 
 
@@ -156,7 +155,7 @@ class ModflowSwr1(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading swr1 process file...\n")
+            print("loading swr1 process file...")
 
         # todo: everything
 

--- a/flopy/modflow/mfswt.py
+++ b/flopy/modflow/mfswt.py
@@ -7,8 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow/MODFLOW-2005-Guide/swt.htm>`_.
 
 """
-import sys
-
 import numpy as np
 
 from ..pakbase import Package
@@ -628,7 +626,7 @@ class ModflowSwt(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading swt package file...\n")
+            print("loading swt package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:
@@ -645,7 +643,7 @@ class ModflowSwt(Package):
 
         # read dataset 1
         if model.verbose:
-            sys.stdout.write("  loading swt dataset 1\n")
+            print("  loading swt dataset 1")
         t = line.strip().split()
         ipakcb, iswtoc, nsystm, ithk, ivoid, istpcs, icrcc = (
             int(t[0]),
@@ -664,13 +662,13 @@ class ModflowSwt(Package):
         lnwt = None
         if nsystm > 0:
             if model.verbose:
-                sys.stdout.write("  loading swt dataset 2\n")
+                print("  loading swt dataset 2")
             lnwt = np.empty((nsystm), dtype=np.int32)
             lnwt = read1d(f, lnwt) - 1
 
         # read dataset 3
         if model.verbose:
-            sys.stdout.write("  loading swt dataset 3\n")
+            print("  loading swt dataset 3")
         line = f.readline()
         t = line.strip().split()
         (
@@ -699,21 +697,21 @@ class ModflowSwt(Package):
 
         # read dataset 4
         if model.verbose:
-            sys.stdout.write("  loading swt dataset 4")
+            print("  loading swt dataset 4")
         gl0 = Util2d.load(
             f, model, (nrow, ncol), np.float32, "gl0", ext_unit_dict
         )
 
         # read dataset 5
         if model.verbose:
-            sys.stdout.write("  loading swt dataset 5")
+            print("  loading swt dataset 5")
         sgm = Util2d.load(
             f, model, (nrow, ncol), np.float32, "sgm", ext_unit_dict
         )
 
         # read dataset 6
         if model.verbose:
-            sys.stdout.write("  loading swt dataset 6")
+            print("  loading swt dataset 6")
         sgs = Util2d.load(
             f, model, (nrow, ncol), np.float32, "sgs", ext_unit_dict
         )
@@ -737,7 +735,7 @@ class ModflowSwt(Package):
             kk = lnwt[k] + 1
             # thick
             if model.verbose:
-                sys.stdout.write(f"  loading swt dataset 7 for layer {kk}\n")
+                print(f"  loading swt dataset 7 for layer {kk}")
             t = Util2d.load(
                 f,
                 model,
@@ -750,9 +748,7 @@ class ModflowSwt(Package):
             if icrcc != 0:
                 # sse
                 if model.verbose:
-                    sys.stdout.write(
-                        f"  loading swt dataset 8 for layer {kk}\n"
-                    )
+                    print(f"  loading swt dataset 8 for layer {kk}")
                 t = Util2d.load(
                     f,
                     model,
@@ -764,9 +760,7 @@ class ModflowSwt(Package):
                 sse[k] = t
                 # ssv
                 if model.verbose:
-                    sys.stdout.write(
-                        f"  loading swt dataset 9 for layer {kk}\n"
-                    )
+                    print(f"  loading swt dataset 9 for layer {kk}")
                 t = Util2d.load(
                     f,
                     model,
@@ -779,9 +773,7 @@ class ModflowSwt(Package):
             else:
                 # cr
                 if model.verbose:
-                    sys.stdout.write(
-                        f"  loading swt dataset 10 for layer {kk}\n"
-                    )
+                    print(f"  loading swt dataset 10 for layer {kk}")
                 t = Util2d.load(
                     f,
                     model,
@@ -793,9 +785,7 @@ class ModflowSwt(Package):
                 cr[k] = t
                 # cc
                 if model.verbose:
-                    sys.stdout.write(
-                        f"  loading swt dataset 11 for layer {kk}\n"
-                    )
+                    print(f"  loading swt dataset 11 for layer {kk}")
                 t = Util2d.load(
                     f,
                     model,
@@ -807,7 +797,7 @@ class ModflowSwt(Package):
                 cc[k] = t
             # void
             if model.verbose:
-                sys.stdout.write(f"  loading swt dataset 12 for layer {kk}\n")
+                print(f"  loading swt dataset 12 for layer {kk}")
             t = Util2d.load(
                 f,
                 model,
@@ -819,7 +809,7 @@ class ModflowSwt(Package):
             void[k] = t
             # sub
             if model.verbose:
-                sys.stdout.write(f"  loading swt dataset 13 for layer {kk}\n")
+                print(f"  loading swt dataset 13 for layer {kk}")
             t = Util2d.load(
                 f,
                 model,
@@ -840,9 +830,7 @@ class ModflowSwt(Package):
         for k in range(nlay):
             if istpcs != 0:
                 if model.verbose:
-                    sys.stdout.write(
-                        f"  loading swt dataset 14 for layer {kk}\n"
-                    )
+                    print(f"  loading swt dataset 14 for layer {kk}")
                 t = Util2d.load(
                     f,
                     model,
@@ -854,9 +842,7 @@ class ModflowSwt(Package):
                 pcsoff[k] = t
             else:
                 if model.verbose:
-                    sys.stdout.write(
-                        f"  loading swt dataset 15 for layer {kk}\n"
-                    )
+                    print(f"  loading swt dataset 15 for layer {kk}")
                 t = Util2d.load(
                     f,
                     model,
@@ -872,7 +858,7 @@ class ModflowSwt(Package):
         if iswtoc > 0:
             # dataset 16
             if model.verbose:
-                sys.stdout.write(f"  loading swt dataset 15 for layer {kk}\n")
+                print(f"  loading swt dataset 15 for layer {kk}")
             ids16 = np.empty(26, dtype=np.int32)
             ids16 = read1d(f, ids16)
             # for k in range(1, 26, 2):
@@ -882,9 +868,7 @@ class ModflowSwt(Package):
             ids17 = [0] * iswtoc
             for k in range(iswtoc):
                 if model.verbose:
-                    sys.stdout.write(
-                        f"  loading swt dataset 17 for iswtoc {k + 1}\n"
-                    )
+                    print(f"  loading swt dataset 17 for iswtoc {k + 1}")
                 t = np.empty(30, dtype=np.int32)
                 t = read1d(f, t)
                 t[0:4] -= 1

--- a/flopy/modflow/mfupw.py
+++ b/flopy/modflow/mfupw.py
@@ -7,8 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow-nwt/MODFLOW-NWT-Guide/upw_upstream_weighting_package.htm>`_.
 
 """
-
-import sys
 import numpy as np
 from .mfpar import ModflowPar as mfpar
 from ..pakbase import Package
@@ -386,7 +384,7 @@ class ModflowUpw(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading upw package file...\n")
+            print("loading upw package file...")
 
         if model.version != "mfnwt":
             print(

--- a/flopy/modflow/mfuzf1.py
+++ b/flopy/modflow/mfuzf1.py
@@ -7,8 +7,6 @@ MODFLOW Guide
 <https://water.usgs.gov/nrp/gwsoftware/modflow2000/MFDOC/index.html?uzf_unsaturated_zone_flow_pack.htm>`_.
 
 """
-
-import sys
 import numpy as np
 from ..utils.flopy_io import pop_item, line_parse
 from ..pakbase import Package
@@ -919,7 +917,7 @@ class ModflowUzf1(Package):
 
         """
         if model.verbose:
-            sys.stdout.write("loading uzf package file...\n")
+            print("loading uzf package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:

--- a/flopy/modflow/mfwel.py
+++ b/flopy/modflow/mfwel.py
@@ -7,8 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow/MODFLOW-2005-Guide/index.html?wel.htm>`_.
 
 """
-
-import sys
 import numpy as np
 from ..utils import MfList
 from ..pakbase import Package
@@ -410,7 +408,7 @@ class ModflowWel(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading wel package file...\n")
+            print("loading wel package file...")
 
         return Package.load(
             f,

--- a/flopy/modflow/mfzon.py
+++ b/flopy/modflow/mfzon.py
@@ -7,7 +7,6 @@ MODFLOW Guide
 <http://water.usgs.gov/ogw/modflow-nwt/MODFLOW-NWT-Guide/zone.htm>`_.
 
 """
-import sys
 import numpy as np
 from ..pakbase import Package
 from ..utils import Util2d
@@ -165,7 +164,7 @@ class ModflowZon(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading zone package file...\n")
+            print("loading zone package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:
@@ -195,7 +194,7 @@ class ModflowZon(Package):
             else:
                 zonnam = t[0].lower()
             if model.verbose:
-                sys.stdout.write(f'   reading data for "{zonnam:<10s}" zone\n')
+                print(f'   reading data for "{zonnam:<10s}" zone')
             # load data
             t = Util2d.load(
                 f, model, (nrow, ncol), np.int32, zonnam, ext_unit_dict

--- a/flopy/modflowlgr/mflgr.py
+++ b/flopy/modflowlgr/mflgr.py
@@ -5,7 +5,6 @@ mflgr module.
 """
 
 import os
-import sys
 
 from ..mbase import BaseModel
 from ..modflow import Modflow
@@ -425,9 +424,7 @@ class ModflowLgr(BaseModel):
             new_pth = os.getcwd()
         if not os.path.exists(new_pth):
             try:
-                sys.stdout.write(
-                    f"\ncreating model workspace...\n   {new_pth}\n"
-                )
+                print(f"\ncreating model workspace...\n   {new_pth}")
                 os.makedirs(new_pth)
             except:
                 not_valid = new_pth
@@ -439,8 +436,8 @@ class ModflowLgr(BaseModel):
         # --reset the model workspace
         old_pth = self._model_ws
         self._model_ws = new_pth
-        line = f"\nchanging model workspace...\n   {new_pth}\n"
-        sys.stdout.write(line)
+        if self.verbose:
+            print(f"\nchanging model workspace...\n   {new_pth}")
 
         # reset model_ws for the parent
         lpth = os.path.abspath(old_pth)

--- a/flopy/mt3d/mt.py
+++ b/flopy/mt3d/mt.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import numpy as np
 from ..mbase import BaseModel
 from ..pakbase import Package
@@ -498,9 +497,7 @@ class Mt3dms(BaseModel):
         modelname_extension = ext[1:]  # without '.'
 
         if verbose:
-            sys.stdout.write(
-                f"\nCreating new model with name: {modelname}\n{50 * '-'}\n\n"
-            )
+            print(f"\nCreating new model with name: {modelname}\n{50 * '-'}\n")
         mt = cls(
             modelname=modelname,
             namefile_ext=modelname_extension,
@@ -580,7 +577,7 @@ class Mt3dms(BaseModel):
             raise Exception(f"error loading BTN: {e!s}")
         files_successfully_loaded.append(btn.filename)
         if mt.verbose:
-            sys.stdout.write(f"   {pck.name[0]:4s} package load...success\n")
+            print(f"   {pck.name[0]:4s} package load...success")
         ext_unit_dict.pop(btn_key).filehandle.close()
         ncomp = mt.btn.ncomp
         # reserved unit numbers for .ucn, s.ucn, .obs, .mas, .cnf
@@ -629,15 +626,14 @@ class Mt3dms(BaseModel):
                             )
                             files_successfully_loaded.append(item.filename)
                             if mt.verbose:
-                                sys.stdout.write(
-                                    f"   {pck.name[0]:4s} package load...success\n"
+                                print(
+                                    f"   {pck.name[0]:4s} package load...success"
                                 )
                         except BaseException as o:
                             if mt.verbose:
-                                sys.stdout.write(
-                                    "   {:4s} package load...failed\n   {!s}\n".format(
-                                        item.filetype, o
-                                    )
+                                print(
+                                    f"   {item.filetype:4s} package load"
+                                    f"...failed\n   {o!s}"
                                 )
                             files_not_loaded.append(item.filename)
                     else:
@@ -646,25 +642,21 @@ class Mt3dms(BaseModel):
                         )
                         files_successfully_loaded.append(item.filename)
                         if mt.verbose:
-                            sys.stdout.write(
-                                f"   {pck.name[0]:4s} package load...success\n"
+                            print(
+                                f"   {pck.name[0]:4s} package load...success"
                             )
                 else:
                     if mt.verbose:
-                        sys.stdout.write(
-                            f"   {item.filetype:4s} package load...skipped\n"
-                        )
+                        print(f"   {item.filetype:4s} package load...skipped")
                     files_not_loaded.append(item.filename)
             elif "data" not in item.filetype.lower():
                 files_not_loaded.append(item.filename)
                 if mt.verbose:
-                    sys.stdout.write(
-                        f"   {item.filetype:4s} package load...skipped\n"
-                    )
+                    print(f"   {item.filetype:4s} package load...skipped")
             elif "data" in item.filetype.lower():
                 if mt.verbose:
-                    sys.stdout.write(
-                        "   {} file load...skipped\n      {}\n".format(
+                    print(
+                        "   {} file load...skipped\n      {}".format(
                             item.filetype, os.path.basename(item.filename)
                         )
                     )
@@ -692,9 +684,9 @@ class Mt3dms(BaseModel):
                     item.filehandle.close()
             except KeyError:
                 if mt.verbose:
-                    sys.stdout.write(
+                    print(
                         "\nWARNING:\n    External file unit "
-                        "{} does not exist in ext_unit_dict.\n".format(key)
+                        f"{key} does not exist in ext_unit_dict."
                     )
 
         # write message indicating packages that were successfully loaded

--- a/flopy/mt3d/mtadv.py
+++ b/flopy/mt3d/mtadv.py
@@ -1,4 +1,3 @@
-import sys
 from ..pakbase import Package
 
 
@@ -308,7 +307,7 @@ class Mt3dAdv(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading adv package file...\n")
+            print("loading adv package file...")
 
         # Open file, if necessary
         openfile = not hasattr(f, "read")

--- a/flopy/mt3d/mtdsp.py
+++ b/flopy/mt3d/mtdsp.py
@@ -1,4 +1,3 @@
-import sys
 import numpy as np
 from ..pakbase import Package
 from ..utils import Util2d, Util3d
@@ -305,7 +304,7 @@ class Mt3dDsp(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading dsp package file...\n")
+            print("loading dsp package file...")
 
         # Set dimensions if necessary
         if nlay is None:

--- a/flopy/mt3d/mtgcg.py
+++ b/flopy/mt3d/mtgcg.py
@@ -1,4 +1,3 @@
-import sys
 from ..pakbase import Package
 
 
@@ -183,7 +182,7 @@ class Mt3dGcg(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading gcg package file...\n")
+            print("loading gcg package file...")
 
         # Open file, if necessary
         openfile = not hasattr(f, "read")

--- a/flopy/mt3d/mtlkt.py
+++ b/flopy/mt3d/mtlkt.py
@@ -1,4 +1,3 @@
-import sys
 import numpy as np
 
 from ..pakbase import Package
@@ -340,7 +339,7 @@ class Mt3dLkt(Package):
 
         """
         if model.verbose:
-            sys.stdout.write("loading lkt package file...\n")
+            print("loading lkt package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:

--- a/flopy/mt3d/mtrct.py
+++ b/flopy/mt3d/mtrct.py
@@ -1,4 +1,3 @@
-import sys
 import numpy as np
 from ..pakbase import Package
 from ..utils import Util3d
@@ -532,7 +531,7 @@ class Mt3dRct(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading rct package file...\n")
+            print("loading rct package file...")
 
         # Open file, if necessary
         openfile = not hasattr(f, "read")

--- a/flopy/mt3d/mtsft.py
+++ b/flopy/mt3d/mtsft.py
@@ -1,4 +1,3 @@
-import sys
 import numpy as np
 
 from ..pakbase import Package
@@ -532,7 +531,7 @@ class Mt3dSft(Package):
 
         """
         if model.verbose:
-            sys.stdout.write("loading sft package file...\n")
+            print("loading sft package file...")
 
         openfile = not hasattr(f, "read")
         if openfile:

--- a/flopy/mt3d/mtssm.py
+++ b/flopy/mt3d/mtssm.py
@@ -1,4 +1,3 @@
-import sys
 import numpy as np
 import warnings
 from ..pakbase import Package
@@ -560,7 +559,7 @@ class Mt3dSsm(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading ssm package file...\n")
+            print("loading ssm package file...")
 
         # Open file, if necessary
         openfile = not hasattr(f, "read")

--- a/flopy/plot/plotutil.py
+++ b/flopy/plot/plotutil.py
@@ -5,8 +5,6 @@ shapefiles are also included.
 
 """
 import os
-import sys
-import math
 import numpy as np
 import warnings
 from ..utils import Util3d
@@ -1944,7 +1942,7 @@ class SwiConcentration:
             try:
                 dis = model.get_package("DIS")
             except:
-                sys.stdout.write("Error: DIS package not available.\n")
+                print("Error: DIS package not available.")
             self.__botm = np.zeros((dis.nlay + 1, dis.nrow, dis.ncol), float)
             self.__botm[0, :, :] = dis.top.array
             self.__botm[1:, :, :] = dis.botm.array
@@ -1954,7 +1952,7 @@ class SwiConcentration:
                 self.__istrat = swi.istrat
                 self.__nsrf = swi.nsrf
             except (AttributeError, ValueError):
-                sys.stdout.write("Error: SWI2 package not available...\n")
+                print("Error: SWI2 package not available...")
         self.__nlay = self.__botm.shape[0] - 1
         self.__nrow = self.__botm[0, :, :].shape[0]
         self.__ncol = self.__botm[0, :, :].shape[1]

--- a/flopy/seawat/swtvdf.py
+++ b/flopy/seawat/swtvdf.py
@@ -1,4 +1,3 @@
-import sys
 import numpy as np
 from ..pakbase import Package
 from ..utils import Util2d, Util3d
@@ -381,7 +380,7 @@ class SeawatVdf(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading vdf package file...\n")
+            print("loading vdf package file...")
 
         # Open file, if necessary
         openfile = not hasattr(f, "read")

--- a/flopy/seawat/swtvsc.py
+++ b/flopy/seawat/swtvsc.py
@@ -1,4 +1,3 @@
-import sys
 import numpy as np
 from ..pakbase import Package
 from ..utils import Util3d, Transient3d
@@ -324,7 +323,7 @@ class SeawatVsc(Package):
         """
 
         if model.verbose:
-            sys.stdout.write("loading vsc package file...\n")
+            print("loading vsc package file...")
 
         # Open file, if necessary
         openfile = not hasattr(f, "read")

--- a/flopy/utils/swroutputfile.py
+++ b/flopy/utils/swroutputfile.py
@@ -1,4 +1,3 @@
-import sys
 import numpy as np
 
 from ..utils.utils_def import FlopyBinaryData
@@ -409,7 +408,7 @@ class SwrFile(FlopyBinaryData):
                 self.nitems = nitems
             except:
                 if self.verbose:
-                    sys.stdout.write("\nCould not read itemlist")
+                    print("Could not read itemlist")
                 return 0.0, 0.0, 0, 0, 0, False
         try:
             totim = self.read_real()
@@ -596,7 +595,7 @@ class SwrFile(FlopyBinaryData):
         """
         self.file.seek(self.datastart)
         if self.verbose:
-            sys.stdout.write("Generating SWR binary data time list\n")
+            print("Generating SWR binary data time list")
         self._ntimes = 0
         self._times = []
         self._kswrkstpkper = []
@@ -610,7 +609,7 @@ class SwrFile(FlopyBinaryData):
             if self.verbose:
                 v = divmod(float(idx), 72.0)
                 if v[1] == 0.0:
-                    sys.stdout.write(".")
+                    print(".", end="")
             # read header
             totim, dt, kper, kstp, kswr, success = self._read_header()
             if success:
@@ -633,7 +632,7 @@ class SwrFile(FlopyBinaryData):
                 self._recordarray.append(header)
             else:
                 if self.verbose:
-                    sys.stdout.write("\n")
+                    print()
                 self._recordarray = np.array(
                     self._recordarray, dtype=self.header_dtype
                 )


### PR DESCRIPTION
This simplifies how verbose messages are printed (note that `print("x")` is equivalent to `sys.stdout.write("x\n")`). There are no other changes to the outputs, with the exception of:

- The message "changing model workspace..." should be shown with `verbose=True` (it was always shown before)
- `flopy/modflow/mfswt.py` was missing newlines, and would have shown multiple messages on one line, but now it shows one message per line

One consideration in `flopy/modflow/mffhb.py` is to change (e.g.) "dataset 2 will not be preserved in the created hfb object" print statements into warnings, or to print them to [sys.stderr](https://docs.python.org/3/library/sys.html#sys.stderr).

Some unused imports are also tidied up, along with `import sys`.