### PR TITLE
refactor(flake8): F821 for 'undefined name' errors

### DIFF
--- a/flopy/mf6/data/mfdatalist.py
+++ b/flopy/mf6/data/mfdatalist.py
@@ -1640,7 +1640,7 @@ class MFTransientList(MFList, mfdata.MFTransient, DataListInterface):
                     return True
             return False
         else:
-            self.get_data_prep(layer)
+            self.get_data_prep(key)
             return super().has_data()
 
     def get_data(self, key=None, apply_mult=False, **kwargs):

--- a/release/make-release.py
+++ b/release/make-release.py
@@ -5,6 +5,7 @@ import json
 import os
 import subprocess
 import sys
+from importlib.machinery import SourceFileLoader
 
 # file_paths dictionary has file names and the path to the file. Enter '.'
 # as the path if the file is in the root repository directory
@@ -20,12 +21,12 @@ file_paths = {
 pak = "flopy"
 
 # local import of package variables in flopy/version.py
-# imports author_dict
-exec(open(os.path.join("..", "flopy", "version.py")).read())
+loader = SourceFileLoader("version", os.path.join("..", "flopy", "version.py"))
+version_mod = loader.load_module()
 
 # build authors list for Software/Code citation for FloPy
 authors = []
-for key in author_dict.keys():
+for key in version_mod.author_dict.keys():
     t = key.split()
     author = f"{t[-1]}"
     for str in t[0:-1]:


### PR DESCRIPTION
Resolve a few [flake8 errors](https://flake8.pycqa.org/en/2.6.0/warnings.html) identified with `flake8 --select=F821 .`:
```
./release/make-release.py:28:12: F821 undefined name 'author_dict'
./flopy/mf6/data/mfdatalist.py:1643:32: F821 undefined name 'layer'
```

A review by @spaulins-usgs for `flopy/mf6/data/mfdatalist.py` would be appreciated, as this was a guess.