### PR TITLE
update(read_binary_data_from_file): update for binary layer files with multiple layers

### DIFF
--- a/flopy/mf6/data/mffileaccess.py
+++ b/flopy/mf6/data/mffileaccess.py
@@ -399,6 +399,9 @@ class MFFileAccessArray(MFFileAccess):
     ):
         import flopy.utils.binaryfile as bf
 
+        if data_size != modelgrid.ncpl:
+            read_multi_layer = True
+
         fd = self._open_ext_file(fname, True)
         numpy_type, name = self.datum_to_numpy_type(data_type)
         header_dtype = bf.BinaryHeader.set_dtype(

--- a/flopy/mf6/data/mffileaccess.py
+++ b/flopy/mf6/data/mffileaccess.py
@@ -400,8 +400,9 @@ class MFFileAccessArray(MFFileAccess):
     ):
         import flopy.utils.binaryfile as bf
 
-        if data_size != modelgrid.ncpl:
-            read_multi_layer = True
+        if not isinstance(modelgrid.ncpl, np.ndarray):
+            if data_size != modelgrid.ncpl:
+                read_multi_layer = True
 
         fd = self._open_ext_file(fname, True)
         numpy_type, name = self.datum_to_numpy_type(data_type)


### PR DESCRIPTION
Previously, code read the entire file without stripping headers after first layer. Enforce read_multi_layer=True if data_size != ncpl