### PR TITLE
fix(array): getting array data (#1028)

### DIFF
--- a/autotest/t505_test.py
+++ b/autotest/t505_test.py
@@ -399,8 +399,8 @@ def test_array():
         nlay=4,
         nrow=2,
         ncol=2,
-        delr=500.0,
-        delc=500.0,
+        delr=5000.0,
+        delc=5000.0,
         top=100.0,
         botm=[50.0, 0.0, -50.0, -100.0],
         filename="{}.dis".format(model_name),
@@ -414,7 +414,7 @@ def test_array():
         save_flows=True,
         alternative_cell_averaging="logarithmic",
         icelltype=1,
-        k=5.0,
+        k=50.0,
     )
 
     aux = {1: [[50.0], [1.3]], 3: [[200.0], [1.5]]}
@@ -425,7 +425,7 @@ def test_array():
         print_flows=True,
         auxiliary=[("var1", "var2")],
         irch=irch,
-        recharge={1: 1.0, 2: 2.0},
+        recharge={1: 0.0001, 2: 0.0002},
         aux=aux,
     )
     val_irch = rcha.irch.array.sum(axis=(1, 2, 3))
@@ -437,27 +437,29 @@ def test_array():
     assert val_irch_2[0] is None
     assert val_irch_2[1][1, 1] == 1
     assert val_irch_2[2][1, 1] == 3
-    assert val_irch_2[3] == []
+    assert val_irch_2[3] is None
+    val_irch_2_3 = rcha.irch.get_data(3)
+    assert val_irch_2_3 is None
     val_rch = rcha.recharge.array.sum(axis=(1, 2, 3))
     assert val_rch[0] == 0.0
-    assert val_rch[1] == 4.0
-    assert val_rch[2] == 8.0
-    assert val_rch[3] == 8.0
+    assert val_rch[1] == 0.0004
+    assert val_rch[2] == 0.0008
+    assert val_rch[3] == 0.0008
     val_rch_2 = rcha.recharge.get_data()
     assert val_rch_2[0] is None
-    assert val_rch_2[1][0, 0] == 1.0
-    assert val_rch_2[2][0, 0] == 2.0
-    assert val_rch_2[3] == []
+    assert val_rch_2[1][0, 0] == 0.0001
+    assert val_rch_2[2][0, 0] == 0.0002
+    assert val_rch_2[3] is None
     aux_data_0 = rcha.aux.get_data(0)
     assert aux_data_0 is None
     aux_data_1 = rcha.aux.get_data(1)
     assert aux_data_1[0][0][0] == 50.0
     aux_data_2 = rcha.aux.get_data(2)
-    assert aux_data_2 == []
+    assert aux_data_2 is None
     aux_data_3 = rcha.aux.get_data(3)
     assert aux_data_3[0][0][0] == 200.0
 
-    welspdict = {1: [[(0, 0, 0), -25.0, 0.0]], 2: [[(0, 0, 0), 25.0, 0.0]]}
+    welspdict = {1: [[(0, 0, 0), 0.25, 0.0]], 2: [[(0, 0, 0), 0.1, 0.0]]}
     wel = flopy.mf6.ModflowGwfwel(
         model,
         print_input=True,
@@ -469,9 +471,9 @@ def test_array():
     )
     wel_array = wel.stress_period_data.array
     assert wel_array[0] is None
