### PR TITLE
skip .prj copy if exists

### DIFF
--- a/flopy/export/shapefile_utils.py
+++ b/flopy/export/shapefile_utils.py
@@ -624,7 +624,12 @@ def write_prj(shpname, mg=None, epsg=None, prj=None, wkt_string=None):
         prjtxt = CRS.getprj(epsg)
     # copy a supplied prj file
     elif prj is not None:
-        shutil.copy(prj, prjname)
+        if os.path.exists(prjname):
+            print(
+                ".prj file {} already exists ".format(prjname)
+            )
+        else:
+            shutil.copy(prj, prjname)
 
     elif mg is not None:
         if mg.epsg is not None:

--- a/flopy/export/shapefile_utils.py
+++ b/flopy/export/shapefile_utils.py
@@ -625,9 +625,7 @@ def write_prj(shpname, mg=None, epsg=None, prj=None, wkt_string=None):
     # copy a supplied prj file
     elif prj is not None:
         if os.path.exists(prjname):
-            print(
-                ".prj file {} already exists ".format(prjname)
-            )
+            print(".prj file {} already exists ".format(prjname))
         else:
             shutil.copy(prj, prjname)
 


### PR DESCRIPTION
This raises a shutil error if the .prj file already exists and belongs to another user.