### PR TITLE
fix(UnstructuredGrid)

### DIFF
--- a/autotest/t080_test.py
+++ b/autotest/t080_test.py
@@ -4,6 +4,7 @@ HeadUFile get_ts tests using t505_test.py
 
 import os
 import platform
+import numpy as np
 
 try:
     from shapely.geometry import Polygon
@@ -128,5 +129,57 @@ def test_mfusg():
     return
 
 
+def test_usg_iverts():
+    iverts = [
+        [4, 3, 2, 1, 0, None],
+        [7, 0, 1, 6, 5, None],
+        [11, 10, 9, 8, 2, 3],
+        [1, 6, 13, 12, 8, 2],
+        [15, 14, 13, 6, 5, None],
+        [10, 9, 18, 17, 16, None],
+        [8, 12, 20, 19, 18, 9],
+        [22, 14, 13, 12, 20, 21],
+        [24, 17, 18, 19, 23, None],
+        [21, 20, 19, 23, 25, None]
+    ]
+    verts = [
+        [0.0, 22.5],
+        [5.1072, 22.5],
+        [7.5, 24.0324],
+        [7.5, 30.0],
+        [0.0, 30.0],
+        [0.0, 7.5],
+        [4.684, 7.5],
+        [0.0, 15.0],
+        [14.6582, 21.588],
+        [22.5, 24.3766],
+        [22.5, 30.0],
+        [15.0, 30.0],
+        [15.3597, 8.4135],
+        [7.5, 5.6289],
+        [7.5, 0.0],
+        [0.0, 0.0],
+        [30.0, 30.0],
+        [30.0, 22.5],
+        [25.3285, 22.5],
+        [24.8977, 7.5],
+        [22.5, 5.9676],
+        [22.5, 0.0],
+        [15.0, 0.0],
+        [30.0, 7.5],
+        [30.0, 15.0],
+        [30.0, 0.0]
+    ]
+
+    grid = flopy.discretization.UnstructuredGrid(
+        verts, iverts, ncpl=[len(iverts)]
+    )
+
+    iverts = grid.iverts
+    if any(None in l for l in iverts):
+        raise ValueError("None type should not be returned in iverts list")
+
+
 if __name__ == "__main__":
     test_mfusg()
+    test_usg_iverts()

--- a/flopy/discretization/unstructuredgrid.py
+++ b/flopy/discretization/unstructuredgrid.py
@@ -563,7 +563,7 @@ class UnstructuredGrid(Grid):
 
             xcellvert = []
             ycellvert = []
-            for ix in iverts:
+            for ix in (iv for iv in iverts if iv is not None):
                 xcellvert.append(vertexdict[ix][0])
                 ycellvert.append(vertexdict[ix][1])
 

--- a/flopy/discretization/unstructuredgrid.py
+++ b/flopy/discretization/unstructuredgrid.py
@@ -200,7 +200,8 @@ class UnstructuredGrid(Grid):
 
     @property
     def iverts(self):
-        return self._iverts
+        if self._iverts is not None:
+            return [list(filter((None).__ne__, i)) for i in self._iverts]
 
     @property
     def verts(self):
@@ -559,11 +560,11 @@ class UnstructuredGrid(Grid):
         yvertices = []
 
         # build xy vertex and cell center info
-        for iverts in self._iverts:
+        for iverts in self.iverts:
 
             xcellvert = []
             ycellvert = []
-            for ix in (iv for iv in iverts if iv is not None):
+            for ix in iverts:
                 xcellvert.append(vertexdict[ix][0])
                 ycellvert.append(vertexdict[ix][1])
 

--- a/flopy/discretization/vertexgrid.py
+++ b/flopy/discretization/vertexgrid.py
@@ -125,7 +125,20 @@ class VertexGrid(Grid):
 
     @property
     def iverts(self):
