### PR TITLE
make sure shape in variables 'zones' and 'retardation' is 3d in Modpath7Sim

### DIFF
--- a/flopy/modpath/mp7bas.py
+++ b/flopy/modpath/mp7bas.py
@@ -55,24 +55,14 @@ class Modpath7Bas(Package):
 
         self._generate_heading()
 
-        if model.flowmodel.version == "mf6":
-            self.laytyp = Util2d(
-                self.parent,
-                (shape[0],),
-                np.int32,
-                model.laytyp,
-                name="bas - laytype",
-                locat=self.unit_number[0],
-            )
-        else:
-            self.laytyp = Util2d(
-                self.parent,
-                (shape[0],),
-                np.int32,
-                model.laytyp,
-                name="bas - laytype",
-                locat=self.unit_number[0],
-            )
+        self.laytyp = Util2d(
+            self.parent,
+            (shape[0],),
+            np.int32,
+            model.laytyp,
+            name="bas - laytype",
+            locat=self.unit_number[0],
+        )
         if model.flowmodel.version != "mf6":
             self.ibound = Util3d(
                 model,

--- a/flopy/modpath/mp7sim.py
+++ b/flopy/modpath/mp7sim.py
@@ -498,6 +498,14 @@ class Modpath7Sim(Package):
         self.timepointoption = timepointoption
         self.timepointdata = timepointdata
 
+        shape = self.parent.shape
+        if len(shape) == 3:
+            shape3d = shape
+        elif len(shape) == 2:
+            shape3d = (shape[0], 1, shape[1])
+        else:
+            shape3d = (1, 1, shape[0])
+
         # zonedataoption
         try:
             self.zonedataoption = onoffOpt[zonedataoption.lower()].value
@@ -517,7 +525,7 @@ class Modpath7Sim(Package):
                 )
             self.zones = Util3d(
                 model,
-                self.parent.shape,
+                shape3d,
                 np.int32,
                 zones,
                 name="zones",
@@ -541,7 +549,7 @@ class Modpath7Sim(Package):
                 )
             self.retardation = Util3d(
                 model,
-                self.parent.shape,
+                shape3d,
                 np.float32,
                 retardation,
                 name="retardation",


### PR DESCRIPTION
This pull request fixes a bug where the variable `zones` (and probably `retardation` as well, but I did not test this) cannot be supplied to the class `Modpath7Sim` for a model with a disv-discretisation. Right now this would generate the following error:
`ValueError: Util3d: expected 3 dimensions, found shape (nlay, ncpl)`

I copied some code from `Modpath7Bas` to make sure the supplied shape is 3d.