### PR TITLE
update(MFBlockHeader): fix for very slow loading of package OBS files when many blocks exist in OBS file

### DIFF
--- a/flopy/mf6/mfpackage.py
+++ b/flopy/mf6/mfpackage.py
@@ -1227,6 +1227,8 @@ class MFBlock:
 
     def header_exists(self, key, data_path=None):
         if not isinstance(key, list):
+            if key is None:
+                return
             comp_key_list = [key]
         else:
             comp_key_list = key


### PR DESCRIPTION
update `header_exists()`: when None is provided for key, do not check against block header names (significantly speeds OBS loading).