### PR TITLE
fix(packaging): add docs/*.md to MANIFEST.in for sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include pyproject.toml
+include docs/*.md
 include flopy/mf6/data/dfn/*.dfn
 include flopy/plot/mplstyle/*.mplstyle


### PR DESCRIPTION
As noted in https://github.com/modflowpy/flopy/issues/1390#issuecomment-1085200752 the package build was missing `long_description`, because `docs/PyPI_release.md` was not included with the source distribution `MANIFEST.in`.

This fix includes all markdown files in `docs` with the source distribution.