-        return [[t[0]] + list(t)[4:] for t in self._cell2d]
+        if self._cell2d is not None:
+            return [[t[0]] + list(t)[4:] for t in self.cell2d]
+        elif self._cell1d is not None:
+            return [[t[0]] + list(t)[3:] for t in self.cell1d]
+
+    @property
+    def cell1d(self):
+        if self._cell1d is not None:
+            return [list(filter((None).__ne__, t)) for t in self._cell1d]
+
+    @property
+    def cell2d(self):
+        if self._cell2d is not None:
+            return [list(filter((None).__ne__, t)) for t in self._cell2d]
 
     @property
     def verts(self):
@@ -342,7 +355,7 @@ class VertexGrid(Grid):
             zcenters = []
             zvertices = []
             vertexdict = {v[0]: [v[1], v[2], v[3]] for v in self._vertices}
-            for cell1d in self._cell1d:
+            for cell1d in self.cell1d:
                 cell1d = tuple(cell1d)
                 xcenters.append(cell1d[1])
                 ycenters.append(cell1d[2])
@@ -350,8 +363,7 @@ class VertexGrid(Grid):
 
                 vert_number = []
                 for i in cell1d[3:]:
-                    if i is not None:
-                        vert_number.append(int(i))
+                    vert_number.append(int(i))
 
                 xcellvert = []
                 ycellvert = []
@@ -367,15 +379,14 @@ class VertexGrid(Grid):
         else:
             vertexdict = {v[0]: [v[1], v[2]] for v in self._vertices}
             # build xy vertex and cell center info
-            for cell2d in self._cell2d:
+            for cell2d in self.cell2d:
                 cell2d = tuple(cell2d)
                 xcenters.append(cell2d[1])
                 ycenters.append(cell2d[2])
 
                 vert_number = []
                 for i in cell2d[4:]:
-                    if i is not None:
-                        vert_number.append(int(i))
+                    vert_number.append(int(i))
 
                 xcellvert = []
                 ycellvert = []

--- a/flopy/mf6/mfmodel.py
+++ b/flopy/mf6/mfmodel.py
@@ -421,7 +421,7 @@ class MFModel(PackageContainer, ModelInterface):
                 xcenters = None
                 ycenters = None
             else:
-                iverts = [list(i)[4:] for i in cell2d]
+                iverts = [list(filter((None).__ne__, i))[4:] for i in cell2d]
                 xcenters = dis.cell2d.array["xc"]
                 ycenters = dis.cell2d.array["yc"]
             vertices = dis.vertices.array

--- a/flopy/mf6/mfmodel.py
+++ b/flopy/mf6/mfmodel.py
@@ -421,7 +421,7 @@ class MFModel(PackageContainer, ModelInterface):
                 xcenters = None
                 ycenters = None
             else:
-                iverts = [list(filter((None).__ne__, i))[4:] for i in cell2d]
+                iverts = [list(i)[4:] for i in cell2d]
                 xcenters = dis.cell2d.array["xc"]
                 ycenters = dis.cell2d.array["yc"]
             vertices = dis.vertices.array

--- a/flopy/utils/gridintersect.py
+++ b/flopy/utils/gridintersect.py
@@ -45,7 +45,6 @@ if shapely_warning is not None and not SHAPELY_GE_20:
                 )
             yield
 
-
 elif SHAPELY_LT_18 and NUMPY_GE_121:
 
     @contextlib.contextmanager
@@ -57,7 +56,6 @@ elif SHAPELY_LT_18 and NUMPY_GE_121:
                 DeprecationWarning,
             )
             yield
-
 
 else:
 


### PR DESCRIPTION
Loading an mf6 DISU model with variable voronoi grid results in extraneous iverts entries
of None (Iverts appears to be a consistent (not jagged) shape). This results in a vertexdict
indexing error in UnstructuredGrid._build_grid_geometry_info when using plot() methods.

Filter out None entries from iverts in UnstructuredGrid._build_grid_geometry_info