### PR TITLE
refactor(distutils): Version classes are deprecated, use internal class

### DIFF
--- a/flopy/export/netcdf.py
+++ b/flopy/export/netcdf.py
@@ -673,10 +673,10 @@ class NetCdf:
         needed for the netcdf file
         """
         pyproj = import_optional_dependency("pyproj")
-        from distutils.version import LooseVersion
+        from ..utils.parse_version import Version
 
         # Check if using newer pyproj version conventions
-        pyproj220 = LooseVersion(pyproj.__version__) >= LooseVersion("2.2.0")
+        pyproj220 = Version(pyproj.__version__) >= Version("2.2.0")
 
         proj4_str = self.proj4_str
         print(f"initialize_geometry::proj4_str = {proj4_str}")

--- a/flopy/utils/gridintersect.py
+++ b/flopy/utils/gridintersect.py
@@ -1,19 +1,19 @@
 import numpy as np
 import contextlib
 import warnings
-from distutils.version import LooseVersion
 
 from .utl_import import import_optional_dependency
 
 from .geometry import transform
 from .geospatial_utils import GeoSpatialUtil
+from .parse_version import Version
 
-NUMPY_GE_121 = str(np.__version__) >= LooseVersion("1.21")
+NUMPY_GE_121 = Version(np.__version__) >= Version("1.21")
 
 shapely = import_optional_dependency("shapely", errors="silent")
 if shapely is not None:
-    SHAPELY_GE_20 = str(shapely.__version__) >= LooseVersion("2.0")
-    SHAPELY_LT_18 = str(shapely.__version__) < LooseVersion("1.8")
+    SHAPELY_GE_20 = Version(shapely.__version__) >= Version("2.0")
+    SHAPELY_LT_18 = Version(shapely.__version__) < Version("1.8")
 else:
     SHAPELY_GE_20 = False
     SHAPELY_LT_18 = False


### PR DESCRIPTION
This resolves a new DeprecationWarning:
> flopy/flopy/utils/gridintersect.py:15: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.

Version from flopy.utils.parse_version was vendored from pypa/packaging in #1262, so is suitable and convenient.