### PR TITLE
refactor(exceptions): reclassify IOError as OSError or other type

### DIFF
--- a/autotest/t003_test.py
+++ b/autotest/t003_test.py
@@ -71,7 +71,7 @@ def test_loadoc():
     return
 
 
-@raises(IOError)
+@raises(OSError)
 def test_loadoc_lenfail():
     ws = os.path.join("temp", "t003")
     ml = flopy.modflow.Modflow(model_ws=ws)
@@ -111,12 +111,12 @@ def test_loadoc_nstpfail():
     return
 
 
-@raises(IOError)
+@raises(OSError)
 def test_load_nam_mf_nonexistant_file():
     ml = flopy.modflow.Modflow.load("nonexistant.nam")
 
 
-@raises(IOError)
+@raises(OSError)
 def test_load_nam_mt_nonexistant_file():
     ml = flopy.mt3d.Mt3dms.load("nonexistant.nam")
 

--- a/autotest/t017_test.py
+++ b/autotest/t017_test.py
@@ -46,7 +46,7 @@ def test_formattedfile_read():
     fname = os.path.join(cpth, "empty.githds")
     with open(fname, "w"):
         pass
-    with assert_raises(IOError):
+    with assert_raises(ValueError):
         flopy.utils.FormattedHeadFile(fname)
 
     return
@@ -86,9 +86,9 @@ def test_binaryfile_read():
     fname = os.path.join(cpth, "empty.githds")
     with open(fname, "w"):
         pass
-    with assert_raises(IOError):
+    with assert_raises(ValueError):
         flopy.utils.HeadFile(fname)
-    with assert_raises(IOError):
+    with assert_raises(ValueError):
         flopy.utils.HeadFile(fname, "head", "single")
 
     return
@@ -210,7 +210,7 @@ def test_cellbudgetfile_position():
     fname = os.path.join(cpth, "empty.gitcbc")
     with open(fname, "w"):
         pass
-    with assert_raises(IOError):
+    with assert_raises(ValueError):
         flopy.utils.CellBudgetFile(fname)
 
     return

--- a/flopy/mf6/mfpackage.py
+++ b/flopy/mf6/mfpackage.py
@@ -1844,7 +1844,7 @@ class MFPackage(PackageContainer, PackageInterface):
                             for key in dataset.get_active_key_list():
                                 try:
                                     data = dataset.get_data(key=key[0])
-                                except (IOError, OSError, MFDataException):
+                                except (OSError, MFDataException):
                                     # TODO: Handle case where external file
                                     # path has been moved
                                     data = None
@@ -1857,7 +1857,7 @@ class MFPackage(PackageContainer, PackageInterface):
                             new_size = -1
                             try:
                                 data = dataset.get_data()
-                            except (IOError, OSError, MFDataException):
+                            except (OSError, MFDataException):
                                 # TODO: Handle case where external file
                                 # path has been moved
                                 data = None

--- a/flopy/mf6/utils/output_util.py
+++ b/flopy/mf6/utils/output_util.py
@@ -183,7 +183,7 @@ class MF6Output:
                         try:
                             f = os.path.join(self._sim_ws, f)
                             return HeadFile(f, text=text)
-                        except (IOError, FileNotFoundError):
+                        except OSError:
                             return
 
                 setattr(self.__class__, rectype, get_layerfile_data)
@@ -270,7 +270,7 @@ class MF6Output:
             try:
                 budget_file = os.path.join(self._sim_ws, self._budget[0])
                 return CellBudgetFile(budget_file, precision=precision)
-            except (IOError, FileNotFoundError):
+            except OSError:
                 return None
 
     def __obs(self, f=None):
@@ -290,7 +290,7 @@ class MF6Output:
             try:
                 obs_file = os.path.join(self._sim_ws, obs_file)
                 return Mf6Obs(obs_file)
-            except (IOError, FileNotFoundError):
+            except OSError:
                 return None
 
     def __csv(self, f=None):
@@ -310,7 +310,7 @@ class MF6Output:
             try:
                 csv_file = os.path.join(self._sim_ws, csv_file)
                 return CsvFile(csv_file)
-            except (IOError, FileNotFoundError):
+            except OSError:
                 return None
 
     def __list(self):
