### PR TITLE
refactor(netcdf): sync data, revise logger and exceptions

### DIFF
--- a/autotest/t027_test.py
+++ b/autotest/t027_test.py
@@ -380,8 +380,10 @@ def test_export():
     if netCDF4 is not None:
         fcw = m.wel.export(os.path.join(cpth, "MNW2-Fig28_well.nc"))
         fcw.write()
-        fcm = m.mnw2.export(os.path.join(cpth, "MNW2-Fig28.nc"))
-        fcm.write()
+        fpth = os.path.join(cpth, "MNW2-Fig28.nc")
+        # test context statement
+        with m.mnw2.export(fpth):
+            pass
         fpth = os.path.join(cpth, "MNW2-Fig28.nc")
         nc = netCDF4.Dataset(fpth)
         assert np.array_equal(


### PR DESCRIPTION
This PR refactors several things:

- Use [netCDF4's `sync()` method](https://unidata.github.io/netcdf4-python/#Dataset.sync) to write data to disk, which should avoid "NetCDF: Unknown file format" issues. This should be added at the end of methods that modify the netCDF file.
- Logger messages should now print one per line (using `print(..., end="")`, because the message already has `\n`)
- `NetCDF.__init__` should raise `ImportError` if python-dateutil is not installed, rather than print a message.
- Remove `_dt_str` private method, as it's only used once; rewrite to use [strftime format codes](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes)
- Show exceptions to logger messages, or [chain](https://docs.python.org/3/tutorial/errors.html#exception-chaining) them (where appropriate)
- Add context manager feature to NetCdf class, so it can be used in a with statement. This is because it returns an open dataset, which can be written/closed outside the with statement.