### PR TITLE
fix(numpy elementwise comparison): Fixed numpy FutureWarning

### DIFF
--- a/flopy/mf6/data/mfdatalist.py
+++ b/flopy/mf6/data/mfdatalist.py
@@ -1679,7 +1679,10 @@ class MFTransientList(MFList, mfdata.MFTransient, DataListInterface):
                         self.empty_keys[key] = True
                     else:
                         self.empty_keys[key] = False
-                        if "check" in list_item:
+                        if (
+                            isinstance(list_item, dict)
+                            and "check" in list_item
+                        ):
                             check = list_item["check"]
                         else:
                             check = True


### PR DESCRIPTION
No elementwise compare is needed if user passes in a numpy recarray, this is only necessary for dictionaries.