-    assert wel_array[1][0][1] == -25.0
-    assert wel_array[2][0][1] == 25.0
-    assert wel_array[3][0][1] == 25.0
+    assert wel_array[1][0][1] == 0.25
+    assert wel_array[2][0][1] == 0.1
+    assert wel_array[3][0][1] == 0.1
 
     drnspdict = {
         0: [[(0, 0, 0), 60.0, 10.0]],
@@ -500,6 +502,17 @@ def test_array():
     drn_gd_3 = drn.stress_period_data.get_data(3)
     assert drn_gd_3[0][1] == 55.0
 
+    ghbspdict = {
+        0: [[(0, 1, 1), 60.0, 10.0]],
+    }
+    ghb = flopy.mf6.ModflowGwfghb(
+        model,
+        print_input=True,
+        print_flows=True,
+        stress_period_data=ghbspdict,
+        save_flows=False,
+        pname="GHB-1",
+    )
     # test writing and loading model
     sim.write_simulation()
     if run:
@@ -526,31 +539,31 @@ def test_array():
     assert val_irch_2[0] is None
     assert val_irch_2[1][1, 1] == 1
     assert val_irch_2[2][1, 1] == 3
-    assert val_irch_2[3] == []
+    assert val_irch_2[3] is None
     val_rch = rcha.recharge.array.sum(axis=(1, 2, 3))
     assert val_rch[0] == 0.0
-    assert val_rch[1] == 4.0
-    assert val_rch[2] == 8.0
-    assert val_rch[3] == 8.0
+    assert val_rch[1] == 0.0004
+    assert val_rch[2] == 0.0008
+    assert val_rch[3] == 0.0008
     val_rch_2 = rcha.recharge.get_data()
     assert val_rch_2[0] is None
-    assert val_rch_2[1][0, 0] == 1.0
-    assert val_rch_2[2][0, 0] == 2.0
-    assert val_rch_2[3] == []
+    assert val_rch_2[1][0, 0] == 0.0001
+    assert val_rch_2[2][0, 0] == 0.0002
+    assert val_rch_2[3] is None
     aux_data_0 = rcha.aux.get_data(0)
     assert aux_data_0 is None
     aux_data_1 = rcha.aux.get_data(1)
     assert aux_data_1[0][0][0] == 50.0
     aux_data_2 = rcha.aux.get_data(2)
-    assert aux_data_2 == []
+    assert aux_data_2 is None
     aux_data_3 = rcha.aux.get_data(3)
     assert aux_data_3[0][0][0] == 200.0
 
     wel_array = wel.stress_period_data.array
     assert wel_array[0] is None
-    assert wel_array[1][0][1] == -25.0
-    assert wel_array[2][0][1] == 25.0
-    assert wel_array[3][0][1] == 25.0
+    assert wel_array[1][0][1] == 0.25
+    assert wel_array[2][0][1] == 0.1
+    assert wel_array[3][0][1] == 0.1
 
     drn_array = drn.stress_period_data.array
     assert drn_array[0][0][1] == 60.0

--- a/autotest/t505_test.py
+++ b/autotest/t505_test.py
@@ -353,12 +353,19 @@ def test_multi_model():
 
 
 def test_array():
+    # get_data
+    # empty data in period block vs data repeating
+    # array
+    # aux values, test that they work the same as other arrays (is a value
+    # of zero always used even if aux is defined in a previous stress
+    # period?)
+
     import flopy
 
     mf6 = flopy.mf6
-    sim_name = "testsim"
-    model_name = "testmodel"
-    out_dir = "tmp"
+    sim_name = "test_array"
+    model_name = "test_array"
+    out_dir = os.path.join("temp", "t505_test_array")
 
     tdis_name = "{}.tdis".format(sim_name)
     sim = mf6.MFSimulation(
@@ -366,7 +373,22 @@ def test_array():
     )
     tdis_rc = [(6.0, 2, 1.0), (6.0, 3, 1.0), (6.0, 3, 1.0), (6.0, 3, 1.0)]
     tdis = mf6.ModflowTdis(sim, time_units="DAYS", nper=4, perioddata=tdis_rc)
-
+    ims_package = ModflowIms(
+        sim,
+        pname="my_ims_file",
+        filename=f"{sim_name}.ims",
+        print_option="ALL",
+        complexity="SIMPLE",
+        outer_dvclose=0.00001,
+        outer_maximum=50,
+        under_relaxation="NONE",
+        inner_maximum=30,
+        inner_dvclose=0.00001,
+        linear_acceleration="CG",
+        preconditioner_levels=7,
+        preconditioner_drop_tolerance=0.01,
+        number_orthogonalizations=2,
+    )
     model = mf6.ModflowGwf(
         sim, modelname=model_name, model_nam_file="{}.nam".format(model_name)
     )
@@ -374,27 +396,66 @@ def test_array():
     dis = mf6.ModflowGwfdis(
         model,
         length_units="FEET",
-        nlay=1,
+        nlay=4,
         nrow=2,
         ncol=2,
         delr=500.0,
         delc=500.0,
         top=100.0,
-        botm=50.0,
+        botm=[50.0, 0.0, -50.0, -100.0],
         filename="{}.dis".format(model_name),
     )
-    irch = {1: [[0, 1], [2, 1]], 2: [[0, 1], [2, 3]]}
-    rcha = mf6.ModflowGwfrcha(model, irch=irch, recharge={0: 1.0, 2: 2.0})
+    ic_package = mf6.ModflowGwfic(
+        model, strt=90.0, filename=f"{model_name}.ic"
+    )
+    npf_package = mf6.ModflowGwfnpf(
+        model,
+        pname="npf_1",
+        save_flows=True,
+        alternative_cell_averaging="logarithmic",
+        icelltype=1,
+        k=5.0,
+    )
+
+    aux = {1: [[50.0], [1.3]], 3: [[200.0], [1.5]]}
+    irch = {1: [[0, 2], [2, 1]], 2: [[0, 1], [2, 3]]}
+    rcha = mf6.ModflowGwfrcha(
+        model,
+        print_input=True,
+        print_flows=True,
+        auxiliary=[("var1", "var2")],
+        irch=irch,
+        recharge={1: 1.0, 2: 2.0},
+        aux=aux,
+    )
     val_irch = rcha.irch.array.sum(axis=(1, 2, 3))
-    assert val_irch[0] == 0
-    assert val_irch[1] == 4
+    assert val_irch[0] == 4
+    assert val_irch[1] == 5
     assert val_irch[2] == 6
     assert val_irch[3] == 6
+    val_irch_2 = rcha.irch.get_data()
+    assert val_irch_2[0] is None
+    assert val_irch_2[1][1, 1] == 1
+    assert val_irch_2[2][1, 1] == 3
+    assert val_irch_2[3] == []
     val_rch = rcha.recharge.array.sum(axis=(1, 2, 3))
-    assert val_rch[0] == 4.0
+    assert val_rch[0] == 0.0
     assert val_rch[1] == 4.0
     assert val_rch[2] == 8.0
     assert val_rch[3] == 8.0
+    val_rch_2 = rcha.recharge.get_data()
+    assert val_rch_2[0] is None
+    assert val_rch_2[1][0, 0] == 1.0
+    assert val_rch_2[2][0, 0] == 2.0
+    assert val_rch_2[3] == []
+    aux_data_0 = rcha.aux.get_data(0)
+    assert aux_data_0 is None
+    aux_data_1 = rcha.aux.get_data(1)
+    assert aux_data_1[0][0][0] == 50.0
+    aux_data_2 = rcha.aux.get_data(2)
+    assert aux_data_2 == []
+    aux_data_3 = rcha.aux.get_data(3)
+    assert aux_data_3[0][0][0] == 200.0
 
     welspdict = {1: [[(0, 0, 0), -25.0, 0.0]], 2: [[(0, 0, 0), 25.0, 0.0]]}
     wel = flopy.mf6.ModflowGwfwel(
@@ -411,6 +472,99 @@ def test_array():
     assert wel_array[1][0][1] == -25.0
     assert wel_array[2][0][1] == 25.0
     assert wel_array[3][0][1] == 25.0
+
+    drnspdict = {
+        0: [[(0, 0, 0), 60.0, 10.0]],
+        2: [],
+        3: [[(0, 0, 0), 55.0, 5.0]],
+    }
+    drn = flopy.mf6.ModflowGwfdrn(
+        model,
+        print_input=True,
+        print_flows=True,
+        stress_period_data=drnspdict,
+        save_flows=False,
+        pname="DRN-1",
+    )
+    drn_array = drn.stress_period_data.array
+    assert drn_array[0][0][1] == 60.0
+    assert drn_array[1][0][1] == 60.0
+    assert drn_array[2] is None
+    assert drn_array[3][0][1] == 55.0
+    drn_gd_0 = drn.stress_period_data.get_data(0)
+    assert drn_gd_0[0][1] == 60.0
+    drn_gd_1 = drn.stress_period_data.get_data(1)
+    assert drn_gd_1 is None
+    drn_gd_2 = drn.stress_period_data.get_data(2)
+    assert drn_gd_2 == []
+    drn_gd_3 = drn.stress_period_data.get_data(3)
+    assert drn_gd_3[0][1] == 55.0
+
+    # test writing and loading model
+    sim.write_simulation()
+    if run:
+        sim.run_simulation()
+
+    test_sim = MFSimulation.load(
+        sim_name,
+        "mf6",
+        exe_name,
+        out_dir,
+        write_headers=False,
+    )
+    model = test_sim.get_model()
+    rcha = model.get_package("rcha")
+    wel = model.get_package("wel")
+    drn = model.get_package("drn")
+    # do same tests as above
+    val_irch = rcha.irch.array.sum(axis=(1, 2, 3))
+    assert val_irch[0] == 4
+    assert val_irch[1] == 5
+    assert val_irch[2] == 6
+    assert val_irch[3] == 6
+    val_irch_2 = rcha.irch.get_data()
+    assert val_irch_2[0] is None
+    assert val_irch_2[1][1, 1] == 1
+    assert val_irch_2[2][1, 1] == 3
+    assert val_irch_2[3] == []
+    val_rch = rcha.recharge.array.sum(axis=(1, 2, 3))
+    assert val_rch[0] == 0.0
+    assert val_rch[1] == 4.0
+    assert val_rch[2] == 8.0
+    assert val_rch[3] == 8.0
+    val_rch_2 = rcha.recharge.get_data()
+    assert val_rch_2[0] is None
+    assert val_rch_2[1][0, 0] == 1.0
+    assert val_rch_2[2][0, 0] == 2.0
+    assert val_rch_2[3] == []
+    aux_data_0 = rcha.aux.get_data(0)
+    assert aux_data_0 is None
+    aux_data_1 = rcha.aux.get_data(1)
+    assert aux_data_1[0][0][0] == 50.0
+    aux_data_2 = rcha.aux.get_data(2)
+    assert aux_data_2 == []
+    aux_data_3 = rcha.aux.get_data(3)
+    assert aux_data_3[0][0][0] == 200.0
+
+    wel_array = wel.stress_period_data.array
+    assert wel_array[0] is None
+    assert wel_array[1][0][1] == -25.0
+    assert wel_array[2][0][1] == 25.0
+    assert wel_array[3][0][1] == 25.0
+
+    drn_array = drn.stress_period_data.array
+    assert drn_array[0][0][1] == 60.0
+    assert drn_array[1][0][1] == 60.0
+    assert drn_array[2] is None
+    assert drn_array[3][0][1] == 55.0
+    drn_gd_0 = drn.stress_period_data.get_data(0)
+    assert drn_gd_0[0][1] == 60.0
+    drn_gd_1 = drn.stress_period_data.get_data(1)
+    assert drn_gd_1 is None
+    drn_gd_2 = drn.stress_period_data.get_data(2)
+    assert drn_gd_2 == []
+    drn_gd_3 = drn.stress_period_data.get_data(3)
+    assert drn_gd_3[0][1] == 55.0
 
 
 def test_np001():
@@ -819,6 +973,7 @@ def test_np001():
     sim.rename_all_packages("file_rename")
     sim.set_sim_path(rename_folder)
     sim.write_simulation()
+
     if run:
         sim.run_simulation()
         sim.delete_output_files()
@@ -1222,7 +1377,7 @@ def test_np002():
     md2 = sim2.get_model()
     ghb2 = md2.get_package("ghb")
     spd2 = ghb2.stress_period_data.get_data(1)
-    assert spd2 is None
+    assert spd2 == []
 
     # test paths
     sim_path_test = os.path.join(run_folder, "sim_path")

--- a/flopy/mf6/data/mfdata.py
+++ b/flopy/mf6/data/mfdata.py
@@ -100,6 +100,12 @@ class MFTransient:
             self._verify_sp(transient_key)
         self._current_key = transient_key
         if transient_key not in self._data_storage:
+            if (
+                isinstance(transient_key, tuple)
+                and transient_key[0] in self._data_storage
+            ):
+                self._current_key = transient_key[0]
+                return
             self.add_transient_key(transient_key)
 
     def _set_data_prep(self, data, transient_key=0):
@@ -267,6 +273,10 @@ class MFData(DataInterface):
 
     def __str__(self):
         return str(self._get_storage_obj())
+
+    @property
+    def path(self):
+        return self._path
 
     @property
     def array(self):

--- a/flopy/mf6/data/mfdataarray.py
+++ b/flopy/mf6/data/mfdataarray.py
@@ -721,18 +721,13 @@ class MFArray(MFMultiDimVar):
             layer = (layer,)
         storage = self._get_storage_obj()
         if storage is not None:
-            block_exists = self._block.header_exists(
-                self._current_key, self.path
-            )
             try:
-                data = storage.get_data(
-                    layer, apply_mult, block_exists=block_exists
-                )
+                data = storage.get_data(layer, apply_mult)
                 if (
                     "array" in kwargs
                     and kwargs["array"]
                     and isinstance(self, MFTransientArray)
-                    and data != []
+                    and data is not []
                 ):
                     data = np.expand_dims(data, 0)
                 return data
@@ -1698,10 +1693,6 @@ class MFTransientArray(MFArray, MFTransient):
                             else:
                                 output = {sp: data}
                         else:
-                            if data is None and self._block.header_exists(
-                                self._current_key, self.path
-                            ):
-                                data = []
                             if "array" in kwargs:
                                 output.append(data)
                             else:

--- a/flopy/mf6/data/mfdatalist.py
+++ b/flopy/mf6/data/mfdatalist.py
@@ -1641,14 +1641,12 @@ class MFTransientList(MFList, mfdata.MFTransient, DataListInterface):
                         0
                     ].simulation_time
                     num_sp = sim_time.get_num_stress_periods()
+                    data = None
                     for sp in range(0, num_sp):
                         if sp in self._data_storage:
                             self.get_data_prep(sp)
-                            output.append(
-                                super().get_data(apply_mult=apply_mult)
-                            )
-                        else:
-                            output.append(None)
+                            data = super().get_data(apply_mult=apply_mult)
+                        output.append(data)
                     return output
                 else:
                     output = {}

--- a/flopy/mf6/data/mfdatascalar.py
+++ b/flopy/mf6/data/mfdatascalar.py
@@ -82,7 +82,7 @@ class MFScalar(mfdata.MFData):
                     return np.int32
         return None
 
-    def has_data(self):
+    def has_data(self, key=None):
         """Returns whether this object has data associated with it."""
         try:
             return self._get_storage_obj().has_data()
@@ -771,16 +771,13 @@ class MFScalarTransient(MFScalar, mfdata.MFTransient):
 
     def has_data(self, key=None):
         if key is None:
-            data_found = False
             for sto_key in self._data_storage.keys():
                 self.get_data_prep(sto_key)
-                data_found = data_found or super().has_data()
-                if data_found:
-                    break
+                if super().has_data():
+                    return True
         else:
             self.get_data_prep(key)
-            data_found = super().has_data()
-        return data_found
+            return super().has_data()
 
     def get_data(self, key=0, **kwargs):
         """Returns the data for stress period `key`.
@@ -852,7 +849,7 @@ class MFScalarTransient(MFScalar, mfdata.MFTransient):
                         ext_file_action=ext_file_action
                     )
                     file_entry.append(text_entry)
-            if file_entry > 1:
+            if len(file_entry) > 1:
                 return "\n\n".join(file_entry)
             elif file_entry == 1:
                 return file_entry[0]

--- a/flopy/mf6/data/mfdatastorage.py
+++ b/flopy/mf6/data/mfdatastorage.py
@@ -633,10 +633,14 @@ class DataStorage:
 
     def has_data(self, layer=None):
         ret_val = self._access_data(layer, False)
-        return ret_val is not None and ret_val != False
+        return ret_val is not None and ret_val is not False
 
-    def get_data(self, layer=None, apply_mult=True):
-        return self._access_data(layer, True, apply_mult=apply_mult)
+    def get_data(self, layer=None, apply_mult=True, block_exists=False):
+        data = self._access_data(layer, True, apply_mult=apply_mult)
+        if data is None and block_exists:
+            return []
+        else:
+            return data
 
     def _access_data(self, layer, return_data=False, apply_mult=True):
         layer_check = self._resolve_layer(layer)
@@ -2341,7 +2345,10 @@ class DataStorage:
                 ):
                     full_data = data_out
                 else:
-                    full_data[layer] = data_out
+                    if is_aux and full_data.shape == data_out.shape:
+                        full_data = data_out
+                    else:
+                        full_data[layer] = data_out
             if is_aux:
                 if full_data is not None:
                     all_none = False


### PR DESCRIPTION
Getting array data (<data object>.array) fixed so that empty stress periods repeat data from the last previous stress period with data. If there is no previous stress period with data, None is used for MFDataList arrays and an array of zeros is used for MFDataArray arrays.