### PR TITLE
Hotfix subdirs

### DIFF
--- a/autotest/t501_test.py
+++ b/autotest/t501_test.py
@@ -171,33 +171,36 @@ def test_mf6_subdir():
 
     sim = flopy.mf6.MFSimulation(sim_ws=base_dir)
     tdis = flopy.mf6.modflow.mftdis.ModflowTdis(sim)
-    gwf = flopy.mf6.ModflowGwf(sim, model_rel_path='level2')
+    gwf = flopy.mf6.ModflowGwf(sim, model_rel_path="level2")
     ims = flopy.mf6.modflow.mfims.ModflowIms(sim)
     sim.register_ims_package(ims, [])
     dis = flopy.mf6.modflow.mfgwfdis.ModflowGwfdis(gwf)
-    sim.set_all_data_external(external_data_folder='dat')
+    sim.set_all_data_external(external_data_folder="dat")
     sim.write_simulation()
 
     sim_r = flopy.mf6.MFSimulation.load(
-        'mfsim.nam',
+        "mfsim.nam",
         sim_ws=sim.simulation_data.mfpath.get_sim_path(),
     )
     gwf_r = sim_r.get_model()
-    assert gwf.dis.delc.get_file_entry() == gwf_r.dis.delc.get_file_entry(), (
-        "Something wrong with model external paths")
+    assert (
+        gwf.dis.delc.get_file_entry() == gwf_r.dis.delc.get_file_entry()
+    ), "Something wrong with model external paths"
 
     sim_r.set_all_data_internal()
     sim_r.set_all_data_external(
-        external_data_folder=os.path.join('dat', "dat_l2"))
+        external_data_folder=os.path.join("dat", "dat_l2")
+    )
     sim_r.write_simulation()
 
     sim_r2 = flopy.mf6.MFSimulation.load(
-        'mfsim.nam',
+        "mfsim.nam",
         sim_ws=sim_r.simulation_data.mfpath.get_sim_path(),
     )
     gwf_r2 = sim_r.get_model()
-    assert gwf_r.dis.delc.get_file_entry() == gwf_r2.dis.delc.get_file_entry(), (
-        "Something wrong with model external paths")
+    assert (
+        gwf_r.dis.delc.get_file_entry() == gwf_r2.dis.delc.get_file_entry()
+    ), "Something wrong with model external paths"
 
 
 if __name__ == "__main__":

--- a/autotest/t501_test.py
+++ b/autotest/t501_test.py
@@ -165,6 +165,31 @@ def test_mf6_string_to_file_path():
             raise AssertionError("Relative path error")
 
 
+def test_mf6_subdir():
+    base_dir = base_test_dir(__file__, rel_path="temp", verbose=True)
+    test_setup = FlopyTestSetup(verbose=True, test_dirs=base_dir)
+
+    sim = flopy.mf6.MFSimulation(sim_ws=base_dir)
+    tdis = flopy.mf6.modflow.mftdis.ModflowTdis(sim)
+    gwf = flopy.mf6.ModflowGwf(sim, model_rel_path='level2')
+    ims = flopy.mf6.modflow.mfims.ModflowIms(sim)
+    sim.register_ims_package(ims, [])
+    dis = flopy.mf6.modflow.mfgwfdis.ModflowGwfdis(gwf)
+    sim.set_all_data_external(external_data_folder='dat')
+    sim.write_simulation()
+
+    sim_r = flopy.mf6.MFSimulation.load(
+        'mfsim.nam',
+        sim_ws=sim.simulation_data.mfpath.get_sim_path(),
+    )
+    gwf_r = sim_r.get_model()
+    assert gwf.dis.delc.get_file_entry() == gwf_r.dis.delc.get_file_entry(), (
+        "Something wrong with model external paths")
+
+
+
+
 if __name__ == "__main__":
-    test_mf6()
-    test_mf6_string_to_file_path()
+    # test_mf6()
+    # test_mf6_string_to_file_path()
+    test_mf6_subdir()

--- a/autotest/t501_test.py
+++ b/autotest/t501_test.py
@@ -186,7 +186,18 @@ def test_mf6_subdir():
     assert gwf.dis.delc.get_file_entry() == gwf_r.dis.delc.get_file_entry(), (
         "Something wrong with model external paths")
 
+    sim_r.set_all_data_internal()
+    sim_r.set_all_data_external(
+        external_data_folder=os.path.join('dat', "dat_l2"))
+    sim_r.write_simulation()
 
+    sim_r2 = flopy.mf6.MFSimulation.load(
+        'mfsim.nam',
+        sim_ws=sim_r.simulation_data.mfpath.get_sim_path(),
+    )
+    gwf_r2 = sim_r.get_model()
+    assert gwf_r.dis.delc.get_file_entry() == gwf_r2.dis.delc.get_file_entry(), (
+        "Something wrong with model external paths")
 
 
 if __name__ == "__main__":

--- a/flopy/mf6/data/mfdatastorage.py
+++ b/flopy/mf6/data/mfdatastorage.py
@@ -1516,7 +1516,7 @@ class DataStorage:
                 fp_rp_l = fp_relative.split(os.path.sep)
                 rp_l_r = rel_path.split(os.path.sep)[::-1]
                 for i, rp in enumerate(rp_l_r):
-                    if rp != fp_rp_l[len(rp_l_r)-i-1]:
+                    if rp != fp_rp_l[len(rp_l_r) - i - 1]:
                         fp_relative = os.path.join(rp, fp_relative)
         fp = self._simulation_data.mfpath.resolve_path(fp_relative, model_name)
         if data is not None:

--- a/flopy/mf6/data/mfdatastorage.py
+++ b/flopy/mf6/data/mfdatastorage.py
@@ -1511,7 +1511,13 @@ class DataStorage:
             ]
             if rel_path is not None and len(rel_path) > 0 and rel_path != ".":
                 # include model relative path in external file path
-                fp_relative = os.path.join(rel_path, file_path)
+                # only if model relative path is not already in external
+                #  file path i.e. when reading!
+                fp_rp_l = os.path.normpath(fp_relative).split(os.path.sep)
+                rp_l_r = os.path.normpath(rel_path).split(os.path.sep)[::-1]
+                for i, rp in enumerate(rp_l_r):
+                    if rp != fp_rp_l[len(rp_l_r)-i-1]:
+                        fp_relative = os.path.join(rp, fp_relative)
         fp = self._simulation_data.mfpath.resolve_path(fp_relative, model_name)
         if data is not None:
             if self.data_structure_type == DataStructureType.recarray:

--- a/flopy/mf6/data/mfdatastorage.py
+++ b/flopy/mf6/data/mfdatastorage.py
@@ -1513,8 +1513,8 @@ class DataStorage:
                 # include model relative path in external file path
                 # only if model relative path is not already in external
                 #  file path i.e. when reading!
-                fp_rp_l = os.path.normpath(fp_relative).split(os.path.sep)
-                rp_l_r = os.path.normpath(rel_path).split(os.path.sep)[::-1]
+                fp_rp_l = fp_relative.split(os.path.sep)
+                rp_l_r = rel_path.split(os.path.sep)[::-1]
                 for i, rp in enumerate(rp_l_r):
                     if rp != fp_rp_l[len(rp_l_r)-i-1]:
                         fp_relative = os.path.join(rp, fp_relative)


### PR DESCRIPTION
Checking for model_relative_path already existing in external file filename, which will be the case when reading in a model. 
Will only append model_relative_path where not already present in file name. Should improve support for models using external file storage and simulations with models in sub directories. 

Should fix #1289 and possibly also #1115 and #1126