### PR TITLE
fix(simulation packages): *** Breaks interface ***

### DIFF
--- a/.github/workflows/ci-mf6.yml
+++ b/.github/workflows/ci-mf6.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Install pymake, xmipy, modflowapi, and flopy
       run: |
         python -m pip install --upgrade pip
-        pip install https://github.com/modflowpy/flopy/zipball/develop
+        pip install https://github.com/scottrp/flopy/zipball/develop
         pip install https://github.com/modflowpy/pymake/zipball/master
         pip install https://github.com/Deltares/xmipy/zipball/develop
         pip install https://github.com/MODFLOW-USGS/modflowapi/zipball/develop

--- a/.github/workflows/ci-mf6.yml
+++ b/.github/workflows/ci-mf6.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Install pymake, xmipy, modflowapi, and flopy
       run: |
         python -m pip install --upgrade pip
-        pip install https://github.com/scottrp/flopy/zipball/develop
+        pip install https://github.com/modflowpy/flopy/zipball/develop
         pip install https://github.com/modflowpy/pymake/zipball/master
         pip install https://github.com/Deltares/xmipy/zipball/develop
         pip install https://github.com/MODFLOW-USGS/modflowapi/zipball/develop
@@ -63,7 +63,7 @@ jobs:
 
     - name: Clone MODFLOW 6 repo
       run: |
-        git clone https://github.com/spaulins-usgs/modflow6.git modflow6
+        git clone https://github.com/MODFLOW-USGS/modflow6.git modflow6
 
     - name: Update flopy MODFLOW 6 classes
       working-directory: ./modflow6/autotest

--- a/.github/workflows/ci-mf6.yml
+++ b/.github/workflows/ci-mf6.yml
@@ -63,7 +63,7 @@ jobs:
 
     - name: Clone MODFLOW 6 repo
       run: |
-        git clone https://github.com/MODFLOW-USGS/modflow6.git modflow6
+        git clone https://github.com/spaulins-usgs/modflow6.git modflow6
 
     - name: Update flopy MODFLOW 6 classes
       working-directory: ./modflow6/autotest

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -87,7 +87,7 @@ jobs:
         use-only-tar-bz2: true
 
     - name: Add packages to flopy environment using conda
-      run: |
+      run: | 
         conda env update --name flopy --file etc/environment.yml
 
     - name: Upgrade pip

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -87,7 +87,7 @@ jobs:
         use-only-tar-bz2: true
 
     - name: Add packages to flopy environment using conda
-      run: | 
+      run: |
         conda env update --name flopy --file etc/environment.yml
 
     - name: Upgrade pip

--- a/autotest/t504_test.py
+++ b/autotest/t504_test.py
@@ -590,6 +590,8 @@ def test045_lake1ss_table():
 
     # change some settings
     model = sim.get_model(model_name)
+    lak = model.get_package("lak")
+    laktbl = lak.get_package("laktab")
     laktbl = model.get_package("laktab").table
     laktbl_data = laktbl.get_data()
     laktbl_data[-1][0] = 700.0

--- a/autotest/t505_test.py
+++ b/autotest/t505_test.py
@@ -7,6 +7,7 @@ import flopy
 import flopy.utils.binaryfile as bf
 from flopy.mf6.data.mfdatastorage import DataStorageType
 from flopy.mf6.mfbase import FlopyException, MFDataException
+from flopy.mf6.modflow.mfutltas import ModflowUtltas
 from flopy.mf6.modflow.mfgwf import ModflowGwf
 from flopy.mf6.modflow.mfgwfchd import ModflowGwfchd
 from flopy.mf6.modflow.mfgwfdis import ModflowGwfdis
@@ -19,6 +20,8 @@ from flopy.mf6.modflow.mfgwfgnc import ModflowGwfgnc
 from flopy.mf6.modflow.mfgwfgwf import ModflowGwfgwf
 from flopy.mf6.modflow.mfgwfhfb import ModflowGwfhfb
 from flopy.mf6.modflow.mfgwfic import ModflowGwfic
+from flopy.mf6.modflow.mfgwflak import ModflowGwflak
+from flopy.mf6.modflow.mfutllaktab import ModflowUtllaktab
 from flopy.mf6.modflow.mfgwfnpf import ModflowGwfnpf
 from flopy.mf6.modflow.mfgwfoc import ModflowGwfoc
 from flopy.mf6.modflow.mfgwfrch import ModflowGwfrch
@@ -27,6 +30,7 @@ from flopy.mf6.modflow.mfgwfriv import ModflowGwfriv
 from flopy.mf6.modflow.mfgwfsfr import ModflowGwfsfr
 from flopy.mf6.modflow.mfgwfsto import ModflowGwfsto
 from flopy.mf6.modflow.mfgwfwel import ModflowGwfwel
+from flopy.mf6.modflow.mfgwfmvr import ModflowGwfmvr
 from flopy.mf6.modflow.mfims import ModflowIms
 from flopy.mf6.modflow.mfsimulation import MFSimulation
 from flopy.mf6.modflow.mftdis import ModflowTdis
@@ -265,12 +269,25 @@ def test_multi_model():
         chdspd=chdspd,
         welspd=welspd,
     )
+    lakpd = [(0, -100.0, 1)]
+    lakecn = [(0, 0, (0, 0, 0), "HORIZONTAL", 1.0, 0.1, 1.0, 10.0, 1.0)]
+    lak_2 = ModflowGwflak(
+        gwf2,
+        pname="lak2",
+        print_input=True,
+        mover=True,
+        nlakes=1,
+        noutlets=0,
+        ntables=0,
+        packagedata=lakpd,
+        connectiondata=lakecn,
+    )
 
     # gwf-gwf
     gwfgwf_data = []
     for col in range(0, ncol):
         gwfgwf_data.append(
-            [(0, 0, col), (0, 0, 0), 1, 0.5, 0.5, 1.0, 0.0, 1.0]
+            [(0, 0, col), (0, 0, col), 1, 0.5, 0.5, 1.0, 0.0, 1.0]
         )
     gwfgwf = flopy.mf6.ModflowGwfgwf(
         sim,
@@ -281,6 +298,44 @@ def test_multi_model():
         exchangedata=gwfgwf_data,
         auxiliary=["ANGLDEGX", "CDIST"],
         filename="flow1_flow2.gwfgwf",
+    )
+    # set up mvr package
+    wel_1 = gwf1.get_package("wel")
+    wel_1.mover.set_data(True)
+    wel_name_1 = wel_1.name[0]
+    lak_name_2 = lak_2.name[0]
+    package_data = [(gwf1.name, wel_name_1), (gwf2.name, lak_name_2)]
+    period_data = [
+        (gwf1.name, wel_name_1, 0, gwf2.name, lak_name_2, 0, "FACTOR", 1.0)
+    ]
+    fname = "gwfgwf.input.mvr"
+    gwfgwf.mvr.initialize(
+        filename=fname,
+        modelnames=True,
+        print_input=True,
+        print_flows=True,
+        maxpackages=2,
+        maxmvr=1,
+        packages=package_data,
+        perioddata=period_data,
+    )
+
+    gnc_data = []
+    for col in range(0, ncol):
+        if col < ncol / 2.0:
+            gnc_data.append(((0, 0, col), (0, 0, col), (0, 0, col + 1), 0.25))
+        else:
+            gnc_data.append(((0, 0, col), (0, 0, col), (0, 0, col - 1), 0.25))
+
+    # set up gnc package
+    fname = "gwfgwf.input.gnc"
+    gwfgwf.gnc.initialize(
+        filename=fname,
+        print_input=True,
+        print_flows=True,
+        numgnc=ncol,
+        numalphaj=1,
+        gncdata=gnc_data,
     )
 
     # Observe flow for exchange
@@ -327,7 +382,7 @@ def test_multi_model():
         inner_maximum=ninner,
         inner_dvclose=hclose,
         rcloserecord=rclose,
-        linear_acceleration="CG",
+        linear_acceleration="BICGSTAB",
         scaling_method="NONE",
         reordering_method="NONE",
         relaxation_factor=relax,
@@ -418,11 +473,11 @@ def test_array():
         filename=f"{sim_name}.ims",
         print_option="ALL",
         complexity="SIMPLE",
-        outer_dvclose=0.00001,
+        outer_dvclose=0.0001,
         outer_maximum=50,
         under_relaxation="NONE",
         inner_maximum=30,
-        inner_dvclose=0.00001,
+        inner_dvclose=0.0001,
         linear_acceleration="CG",
         preconditioner_levels=7,
         preconditioner_drop_tolerance=0.01,
@@ -456,6 +511,17 @@ def test_array():
         k=50.0,
     )
 
+    oc_package = ModflowGwfoc(
+        model,
+        budget_filerecord=[("test_array.cbc",)],
+        head_filerecord=[("test_array.hds",)],
+        saverecord={
+            0: [("HEAD", "ALL"), ("BUDGET", "ALL")],
+            1: [],
+        },
+        printrecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+    )
+
     aux = {1: [[50.0], [1.3]], 3: [[200.0], [1.5]]}
     irch = {1: [[0, 2], [2, 1]], 2: [[0, 1], [2, 3]]}
     rcha = mf6.ModflowGwfrcha(
@@ -464,7 +530,7 @@ def test_array():
         print_flows=True,
         auxiliary=[("var1", "var2")],
         irch=irch,
-        recharge={1: 0.0001, 2: 0.0002},
+        recharge={1: 0.0001, 2: 0.00001},
         aux=aux,
     )
     val_irch = rcha.irch.array.sum(axis=(1, 2, 3))
@@ -482,12 +548,12 @@ def test_array():
     val_rch = rcha.recharge.array.sum(axis=(1, 2, 3))
     assert val_rch[0] == 0.0
     assert val_rch[1] == 0.0004
-    assert val_rch[2] == 0.0008
-    assert val_rch[3] == 0.0008
+    assert val_rch[2] == 0.00004
+    assert val_rch[3] == 0.00004
     val_rch_2 = rcha.recharge.get_data()
     assert val_rch_2[0] is None
     assert val_rch_2[1][0, 0] == 0.0001
-    assert val_rch_2[2][0, 0] == 0.0002
+    assert val_rch_2[2][0, 0] == 0.00001
     assert val_rch_2[3] is None
     aux_data_0 = rcha.aux.get_data(0)
     assert aux_data_0 is None
@@ -503,6 +569,7 @@ def test_array():
         model,
         print_input=True,
         print_flows=True,
+        mover=True,
         stress_period_data=welspdict,
         save_flows=False,
         auxiliary="CONCENTRATION",
@@ -552,6 +619,73 @@ def test_array():
         save_flows=False,
         pname="GHB-1",
     )
+
+    lakpd = [(0, 70.0, 1), (1, 65.0, 1)]
+    lakecn = [
+        (0, 0, (0, 0, 0), "HORIZONTAL", 1.0, 60.0, 90.0, 10.0, 1.0),
+        (1, 0, (0, 1, 1), "HORIZONTAL", 1.0, 60.0, 90.0, 10.0, 1.0),
+    ]
+    lak_tables = [(0, "lak01.tab"), (1, "lak02.tab")]
+    lak = ModflowGwflak(
+        model,
+        pname="lak",
+        print_input=True,
+        mover=True,
+        nlakes=2,
+        noutlets=0,
+        ntables=1,
+        packagedata=lakpd,
+        connectiondata=lakecn,
+        tables=lak_tables,
+    )
+
+    table_01 = [
+        (30.0, 100000.0, 10000.0),
+        (40.0, 200500.0, 10100.0),
+        (50.0, 301200.0, 10130.0),
+        (60.0, 402000.0, 10180.0),
+        (70.0, 503000.0, 10200.0),
+        (80.0, 700000.0, 20000.0),
+    ]
+    lak_tab = ModflowUtllaktab(
+        model,
+        filename="lak01.tab",
+        nrow=6,
+        ncol=3,
+        table=table_01,
+    )
+
+    table_02 = [
+        (40.0, 100000.0, 10000.0),
+        (50.0, 200500.0, 10100.0),
+        (60.0, 301200.0, 10130.0),
+        (70.0, 402000.0, 10180.0),
+        (80.0, 503000.0, 10200.0),
+        (90.0, 700000.0, 20000.0),
+    ]
+    lak_tab_2 = ModflowUtllaktab(
+        model,
+        filename="lak02.tab",
+        nrow=6,
+        ncol=3,
+        table=table_02,
+    )
+    wel_name_1 = wel.name[0]
+    lak_name_2 = lak.name[0]
+    package_data = [(wel_name_1,), (lak_name_2,)]
+    period_data = [(wel_name_1, 0, lak_name_2, 0, "FACTOR", 1.0)]
+    fname = f"{model.name}.input.mvr"
+    mvr = ModflowGwfmvr(
+        parent_model_or_package=model,
+        filename=fname,
+        print_input=True,
+        print_flows=True,
+        maxpackages=2,
+        maxmvr=1,
+        packages=package_data,
+        perioddata=period_data,
+    )
+
     # test writing and loading model
     sim.write_simulation()
     if run:
@@ -569,6 +703,8 @@ def test_array():
     rcha = model.get_package("rcha")
     wel = model.get_package("wel")
     drn = model.get_package("drn")
+    lak = model.get_package("lak")
+    lak_tab = model.get_package("laktab")
     assert os.path.split(dis.filename)[1] == f"{model_name} 1.dis"
     # do same tests as above
     val_irch = rcha.irch.array.sum(axis=(1, 2, 3))
@@ -584,12 +720,12 @@ def test_array():
     val_rch = rcha.recharge.array.sum(axis=(1, 2, 3))
     assert val_rch[0] == 0.0
     assert val_rch[1] == 0.0004
-    assert val_rch[2] == 0.0008
-    assert val_rch[3] == 0.0008
+    assert val_rch[2] == 0.00004
+    assert val_rch[3] == 0.00004
     val_rch_2 = rcha.recharge.get_data()
     assert val_rch_2[0] is None
     assert val_rch_2[1][0, 0] == 0.0001
-    assert val_rch_2[2][0, 0] == 0.0002
+    assert val_rch_2[2][0, 0] == 0.00001
     assert val_rch_2[3] is None
     aux_data_0 = rcha.aux.get_data(0)
     assert aux_data_0 is None
@@ -619,6 +755,18 @@ def test_array():
     assert drn_gd_2 == []
     drn_gd_3 = drn.stress_period_data.get_data(3)
     assert drn_gd_3[0][1] == 55.0
+
+    lak_tab_array = lak.tables.get_data()
+    assert lak_tab_array[0][1] == "lak01.tab"
+    assert lak_tab_array[1][1] == "lak02.tab"
+
+    assert len(lak_tab) == 2
+    lak_tab_1 = lak_tab[0].table.get_data()
+    assert lak_tab_1[0][0] == 30.0
+    assert lak_tab_1[5][2] == 20000.0
+    lak_tab_2 = lak_tab[1].table.get_data()
+    assert lak_tab_2[0][0] == 40.0
+    assert lak_tab_2[4][1] == 503000.0
 
 
 def test_binary_read():
@@ -1182,28 +1330,6 @@ def test_np001():
         sim.run_simulation()
         sim.delete_output_files()
 