@@ -325,7 +325,7 @@ class MF6Output:
             try:
                 list_file = os.path.join(self._sim_ws, self._lst)
                 return Mf6ListBudget(list_file)
-            except (AssertionError, IOError, FileNotFoundError):
+            except (AssertionError, OSError):
                 return None
 
     def __mulitfile_handler(self, f, flist):

--- a/flopy/modflow/mf.py
+++ b/flopy/modflow/mf.py
@@ -716,7 +716,7 @@ class Modflow(BaseModel):
         ):
             namefile_path += ".nam"
         if not os.path.isfile(namefile_path):
-            raise IOError(f"cannot find name file: {namefile_path}")
+            raise OSError(f"cannot find name file: {namefile_path}")
 
         # Determine model name from 'f', without any extension or path
         modelname = os.path.splitext(os.path.basename(f))[0]
@@ -950,7 +950,7 @@ class Modflow(BaseModel):
                 print(f"      {os.path.basename(fname)}")
             if len(files_not_loaded) > 0:
                 print(
-                    "   The following {len(files_not_loaded)} packages "
+                    f"   The following {len(files_not_loaded)} packages "
                     "were not loaded."
                 )
                 for fname in files_not_loaded:

--- a/flopy/modflow/mfoc.py
+++ b/flopy/modflow/mfoc.py
@@ -795,7 +795,7 @@ class ModflowOc(Package):
 
         # validate the size of nstp
         if len(nstp) != nper:
