### PR TITLE
Think mg extent is x0,x1,y0,y1?

### DIFF
--- a/autotest/t007_test.py
+++ b/autotest/t007_test.py
@@ -426,7 +426,7 @@ def test_export_array():
             if "yllcorner" in line.lower():
                 val = float(line.strip().split()[-1])
                 if rotate:
-                    assert np.abs(val - m.modelgrid.extent[1]) < 1e-6
+                    assert np.abs(val - m.modelgrid.extent[2]) < 1e-6
                 else:
                     assert np.abs(val - m.modelgrid.yoffset) < 1e-6
             if "cellsize" in line.lower():

--- a/flopy/export/utils.py
+++ b/flopy/export/utils.py
@@ -1488,7 +1488,7 @@ def export_array(
             if rotate is not None:
                 a = rotate(a, modelgrid.angrot, cval=nodata)
                 height_rot, width_rot = a.shape
-                xmin, ymin, xmax, ymax = modelgrid.extent
+                xmin, xmax, ymin, ymax = modelgrid.extent
                 dx = (xmax - xmin) / width_rot
                 dy = (ymax - ymin) / height_rot
                 cellsize = np.max((dx, dy))


### PR DESCRIPTION
quick fix in export.utils.export_array(). 

Is this the preferred method for exporting rasters from model?