-    try:
-        error_occurred = False
-        well_spd = {
-            0: {
-                "filename": "wel0.bin",
-                "binary": True,
-                "data": [((0, 0, 4), -2000.0), ((0, 0, 7), -2.0)],
-            }
-        }
-        wel_package = ModflowGwfwel(
-            model,
-            boundnames=True,
-            print_input=True,
-            print_flows=True,
-            save_flows=True,
-            maxbound=2,
-            stress_period_data=well_spd,
-        )
-    except MFDataException:
-        error_occurred = True
-    assert error_occurred
-
     # test error checking
     drn_package = ModflowGwfdrn(
         model,
@@ -1265,7 +1391,7 @@ def test_np001():
     mpath = sim.simulation_data.mfpath.get_model_path(model.name)
     spath = sim.simulation_data.mfpath.get_sim_path()
     found_cellid = False
-    with open(os.path.join(mpath, "np001_mod.wel"), "r") as fd:
+    with open(os.path.join(mpath, "np001_mod.wel_1"), "r") as fd:
         for line in fd:
             line_lst = line.strip().split()
             if (
@@ -1281,7 +1407,7 @@ def test_np001():
     well_spd = {0: [(-1, -1, -1, -2000.0), (0, 0, 7, -2.0)], 1: []}
     wel_package = ModflowGwfwel(
         model,
-        pname="wel_1",
+        pname="wel_2",
         filename="file_rename.wel",
         print_input=True,
         print_flows=True,
@@ -1313,7 +1439,7 @@ def test_np001():
         spath,
         write_headers=False,
     )
-    wel = test_sim.get_model().get_package("wel_1")
+    wel = test_sim.get_model().get_package("wel_2")
     wel._filename = "np001_spd_test.wel"
     wel.write()
     found_begin = False
@@ -1330,6 +1456,29 @@ def test_np001():
                     if len(line.strip()) > 0:
                         text_between_begin_and_end = True
     assert found_begin and found_end and not text_between_begin_and_end
+
+    # test adding package with invalid data
+    try:
+        error_occurred = False
+        well_spd = {
+            0: {
+                "filename": "wel0.bin",
+                "binary": True,
+                "data": [((0, 0, 4), -2000.0), ((0, 0, 7), -2.0)],
+            }
+        }
+        wel_package = ModflowGwfwel(
+            model,
+            boundnames=True,
+            print_input=True,
+            print_flows=True,
+            save_flows=True,
+            maxbound=2,
+            stress_period_data=well_spd,
+        )
+    except MFDataException:
+        error_occurred = True
+    assert error_occurred
 
     return
 
@@ -1494,9 +1643,10 @@ def test_np002():
     rch_array[0, 3] = 0.02
     rch_array[0, 6] = 0.1
 
-    rch_package.tas.initialize(
+    tas = ModflowUtltas(
+        rch_package,
         filename="np002_mod.rch.tas",
-        tas_array={0.0: rch_array, 6.0: rch_array},
+        tas_array={0.0: rch_array, 6.0: rch_array, 12.0: rch_array},
         time_series_namerecord="rcharray",
         interpolation_methodrecord="linear",
     )
@@ -1548,6 +1698,7 @@ def test_np002():
     )
     chd_package = ModflowGwfchd(
         model,
+        pname="chd_2",
         print_input=True,
         print_flows=True,
         maxbound=1,
@@ -1564,7 +1715,7 @@ def test_np002():
         "checker threshold of 0.5" in summary
     )
     assert "Not a number" in summary
-
+    model.remove_package("chd_2")
     # check case where aux variable defined and stress period data has empty
     # stress period
     model.remove_package("ghb")
@@ -1576,7 +1727,15 @@ def test_np002():
         stress_period_data={0: [((0, 0, 9), 125.0, 60.0, 0.0)], 1: [()]},
         auxiliary=["CONCENTRATION"],
     )
+    # add adaptive time stepping
+    period_data = [
+        (0, 3.0, 1.0e-5, 6.0, 2.0, 5.0),
+        (1, 3.0, 1.0e-5, 6.0, 2.0, 5.0),
+    ]
+    ats = tdis_package.ats.initialize(maxats=2, perioddata=period_data)
+
     sim.write_simulation()
+    sim.run_simulation()
     sim2 = MFSimulation.load(
         sim_name=test_ex_name,
         version="mf6",
@@ -1601,6 +1760,9 @@ def test_np002():
     assert os.path.exists(
         os.path.join(ext_full_path, "np002_mod.dis_botm.txt")
     )
+
+    # run
+    sim.run_simulation()
 
     return
 
@@ -3295,7 +3457,6 @@ def test006_2models_gnc():
         print_flows=True,
         save_flows=True,
         auxiliary="testaux",
-        gnc_filerecord=gnc_path,
         nexg=26,
         exchangedata=newexgrecarray,
         exgtype="gwf6-gwf6",
@@ -3310,7 +3471,6 @@ def test006_2models_gnc():
         print_flows=True,
         save_flows=True,
         auxiliary="testaux",
-        gnc_filerecord=gnc_path,
         nexg=36,
         exchangedata=exgrecarray,
         exgtype="gwf6-gwf6",
@@ -3322,19 +3482,7 @@ def test006_2models_gnc():
     gncrecarray = testutils.read_gncrecarray(os.path.join(pth, "gnc.txt"))
     # test gnc delete
     new_gncrecarray = gncrecarray[10:]
-    gnc_package = ModflowGwfgnc(
-        sim,
-        filename=gnc_path,
-        print_input=True,
-        print_flows=True,
-        numgnc=26,
-        numalphaj=1,
-        gncdata=new_gncrecarray,
-    )
-    sim.remove_package(gnc_package.package_type)
-
-    gnc_package = ModflowGwfgnc(
-        sim,
+    gnc_package = exg_package.gnc.initialize(
         filename=gnc_path,
         print_input=True,
         print_flows=True,

--- a/examples/Tutorials/modflow6data/tutorial09_mf6_data.py
+++ b/examples/Tutorials/modflow6data/tutorial09_mf6_data.py
@@ -1,0 +1,298 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: "1.5"
+#       jupytext_version: 1.5.1
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# # MODFLOW 6: Multiple Models - How to create multiple models in a simulation
+#
+# This tutorial shows a simulation using two models, demonstrating how to use
+# exchanges and exchange subpackages.
+#
+# ## Introduction to Multiple Models
+# MODFLOW-6 simulations can contain multiple models, which can be linked
+# through the groundwater exchange package, which can contain mover and
+# ghost node correction subpackages.
+#
+# The following code sets up a basic simulation.
+
+# package import
+import os
+
+import numpy as np
+
+import flopy
+
+# set up where simulation workspace will be stored
+workspace = os.path.join("data", "mf6_working_with_data")
+name = "example_1"
+if not os.path.exists(workspace):
+    os.makedirs(workspace)
+# create the FloPy simulation and tdis objects
+sim = flopy.mf6.MFSimulation(
+    sim_name=name, exe_name="mf6", version="mf6", sim_ws=workspace
+)
+tdis = flopy.mf6.modflow.mftdis.ModflowTdis(
+    sim,
+    pname="tdis",
+    time_units="DAYS",
+    nper=2,
+    perioddata=[(1.0, 1, 1.0), (1.0, 1, 1.0)],
+)
+
+# ## Groundwater Flow Model Setup
+# We will start by setting up two groundwater flow models that are part of the
+# same simulation.
+
+# set up first groundwater flow model
+name_1 = "ex_1_mod_1"
+model_nam_file = f"{name_1}.nam"
+gwf = flopy.mf6.ModflowGwf(
+    sim, modelname=name_1, model_nam_file=model_nam_file
+)
+# create the discretization package
+bot = [-10.0, -50.0, -200.0]
+delrow = delcol = 4.0
+nlay = 3
+nrow = 10
+ncol = 10
+dis = flopy.mf6.modflow.mfgwfdis.ModflowGwfdis(
+    gwf,
+    pname="dis-1",
+    nogrb=True,
+    nlay=nlay,
+    nrow=nrow,
+    ncol=ncol,
+    delr=delrow,
+    delc=delcol,
+    top=0.0,
+    botm=bot,
+)
+# create npf package
+npf = flopy.mf6.ModflowGwfnpf(
+    gwf,
+    pname="npf-1",
+    save_flows=True,
+    icelltype=[1, 1, 1],
+    k=10.0,
+    k33=5.0,
+    xt3doptions="xt3d rhs",
+    # rewet_record="REWET WETFCT 1.0 IWETIT 1 IHDWET 0",
+)
+# create ic package
+ic_package = flopy.mf6.modflow.mfgwfic.ModflowGwfic(gwf, strt=0.0)
+
+# create ghb package
+ghb_spd = {0: [((0, 0, 0), -1.0, 1000.0)]}
+ghb = flopy.mf6.modflow.mfgwfghb.ModflowGwfghb(
+    gwf,
+    print_input=True,
+    print_flows=True,
+    pname="ghb-1",
+    maxbound=1,
+    stress_period_data=ghb_spd,
+)
+
+# create wel package
+welspd = {0: [((0, 5, ncol - 1), -100.0)]}
+wel = flopy.mf6.ModflowGwfwel(
+    gwf,
+    print_input=True,
+    print_flows=True,
+    mover=True,
+    stress_period_data=welspd,
+    save_flows=False,
+    pname="WEL-1",
+)
+
+# set up second groundwater flow model with a finer grid
+name_1 = "ex_1_mod_2"
+model_nam_file = f"{name_1}.nam"
+gwf_2 = flopy.mf6.ModflowGwf(
+    sim, modelname=name_1, model_nam_file=model_nam_file
+)
+# create the flopy iterative model solver (ims) package object
+# by default flopy will register both models with the ims package.
+ims = flopy.mf6.modflow.mfims.ModflowIms(
+    sim, pname="ims", complexity="SIMPLE", linear_acceleration="BICGSTAB"
+)
+# no need to create a new ims package.  flopy will automatically register
+# create the discretization package
+bot = [-10.0, -50.0, -200.0]
+dis_2 = flopy.mf6.modflow.mfgwfdis.ModflowGwfdis(
+    gwf_2,
+    pname="dis-2",
+    nogrb=True,
+    nlay=nlay,
+    nrow=nrow * 2,
+    ncol=ncol * 2,
+    delr=delrow / 2.0,
+    delc=delcol / 2.0,
+    top=0.0,
+    botm=bot,
+)
+# create npf package
+npf_2 = flopy.mf6.ModflowGwfnpf(
+    gwf_2,
+    pname="npf-2",
+    save_flows=True,
+    icelltype=[1, 1, 1],
+    k=10.0,
+    k33=5.0,
+    xt3doptions="xt3d rhs",
+    # rewet_record="REWET WETFCT 1.0 IWETIT 1 IHDWET 0",
+)
+# create ic package
+ic_package_2 = flopy.mf6.modflow.mfgwfic.ModflowGwfic(gwf_2, strt=0.0)
+
+# create ghb package
+ghb_spd = {0: [((0, 0, 19), -10.0, 1000.0)]}
+ghb_2 = flopy.mf6.modflow.mfgwfghb.ModflowGwfghb(
+    gwf_2,
+    print_input=True,
+    print_flows=True,
+    pname="ghb-2",
+    maxbound=1,
+    stress_period_data=ghb_spd,
+)
+
+# create lak package
+lakpd = [(0, -2.0, 1)]
+lakecn = [(0, 0, (0, 5, 0), "HORIZONTAL", 1.0, -5.0, 0.0, 10.0, 10.0)]
+lak_2 = flopy.mf6.ModflowGwflak(
+    gwf_2,
+    pname="lak-2",
+    print_input=True,
+    mover=True,
+    nlakes=1,
+    noutlets=0,
+    ntables=0,
+    packagedata=lakpd,
+    connectiondata=lakecn,
+)
+
+# ## Connecting the Flow Models
+# The two groundwater flow models created above are now part of the same
+# simulation, but they are not connected. To connect them we will use the
+# gwfgwf package and two of its subpackages, gnc and mvr.
+
+# Use exchangedata to define how the two models are connected.  In this
+# example we are connecting the right edge of the first model to the left edge
+# of the second model. The second model is 2x the discretization, so each cell
+# in the first model is connected to two cells in the second model.
+
+gwfgwf_data = []
+row_2 = 0
+for row in range(0, nrow):
+    gwfgwf_data.append([(0, ncol - 1, row), (0, 0, row_2), 1, 2.03, 1.01, 2.0])
+    row_2 += 1
+    gwfgwf_data.append([(0, ncol - 1, row), (0, 0, row_2), 1, 2.03, 1.01, 2.0])
+    row_2 += 1
+
+# create the gwfgwf package
+gwfgwf = flopy.mf6.ModflowGwfgwf(
+    sim,
+    exgtype="GWF6-GWF6",
+    nexg=len(gwfgwf_data),
+    exgmnamea=gwf.name,
+    exgmnameb=gwf_2.name,
+    exchangedata=gwfgwf_data,
+    filename="mod1_mod2.gwfgwf",
+)
+
+# Due to the two model's different cell sizes, the cell centers of the first
+# model do not align with the cell centers in the second model. To correct for
+# this we will use the ghost node correction package (gnc).
+
+gnc_data = []
+col_2 = 0
+weight_close = 1.0 / 1.25
+weight_far = 0.25 / 1.25
+for col in range(0, ncol):
+    if col == 0:
+        gnc_data.append(
+            (
+                (0, nrow - 1, col),
+                (0, 0, col_2),
+                (0, nrow - 1, col),
+                (0, nrow - 1, 0),
+                1.00,
+                0.0,
+            )
+        )
+    else:
+        gnc_data.append(
+            (
+                (0, nrow - 1, col),
+                (0, 0, col_2),
+                (0, nrow - 1, col),
+                (0, nrow - 1, col - 1),
+                weight_close,
+                weight_far,
+            )
+        )
+    col_2 += 1
+    if col == ncol - 1:
+        gnc_data.append(
+            (
+                (0, nrow - 1, col),
+                (0, 0, col_2),
+                (0, nrow - 1, col),
+                (0, nrow - 1, 0),
+                1.00,
+                0.0,
+            )
+        )
+    else:
+        gnc_data.append(
+            (
+                (0, nrow - 1, col),
+                (0, 0, col_2),
+                (0, nrow - 1, col),
+                (0, nrow - 1, col + 1),
+                weight_close,
+                weight_far,
+            )
+        )
+    col_2 += 1
+
+# set up gnc package
+fname = "gwfgwf.input.gnc"
+gwfgwf.gnc.initialize(
+    filename=fname,
+    print_input=True,
+    print_flows=True,
+    numgnc=ncol * 2,
+    numalphaj=2,
+    gncdata=gnc_data,
+)
+
+# The extraction well at the right-hand side of the first model is pumping
+# the water it extracts into a nearby lake at the left-hand side of the
+# second model. Using the mover (mvr) package, water extracted from the first
+# model's wel package is moved to the second model's lak package.
+
+package_data = [(gwf.name, "WEL-1"), (gwf_2.name, "lak-2")]
+period_data = [(gwf.name, "WEL-1", 0, gwf_2.name, "lak-2", 0, "FACTOR", 1.0)]
+fname = "gwfgwf.input.mvr"
+gwfgwf.mvr.initialize(
+    filename=fname,
+    modelnames=True,
+    print_input=True,
+    print_flows=True,
+    maxpackages=2,
+    maxmvr=1,
+    packages=package_data,
+    perioddata=period_data,
+)
+
+sim.write_simulation()
+sim.run_simulation()

--- a/flopy/mf6/data/dfn/gwf-gnc.dfn
+++ b/flopy/mf6/data/dfn/gwf-gnc.dfn
@@ -1,4 +1,6 @@
 # --------------------- gwf gnc options ---------------------
+# flopy subpackage gnc_filerecord gnc gncdata gncdata
+# flopy parent_name_type parent_model_or_package
 
 block options
 name print_input

--- a/flopy/mf6/data/dfn/gwf-mvr.dfn
+++ b/flopy/mf6/data/dfn/gwf-mvr.dfn
@@ -1,4 +1,6 @@
 # --------------------- gwf mvr options ---------------------
+# flopy subpackage mvr_filerecord mvr perioddata perioddata
+# flopy parent_name_type parent_model_or_package MFModel/MFPackage
 
 block options
 name print_input

--- a/flopy/mf6/data/dfn/gwt-mvt.dfn
+++ b/flopy/mf6/data/dfn/gwt-mvt.dfn
@@ -1,4 +1,6 @@
 # --------------------- gwt mvt options ---------------------
+# flopy subpackage mvt_filerecord mvt perioddata perioddata
+# flopy parent_name_type parent_model_or_package MFModel/MFPackage
 
 block options
 name print_input

--- a/flopy/mf6/data/dfn/utl-ats.dfn
+++ b/flopy/mf6/data/dfn/utl-ats.dfn
@@ -1,5 +1,6 @@
 # --------------------- sim ats options ---------------------
-
+# flopy subpackage ats_filerecord ats perioddata ats_perioddata
+# flopy parent_name_type parent_package MFPackage
 
 # --------------------- sim ats dimensions ---------------------
 

--- a/flopy/mf6/data/dfn/utl-laktab.dfn
+++ b/flopy/mf6/data/dfn/utl-laktab.dfn
@@ -1,4 +1,5 @@
 # --------------------- gwf laktab dimensions ---------------------
+# flopy multi-package
 
 block dimensions
 name nrow

--- a/flopy/mf6/data/dfn/utl-obs.dfn
+++ b/flopy/mf6/data/dfn/utl-obs.dfn
@@ -1,5 +1,7 @@
 # --------------------- gwf obs options ---------------------
 # flopy multi-package
+# flopy subpackage obs_filerecord obs continuous observations
+# flopy parent_name_type parent_model_or_package MFModel/MFPackage
 
 block options
 name digits

--- a/flopy/mf6/data/dfn/utl-sfrtab.dfn
+++ b/flopy/mf6/data/dfn/utl-sfrtab.dfn
@@ -1,4 +1,5 @@
 # --------------------- gwf sfrtab dimensions ---------------------
+# flopy multi-package
 
 block dimensions
 name nrow

--- a/flopy/mf6/data/dfn/utl-tas.dfn
+++ b/flopy/mf6/data/dfn/utl-tas.dfn
@@ -1,5 +1,7 @@
 # --------------------- gwf ts attributes ---------------------
 # flopy multi-package
+# flopy subpackage tas_filerecord tas tas_array timearrayseries
+# flopy parent_name_type parent_package MFPackage
 
 block attributes
 name time_series_namerecord

--- a/flopy/mf6/data/dfn/utl-ts.dfn
+++ b/flopy/mf6/data/dfn/utl-ts.dfn
@@ -1,5 +1,7 @@
 # --------------------- gwf ts attributes ---------------------
 # flopy multi-package
+# flopy subpackage ts_filerecord ts timeseries timeseries
+# flopy parent_name_type parent_package MFPackage
 
 block attributes
 name time_series_namerecord

--- a/flopy/mf6/data/dfn/utl-tvk.dfn
+++ b/flopy/mf6/data/dfn/utl-tvk.dfn
@@ -1,4 +1,6 @@
 # --------------------- gwf tvk options ---------------------
+# flopy subpackage tvk_filerecord tvk tvk_perioddata perioddata
+# flopy parent_name_type parent_package MFPackage
 
 block options
 name print_input

--- a/flopy/mf6/data/dfn/utl-tvs.dfn
+++ b/flopy/mf6/data/dfn/utl-tvs.dfn
@@ -1,4 +1,6 @@
 # --------------------- gwf tvs options ---------------------
+# flopy subpackage tvs_filerecord tvs tvs_perioddata perioddata
+# flopy parent_name_type parent_package MFPackage
 
 block options
 name disable_storage_change_integration

--- a/flopy/mf6/data/mfdatastorage.py
+++ b/flopy/mf6/data/mfdatastorage.py
@@ -320,6 +320,7 @@ class DataStorage:
         self.in_model = (
             self.data_dimensions is not None
             and len(package_dim.package_path) > 1
+            and package_dim.model_dim[0].model_name is not None
             and package_dim.model_dim[0].model_name.lower()
             == package_dim.package_path[0]
         )

--- a/flopy/mf6/data/mfstructure.py
+++ b/flopy/mf6/data/mfstructure.py
@@ -210,7 +210,6 @@ class DfnPackage(Dfn):
         for item in self.dfn_list[0]:
             if item == "multi-package":
                 header_dict["multi-package"] = True
-
         for dfn_entry in self.dfn_list[1:]:
             # load next data item
             new_data_item_struct = MFDataItemStructure()
@@ -500,7 +499,11 @@ class DfnFile(Dfn):
                 # load flopy data
                 if line_lst[2] == "multi-package":
                     header_dict["multi-package"] = True
-
+                if line_lst[2] == "parent_name_type" and len(line_lst) == 5:
+                    header_dict["parent_name_type"] = [
+                        line_lst[3],
+                        line_lst[4],
+                    ]
         # load file definitions
         for line in dfn_fp:
             if self._valid_line(line):
@@ -2094,6 +2097,15 @@ class MFInputFileStructure:
         )
         self.multi_package_support = "multi-package" in self.header
         self.dfn_list = dfn_file.dfn_list
+        self.sub_package = self._sub_package()
+
+    def _sub_package(self):
+        mfstruct = MFStructure()
+        for value in mfstruct.flopy_dict.values():
+            if value is not None and "construct_package" in value:
+                if self.file_type == value["construct_package"]:
+                    return True
+        return False
 
     def is_valid(self):
         valid = True
@@ -2450,12 +2462,32 @@ class MFStructure:
             mf_dfn = Dfn()
             dfn_files = mf_dfn.get_file_list()
 
-            # load flopy-specific settings
-            self.__load_flopy()
-
             # get common
             common_dfn = DfnFile("common.dfn")
             self.sim_struct.process_dfn(common_dfn)
+
+            # process each file's flopy header
+            for file in dfn_files:
+                dfn_path, tail = os.path.split(os.path.realpath(__file__))
+                dfn_path = os.path.join(dfn_path, "dfn")
+                dfn_file = os.path.join(dfn_path, file)
+                with open(dfn_file, "r") as fd_dfn:
+                    for line in fd_dfn:
+                        if len(line) < 1 or line[0] != "#":
+                            break
+                        line_lst = line.strip().split()
+                        if len(line_lst) > 2 and line_lst[1] == "flopy":
+                            # load flopy data
+                            if (
+                                line_lst[2] == "subpackage"
+                                and len(line_lst) == 7
+                            ):
+                                sp_dict = {
+                                    "construct_package": line_lst[4],
+                                    "construct_data": line_lst[5],
+                                    "parameter_name": line_lst[6],
+                                }
+                                MFStructure().flopy_dict[line_lst[3]] = sp_dict
 
             # process each file
             for file in dfn_files:
@@ -2468,26 +2500,6 @@ class MFStructure:
             self.sim_struct.tag_read_as_arrays()
 
         return True
-
-    def __load_flopy(self):
-        current_variable = None
-        var_info = {}
-        dfn_path, tail = os.path.split(os.path.realpath(__file__))
-        flopy_path = os.path.join(dfn_path, "dfn", "flopy.dfn")
-        dfn_fp = open(flopy_path, "r")
-        for line in dfn_fp:
-            if self.__valid_line(line):
-                lst_line = line.strip().split()
-                if lst_line[0].lower() == "name":
-                    # store current variable
-                    self.flopy_dict[current_variable] = var_info
-                    # reset var_info dict
-                    var_info = {}
-                    current_variable = lst_line[1].lower()
-                else:
-                    var_info[lst_line[0].lower()] = lst_line[1].lower()
-        # store last variable
-        self.flopy_dict[current_variable] = var_info
 
     @staticmethod
     def __valid_line(line):

--- a/flopy/mf6/mfbase.py
+++ b/flopy/mf6/mfbase.py
@@ -285,7 +285,7 @@ class MFFileMgmt:
                 path_lst = path.split(os.path.sep)
                 new_path = ""
                 for i, mrp in enumerate(model_rel_path_lst):
-                    if mrp != path_lst[i]:
+                    if i >= len(path_lst) or mrp != path_lst[i]:
                         new_path = os.path.join(new_path, path_lst[i])
                 for rp in path_lst[len(model_rel_path_lst) :]:
                     new_path = os.path.join(new_path, rp)

--- a/flopy/mf6/mfmodel.py
+++ b/flopy/mf6/mfmodel.py
@@ -1550,7 +1550,14 @@ class MFModel(PackageContainer, ModelInterface):
         for package in self.packagelist:
             if package.package_type not in package_type_count:
                 base_filename, leaf = os.path.split(package.filename)
-                new_fileleaf = f"{name}.{package.package_type}"
+                lleaf = leaf.split(".")
+                if len(lleaf) > 1:
+                    # keep existing extension
+                    ext = lleaf[-1]
+                else:
+                    # no extension found, create a new one
+                    ext = package.package_type
+                new_fileleaf = f"{name}.{ext}"
                 if base_filename != "":
                     package.filename = os.path.join(
                         base_filename, new_fileleaf
@@ -1677,6 +1684,7 @@ class MFModel(PackageContainer, ModelInterface):
         if package.package_type.lower() == "nam":
             return path, self.structure.name_file_struct_obj
 
+        package_extension = package.package_type
         if set_package_name:
             # produce a default package name
             if (
@@ -1688,12 +1696,22 @@ class MFModel(PackageContainer, ModelInterface):
                 for package_name in name_iter:
                     if package_name not in self.package_name_dict:
                         package.package_name = package_name
+                        suffix = package_name.split("_")
+                        if (
+                            len(suffix) > 1
+                            and datautil.DatumUtil.is_int(suffix[-1])
+                            and suffix[-1] != "0"
+                        ):
+                            # update file extension to make unique
+                            package_extension = (
+                                f"{package_extension}_{suffix[-1]}"
+                            )
                         break
             else:
                 package.package_name = package.package_type
 
         if set_package_filename:
-            package._filename = f"{self.name}.{package.package_type}"
+            package._filename = f"{self.name}.{package_extension}"
 
         if add_to_package_list:
             self._add_package(package, path)
@@ -1710,9 +1728,12 @@ class MFModel(PackageContainer, ModelInterface):
                 # recarray
                 file_mgr = self.simulation_data.mfpath
                 model_rel_path = file_mgr.model_relative_path[self.name]
-                package_rel_path = os.path.join(
-                    model_rel_path, package.filename
-                )
+                if model_rel_path != ".":
+                    package_rel_path = os.path.join(
+                        model_rel_path, package.filename
+                    )
+                else:
+                    package_rel_path = package.filename
                 self.name_file.packages.update_record(
                     [
                         f"{pkg_type}6",

--- a/flopy/mf6/mfpackage.py
+++ b/flopy/mf6/mfpackage.py
@@ -15,7 +15,7 @@ from ..version import __version__
 from .coordinates import modeldimensions
 from .data import mfdata, mfdataarray, mfdatalist, mfdatascalar, mfstructure
 from .data.mfdatautil import DataSearchOutput, MFComment, cellids_equal
-from .data.mfstructure import DatumType, MFDataItemStructure
+from .data.mfstructure import DatumType, MFDataItemStructure, MFStructure
 from .mfbase import (
     ExtFileAction,
     FlopyException,
@@ -1180,24 +1180,36 @@ class MFBlock:
                                 dataset.structure.name, self.structure.name
                             ),
                         )
-                    if isinstance(data, np.recarray):
-                        file_location = data[-1][index]
-                    else:
-                        file_location = data
                     package_info_list = []
-                    file_path, file_name = os.path.split(file_location)
-                    dict_package_name = f"{package_type_found}_{self.path[-2]}"
-                    package_info_list.append(
-                        (
-                            package_type_found,
-                            file_name,
-                            file_path,
-                            dict_package_name,
+                    if isinstance(data, np.recarray):
+                        for row in data:
+                            self._add_to_info_list(
+                                package_info_list,
+                                row[index],
+                                package_type_found,
+                            )
+                    else:
+                        self._add_to_info_list(
+                            package_info_list, data, package_type_found
                         )
-                    )
+
                     return package_info_list
                 return None
         return None
+
+    def _add_to_info_list(
+        self, package_info_list, file_location, package_type_found
+    ):
+        file_path, file_name = os.path.split(file_location)
+        dict_package_name = f"{package_type_found}_{self.path[-2]}"
+        package_info_list.append(
+            (
+                package_type_found,
+                file_name,
+                file_path,
+                dict_package_name,
+            )
+        )
 
     def _save_comments(self, arr_line, line, key, comments):
         # FIX: Save these comments somewhere in the data set
@@ -1534,8 +1546,8 @@ class MFPackage(PackageContainer, PackageInterface):
 
     Parameters
     ----------
-    model_or_sim : MFModel of MFSimulation
-        The parent model or simulation containing this package
+    parent : MFModel, MFSimulation, or MFPackage
+        The parent model, simulation, or package containing this package
     package_type : str
         String defining the package type
     filename : str
@@ -1547,8 +1559,6 @@ class MFPackage(PackageContainer, PackageInterface):
     loading_package : bool
         Whether or not to add this package to the parent container's package
         list during initialization
-    parent_file : MFPackage
-        Parent package that contains this package
 
     Attributes
     ----------
@@ -1565,19 +1575,26 @@ class MFPackage(PackageContainer, PackageInterface):
 
     def __init__(
         self,
-        model_or_sim,
+        parent,
         package_type,
         filename=None,
         pname=None,
         loading_package=False,
-        parent_file=None,
+        **kwargs,
     ):
-
-        self.model_or_sim = model_or_sim
+        if isinstance(parent, MFPackage):
+            self.model_or_sim = parent.model_or_sim
+            self.parent_file = parent
+        elif "parent_file" in kwargs:
+            self.model_or_sim = parent
+            self.parent_file = kwargs["parent_file"]
+        else:
+            self.model_or_sim = parent
+            self.parent_file = None
         self._data_list = []
         self._package_type = package_type
-        if model_or_sim.type == "Model" and package_type.lower() != "nam":
-            self.model_name = model_or_sim.name
+        if self.model_or_sim.type == "Model" and package_type.lower() != "nam":
+            self.model_name = self.model_or_sim.name
         else:
             self.model_name = None
 
@@ -1585,11 +1602,14 @@ class MFPackage(PackageContainer, PackageInterface):
         if not hasattr(self, "dfn_file_name"):
             self.dfn_file_name = ""
 
-        if model_or_sim.type != "Model" and model_or_sim.type != "Simulation":
+        if (
+            self.model_or_sim.type != "Model"
+            and self.model_or_sim.type != "Simulation"
+        ):
             message = (
                 "Invalid model_or_sim parameter. Expecting either a "
                 'model or a simulation. Instead type "{}" was '
-                "given.".format(type(model_or_sim))
+                "given.".format(type(self.model_or_sim))
             )
             type_, value_, traceback_ = sys.exc_info()
             raise MFDataException(
@@ -1603,14 +1623,13 @@ class MFPackage(PackageContainer, PackageInterface):
                 value_,
                 traceback_,
                 message,
-                model_or_sim.simulation_data.debug,
+                self.model_or_sim.simulation_data.debug,
             )
 
-        super().__init__(model_or_sim.simulation_data, self.model_name)
+        super().__init__(self.model_or_sim.simulation_data, self.model_name)
 
-        self.parent = model_or_sim
-        self._simulation_data = model_or_sim.simulation_data
-        self.parent_file = parent_file
+        self._simulation_data = self.model_or_sim.simulation_data
+
         self.blocks = {}
         self.container_type = []
         self.loading_package = loading_package
@@ -1633,7 +1652,7 @@ class MFPackage(PackageContainer, PackageInterface):
                     value_,
                     traceback_,
                     message,
-                    model_or_sim.simulation_data.debug,
+                    self.model_or_sim.simulation_data.debug,
                 )
 
             self.package_name = pname.lower()
@@ -1641,7 +1660,7 @@ class MFPackage(PackageContainer, PackageInterface):
             self.package_name = None
 
         if filename is None:
-            if model_or_sim.type == "Simulation":
+            if self.model_or_sim.type == "Simulation":
                 # filename uses simulation base name
                 base_name = os.path.basename(
                     os.path.normpath(self.model_or_sim.name)
@@ -1671,12 +1690,12 @@ class MFPackage(PackageContainer, PackageInterface):
                     value_,
                     traceback_,
                     message,
-                    model_or_sim.simulation_data.debug,
+                    self.model_or_sim.simulation_data.debug,
                 )
             self._filename = MFFileMgmt.string_to_file_path(
                 datautil.clean_filename(filename)
             )
-        self.path, self.structure = model_or_sim.register_package(
+        self.path, self.structure = self.model_or_sim.register_package(
             self, not loading_package, pname is None, filename is None
         )
         self.dimensions = self.create_package_dimensions()
@@ -1690,7 +1709,7 @@ class MFPackage(PackageContainer, PackageInterface):
                     "WARNING: Package type {} failed to register property."
                     " {}".format(self._package_type, self.path)
                 )
-        if parent_file is not None:
+        if self.parent_file is not None:
             self.container_type.append(PackageContainerType.package)
         # init variables that may be used later
         self.post_block_comments = None
@@ -1698,6 +1717,14 @@ class MFPackage(PackageContainer, PackageInterface):
         self.bc_color = "black"
         self.__inattr = False
         self._child_package_groups = {}
+        if (
+            self.parent_file is not None
+            and "child_builder_call" not in kwargs
+            and package_type in self.parent_file._child_package_groups
+        ):
+            # initialize as part of the parent's child package group
+            chld_pkg_grp = self.parent_file._child_package_groups[package_type]
+            chld_pkg_grp.init_package(self, self._filename)
 
     def __init_subclass__(cls):
         """Register package type"""
@@ -1754,8 +1781,7 @@ class MFPackage(PackageContainer, PackageInterface):
         """Package's file name."""
         if (
             isinstance(self.parent_file, MFPackage)
-            and self.structure.file_type
-            in self.parent_file._child_package_groups
+            and self.package_type in self.parent_file._child_package_groups
         ):
             fname = datautil.clean_filename(fname)
             try:
@@ -1791,12 +1817,12 @@ class MFPackage(PackageContainer, PackageInterface):
     @property
     def parent(self):
         """Parent package"""
-        return self._parent
+        return self.model_or_sim
 
     @parent.setter
     def parent(self, parent):
         """Parent package"""
-        self._parent = parent
+        assert False, "Do not use this setter to set the parent"
 
     @property
     def plottable(self):
@@ -1822,6 +1848,15 @@ class MFPackage(PackageContainer, PackageInterface):
         """List of data in this package."""
         # return [data_object, data_object, ...]
         return self._data_list
+
+    def _add_package(self, package, path):
+        pkg_type = package.package_type.lower()
+        if pkg_type in self.package_type_dict:
+            for existing_pkg in self.package_type_dict[pkg_type]:
+                if existing_pkg is package:
+                    # do not add the same package twice
+                    return
+        super()._add_package(package, path)
 
     def check(self, f=None, verbose=True, level=1, checktype=None):
         """Data check, returns True on success."""
@@ -2232,6 +2267,17 @@ class MFPackage(PackageContainer, PackageInterface):
         # create child package object
         child_pkgs_name = f"utl{pkg_type}packages"
         child_pkgs_obj = self.package_factory(child_pkgs_name, "")
+        if child_pkgs_obj is None and self.model_or_sim.model_type is None:
+            # simulation level object, try just the package type in the name
+            child_pkgs_name = f"{pkg_type}packages"
+            child_pkgs_obj = self.package_factory(child_pkgs_name, "")
+        if child_pkgs_obj is None:
+            # see if the package is part of one of the supported model types
+            for model_type in MFStructure().sim_struct.model_types:
+                child_pkgs_name = f"{model_type}{pkg_type}packages"
+                child_pkgs_obj = self.package_factory(child_pkgs_name, "")
+                if child_pkgs_obj is not None:
+                    break
         child_pkgs = child_pkgs_obj(
             self.model_or_sim, self, pkg_type, filerecord, None, package_obj
         )
@@ -2252,7 +2298,7 @@ class MFPackage(PackageContainer, PackageInterface):
                 pkg_type, self.model_or_sim.model_type
             )
             package = package_obj(
-                self.model_or_sim, filename=child_path, parent_file=self
+                self, filename=child_path, child_builder_call=True
             )
             assert hasattr(package, parameter_name)
 
@@ -2281,7 +2327,7 @@ class MFPackage(PackageContainer, PackageInterface):
                 setattr(package, parameter_name, data)
 
             # append package to list
-            package_group._init_package(package, child_path)
+            package_group.init_package(package, child_path)
 
     def build_mfdata(self, var_name, data=None):
         """Returns the appropriate data type object (mfdatalist, mfdataarray,
@@ -2733,16 +2779,9 @@ class MFPackage(PackageContainer, PackageInterface):
                 and self.model_or_sim.type == "Simulation"
             ):
                 # get exchange file name associated with gnc package
-                exg_file_name = None
-                for exg in self.model_or_sim.exchange_files:
-                    gnc_data = exg.gnc_filerecord.get_data()
-                    if (
-                        gnc_data is not None
-                        and gnc_data[0][0].lower() == self.filename.lower()
-                    ):
-                        exg_file_name = exg.filename
-                        self.parent = exg
-                if exg_file_name is None:
+                if self.parent_file is not None:
+                    exg_file_name = self.parent_file.filename
+                else:
                     raise Exception(
                         "Can not create a simulation-level "
                         "gnc file without a corresponding "
@@ -2945,7 +2984,7 @@ class MFChildPackages:
 
     def __init__(
         self,
-        model,
+        model_or_sim,
         parent,
         pkg_type,
         filerecord,
@@ -2956,7 +2995,7 @@ class MFChildPackages:
         self._filerecord = filerecord
         if package is not None:
             self._packages.append(package)
-        self._model = model
+        self._model_or_sim = model_or_sim
         self._cpparent = parent
         self._pkg_type = pkg_type
         self._package_class = package_class
@@ -2986,7 +3025,7 @@ class MFChildPackages:
     def __setattr__(self, key, value):
         if (
             key != "_packages"
-            and key != "_model"
+            and key != "_model_or_sim"
             and key != "_cpparent"
             and key != "_inattr"
             and key != "_filerecord"
@@ -3036,7 +3075,7 @@ class MFChildPackages:
             suffix += 1
         return possible_path
 
-    def _init_package(self, package, fname):
+    def init_package(self, package, fname):
         # clear out existing packages
         self._remove_packages()
         if fname is None:
@@ -3084,10 +3123,14 @@ class MFChildPackages:
             new_file_record_data.append((fname,))
             self._filerecord.set_data(new_file_record_data)
 
+        for existing_pkg in self._packages:
+            if existing_pkg is package:
+                # do not add the same package twice
+                return
         # add the package to the list
         self._packages.append(package)
 
     def _remove_packages(self):
         for package in self._packages:
-            self._model.remove_package(package)
+            self._model_or_sim.remove_package(package)
         self._packages = []

--- a/flopy/mf6/mfpackage.py
+++ b/flopy/mf6/mfpackage.py
@@ -2328,6 +2328,7 @@ class MFPackage(PackageContainer, PackageInterface):
 
             # append package to list
             package_group.init_package(package, child_path)
+            return package
 
     def build_mfdata(self, var_name, data=None):
         """Returns the appropriate data type object (mfdatalist, mfdataarray,

--- a/flopy/mf6/modflow/mfgnc.py
+++ b/flopy/mf6/modflow/mfgnc.py
@@ -104,7 +104,9 @@ class ModflowGnc(mfpackage.MFPackage):
     dfn_file_name = "gwf-gnc.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name print_input",

--- a/flopy/mf6/modflow/mfgnc.py
+++ b/flopy/mf6/modflow/mfgnc.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -104,9 +104,7 @@ class ModflowGnc(mfpackage.MFPackage):
     dfn_file_name = "gwf-gnc.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name print_input",
@@ -203,7 +201,7 @@ class ModflowGnc(mfpackage.MFPackage):
         gncdata=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             simulation, "gnc", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgnc.py
+++ b/flopy/mf6/modflow/mfgnc.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -203,10 +203,10 @@ class ModflowGnc(mfpackage.MFPackage):
         gncdata=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            simulation, "gnc", filename, pname, loading_package, parent_file
+            simulation, "gnc", filename, pname, loading_package, **kwargs
         )
 
         # set up variables
@@ -217,3 +217,71 @@ class ModflowGnc(mfpackage.MFPackage):
         self.numalphaj = self.build_mfdata("numalphaj", numalphaj)
         self.gncdata = self.build_mfdata("gncdata", gncdata)
         self._init_complete = True
+
+
+class GncPackages(mfpackage.MFChildPackages):
+    """
+    GncPackages is a container class for the ModflowGnc class.
+
+    Methods
+    ----------
+    initialize
+        Initializes a new ModflowGnc package removing any sibling child
+        packages attached to the same parent package. See ModflowGnc init
+        documentation for definition of parameters.
+    append_package
+        Adds a new ModflowGwfgnc package to the container. See ModflowGwfgnc
+        init documentation for definition of parameters.
+    """
+
+    package_abbr = "gncpackages"
+
+    def initialize(
+        self,
+        print_input=None,
+        print_flows=None,
+        explicit=None,
+        numgnc=None,
+        numalphaj=None,
+        gncdata=None,
+        filename=None,
+        pname=None,
+    ):
+        new_package = ModflowGnc(
+            self._cpparent,
+            print_input=print_input,
+            print_flows=print_flows,
+            explicit=explicit,
+            numgnc=numgnc,
+            numalphaj=numalphaj,
+            gncdata=gncdata,
+            filename=filename,
+            pname=pname,
+            child_builder_call=True,
+        )
+        self.init_package(new_package, filename)
+
+    def append_package(
+        self,
+        print_input=None,
+        print_flows=None,
+        explicit=None,
+        numgnc=None,
+        numalphaj=None,
+        gncdata=None,
+        filename=None,
+        pname=None,
+    ):
+        new_package = ModflowGwfgnc(
+            self._cpparent,
+            print_input=print_input,
+            print_flows=print_flows,
+            explicit=explicit,
+            numgnc=numgnc,
+            numalphaj=numalphaj,
+            gncdata=gncdata,
+            filename=filename,
+            pname=pname,
+            child_builder_call=True,
+        )
+        self._append_package(new_package, filename)

--- a/flopy/mf6/modflow/mfgwf.py
+++ b/flopy/mf6/modflow/mfgwf.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfmodel
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 

--- a/flopy/mf6/modflow/mfgwf.py
+++ b/flopy/mf6/modflow/mfgwf.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfmodel
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 

--- a/flopy/mf6/modflow/mfgwfapi.py
+++ b/flopy/mf6/modflow/mfgwfapi.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwfapi(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -172,10 +172,10 @@ class ModflowGwfapi(mfpackage.MFPackage):
         maxbound=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "api", filename, pname, loading_package, parent_file
+            model, "api", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwfapi.py
+++ b/flopy/mf6/modflow/mfgwfapi.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -68,9 +68,7 @@ class ModflowGwfapi(mfpackage.MFPackage):
     dfn_file_name = "gwf-api.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name boundnames",
@@ -172,7 +170,7 @@ class ModflowGwfapi(mfpackage.MFPackage):
         maxbound=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "api", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwfapi.py
+++ b/flopy/mf6/modflow/mfgwfapi.py
@@ -68,7 +68,9 @@ class ModflowGwfapi(mfpackage.MFPackage):
     dfn_file_name = "gwf-api.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name boundnames",

--- a/flopy/mf6/modflow/mfgwfbuy.py
+++ b/flopy/mf6/modflow/mfgwfbuy.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -96,9 +96,7 @@ class ModflowGwfbuy(mfpackage.MFPackage):
     dfn_file_name = "gwf-buy.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name hhformulation_rhs",
@@ -235,7 +233,7 @@ class ModflowGwfbuy(mfpackage.MFPackage):
         packagedata=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "buy", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwfbuy.py
+++ b/flopy/mf6/modflow/mfgwfbuy.py
@@ -96,7 +96,9 @@ class ModflowGwfbuy(mfpackage.MFPackage):
     dfn_file_name = "gwf-buy.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name hhformulation_rhs",

--- a/flopy/mf6/modflow/mfgwfbuy.py
+++ b/flopy/mf6/modflow/mfgwfbuy.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwfbuy(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -235,10 +235,10 @@ class ModflowGwfbuy(mfpackage.MFPackage):
         packagedata=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "buy", filename, pname, loading_package, parent_file
+            model, "buy", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwfchd.py
+++ b/flopy/mf6/modflow/mfgwfchd.py
@@ -117,7 +117,10 @@ class ModflowGwfchd(mfpackage.MFPackage):
     dfn_file_name = "gwf-chd.dfn"
 
     dfn = [
-        ["header", "multi-package",],
+        [
+            "header",
+            "multi-package",
+        ],
         [
             "block options",
             "name auxiliary",

--- a/flopy/mf6/modflow/mfgwfchd.py
+++ b/flopy/mf6/modflow/mfgwfchd.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -117,10 +117,7 @@ class ModflowGwfchd(mfpackage.MFPackage):
     dfn_file_name = "gwf-chd.dfn"
 
     dfn = [
-        [
-            "header",
-            "multi-package",
-        ],
+        ["header", "multi-package",],
         [
             "block options",
             "name auxiliary",
@@ -324,7 +321,7 @@ class ModflowGwfchd(mfpackage.MFPackage):
         stress_period_data=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "chd", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwfchd.py
+++ b/flopy/mf6/modflow/mfgwfchd.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwfchd(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -324,10 +324,10 @@ class ModflowGwfchd(mfpackage.MFPackage):
         stress_period_data=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "chd", filename, pname, loading_package, parent_file
+            model, "chd", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwfcsub.py
+++ b/flopy/mf6/modflow/mfgwfcsub.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwfcsub(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -1039,10 +1039,10 @@ class ModflowGwfcsub(mfpackage.MFPackage):
         stress_period_data=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "csub", filename, pname, loading_package, parent_file
+            model, "csub", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwfcsub.py
+++ b/flopy/mf6/modflow/mfgwfcsub.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -322,9 +322,7 @@ class ModflowGwfcsub(mfpackage.MFPackage):
     dfn_file_name = "gwf-csub.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name boundnames",
@@ -1039,7 +1037,7 @@ class ModflowGwfcsub(mfpackage.MFPackage):
         stress_period_data=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "csub", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwfcsub.py
+++ b/flopy/mf6/modflow/mfgwfcsub.py
@@ -322,7 +322,9 @@ class ModflowGwfcsub(mfpackage.MFPackage):
     dfn_file_name = "gwf-csub.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name boundnames",

--- a/flopy/mf6/modflow/mfgwfdis.py
+++ b/flopy/mf6/modflow/mfgwfdis.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator
 
@@ -90,9 +90,7 @@ class ModflowGwfdis(mfpackage.MFPackage):
     dfn_file_name = "gwf-dis.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name length_units",
@@ -215,7 +213,7 @@ class ModflowGwfdis(mfpackage.MFPackage):
         idomain=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "dis", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwfdis.py
+++ b/flopy/mf6/modflow/mfgwfdis.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwfdis(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -215,10 +215,10 @@ class ModflowGwfdis(mfpackage.MFPackage):
         idomain=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "dis", filename, pname, loading_package, parent_file
+            model, "dis", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwfdis.py
+++ b/flopy/mf6/modflow/mfgwfdis.py
@@ -90,7 +90,9 @@ class ModflowGwfdis(mfpackage.MFPackage):
     dfn_file_name = "gwf-dis.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name length_units",

--- a/flopy/mf6/modflow/mfgwfdisu.py
+++ b/flopy/mf6/modflow/mfgwfdisu.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwfdisu(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -470,10 +470,10 @@ class ModflowGwfdisu(mfpackage.MFPackage):
         cell2d=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "disu", filename, pname, loading_package, parent_file
+            model, "disu", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwfdisu.py
+++ b/flopy/mf6/modflow/mfgwfdisu.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -205,9 +205,7 @@ class ModflowGwfdisu(mfpackage.MFPackage):
     dfn_file_name = "gwf-disu.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name length_units",
@@ -470,7 +468,7 @@ class ModflowGwfdisu(mfpackage.MFPackage):
         cell2d=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "disu", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwfdisu.py
+++ b/flopy/mf6/modflow/mfgwfdisu.py
@@ -205,7 +205,9 @@ class ModflowGwfdisu(mfpackage.MFPackage):
     dfn_file_name = "gwf-disu.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name length_units",

--- a/flopy/mf6/modflow/mfgwfdisv.py
+++ b/flopy/mf6/modflow/mfgwfdisv.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -118,9 +118,7 @@ class ModflowGwfdisv(mfpackage.MFPackage):
     dfn_file_name = "gwf-disv.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name length_units",
@@ -312,7 +310,7 @@ class ModflowGwfdisv(mfpackage.MFPackage):
         cell2d=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "disv", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwfdisv.py
+++ b/flopy/mf6/modflow/mfgwfdisv.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwfdisv(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -312,10 +312,10 @@ class ModflowGwfdisv(mfpackage.MFPackage):
         cell2d=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "disv", filename, pname, loading_package, parent_file
+            model, "disv", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwfdisv.py
+++ b/flopy/mf6/modflow/mfgwfdisv.py
@@ -118,7 +118,9 @@ class ModflowGwfdisv(mfpackage.MFPackage):
     dfn_file_name = "gwf-disv.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name length_units",

--- a/flopy/mf6/modflow/mfgwfdrn.py
+++ b/flopy/mf6/modflow/mfgwfdrn.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwfdrn(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -374,10 +374,10 @@ class ModflowGwfdrn(mfpackage.MFPackage):
         stress_period_data=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "drn", filename, pname, loading_package, parent_file
+            model, "drn", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwfdrn.py
+++ b/flopy/mf6/modflow/mfgwfdrn.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -139,10 +139,7 @@ class ModflowGwfdrn(mfpackage.MFPackage):
     dfn_file_name = "gwf-drn.dfn"
 
     dfn = [
-        [
-            "header",
-            "multi-package",
-        ],
+        ["header", "multi-package",],
         [
             "block options",
             "name auxiliary",
@@ -374,7 +371,7 @@ class ModflowGwfdrn(mfpackage.MFPackage):
         stress_period_data=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "drn", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwfdrn.py
+++ b/flopy/mf6/modflow/mfgwfdrn.py
@@ -139,7 +139,10 @@ class ModflowGwfdrn(mfpackage.MFPackage):
     dfn_file_name = "gwf-drn.dfn"
 
     dfn = [
-        ["header", "multi-package",],
+        [
+            "header",
+            "multi-package",
+        ],
         [
             "block options",
             "name auxiliary",

--- a/flopy/mf6/modflow/mfgwfevt.py
+++ b/flopy/mf6/modflow/mfgwfevt.py
@@ -157,7 +157,10 @@ class ModflowGwfevt(mfpackage.MFPackage):
     dfn_file_name = "gwf-evt.dfn"
 
     dfn = [
-        ["header", "multi-package",],
+        [
+            "header",
+            "multi-package",
+        ],
         [
             "block options",
             "name fixed_cell",

--- a/flopy/mf6/modflow/mfgwfevt.py
+++ b/flopy/mf6/modflow/mfgwfevt.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -157,10 +157,7 @@ class ModflowGwfevt(mfpackage.MFPackage):
     dfn_file_name = "gwf-evt.dfn"
 
     dfn = [
-        [
-            "header",
-            "multi-package",
-        ],
+        ["header", "multi-package",],
         [
             "block options",
             "name fixed_cell",
@@ -441,7 +438,7 @@ class ModflowGwfevt(mfpackage.MFPackage):
         stress_period_data=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "evt", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwfevt.py
+++ b/flopy/mf6/modflow/mfgwfevt.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwfevt(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -441,10 +441,10 @@ class ModflowGwfevt(mfpackage.MFPackage):
         stress_period_data=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "evt", filename, pname, loading_package, parent_file
+            model, "evt", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwfevta.py
+++ b/flopy/mf6/modflow/mfgwfevta.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwfevta(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -324,10 +324,10 @@ class ModflowGwfevta(mfpackage.MFPackage):
         aux=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "evta", filename, pname, loading_package, parent_file
+            model, "evta", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwfevta.py
+++ b/flopy/mf6/modflow/mfgwfevta.py
@@ -118,7 +118,10 @@ class ModflowGwfevta(mfpackage.MFPackage):
     dfn_file_name = "gwf-evta.dfn"
 
     dfn = [
-        ["header", "multi-package",],
+        [
+            "header",
+            "multi-package",
+        ],
         [
             "block options",
             "name readasarrays",

--- a/flopy/mf6/modflow/mfgwfevta.py
+++ b/flopy/mf6/modflow/mfgwfevta.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -118,10 +118,7 @@ class ModflowGwfevta(mfpackage.MFPackage):
     dfn_file_name = "gwf-evta.dfn"
 
     dfn = [
-        [
-            "header",
-            "multi-package",
-        ],
+        ["header", "multi-package",],
         [
             "block options",
             "name readasarrays",
@@ -324,7 +321,7 @@ class ModflowGwfevta(mfpackage.MFPackage):
         aux=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "evta", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwfghb.py
+++ b/flopy/mf6/modflow/mfgwfghb.py
@@ -128,7 +128,10 @@ class ModflowGwfghb(mfpackage.MFPackage):
     dfn_file_name = "gwf-ghb.dfn"
 
     dfn = [
-        ["header", "multi-package",],
+        [
+            "header",
+            "multi-package",
+        ],
         [
             "block options",
             "name auxiliary",

--- a/flopy/mf6/modflow/mfgwfghb.py
+++ b/flopy/mf6/modflow/mfgwfghb.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -128,10 +128,7 @@ class ModflowGwfghb(mfpackage.MFPackage):
     dfn_file_name = "gwf-ghb.dfn"
 
     dfn = [
-        [
-            "header",
-            "multi-package",
-        ],
+        ["header", "multi-package",],
         [
             "block options",
             "name auxiliary",
@@ -354,7 +351,7 @@ class ModflowGwfghb(mfpackage.MFPackage):
         stress_period_data=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "ghb", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwfghb.py
+++ b/flopy/mf6/modflow/mfgwfghb.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwfghb(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -354,10 +354,10 @@ class ModflowGwfghb(mfpackage.MFPackage):
         stress_period_data=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "ghb", filename, pname, loading_package, parent_file
+            model, "ghb", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwfgnc.py
+++ b/flopy/mf6/modflow/mfgwfgnc.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwfgnc(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -203,10 +203,10 @@ class ModflowGwfgnc(mfpackage.MFPackage):
         gncdata=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "gnc", filename, pname, loading_package, parent_file
+            model, "gnc", filename, pname, loading_package, **kwargs
         )
 
         # set up variables
@@ -217,3 +217,71 @@ class ModflowGwfgnc(mfpackage.MFPackage):
         self.numalphaj = self.build_mfdata("numalphaj", numalphaj)
         self.gncdata = self.build_mfdata("gncdata", gncdata)
         self._init_complete = True
+
+
+class GwfgncPackages(mfpackage.MFChildPackages):
+    """
+    GwfgncPackages is a container class for the ModflowGwfgnc class.
+
+    Methods
+    ----------
+    initialize
+        Initializes a new ModflowGwfgnc package removing any sibling child
+        packages attached to the same parent package. See ModflowGwfgnc init
+        documentation for definition of parameters.
+    append_package
+        Adds a new ModflowGwfgnc package to the container. See ModflowGwfgnc
+        init documentation for definition of parameters.
+    """
+
+    package_abbr = "gwfgncpackages"
+
+    def initialize(
+        self,
+        print_input=None,
+        print_flows=None,
+        explicit=None,
+        numgnc=None,
+        numalphaj=None,
+        gncdata=None,
+        filename=None,
+        pname=None,
+    ):
+        new_package = ModflowGwfgnc(
+            self._cpparent,
+            print_input=print_input,
+            print_flows=print_flows,
+            explicit=explicit,
+            numgnc=numgnc,
+            numalphaj=numalphaj,
+            gncdata=gncdata,
+            filename=filename,
+            pname=pname,
+            child_builder_call=True,
+        )
+        self.init_package(new_package, filename)
+
+    def append_package(
+        self,
+        print_input=None,
+        print_flows=None,
+        explicit=None,
+        numgnc=None,
+        numalphaj=None,
+        gncdata=None,
+        filename=None,
+        pname=None,
+    ):
+        new_package = ModflowGwfgnc(
+            self._cpparent,
+            print_input=print_input,
+            print_flows=print_flows,
+            explicit=explicit,
+            numgnc=numgnc,
+            numalphaj=numalphaj,
+            gncdata=gncdata,
+            filename=filename,
+            pname=pname,
+            child_builder_call=True,
+        )
+        self._append_package(new_package, filename)

--- a/flopy/mf6/modflow/mfgwfgnc.py
+++ b/flopy/mf6/modflow/mfgwfgnc.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -104,9 +104,7 @@ class ModflowGwfgnc(mfpackage.MFPackage):
     dfn_file_name = "gwf-gnc.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name print_input",
@@ -203,7 +201,7 @@ class ModflowGwfgnc(mfpackage.MFPackage):
         gncdata=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "gnc", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwfgnc.py
+++ b/flopy/mf6/modflow/mfgwfgnc.py
@@ -104,7 +104,9 @@ class ModflowGwfgnc(mfpackage.MFPackage):
     dfn_file_name = "gwf-gnc.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name print_input",

--- a/flopy/mf6/modflow/mfgwfgwf.py
+++ b/flopy/mf6/modflow/mfgwfgwf.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -170,10 +170,7 @@ class ModflowGwfgwf(mfpackage.MFPackage):
     dfn_file_name = "exg-gwfgwf.dfn"
 
     dfn = [
-        [
-            "header",
-            "multi-package",
-        ],
+        ["header", "multi-package",],
         [
             "block options",
             "name auxiliary",
@@ -484,7 +481,7 @@ class ModflowGwfgwf(mfpackage.MFPackage):
         exchangedata=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             simulation, "gwfgwf", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwfgwf.py
+++ b/flopy/mf6/modflow/mfgwfgwf.py
@@ -170,7 +170,10 @@ class ModflowGwfgwf(mfpackage.MFPackage):
     dfn_file_name = "exg-gwfgwf.dfn"
 
     dfn = [
-        ["header", "multi-package",],
+        [
+            "header",
+            "multi-package",
+        ],
         [
             "block options",
             "name auxiliary",

--- a/flopy/mf6/modflow/mfgwfgwf.py
+++ b/flopy/mf6/modflow/mfgwfgwf.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -77,27 +77,16 @@ class ModflowGwfgwf(mfpackage.MFPackage):
     xt3d : boolean
         * xt3d (boolean) keyword that activates the XT3D formulation between
           the cells connected with this GWF-GWF Exchange.
-    gnc_filerecord : [gnc6_filename]
-        * gnc6_filename (string) is the file name for ghost node correction
-          input file. Information for the ghost nodes are provided in the file
-          provided with these keywords. The format for specifying the ghost
-          nodes is the same as described for the GNC Package of the GWF Model.
-          This includes specifying OPTIONS, DIMENSIONS, and GNCDATA blocks. The
-          order of the ghost nodes must follow the same order as the order of
-          the cells in the EXCHANGEDATA block. For the GNCDATA, noden and all
-          of the nodej values are assumed to be located in model 1, and nodem
-          is assumed to be in model 2.
-    mvr_filerecord : [mvr6_filename]
-        * mvr6_filename (string) is the file name of the water mover input file
-          to apply to this exchange. Information for the water mover are
-          provided in the file provided with these keywords. The format for
-          specifying the water mover information is the same as described for
-          the Water Mover (MVR) Package of the GWF Model, with two exceptions.
-          First, in the PACKAGES block, the model name must be included as a
-          separate string before each package. Second, the appropriate model
-          name must be included before package name 1 and package name 2 in the
-          BEGIN PERIOD block. This allows providers and receivers to be located
-          in both models listed as part of this exchange.
+    gncdata : {varname:data} or gncdata data
+        * Contains data for the gnc package. Data can be stored in a dictionary
+          containing data for the gnc package with variable names as keys and
+          package data as values. Data just for the gncdata variable is also
+          acceptable. See gnc package documentation for more information.
+    perioddata : {varname:data} or perioddata data
+        * Contains data for the mvr package. Data can be stored in a dictionary
+          containing data for the mvr package with variable names as keys and
+          package data as values. Data just for the perioddata variable is also
+          acceptable. See mvr package documentation for more information.
     observations : {varname:data} or continuous data
         * Contains data for the obs package. Data can be stored in a dictionary
           containing data for the obs package with variable names as keys and
@@ -274,6 +263,9 @@ class ModflowGwfgwf(mfpackage.MFPackage):
             "reader urword",
             "tagged true",
             "optional true",
+            "construct_package gnc",
+            "construct_data gncdata",
+            "parameter_name gncdata",
         ],
         [
             "block options",
@@ -313,6 +305,9 @@ class ModflowGwfgwf(mfpackage.MFPackage):
             "reader urword",
             "tagged true",
             "optional true",
+            "construct_package mvr",
+            "construct_data perioddata",
+            "parameter_name perioddata",
         ],
         [
             "block options",
@@ -481,18 +476,18 @@ class ModflowGwfgwf(mfpackage.MFPackage):
         cvoptions=None,
         newton=None,
         xt3d=None,
-        gnc_filerecord=None,
-        mvr_filerecord=None,
+        gncdata=None,
+        perioddata=None,
         observations=None,
         dev_interfacemodel_on=None,
         nexg=None,
         exchangedata=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            simulation, "gwfgwf", filename, pname, loading_package, parent_file
+            simulation, "gwfgwf", filename, pname, loading_package, **kwargs
         )
 
         # set up variables
@@ -515,11 +510,13 @@ class ModflowGwfgwf(mfpackage.MFPackage):
         self.cvoptions = self.build_mfdata("cvoptions", cvoptions)
         self.newton = self.build_mfdata("newton", newton)
         self.xt3d = self.build_mfdata("xt3d", xt3d)
-        self.gnc_filerecord = self.build_mfdata(
-            "gnc_filerecord", gnc_filerecord
+        self._gnc_filerecord = self.build_mfdata("gnc_filerecord", None)
+        self._gnc_package = self.build_child_package(
+            "gnc", gncdata, "gncdata", self._gnc_filerecord
         )
-        self.mvr_filerecord = self.build_mfdata(
-            "mvr_filerecord", mvr_filerecord
+        self._mvr_filerecord = self.build_mfdata("mvr_filerecord", None)
+        self._mvr_package = self.build_child_package(
+            "mvr", perioddata, "perioddata", self._mvr_filerecord
         )
         self._obs_filerecord = self.build_mfdata("obs_filerecord", None)
         self._obs_package = self.build_child_package(

--- a/flopy/mf6/modflow/mfgwfgwt.py
+++ b/flopy/mf6/modflow/mfgwfgwt.py
@@ -38,7 +38,9 @@ class ModflowGwfgwt(mfpackage.MFPackage):
     dfn_file_name = "exg-gwfgwt.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
     ]
 
     def __init__(

--- a/flopy/mf6/modflow/mfgwfgwt.py
+++ b/flopy/mf6/modflow/mfgwfgwt.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 
 
@@ -52,10 +52,10 @@ class ModflowGwfgwt(mfpackage.MFPackage):
         exgmnameb=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            simulation, "gwfgwt", filename, pname, loading_package, parent_file
+            simulation, "gwfgwt", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwfgwt.py
+++ b/flopy/mf6/modflow/mfgwfgwt.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 
 
@@ -38,9 +38,7 @@ class ModflowGwfgwt(mfpackage.MFPackage):
     dfn_file_name = "exg-gwfgwt.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
     ]
 
     def __init__(
@@ -52,7 +50,7 @@ class ModflowGwfgwt(mfpackage.MFPackage):
         exgmnameb=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             simulation, "gwfgwt", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwfhfb.py
+++ b/flopy/mf6/modflow/mfgwfhfb.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -74,9 +74,7 @@ class ModflowGwfhfb(mfpackage.MFPackage):
     dfn_file_name = "gwf-hfb.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name print_input",
@@ -148,7 +146,7 @@ class ModflowGwfhfb(mfpackage.MFPackage):
         stress_period_data=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "hfb", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwfhfb.py
+++ b/flopy/mf6/modflow/mfgwfhfb.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwfhfb(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -148,10 +148,10 @@ class ModflowGwfhfb(mfpackage.MFPackage):
         stress_period_data=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "hfb", filename, pname, loading_package, parent_file
+            model, "hfb", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwfhfb.py
+++ b/flopy/mf6/modflow/mfgwfhfb.py
@@ -74,7 +74,9 @@ class ModflowGwfhfb(mfpackage.MFPackage):
     dfn_file_name = "gwf-hfb.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name print_input",

--- a/flopy/mf6/modflow/mfgwfic.py
+++ b/flopy/mf6/modflow/mfgwfic.py
@@ -45,7 +45,9 @@ class ModflowGwfic(mfpackage.MFPackage):
     dfn_file_name = "gwf-ic.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block griddata",
             "name strt",

--- a/flopy/mf6/modflow/mfgwfic.py
+++ b/flopy/mf6/modflow/mfgwfic.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwfic(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -66,10 +66,10 @@ class ModflowGwfic(mfpackage.MFPackage):
         strt=1.0,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "ic", filename, pname, loading_package, parent_file
+            model, "ic", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwfic.py
+++ b/flopy/mf6/modflow/mfgwfic.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator
 
@@ -45,9 +45,7 @@ class ModflowGwfic(mfpackage.MFPackage):
     dfn_file_name = "gwf-ic.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block griddata",
             "name strt",
@@ -66,7 +64,7 @@ class ModflowGwfic(mfpackage.MFPackage):
         strt=1.0,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "ic", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwflak.py
+++ b/flopy/mf6/modflow/mfgwflak.py
@@ -451,7 +451,10 @@ class ModflowGwflak(mfpackage.MFPackage):
     dfn_file_name = "gwf-lak.dfn"
 
     dfn = [
-        ["header", "multi-package",],
+        [
+            "header",
+            "multi-package",
+        ],
         [
             "block options",
             "name auxiliary",

--- a/flopy/mf6/modflow/mfgwflak.py
+++ b/flopy/mf6/modflow/mfgwflak.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -451,10 +451,7 @@ class ModflowGwflak(mfpackage.MFPackage):
     dfn_file_name = "gwf-lak.dfn"
 
     dfn = [
-        [
-            "header",
-            "multi-package",
-        ],
+        ["header", "multi-package",],
         [
             "block options",
             "name auxiliary",
@@ -1260,7 +1257,7 @@ class ModflowGwflak(mfpackage.MFPackage):
         perioddata=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "lak", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwflak.py
+++ b/flopy/mf6/modflow/mfgwflak.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwflak(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -1260,10 +1260,10 @@ class ModflowGwflak(mfpackage.MFPackage):
         perioddata=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "lak", filename, pname, loading_package, parent_file
+            model, "lak", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwfmaw.py
+++ b/flopy/mf6/modflow/mfgwfmaw.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwfmaw(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -1071,10 +1071,10 @@ class ModflowGwfmaw(mfpackage.MFPackage):
         perioddata=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "maw", filename, pname, loading_package, parent_file
+            model, "maw", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwfmaw.py
+++ b/flopy/mf6/modflow/mfgwfmaw.py
@@ -387,7 +387,10 @@ class ModflowGwfmaw(mfpackage.MFPackage):
     dfn_file_name = "gwf-maw.dfn"
 
     dfn = [
-        ["header", "multi-package",],
+        [
+            "header",
+            "multi-package",
+        ],
         [
             "block options",
             "name auxiliary",

--- a/flopy/mf6/modflow/mfgwfmaw.py
+++ b/flopy/mf6/modflow/mfgwfmaw.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -387,10 +387,7 @@ class ModflowGwfmaw(mfpackage.MFPackage):
     dfn_file_name = "gwf-maw.dfn"
 
     dfn = [
-        [
-            "header",
-            "multi-package",
-        ],
+        ["header", "multi-package",],
         [
             "block options",
             "name auxiliary",
@@ -1071,7 +1068,7 @@ class ModflowGwfmaw(mfpackage.MFPackage):
         perioddata=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "maw", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwfmvr.py
+++ b/flopy/mf6/modflow/mfgwfmvr.py
@@ -125,7 +125,9 @@ class ModflowGwfmvr(mfpackage.MFPackage):
     dfn_file_name = "gwf-mvr.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name print_input",

--- a/flopy/mf6/modflow/mfgwfmvr.py
+++ b/flopy/mf6/modflow/mfgwfmvr.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -13,9 +13,9 @@ class ModflowGwfmvr(mfpackage.MFPackage):
 
     Parameters
     ----------
-    model : MFModel
-        Model that this package is a part of.  Package is automatically
-        added to model when it is initialized.
+    parent_model_or_package : MFModel/MFPackage
+        Parent_model_or_package that this package is a part of. Package is automatically
+        added to parent_model_or_package when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
         processing purposes only.
@@ -360,7 +360,7 @@ class ModflowGwfmvr(mfpackage.MFPackage):
 
     def __init__(
         self,
-        model,
+        parent_model_or_package,
         loading_package=False,
         print_input=None,
         print_flows=None,
@@ -373,10 +373,15 @@ class ModflowGwfmvr(mfpackage.MFPackage):
         perioddata=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "mvr", filename, pname, loading_package, parent_file
+            parent_model_or_package,
+            "mvr",
+            filename,
+            pname,
+            loading_package,
+            **kwargs
         )
 
         # set up variables
@@ -394,3 +399,83 @@ class ModflowGwfmvr(mfpackage.MFPackage):
         self.packages = self.build_mfdata("packages", packages)
         self.perioddata = self.build_mfdata("perioddata", perioddata)
         self._init_complete = True
+
+
+class GwfmvrPackages(mfpackage.MFChildPackages):
+    """
+    GwfmvrPackages is a container class for the ModflowGwfmvr class.
+
+    Methods
+    ----------
+    initialize
+        Initializes a new ModflowGwfmvr package removing any sibling child
+        packages attached to the same parent package. See ModflowGwfmvr init
+        documentation for definition of parameters.
+    append_package
+        Adds a new ModflowGwfmvr package to the container. See ModflowGwfmvr
+        init documentation for definition of parameters.
+    """
+
+    package_abbr = "gwfmvrpackages"
+
+    def initialize(
+        self,
+        print_input=None,
+        print_flows=None,
+        modelnames=None,
+        budget_filerecord=None,
+        budgetcsv_filerecord=None,
+        maxmvr=None,
+        maxpackages=None,
+        packages=None,
+        perioddata=None,
+        filename=None,
+        pname=None,
+    ):
+        new_package = ModflowGwfmvr(
+            self._cpparent,
+            print_input=print_input,
+            print_flows=print_flows,
+            modelnames=modelnames,
+            budget_filerecord=budget_filerecord,
+            budgetcsv_filerecord=budgetcsv_filerecord,
+            maxmvr=maxmvr,
+            maxpackages=maxpackages,
+            packages=packages,
+            perioddata=perioddata,
+            filename=filename,
+            pname=pname,
+            child_builder_call=True,
+        )
+        self.init_package(new_package, filename)
+
+    def append_package(
+        self,
+        print_input=None,
+        print_flows=None,
+        modelnames=None,
+        budget_filerecord=None,
+        budgetcsv_filerecord=None,
+        maxmvr=None,
+        maxpackages=None,
+        packages=None,
+        perioddata=None,
+        filename=None,
+        pname=None,
+    ):
+        new_package = ModflowGwfmvr(
+            self._cpparent,
+            print_input=print_input,
+            print_flows=print_flows,
+            modelnames=modelnames,
+            budget_filerecord=budget_filerecord,
+            budgetcsv_filerecord=budgetcsv_filerecord,
+            maxmvr=maxmvr,
+            maxpackages=maxpackages,
+            packages=packages,
+            perioddata=perioddata,
+            filename=filename,
+            pname=pname,
+            child_builder_call=True,
+        )
+        self._append_package(new_package, filename)

--- a/flopy/mf6/modflow/mfgwfmvr.py
+++ b/flopy/mf6/modflow/mfgwfmvr.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -125,9 +125,7 @@ class ModflowGwfmvr(mfpackage.MFPackage):
     dfn_file_name = "gwf-mvr.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name print_input",
@@ -373,7 +371,7 @@ class ModflowGwfmvr(mfpackage.MFPackage):
         perioddata=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             parent_model_or_package,
@@ -381,7 +379,7 @@ class ModflowGwfmvr(mfpackage.MFPackage):
             filename,
             pname,
             loading_package,
-            **kwargs
+            **kwargs,
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwfnam.py
+++ b/flopy/mf6/modflow/mfgwfnam.py
@@ -76,7 +76,9 @@ class ModflowGwfnam(mfpackage.MFPackage):
     dfn_file_name = "gwf-nam.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name list",

--- a/flopy/mf6/modflow/mfgwfnam.py
+++ b/flopy/mf6/modflow/mfgwfnam.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwfnam(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -176,10 +176,10 @@ class ModflowGwfnam(mfpackage.MFPackage):
         packages=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "nam", filename, pname, loading_package, parent_file
+            model, "nam", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwfnam.py
+++ b/flopy/mf6/modflow/mfgwfnam.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -76,9 +76,7 @@ class ModflowGwfnam(mfpackage.MFPackage):
     dfn_file_name = "gwf-nam.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name list",
@@ -176,7 +174,7 @@ class ModflowGwfnam(mfpackage.MFPackage):
         packages=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "nam", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwfnpf.py
+++ b/flopy/mf6/modflow/mfgwfnpf.py
@@ -219,7 +219,9 @@ class ModflowGwfnpf(mfpackage.MFPackage):
     dfn_file_name = "gwf-npf.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name save_flows",

--- a/flopy/mf6/modflow/mfgwfnpf.py
+++ b/flopy/mf6/modflow/mfgwfnpf.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -219,9 +219,7 @@ class ModflowGwfnpf(mfpackage.MFPackage):
     dfn_file_name = "gwf-npf.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name save_flows",
@@ -514,7 +512,7 @@ class ModflowGwfnpf(mfpackage.MFPackage):
         wetdry=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "npf", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwfnpf.py
+++ b/flopy/mf6/modflow/mfgwfnpf.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwfnpf(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -92,11 +92,11 @@ class ModflowGwfnpf(mfpackage.MFPackage):
         * k33overk (boolean) keyword to indicate that specified K33 is a ratio
           of K33 divided by K. If this option is specified, then the K33 array
           entered in the NPF Package will be multiplied by K after being read.
-    tvk_filerecord : [tvk_filename]
-        * tvk_filename (string) defines a time-varying hydraulic conductivity
-          (TVK) input file. Records in the TVK file can be used to change
-          hydraulic conductivity properties at specified times or stress
-          periods.
+    perioddata : {varname:data} or tvk_perioddata data
+        * Contains data for the tvk package. Data can be stored in a dictionary
+          containing data for the tvk package with variable names as keys and
+          package data as values. Data just for the perioddata variable is also
+          acceptable. See tvk package documentation for more information.
     icelltype : [integer]
         * icelltype (integer) flag for each cell that specifies how saturated
           thickness is treated. 0 means saturated thickness is held constant;
@@ -370,6 +370,9 @@ class ModflowGwfnpf(mfpackage.MFPackage):
             "reader urword",
             "tagged true",
             "optional true",
+            "construct_package tvk",
+            "construct_data tvk_perioddata",
+            "parameter_name perioddata",
         ],
         [
             "block options",
@@ -500,7 +503,7 @@ class ModflowGwfnpf(mfpackage.MFPackage):
         save_saturation=None,
         k22overk=None,
         k33overk=None,
-        tvk_filerecord=None,
+        perioddata=None,
         icelltype=0,
         k=1.0,
         k22=None,
@@ -511,10 +514,10 @@ class ModflowGwfnpf(mfpackage.MFPackage):
         wetdry=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "npf", filename, pname, loading_package, parent_file
+            model, "npf", filename, pname, loading_package, **kwargs
         )
 
         # set up variables
@@ -535,8 +538,9 @@ class ModflowGwfnpf(mfpackage.MFPackage):
         )
         self.k22overk = self.build_mfdata("k22overk", k22overk)
         self.k33overk = self.build_mfdata("k33overk", k33overk)
-        self.tvk_filerecord = self.build_mfdata(
-            "tvk_filerecord", tvk_filerecord
+        self._tvk_filerecord = self.build_mfdata("tvk_filerecord", None)
+        self._tvk_package = self.build_child_package(
+            "tvk", perioddata, "tvk_perioddata", self._tvk_filerecord
         )
         self.icelltype = self.build_mfdata("icelltype", icelltype)
         self.k = self.build_mfdata("k", k)

--- a/flopy/mf6/modflow/mfgwfoc.py
+++ b/flopy/mf6/modflow/mfgwfoc.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwfoc(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -408,10 +408,10 @@ class ModflowGwfoc(mfpackage.MFPackage):
         printrecord=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "oc", filename, pname, loading_package, parent_file
+            model, "oc", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwfoc.py
+++ b/flopy/mf6/modflow/mfgwfoc.py
@@ -112,7 +112,9 @@ class ModflowGwfoc(mfpackage.MFPackage):
     dfn_file_name = "gwf-oc.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name budget_filerecord",

--- a/flopy/mf6/modflow/mfgwfoc.py
+++ b/flopy/mf6/modflow/mfgwfoc.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -112,9 +112,7 @@ class ModflowGwfoc(mfpackage.MFPackage):
     dfn_file_name = "gwf-oc.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name budget_filerecord",
@@ -408,7 +406,7 @@ class ModflowGwfoc(mfpackage.MFPackage):
         printrecord=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "oc", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwfrch.py
+++ b/flopy/mf6/modflow/mfgwfrch.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -123,10 +123,7 @@ class ModflowGwfrch(mfpackage.MFPackage):
     dfn_file_name = "gwf-rch.dfn"
 
     dfn = [
-        [
-            "header",
-            "multi-package",
-        ],
+        ["header", "multi-package",],
         [
             "block options",
             "name fixed_cell",
@@ -339,7 +336,7 @@ class ModflowGwfrch(mfpackage.MFPackage):
         stress_period_data=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "rch", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwfrch.py
+++ b/flopy/mf6/modflow/mfgwfrch.py
@@ -123,7 +123,10 @@ class ModflowGwfrch(mfpackage.MFPackage):
     dfn_file_name = "gwf-rch.dfn"
 
     dfn = [
-        ["header", "multi-package",],
+        [
+            "header",
+            "multi-package",
+        ],
         [
             "block options",
             "name fixed_cell",

--- a/flopy/mf6/modflow/mfgwfrch.py
+++ b/flopy/mf6/modflow/mfgwfrch.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwfrch(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -339,10 +339,10 @@ class ModflowGwfrch(mfpackage.MFPackage):
         stress_period_data=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "rch", filename, pname, loading_package, parent_file
+            model, "rch", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwfrcha.py
+++ b/flopy/mf6/modflow/mfgwfrcha.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -116,10 +116,7 @@ class ModflowGwfrcha(mfpackage.MFPackage):
     dfn_file_name = "gwf-rcha.dfn"
 
     dfn = [
-        [
-            "header",
-            "multi-package",
-        ],
+        ["header", "multi-package",],
         [
             "block options",
             "name readasarrays",
@@ -305,7 +302,7 @@ class ModflowGwfrcha(mfpackage.MFPackage):
         aux=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "rcha", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwfrcha.py
+++ b/flopy/mf6/modflow/mfgwfrcha.py
@@ -116,7 +116,10 @@ class ModflowGwfrcha(mfpackage.MFPackage):
     dfn_file_name = "gwf-rcha.dfn"
 
     dfn = [
-        ["header", "multi-package",],
+        [
+            "header",
+            "multi-package",
+        ],
         [
             "block options",
             "name readasarrays",

--- a/flopy/mf6/modflow/mfgwfrcha.py
+++ b/flopy/mf6/modflow/mfgwfrcha.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwfrcha(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -305,10 +305,10 @@ class ModflowGwfrcha(mfpackage.MFPackage):
         aux=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "rcha", filename, pname, loading_package, parent_file
+            model, "rcha", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwfriv.py
+++ b/flopy/mf6/modflow/mfgwfriv.py
@@ -129,7 +129,10 @@ class ModflowGwfriv(mfpackage.MFPackage):
     dfn_file_name = "gwf-riv.dfn"
 
     dfn = [
-        ["header", "multi-package",],
+        [
+            "header",
+            "multi-package",
+        ],
         [
             "block options",
             "name auxiliary",

--- a/flopy/mf6/modflow/mfgwfriv.py
+++ b/flopy/mf6/modflow/mfgwfriv.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwfriv(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -365,10 +365,10 @@ class ModflowGwfriv(mfpackage.MFPackage):
         stress_period_data=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "riv", filename, pname, loading_package, parent_file
+            model, "riv", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwfriv.py
+++ b/flopy/mf6/modflow/mfgwfriv.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -129,10 +129,7 @@ class ModflowGwfriv(mfpackage.MFPackage):
     dfn_file_name = "gwf-riv.dfn"
 
     dfn = [
-        [
-            "header",
-            "multi-package",
-        ],
+        ["header", "multi-package",],
         [
             "block options",
             "name auxiliary",
@@ -365,7 +362,7 @@ class ModflowGwfriv(mfpackage.MFPackage):
         stress_period_data=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "riv", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwfsfr.py
+++ b/flopy/mf6/modflow/mfgwfsfr.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwfsfr(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -1272,10 +1272,10 @@ class ModflowGwfsfr(mfpackage.MFPackage):
         perioddata=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "sfr", filename, pname, loading_package, parent_file
+            model, "sfr", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwfsfr.py
+++ b/flopy/mf6/modflow/mfgwfsfr.py
@@ -442,7 +442,10 @@ class ModflowGwfsfr(mfpackage.MFPackage):
     dfn_file_name = "gwf-sfr.dfn"
 
     dfn = [
-        ["header", "multi-package",],
+        [
+            "header",
+            "multi-package",
+        ],
         [
             "block options",
             "name auxiliary",

--- a/flopy/mf6/modflow/mfgwfsfr.py
+++ b/flopy/mf6/modflow/mfgwfsfr.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -442,10 +442,7 @@ class ModflowGwfsfr(mfpackage.MFPackage):
     dfn_file_name = "gwf-sfr.dfn"
 
     dfn = [
-        [
-            "header",
-            "multi-package",
-        ],
+        ["header", "multi-package",],
         [
             "block options",
             "name auxiliary",
@@ -1272,7 +1269,7 @@ class ModflowGwfsfr(mfpackage.MFPackage):
         perioddata=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "sfr", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwfsto.py
+++ b/flopy/mf6/modflow/mfgwfsto.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -83,9 +83,7 @@ class ModflowGwfsto(mfpackage.MFPackage):
     dfn_file_name = "gwf-sto.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name save_flows",
@@ -229,7 +227,7 @@ class ModflowGwfsto(mfpackage.MFPackage):
         transient=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "sto", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwfsto.py
+++ b/flopy/mf6/modflow/mfgwfsto.py
@@ -83,7 +83,9 @@ class ModflowGwfsto(mfpackage.MFPackage):
     dfn_file_name = "gwf-sto.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name save_flows",

--- a/flopy/mf6/modflow/mfgwfsto.py
+++ b/flopy/mf6/modflow/mfgwfsto.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwfsto(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -30,10 +30,11 @@ class ModflowGwfsto(mfpackage.MFPackage):
           greater than or equal to the top of the cell). This option is
           identical to the approach used to calculate storage changes under
           confined conditions in MODFLOW-2005.
-    tvs_filerecord : [tvs_filename]
-        * tvs_filename (string) defines a time-varying storage (TVS) input
-          file. Records in the TVS file can be used to change specific storage
-          and specific yield properties at specified times or stress periods.
+    perioddata : {varname:data} or tvs_perioddata data
+        * Contains data for the tvs package. Data can be stored in a dictionary
+          containing data for the tvs package with variable names as keys and
+          package data as values. Data just for the perioddata variable is also
+          acceptable. See tvs package documentation for more information.
     iconvert : [integer]
         * iconvert (integer) is a flag for each cell that specifies whether or
           not a cell is convertible for the storage calculation. 0 indicates
@@ -114,6 +115,9 @@ class ModflowGwfsto(mfpackage.MFPackage):
             "reader urword",
             "tagged true",
             "optional true",
+            "construct_package tvs",
+            "construct_data tvs_perioddata",
+            "parameter_name perioddata",
         ],
         [
             "block options",
@@ -217,7 +221,7 @@ class ModflowGwfsto(mfpackage.MFPackage):
         save_flows=None,
         storagecoefficient=None,
         ss_confined_only=None,
-        tvs_filerecord=None,
+        perioddata=None,
         iconvert=0,
         ss=1.0e-5,
         sy=0.15,
@@ -225,10 +229,10 @@ class ModflowGwfsto(mfpackage.MFPackage):
         transient=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "sto", filename, pname, loading_package, parent_file
+            model, "sto", filename, pname, loading_package, **kwargs
         )
 
         # set up variables
@@ -239,8 +243,9 @@ class ModflowGwfsto(mfpackage.MFPackage):
         self.ss_confined_only = self.build_mfdata(
             "ss_confined_only", ss_confined_only
         )
-        self.tvs_filerecord = self.build_mfdata(
-            "tvs_filerecord", tvs_filerecord
+        self._tvs_filerecord = self.build_mfdata("tvs_filerecord", None)
+        self._tvs_package = self.build_child_package(
+            "tvs", perioddata, "tvs_perioddata", self._tvs_filerecord
         )
         self.iconvert = self.build_mfdata("iconvert", iconvert)
         self.ss = self.build_mfdata("ss", ss)

--- a/flopy/mf6/modflow/mfgwfuzf.py
+++ b/flopy/mf6/modflow/mfgwfuzf.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -294,10 +294,7 @@ class ModflowGwfuzf(mfpackage.MFPackage):
     dfn_file_name = "gwf-uzf.dfn"
 
     dfn = [
-        [
-            "header",
-            "multi-package",
-        ],
+        ["header", "multi-package",],
         [
             "block options",
             "name auxiliary",
@@ -878,7 +875,7 @@ class ModflowGwfuzf(mfpackage.MFPackage):
         perioddata=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "uzf", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwfuzf.py
+++ b/flopy/mf6/modflow/mfgwfuzf.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwfuzf(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -878,10 +878,10 @@ class ModflowGwfuzf(mfpackage.MFPackage):
         perioddata=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "uzf", filename, pname, loading_package, parent_file
+            model, "uzf", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwfuzf.py
+++ b/flopy/mf6/modflow/mfgwfuzf.py
@@ -294,7 +294,10 @@ class ModflowGwfuzf(mfpackage.MFPackage):
     dfn_file_name = "gwf-uzf.dfn"
 
     dfn = [
-        ["header", "multi-package",],
+        [
+            "header",
+            "multi-package",
+        ],
         [
             "block options",
             "name auxiliary",

--- a/flopy/mf6/modflow/mfgwfwel.py
+++ b/flopy/mf6/modflow/mfgwfwel.py
@@ -141,7 +141,10 @@ class ModflowGwfwel(mfpackage.MFPackage):
     dfn_file_name = "gwf-wel.dfn"
 
     dfn = [
-        ["header", "multi-package",],
+        [
+            "header",
+            "multi-package",
+        ],
         [
             "block options",
             "name auxiliary",

--- a/flopy/mf6/modflow/mfgwfwel.py
+++ b/flopy/mf6/modflow/mfgwfwel.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwfwel(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -406,10 +406,10 @@ class ModflowGwfwel(mfpackage.MFPackage):
         stress_period_data=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "wel", filename, pname, loading_package, parent_file
+            model, "wel", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwfwel.py
+++ b/flopy/mf6/modflow/mfgwfwel.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -141,10 +141,7 @@ class ModflowGwfwel(mfpackage.MFPackage):
     dfn_file_name = "gwf-wel.dfn"
 
     dfn = [
-        [
-            "header",
-            "multi-package",
-        ],
+        ["header", "multi-package",],
         [
             "block options",
             "name auxiliary",
@@ -406,7 +403,7 @@ class ModflowGwfwel(mfpackage.MFPackage):
         stress_period_data=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "wel", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwt.py
+++ b/flopy/mf6/modflow/mfgwt.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfmodel
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 

--- a/flopy/mf6/modflow/mfgwt.py
+++ b/flopy/mf6/modflow/mfgwt.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfmodel
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 

--- a/flopy/mf6/modflow/mfgwtadv.py
+++ b/flopy/mf6/modflow/mfgwtadv.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 
 
@@ -36,9 +36,7 @@ class ModflowGwtadv(mfpackage.MFPackage):
     dfn_file_name = "gwt-adv.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name scheme",
@@ -56,7 +54,7 @@ class ModflowGwtadv(mfpackage.MFPackage):
         scheme=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "adv", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwtadv.py
+++ b/flopy/mf6/modflow/mfgwtadv.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 
 
@@ -11,7 +11,7 @@ class ModflowGwtadv(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -56,10 +56,10 @@ class ModflowGwtadv(mfpackage.MFPackage):
         scheme=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "adv", filename, pname, loading_package, parent_file
+            model, "adv", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwtadv.py
+++ b/flopy/mf6/modflow/mfgwtadv.py
@@ -36,7 +36,9 @@ class ModflowGwtadv(mfpackage.MFPackage):
     dfn_file_name = "gwt-adv.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name scheme",

--- a/flopy/mf6/modflow/mfgwtapi.py
+++ b/flopy/mf6/modflow/mfgwtapi.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwtapi(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -172,10 +172,10 @@ class ModflowGwtapi(mfpackage.MFPackage):
         maxbound=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "api", filename, pname, loading_package, parent_file
+            model, "api", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwtapi.py
+++ b/flopy/mf6/modflow/mfgwtapi.py
@@ -68,7 +68,9 @@ class ModflowGwtapi(mfpackage.MFPackage):
     dfn_file_name = "gwt-api.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name boundnames",

--- a/flopy/mf6/modflow/mfgwtapi.py
+++ b/flopy/mf6/modflow/mfgwtapi.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -68,9 +68,7 @@ class ModflowGwtapi(mfpackage.MFPackage):
     dfn_file_name = "gwt-api.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name boundnames",
@@ -172,7 +170,7 @@ class ModflowGwtapi(mfpackage.MFPackage):
         maxbound=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "api", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwtcnc.py
+++ b/flopy/mf6/modflow/mfgwtcnc.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwtcnc(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -323,10 +323,10 @@ class ModflowGwtcnc(mfpackage.MFPackage):
         stress_period_data=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "cnc", filename, pname, loading_package, parent_file
+            model, "cnc", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwtcnc.py
+++ b/flopy/mf6/modflow/mfgwtcnc.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -117,9 +117,7 @@ class ModflowGwtcnc(mfpackage.MFPackage):
     dfn_file_name = "gwt-cnc.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name auxiliary",
@@ -323,7 +321,7 @@ class ModflowGwtcnc(mfpackage.MFPackage):
         stress_period_data=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "cnc", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwtcnc.py
+++ b/flopy/mf6/modflow/mfgwtcnc.py
@@ -117,7 +117,9 @@ class ModflowGwtcnc(mfpackage.MFPackage):
     dfn_file_name = "gwt-cnc.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name auxiliary",

--- a/flopy/mf6/modflow/mfgwtdis.py
+++ b/flopy/mf6/modflow/mfgwtdis.py
@@ -90,7 +90,9 @@ class ModflowGwtdis(mfpackage.MFPackage):
     dfn_file_name = "gwt-dis.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name length_units",

--- a/flopy/mf6/modflow/mfgwtdis.py
+++ b/flopy/mf6/modflow/mfgwtdis.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator
 
@@ -90,9 +90,7 @@ class ModflowGwtdis(mfpackage.MFPackage):
     dfn_file_name = "gwt-dis.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name length_units",
@@ -215,7 +213,7 @@ class ModflowGwtdis(mfpackage.MFPackage):
         idomain=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "dis", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwtdis.py
+++ b/flopy/mf6/modflow/mfgwtdis.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwtdis(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -215,10 +215,10 @@ class ModflowGwtdis(mfpackage.MFPackage):
         idomain=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "dis", filename, pname, loading_package, parent_file
+            model, "dis", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwtdisu.py
+++ b/flopy/mf6/modflow/mfgwtdisu.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -205,9 +205,7 @@ class ModflowGwtdisu(mfpackage.MFPackage):
     dfn_file_name = "gwt-disu.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name length_units",
@@ -470,7 +468,7 @@ class ModflowGwtdisu(mfpackage.MFPackage):
         cell2d=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "disu", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwtdisu.py
+++ b/flopy/mf6/modflow/mfgwtdisu.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwtdisu(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -470,10 +470,10 @@ class ModflowGwtdisu(mfpackage.MFPackage):
         cell2d=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "disu", filename, pname, loading_package, parent_file
+            model, "disu", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwtdisu.py
+++ b/flopy/mf6/modflow/mfgwtdisu.py
@@ -205,7 +205,9 @@ class ModflowGwtdisu(mfpackage.MFPackage):
     dfn_file_name = "gwt-disu.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name length_units",

--- a/flopy/mf6/modflow/mfgwtdisv.py
+++ b/flopy/mf6/modflow/mfgwtdisv.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwtdisv(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -312,10 +312,10 @@ class ModflowGwtdisv(mfpackage.MFPackage):
         cell2d=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "disv", filename, pname, loading_package, parent_file
+            model, "disv", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwtdisv.py
+++ b/flopy/mf6/modflow/mfgwtdisv.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -118,9 +118,7 @@ class ModflowGwtdisv(mfpackage.MFPackage):
     dfn_file_name = "gwt-disv.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name length_units",
@@ -312,7 +310,7 @@ class ModflowGwtdisv(mfpackage.MFPackage):
         cell2d=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "disv", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwtdisv.py
+++ b/flopy/mf6/modflow/mfgwtdisv.py
@@ -118,7 +118,9 @@ class ModflowGwtdisv(mfpackage.MFPackage):
     dfn_file_name = "gwt-disv.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name length_units",

--- a/flopy/mf6/modflow/mfgwtdsp.py
+++ b/flopy/mf6/modflow/mfgwtdsp.py
@@ -86,7 +86,9 @@ class ModflowGwtdsp(mfpackage.MFPackage):
     dfn_file_name = "gwt-dsp.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name xt3d_off",

--- a/flopy/mf6/modflow/mfgwtdsp.py
+++ b/flopy/mf6/modflow/mfgwtdsp.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwtdsp(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -175,10 +175,10 @@ class ModflowGwtdsp(mfpackage.MFPackage):
         atv=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "dsp", filename, pname, loading_package, parent_file
+            model, "dsp", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwtdsp.py
+++ b/flopy/mf6/modflow/mfgwtdsp.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator
 
@@ -86,9 +86,7 @@ class ModflowGwtdsp(mfpackage.MFPackage):
     dfn_file_name = "gwt-dsp.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name xt3d_off",
@@ -175,7 +173,7 @@ class ModflowGwtdsp(mfpackage.MFPackage):
         atv=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "dsp", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwtfmi.py
+++ b/flopy/mf6/modflow/mfgwtfmi.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwtfmi(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -122,10 +122,10 @@ class ModflowGwtfmi(mfpackage.MFPackage):
         packagedata=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "fmi", filename, pname, loading_package, parent_file
+            model, "fmi", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwtfmi.py
+++ b/flopy/mf6/modflow/mfgwtfmi.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -60,9 +60,7 @@ class ModflowGwtfmi(mfpackage.MFPackage):
     dfn_file_name = "gwt-fmi.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name save_flows",
@@ -122,7 +120,7 @@ class ModflowGwtfmi(mfpackage.MFPackage):
         packagedata=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "fmi", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwtfmi.py
+++ b/flopy/mf6/modflow/mfgwtfmi.py
@@ -60,7 +60,9 @@ class ModflowGwtfmi(mfpackage.MFPackage):
     dfn_file_name = "gwt-fmi.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name save_flows",

--- a/flopy/mf6/modflow/mfgwtgwt.py
+++ b/flopy/mf6/modflow/mfgwtgwt.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -167,10 +167,7 @@ class ModflowGwtgwt(mfpackage.MFPackage):
     dfn_file_name = "exg-gwtgwt.dfn"
 
     dfn = [
-        [
-            "header",
-            "multi-package",
-        ],
+        ["header", "multi-package",],
         [
             "block options",
             "name gwfmodelname1",
@@ -444,7 +441,7 @@ class ModflowGwtgwt(mfpackage.MFPackage):
         exchangedata=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             simulation, "gwtgwt", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwtgwt.py
+++ b/flopy/mf6/modflow/mfgwtgwt.py
@@ -167,7 +167,10 @@ class ModflowGwtgwt(mfpackage.MFPackage):
     dfn_file_name = "exg-gwtgwt.dfn"
 
     dfn = [
-        ["header", "multi-package",],
+        [
+            "header",
+            "multi-package",
+        ],
         [
             "block options",
             "name gwfmodelname1",

--- a/flopy/mf6/modflow/mfgwtgwt.py
+++ b/flopy/mf6/modflow/mfgwtgwt.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -82,10 +82,11 @@ class ModflowGwtgwt(mfpackage.MFPackage):
     filein : boolean
         * filein (boolean) keyword to specify that an input filename is
           expected next.
-    mvt_filerecord : [mvt6_filename]
-        * mvt6_filename (string) is the file name of the transport mover input
-          file to apply to this exchange. Information for the transport mover
-          are provided in the file provided with these keywords.
+    perioddata : {varname:data} or perioddata data
+        * Contains data for the mvt package. Data can be stored in a dictionary
+          containing data for the mvt package with variable names as keys and
+          package data as values. Data just for the perioddata variable is also
+          acceptable. See mvt package documentation for more information.
     observations : {varname:data} or continuous data
         * Contains data for the obs package. Data can be stored in a dictionary
           containing data for the obs package with variable names as keys and
@@ -263,6 +264,9 @@ class ModflowGwtgwt(mfpackage.MFPackage):
             "reader urword",
             "tagged true",
             "optional true",
+            "construct_package mvt",
+            "construct_data perioddata",
+            "parameter_name perioddata",
         ],
         [
             "block options",
@@ -433,17 +437,17 @@ class ModflowGwtgwt(mfpackage.MFPackage):
         xt3d_off=None,
         xt3d_rhs=None,
         filein=None,
-        mvt_filerecord=None,
+        perioddata=None,
         observations=None,
         dev_interfacemodel_on=None,
         nexg=None,
         exchangedata=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            simulation, "gwtgwt", filename, pname, loading_package, parent_file
+            simulation, "gwtgwt", filename, pname, loading_package, **kwargs
         )
 
         # set up variables
@@ -466,8 +470,9 @@ class ModflowGwtgwt(mfpackage.MFPackage):
         self.xt3d_off = self.build_mfdata("xt3d_off", xt3d_off)
         self.xt3d_rhs = self.build_mfdata("xt3d_rhs", xt3d_rhs)
         self.filein = self.build_mfdata("filein", filein)
-        self.mvt_filerecord = self.build_mfdata(
-            "mvt_filerecord", mvt_filerecord
+        self._mvt_filerecord = self.build_mfdata("mvt_filerecord", None)
+        self._mvt_package = self.build_child_package(
+            "mvt", perioddata, "perioddata", self._mvt_filerecord
         )
         self._obs_filerecord = self.build_mfdata("obs_filerecord", None)
         self._obs_package = self.build_child_package(

--- a/flopy/mf6/modflow/mfgwtic.py
+++ b/flopy/mf6/modflow/mfgwtic.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwtic(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -60,10 +60,10 @@ class ModflowGwtic(mfpackage.MFPackage):
         strt=0.0,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "ic", filename, pname, loading_package, parent_file
+            model, "ic", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwtic.py
+++ b/flopy/mf6/modflow/mfgwtic.py
@@ -39,7 +39,9 @@ class ModflowGwtic(mfpackage.MFPackage):
     dfn_file_name = "gwt-ic.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block griddata",
             "name strt",

--- a/flopy/mf6/modflow/mfgwtic.py
+++ b/flopy/mf6/modflow/mfgwtic.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator
 
@@ -39,9 +39,7 @@ class ModflowGwtic(mfpackage.MFPackage):
     dfn_file_name = "gwt-ic.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block griddata",
             "name strt",
@@ -60,7 +58,7 @@ class ModflowGwtic(mfpackage.MFPackage):
         strt=0.0,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "ic", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwtist.py
+++ b/flopy/mf6/modflow/mfgwtist.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwtist(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -429,10 +429,10 @@ class ModflowGwtist(mfpackage.MFPackage):
         distcoef=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "ist", filename, pname, loading_package, parent_file
+            model, "ist", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwtist.py
+++ b/flopy/mf6/modflow/mfgwtist.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -137,9 +137,7 @@ class ModflowGwtist(mfpackage.MFPackage):
     dfn_file_name = "gwt-ist.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name save_flows",
@@ -429,7 +427,7 @@ class ModflowGwtist(mfpackage.MFPackage):
         distcoef=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "ist", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwtist.py
+++ b/flopy/mf6/modflow/mfgwtist.py
@@ -137,7 +137,9 @@ class ModflowGwtist(mfpackage.MFPackage):
     dfn_file_name = "gwt-ist.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name save_flows",

--- a/flopy/mf6/modflow/mfgwtlkt.py
+++ b/flopy/mf6/modflow/mfgwtlkt.py
@@ -228,7 +228,10 @@ class ModflowGwtlkt(mfpackage.MFPackage):
     dfn_file_name = "gwt-lkt.dfn"
 
     dfn = [
-        ["header", "multi-package",],
+        [
+            "header",
+            "multi-package",
+        ],
         [
             "block options",
             "name flow_package_name",

--- a/flopy/mf6/modflow/mfgwtlkt.py
+++ b/flopy/mf6/modflow/mfgwtlkt.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwtlkt(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -670,10 +670,10 @@ class ModflowGwtlkt(mfpackage.MFPackage):
         lakeperioddata=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "lkt", filename, pname, loading_package, parent_file
+            model, "lkt", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwtlkt.py
+++ b/flopy/mf6/modflow/mfgwtlkt.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -228,10 +228,7 @@ class ModflowGwtlkt(mfpackage.MFPackage):
     dfn_file_name = "gwt-lkt.dfn"
 
     dfn = [
-        [
-            "header",
-            "multi-package",
-        ],
+        ["header", "multi-package",],
         [
             "block options",
             "name flow_package_name",
@@ -670,7 +667,7 @@ class ModflowGwtlkt(mfpackage.MFPackage):
         lakeperioddata=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "lkt", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwtmst.py
+++ b/flopy/mf6/modflow/mfgwtmst.py
@@ -97,7 +97,9 @@ class ModflowGwtmst(mfpackage.MFPackage):
     dfn_file_name = "gwt-mst.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name save_flows",

--- a/flopy/mf6/modflow/mfgwtmst.py
+++ b/flopy/mf6/modflow/mfgwtmst.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator
 
@@ -97,9 +97,7 @@ class ModflowGwtmst(mfpackage.MFPackage):
     dfn_file_name = "gwt-mst.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name save_flows",
@@ -200,7 +198,7 @@ class ModflowGwtmst(mfpackage.MFPackage):
         sp2=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "mst", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwtmst.py
+++ b/flopy/mf6/modflow/mfgwtmst.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwtmst(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -200,10 +200,10 @@ class ModflowGwtmst(mfpackage.MFPackage):
         sp2=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "mst", filename, pname, loading_package, parent_file
+            model, "mst", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwtmvt.py
+++ b/flopy/mf6/modflow/mfgwtmvt.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -61,9 +61,7 @@ class ModflowGwtmvt(mfpackage.MFPackage):
     dfn_file_name = "gwt-mvt.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name print_input",
@@ -168,7 +166,7 @@ class ModflowGwtmvt(mfpackage.MFPackage):
         budgetcsv_filerecord=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             parent_model_or_package,
@@ -176,7 +174,7 @@ class ModflowGwtmvt(mfpackage.MFPackage):
             filename,
             pname,
             loading_package,
-            **kwargs
+            **kwargs,
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwtmvt.py
+++ b/flopy/mf6/modflow/mfgwtmvt.py
@@ -61,7 +61,9 @@ class ModflowGwtmvt(mfpackage.MFPackage):
     dfn_file_name = "gwt-mvt.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name print_input",

--- a/flopy/mf6/modflow/mfgwtmvt.py
+++ b/flopy/mf6/modflow/mfgwtmvt.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -11,9 +11,9 @@ class ModflowGwtmvt(mfpackage.MFPackage):
 
     Parameters
     ----------
-    model : MFModel
-        Model that this package is a part of.  Package is automatically
-        added to model when it is initialized.
+    parent_model_or_package : MFModel/MFPackage
+        Parent_model_or_package that this package is a part of. Package is automatically
+        added to parent_model_or_package when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
         processing purposes only.
@@ -159,7 +159,7 @@ class ModflowGwtmvt(mfpackage.MFPackage):
 
     def __init__(
         self,
-        model,
+        parent_model_or_package,
         loading_package=False,
         print_input=None,
         print_flows=None,
@@ -168,10 +168,15 @@ class ModflowGwtmvt(mfpackage.MFPackage):
         budgetcsv_filerecord=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "mvt", filename, pname, loading_package, parent_file
+            parent_model_or_package,
+            "mvt",
+            filename,
+            pname,
+            loading_package,
+            **kwargs
         )
 
         # set up variables
@@ -185,3 +190,67 @@ class ModflowGwtmvt(mfpackage.MFPackage):
             "budgetcsv_filerecord", budgetcsv_filerecord
         )
         self._init_complete = True
+
+
+class GwtmvtPackages(mfpackage.MFChildPackages):
+    """
+    GwtmvtPackages is a container class for the ModflowGwtmvt class.
+
+    Methods
+    ----------
+    initialize
+        Initializes a new ModflowGwtmvt package removing any sibling child
+        packages attached to the same parent package. See ModflowGwtmvt init
+        documentation for definition of parameters.
+    append_package
+        Adds a new ModflowGwtmvt package to the container. See ModflowGwtmvt
+        init documentation for definition of parameters.
+    """
+
+    package_abbr = "gwtmvtpackages"
+
+    def initialize(
+        self,
+        print_input=None,
+        print_flows=None,
+        save_flows=None,
+        budget_filerecord=None,
+        budgetcsv_filerecord=None,
+        filename=None,
+        pname=None,
+    ):
+        new_package = ModflowGwtmvt(
+            self._cpparent,
+            print_input=print_input,
+            print_flows=print_flows,
+            save_flows=save_flows,
+            budget_filerecord=budget_filerecord,
+            budgetcsv_filerecord=budgetcsv_filerecord,
+            filename=filename,
+            pname=pname,
+            child_builder_call=True,
+        )
+        self.init_package(new_package, filename)
+
+    def append_package(
+        self,
+        print_input=None,
+        print_flows=None,
+        save_flows=None,
+        budget_filerecord=None,
+        budgetcsv_filerecord=None,
+        filename=None,
+        pname=None,
+    ):
+        new_package = ModflowGwtmvt(
+            self._cpparent,
+            print_input=print_input,
+            print_flows=print_flows,
+            save_flows=save_flows,
+            budget_filerecord=budget_filerecord,
+            budgetcsv_filerecord=budgetcsv_filerecord,
+            filename=filename,
+            pname=pname,
+            child_builder_call=True,
+        )
+        self._append_package(new_package, filename)

--- a/flopy/mf6/modflow/mfgwtmwt.py
+++ b/flopy/mf6/modflow/mfgwtmwt.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwtmwt(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -614,10 +614,10 @@ class ModflowGwtmwt(mfpackage.MFPackage):
         mwtperioddata=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "mwt", filename, pname, loading_package, parent_file
+            model, "mwt", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwtmwt.py
+++ b/flopy/mf6/modflow/mfgwtmwt.py
@@ -203,7 +203,10 @@ class ModflowGwtmwt(mfpackage.MFPackage):
     dfn_file_name = "gwt-mwt.dfn"
 
     dfn = [
-        ["header", "multi-package",],
+        [
+            "header",
+            "multi-package",
+        ],
         [
             "block options",
             "name flow_package_name",

--- a/flopy/mf6/modflow/mfgwtmwt.py
+++ b/flopy/mf6/modflow/mfgwtmwt.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -203,10 +203,7 @@ class ModflowGwtmwt(mfpackage.MFPackage):
     dfn_file_name = "gwt-mwt.dfn"
 
     dfn = [
-        [
-            "header",
-            "multi-package",
-        ],
+        ["header", "multi-package",],
         [
             "block options",
             "name flow_package_name",
@@ -614,7 +611,7 @@ class ModflowGwtmwt(mfpackage.MFPackage):
         mwtperioddata=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "mwt", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwtnam.py
+++ b/flopy/mf6/modflow/mfgwtnam.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -71,9 +71,7 @@ class ModflowGwtnam(mfpackage.MFPackage):
     dfn_file_name = "gwt-nam.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name list",
@@ -148,7 +146,7 @@ class ModflowGwtnam(mfpackage.MFPackage):
         packages=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "nam", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwtnam.py
+++ b/flopy/mf6/modflow/mfgwtnam.py
@@ -71,7 +71,9 @@ class ModflowGwtnam(mfpackage.MFPackage):
     dfn_file_name = "gwt-nam.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name list",

--- a/flopy/mf6/modflow/mfgwtnam.py
+++ b/flopy/mf6/modflow/mfgwtnam.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwtnam(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -148,10 +148,10 @@ class ModflowGwtnam(mfpackage.MFPackage):
         packages=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "nam", filename, pname, loading_package, parent_file
+            model, "nam", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwtoc.py
+++ b/flopy/mf6/modflow/mfgwtoc.py
@@ -113,7 +113,9 @@ class ModflowGwtoc(mfpackage.MFPackage):
     dfn_file_name = "gwt-oc.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name budget_filerecord",

--- a/flopy/mf6/modflow/mfgwtoc.py
+++ b/flopy/mf6/modflow/mfgwtoc.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -113,9 +113,7 @@ class ModflowGwtoc(mfpackage.MFPackage):
     dfn_file_name = "gwt-oc.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name budget_filerecord",
@@ -409,7 +407,7 @@ class ModflowGwtoc(mfpackage.MFPackage):
         printrecord=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "oc", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwtoc.py
+++ b/flopy/mf6/modflow/mfgwtoc.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwtoc(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -409,10 +409,10 @@ class ModflowGwtoc(mfpackage.MFPackage):
         printrecord=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "oc", filename, pname, loading_package, parent_file
+            model, "oc", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwtsft.py
+++ b/flopy/mf6/modflow/mfgwtsft.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -226,10 +226,7 @@ class ModflowGwtsft(mfpackage.MFPackage):
     dfn_file_name = "gwt-sft.dfn"
 
     dfn = [
-        [
-            "header",
-            "multi-package",
-        ],
+        ["header", "multi-package",],
         [
             "block options",
             "name flow_package_name",
@@ -668,7 +665,7 @@ class ModflowGwtsft(mfpackage.MFPackage):
         reachperioddata=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "sft", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwtsft.py
+++ b/flopy/mf6/modflow/mfgwtsft.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwtsft(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -668,10 +668,10 @@ class ModflowGwtsft(mfpackage.MFPackage):
         reachperioddata=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "sft", filename, pname, loading_package, parent_file
+            model, "sft", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwtsft.py
+++ b/flopy/mf6/modflow/mfgwtsft.py
@@ -226,7 +226,10 @@ class ModflowGwtsft(mfpackage.MFPackage):
     dfn_file_name = "gwt-sft.dfn"
 
     dfn = [
-        ["header", "multi-package",],
+        [
+            "header",
+            "multi-package",
+        ],
         [
             "block options",
             "name flow_package_name",

--- a/flopy/mf6/modflow/mfgwtsrc.py
+++ b/flopy/mf6/modflow/mfgwtsrc.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwtsrc(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -325,10 +325,10 @@ class ModflowGwtsrc(mfpackage.MFPackage):
         stress_period_data=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "src", filename, pname, loading_package, parent_file
+            model, "src", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwtsrc.py
+++ b/flopy/mf6/modflow/mfgwtsrc.py
@@ -119,7 +119,9 @@ class ModflowGwtsrc(mfpackage.MFPackage):
     dfn_file_name = "gwt-src.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name auxiliary",

--- a/flopy/mf6/modflow/mfgwtsrc.py
+++ b/flopy/mf6/modflow/mfgwtsrc.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -119,9 +119,7 @@ class ModflowGwtsrc(mfpackage.MFPackage):
     dfn_file_name = "gwt-src.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name auxiliary",
@@ -325,7 +323,7 @@ class ModflowGwtsrc(mfpackage.MFPackage):
         stress_period_data=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "src", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwtssm.py
+++ b/flopy/mf6/modflow/mfgwtssm.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -91,9 +91,7 @@ class ModflowGwtssm(mfpackage.MFPackage):
     dfn_file_name = "gwt-ssm.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name print_flows",
@@ -207,7 +205,7 @@ class ModflowGwtssm(mfpackage.MFPackage):
         fileinput=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "ssm", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwtssm.py
+++ b/flopy/mf6/modflow/mfgwtssm.py
@@ -91,7 +91,9 @@ class ModflowGwtssm(mfpackage.MFPackage):
     dfn_file_name = "gwt-ssm.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name print_flows",

--- a/flopy/mf6/modflow/mfgwtssm.py
+++ b/flopy/mf6/modflow/mfgwtssm.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwtssm(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -207,10 +207,10 @@ class ModflowGwtssm(mfpackage.MFPackage):
         fileinput=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "ssm", filename, pname, loading_package, parent_file
+            model, "ssm", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwtuzt.py
+++ b/flopy/mf6/modflow/mfgwtuzt.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowGwtuzt(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -634,10 +634,10 @@ class ModflowGwtuzt(mfpackage.MFPackage):
         uztperioddata=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "uzt", filename, pname, loading_package, parent_file
+            model, "uzt", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfgwtuzt.py
+++ b/flopy/mf6/modflow/mfgwtuzt.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -212,10 +212,7 @@ class ModflowGwtuzt(mfpackage.MFPackage):
     dfn_file_name = "gwt-uzt.dfn"
 
     dfn = [
-        [
-            "header",
-            "multi-package",
-        ],
+        ["header", "multi-package",],
         [
             "block options",
             "name flow_package_name",
@@ -634,7 +631,7 @@ class ModflowGwtuzt(mfpackage.MFPackage):
         uztperioddata=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "uzt", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfgwtuzt.py
+++ b/flopy/mf6/modflow/mfgwtuzt.py
@@ -212,7 +212,10 @@ class ModflowGwtuzt(mfpackage.MFPackage):
     dfn_file_name = "gwt-uzt.dfn"
 
     dfn = [
-        ["header", "multi-package",],
+        [
+            "header",
+            "multi-package",
+        ],
         [
             "block options",
             "name flow_package_name",

--- a/flopy/mf6/modflow/mfims.py
+++ b/flopy/mf6/modflow/mfims.py
@@ -379,7 +379,9 @@ class ModflowIms(mfpackage.MFPackage):
     dfn_file_name = "sln-ims.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name print_option",

--- a/flopy/mf6/modflow/mfims.py
+++ b/flopy/mf6/modflow/mfims.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -759,10 +759,10 @@ class ModflowIms(mfpackage.MFPackage):
         reordering_method=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            simulation, "ims", filename, pname, loading_package, parent_file
+            simulation, "ims", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfims.py
+++ b/flopy/mf6/modflow/mfims.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -379,9 +379,7 @@ class ModflowIms(mfpackage.MFPackage):
     dfn_file_name = "sln-ims.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name print_option",
@@ -759,7 +757,7 @@ class ModflowIms(mfpackage.MFPackage):
         reordering_method=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             simulation, "ims", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfmvr.py
+++ b/flopy/mf6/modflow/mfmvr.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -125,9 +125,7 @@ class ModflowMvr(mfpackage.MFPackage):
     dfn_file_name = "gwf-mvr.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name print_input",
@@ -373,7 +371,7 @@ class ModflowMvr(mfpackage.MFPackage):
         perioddata=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             parent_model_or_package,
@@ -381,7 +379,7 @@ class ModflowMvr(mfpackage.MFPackage):
             filename,
             pname,
             loading_package,
-            **kwargs
+            **kwargs,
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfmvr.py
+++ b/flopy/mf6/modflow/mfmvr.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -13,9 +13,9 @@ class ModflowMvr(mfpackage.MFPackage):
 
     Parameters
     ----------
-    simulation : MFSimulation
-        Simulation that this package is a part of. Package is automatically
-        added to simulation when it is initialized.
+    parent_model_or_package : MFModel/MFPackage
+        Parent_model_or_package that this package is a part of. Package is automatically
+        added to parent_model_or_package when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
         processing purposes only.
@@ -360,7 +360,7 @@ class ModflowMvr(mfpackage.MFPackage):
 
     def __init__(
         self,
-        simulation,
+        parent_model_or_package,
         loading_package=False,
         print_input=None,
         print_flows=None,
@@ -373,10 +373,15 @@ class ModflowMvr(mfpackage.MFPackage):
         perioddata=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            simulation, "mvr", filename, pname, loading_package, parent_file
+            parent_model_or_package,
+            "mvr",
+            filename,
+            pname,
+            loading_package,
+            **kwargs
         )
 
         # set up variables
@@ -394,3 +399,83 @@ class ModflowMvr(mfpackage.MFPackage):
         self.packages = self.build_mfdata("packages", packages)
         self.perioddata = self.build_mfdata("perioddata", perioddata)
         self._init_complete = True
+
+
+class MvrPackages(mfpackage.MFChildPackages):
+    """
+    MvrPackages is a container class for the ModflowMvr class.
+
+    Methods
+    ----------
+    initialize
+        Initializes a new ModflowMvr package removing any sibling child
+        packages attached to the same parent package. See ModflowMvr init
+        documentation for definition of parameters.
+    append_package
+        Adds a new ModflowGwfmvr package to the container. See ModflowGwfmvr
+        init documentation for definition of parameters.
+    """
+
+    package_abbr = "mvrpackages"
+
+    def initialize(
+        self,
+        print_input=None,
+        print_flows=None,
+        modelnames=None,
+        budget_filerecord=None,
+        budgetcsv_filerecord=None,
+        maxmvr=None,
+        maxpackages=None,
+        packages=None,
+        perioddata=None,
+        filename=None,
+        pname=None,
+    ):
+        new_package = ModflowMvr(
+            self._cpparent,
+            print_input=print_input,
+            print_flows=print_flows,
+            modelnames=modelnames,
+            budget_filerecord=budget_filerecord,
+            budgetcsv_filerecord=budgetcsv_filerecord,
+            maxmvr=maxmvr,
+            maxpackages=maxpackages,
+            packages=packages,
+            perioddata=perioddata,
+            filename=filename,
+            pname=pname,
+            child_builder_call=True,
+        )
+        self.init_package(new_package, filename)
+
+    def append_package(
+        self,
+        print_input=None,
+        print_flows=None,
+        modelnames=None,
+        budget_filerecord=None,
+        budgetcsv_filerecord=None,
+        maxmvr=None,
+        maxpackages=None,
+        packages=None,
+        perioddata=None,
+        filename=None,
+        pname=None,
+    ):
+        new_package = ModflowGwfmvr(
+            self._cpparent,
+            print_input=print_input,
+            print_flows=print_flows,
+            modelnames=modelnames,
+            budget_filerecord=budget_filerecord,
+            budgetcsv_filerecord=budgetcsv_filerecord,
+            maxmvr=maxmvr,
+            maxpackages=maxpackages,
+            packages=packages,
+            perioddata=perioddata,
+            filename=filename,
+            pname=pname,
+            child_builder_call=True,
+        )
+        self._append_package(new_package, filename)

--- a/flopy/mf6/modflow/mfmvr.py
+++ b/flopy/mf6/modflow/mfmvr.py
@@ -125,7 +125,9 @@ class ModflowMvr(mfpackage.MFPackage):
     dfn_file_name = "gwf-mvr.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name print_input",

--- a/flopy/mf6/modflow/mfmvt.py
+++ b/flopy/mf6/modflow/mfmvt.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -61,9 +61,7 @@ class ModflowMvt(mfpackage.MFPackage):
     dfn_file_name = "gwt-mvt.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name print_input",
@@ -168,7 +166,7 @@ class ModflowMvt(mfpackage.MFPackage):
         budgetcsv_filerecord=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             parent_model_or_package,
@@ -176,7 +174,7 @@ class ModflowMvt(mfpackage.MFPackage):
             filename,
             pname,
             loading_package,
-            **kwargs
+            **kwargs,
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfmvt.py
+++ b/flopy/mf6/modflow/mfmvt.py
@@ -61,7 +61,9 @@ class ModflowMvt(mfpackage.MFPackage):
     dfn_file_name = "gwt-mvt.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name print_input",

--- a/flopy/mf6/modflow/mfmvt.py
+++ b/flopy/mf6/modflow/mfmvt.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -11,9 +11,9 @@ class ModflowMvt(mfpackage.MFPackage):
 
     Parameters
     ----------
-    simulation : MFSimulation
-        Simulation that this package is a part of. Package is automatically
-        added to simulation when it is initialized.
+    parent_model_or_package : MFModel/MFPackage
+        Parent_model_or_package that this package is a part of. Package is automatically
+        added to parent_model_or_package when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
         processing purposes only.
@@ -159,7 +159,7 @@ class ModflowMvt(mfpackage.MFPackage):
 
     def __init__(
         self,
-        simulation,
+        parent_model_or_package,
         loading_package=False,
         print_input=None,
         print_flows=None,
@@ -168,10 +168,15 @@ class ModflowMvt(mfpackage.MFPackage):
         budgetcsv_filerecord=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            simulation, "mvt", filename, pname, loading_package, parent_file
+            parent_model_or_package,
+            "mvt",
+            filename,
+            pname,
+            loading_package,
+            **kwargs
         )
 
         # set up variables
@@ -185,3 +190,67 @@ class ModflowMvt(mfpackage.MFPackage):
             "budgetcsv_filerecord", budgetcsv_filerecord
         )
         self._init_complete = True
+
+
+class MvtPackages(mfpackage.MFChildPackages):
+    """
+    MvtPackages is a container class for the ModflowMvt class.
+
+    Methods
+    ----------
+    initialize
+        Initializes a new ModflowMvt package removing any sibling child
+        packages attached to the same parent package. See ModflowMvt init
+        documentation for definition of parameters.
+    append_package
+        Adds a new ModflowGwtmvt package to the container. See ModflowGwtmvt
+        init documentation for definition of parameters.
+    """
+
+    package_abbr = "mvtpackages"
+
+    def initialize(
+        self,
+        print_input=None,
+        print_flows=None,
+        save_flows=None,
+        budget_filerecord=None,
+        budgetcsv_filerecord=None,
+        filename=None,
+        pname=None,
+    ):
+        new_package = ModflowMvt(
+            self._cpparent,
+            print_input=print_input,
+            print_flows=print_flows,
+            save_flows=save_flows,
+            budget_filerecord=budget_filerecord,
+            budgetcsv_filerecord=budgetcsv_filerecord,
+            filename=filename,
+            pname=pname,
+            child_builder_call=True,
+        )
+        self.init_package(new_package, filename)
+
+    def append_package(
+        self,
+        print_input=None,
+        print_flows=None,
+        save_flows=None,
+        budget_filerecord=None,
+        budgetcsv_filerecord=None,
+        filename=None,
+        pname=None,
+    ):
+        new_package = ModflowGwtmvt(
+            self._cpparent,
+            print_input=print_input,
+            print_flows=print_flows,
+            save_flows=save_flows,
+            budget_filerecord=budget_filerecord,
+            budgetcsv_filerecord=budgetcsv_filerecord,
+            filename=filename,
+            pname=pname,
+            child_builder_call=True,
+        )
+        self._append_package(new_package, filename)

--- a/flopy/mf6/modflow/mfnam.py
+++ b/flopy/mf6/modflow/mfnam.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -83,9 +83,7 @@ class ModflowNam(mfpackage.MFPackage):
     dfn_file_name = "sim-nam.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name continue",
@@ -261,7 +259,7 @@ class ModflowNam(mfpackage.MFPackage):
         solutiongroup=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             simulation, "nam", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfnam.py
+++ b/flopy/mf6/modflow/mfnam.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -261,10 +261,10 @@ class ModflowNam(mfpackage.MFPackage):
         solutiongroup=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            simulation, "nam", filename, pname, loading_package, parent_file
+            simulation, "nam", filename, pname, loading_package, **kwargs
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfnam.py
+++ b/flopy/mf6/modflow/mfnam.py
@@ -83,7 +83,9 @@ class ModflowNam(mfpackage.MFPackage):
     dfn_file_name = "sim-nam.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name continue",

--- a/flopy/mf6/modflow/mftdis.py
+++ b/flopy/mf6/modflow/mftdis.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -64,9 +64,7 @@ class ModflowTdis(mfpackage.MFPackage):
     dfn_file_name = "sim-tdis.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name time_units",
@@ -179,7 +177,7 @@ class ModflowTdis(mfpackage.MFPackage):
         perioddata=((1.0, 1, 1.0),),
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             simulation, "tdis", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mftdis.py
+++ b/flopy/mf6/modflow/mftdis.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -28,10 +28,11 @@ class ModflowTdis(mfpackage.MFPackage):
           simulation list file. The value has no effect on the simulation. The
           recommended format for the starting date and time is described at
           https://www.w3.org/TR/NOTE-datetime.
-    ats_filerecord : [ats6_filename]
-        * ats6_filename (string) defines an adaptive time step (ATS) input file
-          defining ATS controls. Records in the ATS file can be used to
-          override the time step behavior for selected stress periods.
+    ats_perioddata : {varname:data} or perioddata data
+        * Contains data for the ats package. Data can be stored in a dictionary
+          containing data for the ats package with variable names as keys and
+          package data as values. Data just for the ats_perioddata variable is
+          also acceptable. See ats package documentation for more information.
     nper : integer
         * nper (integer) is the number of stress periods for the simulation.
     perioddata : [perlen, nstp, tsmult]
@@ -88,6 +89,9 @@ class ModflowTdis(mfpackage.MFPackage):
             "reader urword",
             "tagged true",
             "optional true",
+            "construct_package ats",
+            "construct_data perioddata",
+            "parameter_name ats_perioddata",
         ],
         [
             "block options",
@@ -170,15 +174,15 @@ class ModflowTdis(mfpackage.MFPackage):
         loading_package=False,
         time_units=None,
         start_date_time=None,
-        ats_filerecord=None,
+        ats_perioddata=None,
         nper=1,
         perioddata=((1.0, 1, 1.0),),
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            simulation, "tdis", filename, pname, loading_package, parent_file
+            simulation, "tdis", filename, pname, loading_package, **kwargs
         )
 
         # set up variables
@@ -186,8 +190,9 @@ class ModflowTdis(mfpackage.MFPackage):
         self.start_date_time = self.build_mfdata(
             "start_date_time", start_date_time
         )
-        self.ats_filerecord = self.build_mfdata(
-            "ats_filerecord", ats_filerecord
+        self._ats_filerecord = self.build_mfdata("ats_filerecord", None)
+        self._ats_package = self.build_child_package(
+            "ats", ats_perioddata, "perioddata", self._ats_filerecord
         )
         self.nper = self.build_mfdata("nper", nper)
         self.perioddata = self.build_mfdata("perioddata", perioddata)

--- a/flopy/mf6/modflow/mftdis.py
+++ b/flopy/mf6/modflow/mftdis.py
@@ -64,7 +64,9 @@ class ModflowTdis(mfpackage.MFPackage):
     dfn_file_name = "sim-tdis.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name time_units",

--- a/flopy/mf6/modflow/mfutlats.py
+++ b/flopy/mf6/modflow/mfutlats.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -11,9 +11,9 @@ class ModflowUtlats(mfpackage.MFPackage):
 
     Parameters
     ----------
-    model : MFModel
-        Model that this package is a part of.  Package is automatically
-        added to model when it is initialized.
+    parent_package : MFPackage
+        Parent_package that this package is a part of. Package is automatically
+        added to parent_package when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
         processing purposes only.
@@ -154,16 +154,16 @@ class ModflowUtlats(mfpackage.MFPackage):
 
     def __init__(
         self,
-        model,
+        parent_package,
         loading_package=False,
         maxats=1,
         perioddata=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "ats", filename, pname, loading_package, parent_file
+            parent_package, "ats", filename, pname, loading_package, **kwargs
         )
 
         # set up variables
@@ -191,24 +191,24 @@ class UtlatsPackages(mfpackage.MFChildPackages):
 
     def initialize(self, maxats=1, perioddata=None, filename=None, pname=None):
         new_package = ModflowUtlats(
-            self._model,
+            self._cpparent,
             maxats=maxats,
             perioddata=perioddata,
             filename=filename,
             pname=pname,
-            parent_file=self._cpparent,
+            child_builder_call=True,
         )
-        self._init_package(new_package, filename)
+        self.init_package(new_package, filename)
 
     def append_package(
         self, maxats=1, perioddata=None, filename=None, pname=None
     ):
         new_package = ModflowUtlats(
-            self._model,
+            self._cpparent,
             maxats=maxats,
             perioddata=perioddata,
             filename=filename,
             pname=pname,
-            parent_file=self._cpparent,
+            child_builder_call=True,
         )
         self._append_package(new_package, filename)

--- a/flopy/mf6/modflow/mfutlats.py
+++ b/flopy/mf6/modflow/mfutlats.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -77,9 +77,7 @@ class ModflowUtlats(mfpackage.MFPackage):
     dfn_file_name = "utl-ats.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block dimensions",
             "name maxats",
@@ -160,7 +158,7 @@ class ModflowUtlats(mfpackage.MFPackage):
         perioddata=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             parent_package, "ats", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfutlats.py
+++ b/flopy/mf6/modflow/mfutlats.py
@@ -77,7 +77,9 @@ class ModflowUtlats(mfpackage.MFPackage):
     dfn_file_name = "utl-ats.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block dimensions",
             "name maxats",

--- a/flopy/mf6/modflow/mfutllaktab.py
+++ b/flopy/mf6/modflow/mfutllaktab.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowUtllaktab(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -55,6 +55,7 @@ class ModflowUtllaktab(mfpackage.MFPackage):
     dfn = [
         [
             "header",
+            "multi-package",
         ],
         [
             "block dimensions",
@@ -125,10 +126,10 @@ class ModflowUtllaktab(mfpackage.MFPackage):
         table=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "laktab", filename, pname, loading_package, parent_file
+            model, "laktab", filename, pname, loading_package, **kwargs
         )
 
         # set up variables
@@ -136,49 +137,3 @@ class ModflowUtllaktab(mfpackage.MFPackage):
         self.ncol = self.build_mfdata("ncol", ncol)
         self.table = self.build_mfdata("table", table)
         self._init_complete = True
-
-
-class UtllaktabPackages(mfpackage.MFChildPackages):
-    """
-    UtllaktabPackages is a container class for the ModflowUtllaktab class.
-
-    Methods
-    ----------
-    initialize
-        Initializes a new ModflowUtllaktab package removing any sibling child
-        packages attached to the same parent package. See ModflowUtllaktab init
-        documentation for definition of parameters.
-    append_package
-        Adds a new ModflowUtllaktab package to the container. See ModflowUtllaktab
-        init documentation for definition of parameters.
-    """
-
-    package_abbr = "utllaktabpackages"
-
-    def initialize(
-        self, nrow=None, ncol=None, table=None, filename=None, pname=None
-    ):
-        new_package = ModflowUtllaktab(
-            self._model,
-            nrow=nrow,
-            ncol=ncol,
-            table=table,
-            filename=filename,
-            pname=pname,
-            parent_file=self._cpparent,
-        )
-        self._init_package(new_package, filename)
-
-    def append_package(
-        self, nrow=None, ncol=None, table=None, filename=None, pname=None
-    ):
-        new_package = ModflowUtllaktab(
-            self._model,
-            nrow=nrow,
-            ncol=ncol,
-            table=table,
-            filename=filename,
-            pname=pname,
-            parent_file=self._cpparent,
-        )
-        self._append_package(new_package, filename)

--- a/flopy/mf6/modflow/mfutllaktab.py
+++ b/flopy/mf6/modflow/mfutllaktab.py
@@ -53,7 +53,10 @@ class ModflowUtllaktab(mfpackage.MFPackage):
     dfn_file_name = "utl-laktab.dfn"
 
     dfn = [
-        ["header", "multi-package",],
+        [
+            "header",
+            "multi-package",
+        ],
         [
             "block dimensions",
             "name nrow",

--- a/flopy/mf6/modflow/mfutllaktab.py
+++ b/flopy/mf6/modflow/mfutllaktab.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -53,10 +53,7 @@ class ModflowUtllaktab(mfpackage.MFPackage):
     dfn_file_name = "utl-laktab.dfn"
 
     dfn = [
-        [
-            "header",
-            "multi-package",
-        ],
+        ["header", "multi-package",],
         [
             "block dimensions",
             "name nrow",
@@ -126,7 +123,7 @@ class ModflowUtllaktab(mfpackage.MFPackage):
         table=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "laktab", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfutlobs.py
+++ b/flopy/mf6/modflow/mfutlobs.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -11,9 +11,9 @@ class ModflowUtlobs(mfpackage.MFPackage):
 
     Parameters
     ----------
-    model : MFModel
-        Model that this package is a part of.  Package is automatically
-        added to model when it is initialized.
+    parent_model_or_package : MFModel/MFPackage
+        Parent_model_or_package that this package is a part of. Package is automatically
+        added to parent_model_or_package when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
         processing purposes only.
@@ -187,17 +187,22 @@ class ModflowUtlobs(mfpackage.MFPackage):
 
     def __init__(
         self,
-        model,
+        parent_model_or_package,
         loading_package=False,
         digits=None,
         print_input=None,
         continuous=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "obs", filename, pname, loading_package, parent_file
+            parent_model_or_package,
+            "obs",
+            filename,
+            pname,
+            loading_package,
+            **kwargs
         )
 
         # set up variables
@@ -230,12 +235,12 @@ class UtlobsPackages(mfpackage.MFChildPackages):
         pname=None,
     ):
         new_package = ModflowUtlobs(
-            self._model,
+            self._cpparent,
             digits=digits,
             print_input=print_input,
             continuous=continuous,
             filename=filename,
             pname=pname,
-            parent_file=self._cpparent,
+            child_builder_call=True,
         )
-        self._init_package(new_package, filename)
+        self.init_package(new_package, filename)

--- a/flopy/mf6/modflow/mfutlobs.py
+++ b/flopy/mf6/modflow/mfutlobs.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -78,10 +78,7 @@ class ModflowUtlobs(mfpackage.MFPackage):
     dfn_file_name = "utl-obs.dfn"
 
     dfn = [
-        [
-            "header",
-            "multi-package",
-        ],
+        ["header", "multi-package",],
         [
             "block options",
             "name digits",
@@ -194,7 +191,7 @@ class ModflowUtlobs(mfpackage.MFPackage):
         continuous=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             parent_model_or_package,
@@ -202,7 +199,7 @@ class ModflowUtlobs(mfpackage.MFPackage):
             filename,
             pname,
             loading_package,
-            **kwargs
+            **kwargs,
         )
 
         # set up variables

--- a/flopy/mf6/modflow/mfutlobs.py
+++ b/flopy/mf6/modflow/mfutlobs.py
@@ -78,7 +78,10 @@ class ModflowUtlobs(mfpackage.MFPackage):
     dfn_file_name = "utl-obs.dfn"
 
     dfn = [
-        ["header", "multi-package",],
+        [
+            "header",
+            "multi-package",
+        ],
         [
             "block options",
             "name digits",

--- a/flopy/mf6/modflow/mfutlsfrtab.py
+++ b/flopy/mf6/modflow/mfutlsfrtab.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -64,10 +64,7 @@ class ModflowUtlsfrtab(mfpackage.MFPackage):
     dfn_file_name = "utl-sfrtab.dfn"
 
     dfn = [
-        [
-            "header",
-            "multi-package",
-        ],
+        ["header", "multi-package",],
         [
             "block dimensions",
             "name nrow",
@@ -128,7 +125,7 @@ class ModflowUtlsfrtab(mfpackage.MFPackage):
         table=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "sfrtab", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfutlsfrtab.py
+++ b/flopy/mf6/modflow/mfutlsfrtab.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowUtlsfrtab(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -66,6 +66,7 @@ class ModflowUtlsfrtab(mfpackage.MFPackage):
     dfn = [
         [
             "header",
+            "multi-package",
         ],
         [
             "block dimensions",
@@ -127,10 +128,10 @@ class ModflowUtlsfrtab(mfpackage.MFPackage):
         table=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "sfrtab", filename, pname, loading_package, parent_file
+            model, "sfrtab", filename, pname, loading_package, **kwargs
         )
 
         # set up variables
@@ -138,49 +139,3 @@ class ModflowUtlsfrtab(mfpackage.MFPackage):
         self.ncol = self.build_mfdata("ncol", ncol)
         self.table = self.build_mfdata("table", table)
         self._init_complete = True
-
-
-class UtlsfrtabPackages(mfpackage.MFChildPackages):
-    """
-    UtlsfrtabPackages is a container class for the ModflowUtlsfrtab class.
-
-    Methods
-    ----------
-    initialize
-        Initializes a new ModflowUtlsfrtab package removing any sibling child
-        packages attached to the same parent package. See ModflowUtlsfrtab init
-        documentation for definition of parameters.
-    append_package
-        Adds a new ModflowUtlsfrtab package to the container. See ModflowUtlsfrtab
-        init documentation for definition of parameters.
-    """
-
-    package_abbr = "utlsfrtabpackages"
-
-    def initialize(
-        self, nrow=None, ncol=None, table=None, filename=None, pname=None
-    ):
-        new_package = ModflowUtlsfrtab(
-            self._model,
-            nrow=nrow,
-            ncol=ncol,
-            table=table,
-            filename=filename,
-            pname=pname,
-            parent_file=self._cpparent,
-        )
-        self._init_package(new_package, filename)
-
-    def append_package(
-        self, nrow=None, ncol=None, table=None, filename=None, pname=None
-    ):
-        new_package = ModflowUtlsfrtab(
-            self._model,
-            nrow=nrow,
-            ncol=ncol,
-            table=table,
-            filename=filename,
-            pname=pname,
-            parent_file=self._cpparent,
-        )
-        self._append_package(new_package, filename)

--- a/flopy/mf6/modflow/mfutlsfrtab.py
+++ b/flopy/mf6/modflow/mfutlsfrtab.py
@@ -64,7 +64,10 @@ class ModflowUtlsfrtab(mfpackage.MFPackage):
     dfn_file_name = "utl-sfrtab.dfn"
 
     dfn = [
-        ["header", "multi-package",],
+        [
+            "header",
+            "multi-package",
+        ],
         [
             "block dimensions",
             "name nrow",

--- a/flopy/mf6/modflow/mfutlspc.py
+++ b/flopy/mf6/modflow/mfutlspc.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowUtlspc(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -185,10 +185,10 @@ class ModflowUtlspc(mfpackage.MFPackage):
         perioddata=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "spc", filename, pname, loading_package, parent_file
+            model, "spc", filename, pname, loading_package, **kwargs
         )
 
         # set up variables
@@ -200,63 +200,3 @@ class ModflowUtlspc(mfpackage.MFPackage):
         self.maxbound = self.build_mfdata("maxbound", maxbound)
         self.perioddata = self.build_mfdata("perioddata", perioddata)
         self._init_complete = True
-
-
-class UtlspcPackages(mfpackage.MFChildPackages):
-    """
-    UtlspcPackages is a container class for the ModflowUtlspc class.
-
-    Methods
-    ----------
-    initialize
-        Initializes a new ModflowUtlspc package removing any sibling child
-        packages attached to the same parent package. See ModflowUtlspc init
-        documentation for definition of parameters.
-    append_package
-        Adds a new ModflowUtlspc package to the container. See ModflowUtlspc
-        init documentation for definition of parameters.
-    """
-
-    package_abbr = "utlspcpackages"
-
-    def initialize(
-        self,
-        print_input=None,
-        timeseries=None,
-        maxbound=None,
-        perioddata=None,
-        filename=None,
-        pname=None,
-    ):
-        new_package = ModflowUtlspc(
-            self._model,
-            print_input=print_input,
-            timeseries=timeseries,
-            maxbound=maxbound,
-            perioddata=perioddata,
-            filename=filename,
-            pname=pname,
-            parent_file=self._cpparent,
-        )
-        self._init_package(new_package, filename)
-
-    def append_package(
-        self,
-        print_input=None,
-        timeseries=None,
-        maxbound=None,
-        perioddata=None,
-        filename=None,
-        pname=None,
-    ):
-        new_package = ModflowUtlspc(
-            self._model,
-            print_input=print_input,
-            timeseries=timeseries,
-            maxbound=maxbound,
-            perioddata=perioddata,
-            filename=filename,
-            pname=pname,
-            parent_file=self._cpparent,
-        )
-        self._append_package(new_package, filename)

--- a/flopy/mf6/modflow/mfutlspc.py
+++ b/flopy/mf6/modflow/mfutlspc.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -65,10 +65,7 @@ class ModflowUtlspc(mfpackage.MFPackage):
     dfn_file_name = "utl-spc.dfn"
 
     dfn = [
-        [
-            "header",
-            "multi-package",
-        ],
+        ["header", "multi-package",],
         [
             "block options",
             "name print_input",
@@ -185,7 +182,7 @@ class ModflowUtlspc(mfpackage.MFPackage):
         perioddata=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "spc", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfutlspc.py
+++ b/flopy/mf6/modflow/mfutlspc.py
@@ -65,7 +65,10 @@ class ModflowUtlspc(mfpackage.MFPackage):
     dfn_file_name = "utl-spc.dfn"
 
     dfn = [
-        ["header", "multi-package",],
+        [
+            "header",
+            "multi-package",
+        ],
         [
             "block options",
             "name print_input",

--- a/flopy/mf6/modflow/mfutlspca.py
+++ b/flopy/mf6/modflow/mfutlspca.py
@@ -55,7 +55,10 @@ class ModflowUtlspca(mfpackage.MFPackage):
     dfn_file_name = "utl-spca.dfn"
 
     dfn = [
-        ["header", "multi-package",],
+        [
+            "header",
+            "multi-package",
+        ],
         [
             "block options",
             "name readasarrays",

--- a/flopy/mf6/modflow/mfutlspca.py
+++ b/flopy/mf6/modflow/mfutlspca.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -55,10 +55,7 @@ class ModflowUtlspca(mfpackage.MFPackage):
     dfn_file_name = "utl-spca.dfn"
 
     dfn = [
-        [
-            "header",
-            "multi-package",
-        ],
+        ["header", "multi-package",],
         [
             "block options",
             "name readasarrays",
@@ -149,7 +146,7 @@ class ModflowUtlspca(mfpackage.MFPackage):
         concentration=0.0,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             model, "spca", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfutlspca.py
+++ b/flopy/mf6/modflow/mfutlspca.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -12,7 +12,7 @@ class ModflowUtlspca(mfpackage.MFPackage):
     Parameters
     ----------
     model : MFModel
-        Model that this package is a part of.  Package is automatically
+        Model that this package is a part of. Package is automatically
         added to model when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
@@ -149,10 +149,10 @@ class ModflowUtlspca(mfpackage.MFPackage):
         concentration=0.0,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "spca", filename, pname, loading_package, parent_file
+            model, "spca", filename, pname, loading_package, **kwargs
         )
 
         # set up variables
@@ -164,63 +164,3 @@ class ModflowUtlspca(mfpackage.MFPackage):
         )
         self.concentration = self.build_mfdata("concentration", concentration)
         self._init_complete = True
-
-
-class UtlspcaPackages(mfpackage.MFChildPackages):
-    """
-    UtlspcaPackages is a container class for the ModflowUtlspca class.
-
-    Methods
-    ----------
-    initialize
-        Initializes a new ModflowUtlspca package removing any sibling child
-        packages attached to the same parent package. See ModflowUtlspca init
-        documentation for definition of parameters.
-    append_package
-        Adds a new ModflowUtlspca package to the container. See ModflowUtlspca
-        init documentation for definition of parameters.
-    """
-
-    package_abbr = "utlspcapackages"
-
-    def initialize(
-        self,
-        readasarrays=True,
-        print_input=None,
-        timearrayseries=None,
-        concentration=0.0,
-        filename=None,
-        pname=None,
-    ):
-        new_package = ModflowUtlspca(
-            self._model,
-            readasarrays=readasarrays,
-            print_input=print_input,
-            timearrayseries=timearrayseries,
-            concentration=concentration,
-            filename=filename,
-            pname=pname,
-            parent_file=self._cpparent,
-        )
-        self._init_package(new_package, filename)
-
-    def append_package(
-        self,
-        readasarrays=True,
-        print_input=None,
-        timearrayseries=None,
-        concentration=0.0,
-        filename=None,
-        pname=None,
-    ):
-        new_package = ModflowUtlspca(
-            self._model,
-            readasarrays=readasarrays,
-            print_input=print_input,
-            timearrayseries=timearrayseries,
-            concentration=concentration,
-            filename=filename,
-            pname=pname,
-            parent_file=self._cpparent,
-        )
-        self._append_package(new_package, filename)

--- a/flopy/mf6/modflow/mfutltas.py
+++ b/flopy/mf6/modflow/mfutltas.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -55,10 +55,7 @@ class ModflowUtltas(mfpackage.MFPackage):
     dfn_file_name = "utl-tas.dfn"
 
     dfn = [
-        [
-            "header",
-            "multi-package",
-        ],
+        ["header", "multi-package",],
         [
             "block attributes",
             "name time_series_namerecord",
@@ -173,7 +170,7 @@ class ModflowUtltas(mfpackage.MFPackage):
         tas_array=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             parent_package, "tas", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfutltas.py
+++ b/flopy/mf6/modflow/mfutltas.py
@@ -55,7 +55,10 @@ class ModflowUtltas(mfpackage.MFPackage):
     dfn_file_name = "utl-tas.dfn"
 
     dfn = [
-        ["header", "multi-package",],
+        [
+            "header",
+            "multi-package",
+        ],
         [
             "block attributes",
             "name time_series_namerecord",

--- a/flopy/mf6/modflow/mfutltas.py
+++ b/flopy/mf6/modflow/mfutltas.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -11,9 +11,9 @@ class ModflowUtltas(mfpackage.MFPackage):
 
     Parameters
     ----------
-    model : MFModel
-        Model that this package is a part of.  Package is automatically
-        added to model when it is initialized.
+    parent_package : MFPackage
+        Parent_package that this package is a part of. Package is automatically
+        added to parent_package when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
         processing purposes only.
@@ -165,7 +165,7 @@ class ModflowUtltas(mfpackage.MFPackage):
 
     def __init__(
         self,
-        model,
+        parent_package,
         loading_package=False,
         time_series_namerecord=None,
         interpolation_methodrecord=None,
@@ -173,10 +173,10 @@ class ModflowUtltas(mfpackage.MFPackage):
         tas_array=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "tas", filename, pname, loading_package, parent_file
+            parent_package, "tas", filename, pname, loading_package, **kwargs
         )
 
         # set up variables
@@ -218,16 +218,16 @@ class UtltasPackages(mfpackage.MFChildPackages):
         pname=None,
     ):
         new_package = ModflowUtltas(
-            self._model,
+            self._cpparent,
             time_series_namerecord=time_series_namerecord,
             interpolation_methodrecord=interpolation_methodrecord,
             sfacrecord=sfacrecord,
             tas_array=tas_array,
             filename=filename,
             pname=pname,
-            parent_file=self._cpparent,
+            child_builder_call=True,
         )
-        self._init_package(new_package, filename)
+        self.init_package(new_package, filename)
 
     def append_package(
         self,
@@ -239,13 +239,13 @@ class UtltasPackages(mfpackage.MFChildPackages):
         pname=None,
     ):
         new_package = ModflowUtltas(
-            self._model,
+            self._cpparent,
             time_series_namerecord=time_series_namerecord,
             interpolation_methodrecord=interpolation_methodrecord,
             sfacrecord=sfacrecord,
             tas_array=tas_array,
             filename=filename,
             pname=pname,
-            parent_file=self._cpparent,
+            child_builder_call=True,
         )
         self._append_package(new_package, filename)

--- a/flopy/mf6/modflow/mfutlts.py
+++ b/flopy/mf6/modflow/mfutlts.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -71,10 +71,7 @@ class ModflowUtlts(mfpackage.MFPackage):
     dfn_file_name = "utl-ts.dfn"
 
     dfn = [
-        [
-            "header",
-            "multi-package",
-        ],
+        ["header", "multi-package",],
         [
             "block attributes",
             "name time_series_namerecord",
@@ -242,7 +239,7 @@ class ModflowUtlts(mfpackage.MFPackage):
         timeseries=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             parent_package, "ts", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfutlts.py
+++ b/flopy/mf6/modflow/mfutlts.py
@@ -71,7 +71,10 @@ class ModflowUtlts(mfpackage.MFPackage):
     dfn_file_name = "utl-ts.dfn"
 
     dfn = [
-        ["header", "multi-package",],
+        [
+            "header",
+            "multi-package",
+        ],
         [
             "block attributes",
             "name time_series_namerecord",

--- a/flopy/mf6/modflow/mfutlts.py
+++ b/flopy/mf6/modflow/mfutlts.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -11,9 +11,9 @@ class ModflowUtlts(mfpackage.MFPackage):
 
     Parameters
     ----------
-    model : MFModel
-        Model that this package is a part of.  Package is automatically
-        added to model when it is initialized.
+    parent_package : MFPackage
+        Parent_package that this package is a part of. Package is automatically
+        added to parent_package when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
         processing purposes only.
@@ -232,7 +232,7 @@ class ModflowUtlts(mfpackage.MFPackage):
 
     def __init__(
         self,
-        model,
+        parent_package,
         loading_package=False,
         time_series_namerecord=None,
         interpolation_methodrecord=None,
@@ -242,10 +242,10 @@ class ModflowUtlts(mfpackage.MFPackage):
         timeseries=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "ts", filename, pname, loading_package, parent_file
+            parent_package, "ts", filename, pname, loading_package, **kwargs
         )
 
         # set up variables
@@ -296,7 +296,7 @@ class UtltsPackages(mfpackage.MFChildPackages):
         pname=None,
     ):
         new_package = ModflowUtlts(
-            self._model,
+            self._cpparent,
             time_series_namerecord=time_series_namerecord,
             interpolation_methodrecord=interpolation_methodrecord,
             interpolation_methodrecord_single=interpolation_methodrecord_single,
@@ -305,9 +305,9 @@ class UtltsPackages(mfpackage.MFChildPackages):
             timeseries=timeseries,
             filename=filename,
             pname=pname,
-            parent_file=self._cpparent,
+            child_builder_call=True,
         )
-        self._init_package(new_package, filename)
+        self.init_package(new_package, filename)
 
     def append_package(
         self,
@@ -321,7 +321,7 @@ class UtltsPackages(mfpackage.MFChildPackages):
         pname=None,
     ):
         new_package = ModflowUtlts(
-            self._model,
+            self._cpparent,
             time_series_namerecord=time_series_namerecord,
             interpolation_methodrecord=interpolation_methodrecord,
             interpolation_methodrecord_single=interpolation_methodrecord_single,
@@ -330,6 +330,6 @@ class UtltsPackages(mfpackage.MFChildPackages):
             timeseries=timeseries,
             filename=filename,
             pname=pname,
-            parent_file=self._cpparent,
+            child_builder_call=True,
         )
         self._append_package(new_package, filename)

--- a/flopy/mf6/modflow/mfutltvk.py
+++ b/flopy/mf6/modflow/mfutltvk.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -85,9 +85,7 @@ class ModflowUtltvk(mfpackage.MFPackage):
     dfn_file_name = "utl-tvk.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name print_input",
@@ -215,7 +213,7 @@ class ModflowUtltvk(mfpackage.MFPackage):
         perioddata=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             parent_package, "tvk", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfutltvk.py
+++ b/flopy/mf6/modflow/mfutltvk.py
@@ -85,7 +85,9 @@ class ModflowUtltvk(mfpackage.MFPackage):
     dfn_file_name = "utl-tvk.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name print_input",

--- a/flopy/mf6/modflow/mfutltvk.py
+++ b/flopy/mf6/modflow/mfutltvk.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -11,9 +11,9 @@ class ModflowUtltvk(mfpackage.MFPackage):
 
     Parameters
     ----------
-    model : MFModel
-        Model that this package is a part of.  Package is automatically
-        added to model when it is initialized.
+    parent_package : MFPackage
+        Parent_package that this package is a part of. Package is automatically
+        added to parent_package when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
         processing purposes only.
@@ -208,17 +208,17 @@ class ModflowUtltvk(mfpackage.MFPackage):
 
     def __init__(
         self,
-        model,
+        parent_package,
         loading_package=False,
         print_input=None,
         timeseries=None,
         perioddata=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "tvk", filename, pname, loading_package, parent_file
+            parent_package, "tvk", filename, pname, loading_package, **kwargs
         )
 
         # set up variables
@@ -257,15 +257,15 @@ class UtltvkPackages(mfpackage.MFChildPackages):
         pname=None,
     ):
         new_package = ModflowUtltvk(
-            self._model,
+            self._cpparent,
             print_input=print_input,
             timeseries=timeseries,
             perioddata=perioddata,
             filename=filename,
             pname=pname,
-            parent_file=self._cpparent,
+            child_builder_call=True,
         )
-        self._init_package(new_package, filename)
+        self.init_package(new_package, filename)
 
     def append_package(
         self,
@@ -276,12 +276,12 @@ class UtltvkPackages(mfpackage.MFChildPackages):
         pname=None,
     ):
         new_package = ModflowUtltvk(
-            self._model,
+            self._cpparent,
             print_input=print_input,
             timeseries=timeseries,
             perioddata=perioddata,
             filename=filename,
             pname=pname,
-            parent_file=self._cpparent,
+            child_builder_call=True,
         )
         self._append_package(new_package, filename)

--- a/flopy/mf6/modflow/mfutltvs.py
+++ b/flopy/mf6/modflow/mfutltvs.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on April 11, 2022 16:16:27 UTC
+# FILE created on April 11, 2022 18:22:41 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -83,9 +83,7 @@ class ModflowUtltvs(mfpackage.MFPackage):
     dfn_file_name = "utl-tvs.dfn"
 
     dfn = [
-        [
-            "header",
-        ],
+        ["header",],
         [
             "block options",
             "name disable_storage_change_integration",
@@ -211,7 +209,7 @@ class ModflowUtltvs(mfpackage.MFPackage):
         perioddata=None,
         filename=None,
         pname=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             parent_package, "tvs", filename, pname, loading_package, **kwargs

--- a/flopy/mf6/modflow/mfutltvs.py
+++ b/flopy/mf6/modflow/mfutltvs.py
@@ -83,7 +83,9 @@ class ModflowUtltvs(mfpackage.MFPackage):
     dfn_file_name = "utl-tvs.dfn"
 
     dfn = [
-        ["header",],
+        [
+            "header",
+        ],
         [
             "block options",
             "name disable_storage_change_integration",

--- a/flopy/mf6/modflow/mfutltvs.py
+++ b/flopy/mf6/modflow/mfutltvs.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on March 07, 2022 16:59:43 UTC
+# FILE created on April 11, 2022 16:16:27 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -11,9 +11,9 @@ class ModflowUtltvs(mfpackage.MFPackage):
 
     Parameters
     ----------
-    model : MFModel
-        Model that this package is a part of.  Package is automatically
-        added to model when it is initialized.
+    parent_package : MFPackage
+        Parent_package that this package is a part of. Package is automatically
+        added to parent_package when it is initialized.
     loading_package : bool
         Do not set this parameter. It is intended for debugging and internal
         processing purposes only.
@@ -203,7 +203,7 @@ class ModflowUtltvs(mfpackage.MFPackage):
 
     def __init__(
         self,
-        model,
+        parent_package,
         loading_package=False,
         disable_storage_change_integration=None,
         print_input=None,
@@ -211,10 +211,10 @@ class ModflowUtltvs(mfpackage.MFPackage):
         perioddata=None,
         filename=None,
         pname=None,
-        parent_file=None,
+        **kwargs
     ):
         super().__init__(
-            model, "tvs", filename, pname, loading_package, parent_file
+            parent_package, "tvs", filename, pname, loading_package, **kwargs
         )
 
         # set up variables
@@ -258,16 +258,16 @@ class UtltvsPackages(mfpackage.MFChildPackages):
         pname=None,
     ):
         new_package = ModflowUtltvs(
-            self._model,
+            self._cpparent,
             disable_storage_change_integration=disable_storage_change_integration,
             print_input=print_input,
             timeseries=timeseries,
             perioddata=perioddata,
             filename=filename,
             pname=pname,
-            parent_file=self._cpparent,
+            child_builder_call=True,
         )
-        self._init_package(new_package, filename)
+        self.init_package(new_package, filename)
 
     def append_package(
         self,
@@ -279,13 +279,13 @@ class UtltvsPackages(mfpackage.MFChildPackages):
         pname=None,
     ):
         new_package = ModflowUtltvs(
-            self._model,
+            self._cpparent,
             disable_storage_change_integration=disable_storage_change_integration,
             print_input=print_input,
             timeseries=timeseries,
             perioddata=perioddata,
             filename=filename,
             pname=pname,
-            parent_file=self._cpparent,
+            child_builder_call=True,
         )
         self._append_package(new_package, filename)

--- a/flopy/mf6/utils/generate_classes.py
+++ b/flopy/mf6/utils/generate_classes.py
@@ -63,7 +63,7 @@ def download_dfn(branch, new_dfn_pth):
         print(msg)
         return
 
-    mf6url = "https://github.com/MODFLOW-USGS/modflow6/archive/{}.zip"
+    mf6url = "https://github.com/spaulins-usgs/modflow6/archive/{}.zip"
     mf6url = mf6url.format(branch)
     print(f"  Downloading MODFLOW 6 repository from {mf6url}")
     with tempfile.TemporaryDirectory() as tmpdirname:

--- a/flopy/mf6/utils/generate_classes.py
+++ b/flopy/mf6/utils/generate_classes.py
@@ -63,7 +63,7 @@ def download_dfn(branch, new_dfn_pth):
         print(msg)
         return
 
-    mf6url = "https://github.com/spaulins-usgs/modflow6/archive/{}.zip"
+    mf6url = "https://github.com/MODFLOW-USGS/modflow6/archive/{}.zip"
     mf6url = mf6url.format(branch)
     print(f"  Downloading MODFLOW 6 repository from {mf6url}")
     with tempfile.TemporaryDirectory() as tmpdirname:

--- a/flopy/mf6/utils/output_util.py
+++ b/flopy/mf6/utils/output_util.py
@@ -50,7 +50,7 @@ class MF6Output:
             if isinstance(obj, ModelInterface):
                 self._model = obj
             else:
-                self._model = obj.parent
+                self._model = obj.model_or_sim
             self._mtype = self._model.model_type
             nam_file = self._model.model_nam_file[:-4]
             self._lst = (


### PR DESCRIPTION
*** Breaks interface ***

Adding different types of mvr packages will no longer require modifying flopy code. Flopy code updated to better support generic child packages. The mvr and gnc packages are now sub-packages like the obs/ts/tas packages and uses the sub-package interface 
 (this breaks the existing interface and may require minor modifications to end-user code).  Additionally, mvt, ats, tvk, and tvs all are now sub-packages and use the sub-package interface.  This could potentially break end-user code as well, though these packages are so new the impact will likely be minimal.  Documentation added for adding new packages and models to flopy. Tutorial added for demonstrating a simulation with multiple models.

*** Breaks interface ***