### PR TITLE
Lift pyshp version cap

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - conda-forge::scipy
   - conda-forge::pandas
   - conda-forge::netcdf4
-  - conda-forge::pyshp<2.2.0
+  - conda-forge::pyshp
   - conda-forge::rasterio
   - conda-forge::fiona
   - conda-forge::descartes

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -24,7 +24,7 @@ dependencies:
   - scipy
   - pandas
   - netcdf4
-  - pyshp<2.2.0
+  - pyshp
   - rasterio
   - fiona
   - descartes

--- a/etc/requirements.full.pip.txt
+++ b/etc/requirements.full.pip.txt
@@ -18,7 +18,7 @@ affine
 scipy
 pandas
 netcdf4
-pyshp<2.2.0
+pyshp
 rasterio
 fiona
 descartes

--- a/etc/requirements.windows.pip.txt
+++ b/etc/requirements.windows.pip.txt
@@ -18,7 +18,7 @@ affine
 scipy
 pandas
 netcdf4
-pyshp<2.2.0
+pyshp
 descartes
 pyproj
 shapely

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ netcdf4
 fiona ; python_version < '3.8'
 descartes
 pyproj
-pyshp<2.2.0
+pyshp
 pandas
 scipy
 affine


### PR DESCRIPTION
The `pyshp` package [was restricted](https://github.com/modflowpy/flopy/commit/2160ba6f049a91ba2ed28fc51bee851b92713f7c) to `<2.2.0` for CI issues some time ago. I also noticed [some test cases](https://github.com/modflowpy/flopy/blob/ea6a0a190070f065d74824b421de70d4a66ebcc2/autotest/t074_test_geospatial_util.py#L152) account for API changes introduced in `2.2.0`.

I am able to pass all the tests with `2.3.0`. Wondering if the `pyshp` version restriction can be lifted or if some more tests might be necessary to be sure of compatibility. ~~I will update this PR with more current info after the CI runs.~~ Looks like CI passes (excepting the outstanding Windows failures).