-            raise IOError(
+            raise OSError(
                 f"nstp must be a list with {nper} entries, "
                 f"provided nstp list has {len(nstp)} entries."
             )

--- a/flopy/mt3d/mt.py
+++ b/flopy/mt3d/mt.py
@@ -516,7 +516,7 @@ class Mt3dms(BaseModel):
         # read name file
         namefile_path = os.path.join(mt.model_ws, f)
         if not os.path.isfile(namefile_path):
-            raise IOError(f"cannot find name file: {namefile_path}")
+            raise FileNotFoundError(f"cannot find name file: {namefile_path}")
         try:
             ext_unit_dict = mfreadnam.parsenamefile(
                 namefile_path, mt.mfnam_packages, verbose=verbose

--- a/flopy/utils/binaryfile.py
+++ b/flopy/utils/binaryfile.py
@@ -218,7 +218,7 @@ def get_headfile_precision(filename):
     f.seek(0, 0)  # reset to beginning
     assert f.tell() == 0
     if totalbytes == 0:
-        raise IOError(f"datafile error: file is empty: {filename}")
+        raise ValueError(f"datafile error: file is empty: {filename}")
 
     # first try single
     vartype = [
@@ -260,7 +260,7 @@ def get_headfile_precision(filename):
             result = "double"
         except:
             f.close()
-            raise IOError(
+            raise ValueError(
                 f"Could not determine the precision of the headfile {filename}"
             )
 
@@ -610,7 +610,7 @@ class CellBudgetFile:
         self.file.seek(0, 0)  # reset to beginning
         assert self.file.tell() == 0
         if totalbytes == 0:
-            raise IOError(f"datafile error: file is empty: {filename}")
+            raise ValueError(f"datafile error: file is empty: {filename}")
         self.nrow = 0
         self.ncol = 0
         self.nlay = 0

--- a/flopy/utils/datafile.py
+++ b/flopy/utils/datafile.py
@@ -164,7 +164,7 @@ class LayerFile:
         self.file.seek(0, 0)  # reset to beginning
         assert self.file.tell() == 0
         if totalbytes == 0:
-            raise IOError(f"datafile error: file is empty: {filename}")
+            raise ValueError(f"datafile error: file is empty: {filename}")
         self.nrow = 0
         self.ncol = 0
         self.nlay = 0

--- a/flopy/utils/flopy_io.py
+++ b/flopy/utils/flopy_io.py
@@ -433,9 +433,9 @@ def ulstrd(f, nlist, ra, model, sfac_columns, ext_unit_dict):
                 namdata = ext_unit_dict[inunit]
                 file_handle = namdata.filehandle
             else:
-                raise IOError(errmsg)
+                raise OSError(errmsg)
         else:
-            raise IOError(errmsg)
+            raise OSError(errmsg)
         if namdata.filetype == "DATA(BINARY)":
             binary = True
         if not binary:

--- a/flopy/utils/mfreadnam.py
+++ b/flopy/utils/mfreadnam.py
@@ -112,9 +112,9 @@ def parsenamefile(namfilename, packages, verbose=True):
 
     Raises
     ------
-    IOError:
+    FileNotFoundError
         If namfilename does not exist in the directory.
-    ValueError:
+    ValueError
         For lines that cannot be parsed.
     """
     # initiate the ext_unit_dict dictionary
@@ -125,7 +125,7 @@ def parsenamefile(namfilename, packages, verbose=True):
 
     if not os.path.isfile(namfilename):
         # help diagnose the namfile and directory
-        raise IOError(
+        raise FileNotFoundError(
             f"Could not find {namfilename} "
             f"in directory {os.path.dirname(namfilename)}"
         )
@@ -179,7 +179,7 @@ def parsenamefile(namfilename, packages, verbose=True):
             kwargs["errors"] = "replace"
         try:
             filehandle = open(fname, openmode, **kwargs)
-        except IOError:
+        except OSError:
             if verbose:
                 print(f"could not set filehandle to {fpath}")
             filehandle = None

--- a/flopy/utils/observationfile.py
+++ b/flopy/utils/observationfile.py
@@ -294,7 +294,7 @@ class Mf6Obs(ObsFiles):
                     isBinary = True
                 else:
                     err = "Could not determine if file is binary or ascii"
-                    raise IOError(err)
+                    raise ValueError(err)
         if isBinary:
             # --open binary head file
             self.file = open(filename, "rb")

--- a/flopy/utils/optionblock.py
+++ b/flopy/utils/optionblock.py
@@ -350,11 +350,10 @@ class OptionBlock:
         if openfile:
             try:
                 options = open(options, "r")
-            except IOError:
-                err_msg = (
+            except OSError:
+                raise TypeError(
                     f"Unrecognized type for options variable: {type(options)}"
                 )
-                raise TypeError(err_msg)
 
         option_line = ""
         while True:

--- a/flopy/utils/util_array.py
+++ b/flopy/utils/util_array.py
@@ -2911,10 +2911,9 @@ class Util2d(DataInterface):
         elif cr_dict["type"] == "external":
             ext_unit = ext_unit_dict[cr_dict["nunit"]]
             if ext_unit.filehandle is None:
-                raise IOError(
-                    "cannot read unit {0}, filename: {1}".format(
-                        cr_dict["nunit"], ext_unit.filename
-                    )
+                raise OSError(
+                    f"cannot read unit {cr_dict['nunit']}, "
+                    f"filename: {ext_unit.filename}"
                 )
             elif "binary" not in str(cr_dict["fmtin"].lower()):
                 assert cr_dict["nunit"] in list(ext_unit_dict.keys())

--- a/release/make-release.py
+++ b/release/make-release.py
@@ -176,8 +176,7 @@ def update_version():
                 name_pos = idx + 1
 
     except:
-        msg = "There was a problem updating the version file"
-        raise IOError(msg)
+        raise OSError("There was a problem updating the version file")
 
     try:
         # write new version file
@@ -204,8 +203,7 @@ def update_version():
         f.close()
         print("Successfully updated version.py")
     except:
-        msg = "There was a problem updating the version file"
-        raise IOError(msg)
+        raise OSError("There was a problem updating the version file")
 
     # update README.md with new version information
     update_readme_markdown(vmajor, vminor, vmicro)


### PR DESCRIPTION
Since Python 3.3,  IO and OS exceptions were re-worked as per [PEP 3151](https://www.python.org/dev/peps/pep-3151/). The new main base class is [OSError](https://docs.python.org/3/library/exceptions.html#OSError), with several other exceptions merged, including IOError (i.e. `assert IOError is OSError`).

This PR changes the old IOError alias to OSError, with a few exceptions:

- A few exceptions that detected something wrong with the file contents (empty, could not determine the precision, etc.) should be reclassified as ValueError, since there was no issue with reading the file from the OS.
- Fixed a stray f-string in `flopy/modflow/mf.py` line 953