### PR TITLE
fix(mfusg) flat arrays for layer-based properties

### DIFF
--- a/autotest/t016_test.py
+++ b/autotest/t016_test.py
@@ -380,6 +380,37 @@ def test_freyburg_usg():
 
     return
 
+def test_flat_array_to_util3d_usg():
+    # test mfusg model package constructor with flat arrays
+    # for layer-based properties
+    print("testing usg flat arrays to layer property constructor")
+
+    new_ws = f"{base_dir}_test_usg_freyburg"
+    test_setup = FlopyTestSetup(verbose=True, test_dirs=new_ws)
+
+    model_ws = os.path.join(
+        "..", "examples", "data", "freyberg_usg"
+    )
+    nam = "freyberg.usg.nam"
+    m = flopy.mfusg.MfUsg.load(nam, model_ws=model_ws, exe_name=v)
+
+    custom_array = m.lpf.hk.array
+    
+    msg = "lpf.hk.array should return a flat array disu.nodes long"
+    assert custom_array.ndim == 1 and custom_array.size == m.disu.nodes, msg
+
+    # modify hk array and check updates values are in the lpf
+    custom_array[m.disu.nodelay[1]:m.disu.nodelay[1] + 2] = 999.9
+    lpf_new = flopy.mfusg.MfUsgLpf(m, hk=custom_array)
+
+    msg = "modified flat array provided to lpf constructor is not updated as expected."
+    assert (lpf_new.hk[1][:2] == 999.9).all(), msg
+
+    # ensure we can still write the lpf file
+    m.model_ws = new_ws
+    m.write_input()
+
+    return
 
 if __name__ == "__main__":
     test_usg_disu_load()
@@ -394,3 +425,4 @@ if __name__ == "__main__":
     test_usg_str()
     test_usg_lak()
     test_freyburg_usg()
+    test_flat_array_to_util3d_usg()

--- a/flopy/utils/util_array.py
+++ b/flopy/utils/util_array.py
@@ -795,6 +795,17 @@ class Util3d(DataInterface):
         ):
             self.__value = [self.__value] * self.shape[0]
 
+        # if this is a flat array for an unstructured mfusg model,
+        # convert to a (possibly jagged) list of layer arrays
+        if (
+            self.shape[1] is None
+            and isinstance(self.shape[2], (np.ndarray, list))
+            and len(self.__value) == np.sum(self.shape[2])
+        ):
+            self.__value = np.split(
+                self.__value, np.cumsum(self.shape[2])[:-1]
+            )
+
         # if this is a list or 1-D array with constant values per layer
         if isinstance(self.__value, list) or (
             isinstance(self.__value, np.ndarray) and (self.__value.ndim == 1)


### PR DESCRIPTION
mfusg layer-based properties can not be provided as a flat model-wide array.

-trap for flat mfusg property arrays in Util3d, convert to a (potentially jagged) list
-add test to t016: providing a flat property array to a package constructor
close #1427 