### PR TITLE
feat: get modflow utility

### DIFF
--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2.2.2
         with:
-          python-version: 3.9
+          python-version: 3.8
 
       - name: Upgrade pip
         run: |
@@ -43,20 +43,16 @@ jobs:
 
       - name: Install prerequisites
         run: |
-          pip install https://github.com/modflowpy/pymake/zipball/master
           pip install jupyter jupytext
 
       - name: Install flopy and dependencies
         run: |
-          pip install .[test,doc]
+          pip install .[doc]
 
-      - name: Prepare for the autotests
-        working-directory: ./autotest
+      - name: Install executables and add to PATH
         run: |
-          pytest -v ci_prepare.py
-
-      - name: Add executables directory to path
-        run: |
+          mkdir -p $HOME/.local/bin
+          get-modflow $HOME/.local/bin
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Run jupytext on tutorials

--- a/autotest/test_scripts.py
+++ b/autotest/test_scripts.py
@@ -1,0 +1,136 @@
+"""Test scripts."""
+import socket
+import sys
+from pathlib import Path
+from subprocess import Popen, PIPE
+
+import pytest
+
+
+def is_connected(hostname):
+    """See https://stackoverflow.com/a/20913928/ to test hostname."""
+    try:
+        host = socket.gethostbyname(hostname)
+        s = socket.create_connection((host, 80), 2)
+        s.close()
+        return True
+    except Exception:
+        pass
+    return False
+
+
+requires_github = pytest.mark.skipif(
+    not is_connected("github.com"), reason="github.com is required."
+)
+
+flopy_dir = Path(__file__).parents[1] / "flopy"
+get_modflow_script = flopy_dir / "utils" / "get_modflow.py"
+
+
+@pytest.fixture(scope="session")
+def downloads_dir(tmp_path_factory):
+    downloads_dir = tmp_path_factory.mktemp("Downloads")
+    return downloads_dir
+
+
+def run_py_script(script, *args):
+    """Run a Python script, return tuple (stdout, stderr, returncode)."""
+    args = [sys.executable, str(script)] + [str(g) for g in args]
+    print("running: " + " ".join(args))
+    p = Popen(args, stdout=PIPE, stderr=PIPE)
+    stdout, stderr = p.communicate()
+    stdout = stdout.decode()
+    stderr = stderr.decode()
+    returncode = p.returncode
+    return stdout, stderr, returncode
+
+
+def run_get_modflow_script(*args):
+    return run_py_script(get_modflow_script, *args)
+
+
+def test_script_usage():
+    assert get_modflow_script.exists()
+    stdout, stderr, returncode = run_get_modflow_script("-h")
+    assert "usage" in stdout
+    assert len(stderr) == 0
+    assert returncode == 0
+
+
+@requires_github
+def test_get_modflow(tmp_path, downloads_dir):
+    # exit if extraction directory does not exist
+    bindir = tmp_path / "bin1"
+    assert not bindir.exists()
+    stdout, stderr, returncode = run_get_modflow_script(bindir)
+    assert "does not exist" in stderr
+    assert returncode == 1
+
+    # ensure extraction directory exists
+    bindir.mkdir()
+    assert bindir.exists()
+
+    # attempt to fetch a non-existing release-id
+    stdout, stderr, returncode = run_get_modflow_script(
+        bindir, "--release-id", "1.9", "--downloads-dir", downloads_dir
+    )
+    assert "Release '1.9' not found" in stderr
+    assert returncode == 1
+
+    # fetch latest
+    stdout, stderr, returncode = run_get_modflow_script(
+        bindir, "--downloads-dir", downloads_dir
+    )
+    assert len(stderr) == returncode == 0
+    files = [item.name for item in bindir.iterdir() if item.is_file()]
+    assert len(files) > 20
+
+    # take only a few files using --subset, starting with invalid
+    bindir = tmp_path / "bin2"
+    bindir.mkdir()
+    stdout, stderr, returncode = run_get_modflow_script(
+        bindir, "--subset", "mfnwt,mpx", "--downloads-dir", downloads_dir
+    )
+    assert "subset item not found: mpx" in stderr
+    assert returncode == 1
+    # now valid subset
+    stdout, stderr, returncode = run_get_modflow_script(
+        bindir, "--subset", "mfnwt,mp6", "--downloads-dir", downloads_dir
+    )
+    assert len(stderr) == returncode == 0
+    files = [item.stem for item in bindir.iterdir() if item.is_file()]
+    assert sorted(files) == ["mfnwt", "mfnwtdbl", "mp6"]
+
+    # similar as before, but also specify a ostag
+    bindir = tmp_path / "bin3"
+    bindir.mkdir()
+    stdout, stderr, returncode = run_get_modflow_script(
+        bindir,
+        "--subset",
+        "mfnwt",
+        "--release-id",
+        "2.0",
+        "--ostag",
+        "win64",
+        "--downloads-dir",
+        downloads_dir,
+    )
+    assert len(stderr) == returncode == 0
+    files = [item.name for item in bindir.iterdir() if item.is_file()]
+    assert sorted(files) == ["mfnwt.exe", "mfnwtdbl.exe"]
+
+
+@requires_github
+def test_get_mf6_nightly(tmp_path, downloads_dir):
+    bindir = tmp_path / "bin1"
+    bindir.mkdir()
+    stdout, stderr, returncode = run_get_modflow_script(
+        bindir,
+        "--repo",
+        "modflow6-nightly-build",
+        "--downloads-dir",
+        downloads_dir,
+    )
+    assert len(stderr) == returncode == 0
+    files = [item.name for item in bindir.iterdir() if item.is_file()]
+    assert len(files) >= 4

--- a/docs/get_modflow.md
+++ b/docs/get_modflow.md
@@ -1,0 +1,42 @@
+# Install MODFLOW and related programs
+
+This method describes how to install USGS MODFLOW and related programs for Windows, Mac or Linux using a "get modflow" utility. If FloPy is installed, the utility is available in the Python environment as a `get-modflow` command. The same utility is also available as a Python script `get_modflow.py`, described later.
+
+The utility uses a [GitHub releases API](https://docs.github.com/en/rest/releases) to download versioned archives of programs that have been compiled with modern Intel Fortran compilers. The utility is able to match the binary archive to the operating system, and extract the console programs to a user-defined directory. A prompt can also be used to assist where to install programs.
+
+## Command-line interface
+
+### Using `get-modflow` from FloPy
+
+When FloPy is installed, a `get-modflow` (or `get-modflow.exe` for Windows) program is installed, which is usually installed to the PATH (depending on the Python setup). From a console:
+
+```console
+$ get-modflow --help
+usage: get-modflow [-h]
+...
+```
+
+### Using `get_modflow.py` as a script
+
+The script requires Python 3.6 or later and does not have any dependencies, not even FloPy. It can be downloaded separately and used the same as the console program, except with a different invocation. For example:
+
+```console
+$ wget https://raw.githubusercontent.com/modflowpy/flopy/develop/flopy/utils/get_modflow.py
+$ python3 get_modflow.py --help
+usage: get_modflow.py [-h]
+...
+```
+
+## FloPy module
+
+The same functionality of the command-line interface is available from the FloPy module, as demonstrated below:
+
+```python
+from pathlib import Path
+import flopy
+
+bindir = Path("/tmp/bin")
+bindir.mkdir()
+flopy.utils.get_modflow_main(bindir)
+list(bindir.iterdir())
+```

--- a/flopy/utils/__init__.py
+++ b/flopy/utils/__init__.py
@@ -31,6 +31,7 @@ from .binaryfile import (
 from .check import check
 from .flopy_io import read_fixed_var, write_fixed_var
 from .formattedfile import FormattedHeadFile
+from .get_modflow import run_main as get_modflow_main
 from .gridintersect import GridIntersect, ModflowGridIndices
 from .mflistfile import (
     Mf6ListBudget,

--- a/flopy/utils/get_modflow.py
+++ b/flopy/utils/get_modflow.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""Download and install USGS MODFLOW and related programs.
+
+This script originates from FloPy: https://github.com/modflowpy/flopy
+This file can be downloaded and run independently outside FloPy.
+It requires Python 3.6 or later, and has no dependencies.
+
+See https://developer.github.com/v3/repos/releases/ for GitHub Releases API.
+"""
+import json
+import os
+import sys
+import tempfile
+import urllib
+import urllib.request
+import zipfile
+from pathlib import Path
+
+__all__ = ["run_main"]
+__license__ = "CC0"
+
+owner = "MODFLOW-USGS"
+# key is the repo name, value is the renamed file prefix for the download
+renamed_prefix = {
+    "executables": "modflow_executables",
+    "modflow6-nightly-build": "modflow6_nightly",
+}
+available_repos = list(renamed_prefix.keys())
+available_ostags = ["linux", "mac", "win32", "win64"]
+
+
+def get_ostag():
+    """Determine operating system tag from sys.platform."""
+    if sys.platform.startswith("linux"):
+        return "linux"
+    elif sys.platform.startswith("win"):
+        return "win" + ("64" if sys.maxsize > 2**32 else "32")
+    elif sys.platform.startswith("darwin"):
+        return "mac"
+    raise ValueError(f"platform {sys.platform!r} not supported")
+
+
+def get_avail_releases(api_url):
+    """Get list of available releases."""
+    with urllib.request.urlopen(f"{api_url}/releases") as resp:
+        result = resp.read()
+    releases = json.loads(result.decode())
+    avail_releases = ["latest"]
+    avail_releases.extend(release["tag_name"] for release in releases)
+    return avail_releases
+
+
+def columns_str(items, line_chars=79):
+    """Return str of columns of items, similar to 'ls' command."""
+    item_chars = max(len(item) for item in items)
+    num_cols = line_chars // item_chars
+    num_rows = len(items) // num_cols
+    if len(items) % num_cols != 0:
+        num_rows += 1
+    lines = []
+    for row_num in range(num_rows):
+        row_items = items[row_num::num_rows]
+        lines.append(
+            " ".join(item.ljust(item_chars) for item in row_items).rstrip()
+        )
+    return "\n".join(lines)
+
+
+def run_main(
+    bindir,
+    repo="executables",
+    release_id="latest",
+    ostag=None,
+    subset=None,
+    downloads_dir=None,
+    force=False,
+    quiet=False,
+    _is_cli=False,
+):
+    """Run main method to get MODFLOW and related programs.
+
+    Parameters
+    ----------
+    bindir : str or Path
+        Writable path to extract executables.
+    repo : str, default "executables"
+        Name of GitHub repository. Choose one of "executables" (default) or
+        "modflow6-nightly-build".
+    release_id : str, default "latest"
+        GitHub release ID.
+    ostag : str, optional
+        Operating system tag; default is to automatically choose.
+    subset : str, optional
+        Optional subset of executables to extract, e.g. "mfnwt,mp6"
+    downloads_dir : str or Path, optional
+        Manually specify directory to download archives. Default is to use
+        home Downloads, if available, otherwise a temporary directory.
+    force : bool, default False
+        If True, always download archive. Default False will use archive if
+        previously downloaded in ``downloads_dir``.
+    quiet : bool, default False
+        If True, show fewer messages.
+    _is_cli : bool, default False
+        Control behavior of method if this is run as a command-line interface
+        or as a Python function.
+    """
+    if ostag is None:
+        ostag = get_ostag()
+    exe_suffix = ""
+    if ostag in ["win32", "win64"]:
+        exe_suffix = ".exe"
+        lib_suffix = ".dll"
+    elif ostag == "linux":
+        lib_suffix = ".so"
+    elif ostag == "mac":
+        lib_suffix = ".dylib"
+    else:
+        raise KeyError(
+            f"unrecognized ostag {ostag!r}; choose one of {available_ostags}"
+        )
+
+    if _is_cli and bindir == "?":
+        options = []
+        # check if conda
+        conda_bin = (
+            Path(sys.prefix)
+            / "conda-meta"
+            / ".."
+            / ("Scripts" if ostag.startswith("win") else "bin")
+        )
+        if conda_bin.exists() and os.access(conda_bin, os.W_OK):
+            options.append(conda_bin.resolve())
+        home_local_bin = Path.home() / ".local" / "bin"
+        if home_local_bin.is_dir() and os.access(home_local_bin, os.W_OK):
+            options.append(home_local_bin)
+        local_bin = Path("/usr") / "local" / "bin"
+        if local_bin.is_dir() and os.access(local_bin, os.W_OK):
+            options.append(local_bin)
+        # Windows user
+        windowsapps_dir = Path(
+            os.path.expandvars(r"%LOCALAPPDATA%\Microsoft\WindowsApps")
+        )
+        if windowsapps_dir.is_dir() and os.access(windowsapps_dir, os.W_OK):
+            options.append(windowsapps_dir)
+        # any other possible locations?
+        if not options:
+            raise RuntimeError("could not find any installable folders")
+        print("select a directory to extract executables:")
+        options_d = dict(enumerate(options, 1))
+        for iopt, opt in options_d.items():
+            print(f"{iopt:2d}: {opt}")
+        num_tries = 0
+        while True:
+            num_tries += 1
+            res = input("> ")
+            try:
+                bindir = options_d[int(res)]
+                break
+            except (KeyError, ValueError):
+                if num_tries < 3:
+                    print("invalid option, try choosing option again")
+                else:
+                    raise RuntimeError("invalid option, too many attempts")
+
+    bindir = Path(bindir).resolve()
+    if not bindir.is_dir():
+        raise OSError(f"extraction directory '{bindir}' does not exist")
+    elif not os.access(bindir, os.W_OK):
+        raise OSError(f"extraction directory '{bindir}' is not writable")
+
+    if repo not in available_repos:
+        raise KeyError(
+            f"repo {repo!r} not supported; choose one of {available_repos}"
+        )
+    api_url = f"https://api.github.com/repos/{owner}/{repo}"
+
+    if release_id == "latest":
+        req_url = f"{api_url}/releases/latest"
+    else:
+        req_url = f"{api_url}/releases/tags/{release_id}"
+    try:
+        with urllib.request.urlopen(req_url) as resp:
+            result = resp.read()
+    except urllib.error.HTTPError as err:
+        if err.code == 404:
+            avail_releases = get_avail_releases(api_url)
+            raise ValueError(
+                f"Release {release_id!r} not found -- "
+                f"choose from {avail_releases}"
+            )
+        else:
+            raise err
+    release = json.loads(result.decode())
+    tag_name = release["tag_name"]
+    if not quiet:
+        print(f"fetched release {tag_name!r} from {owner}/{repo}")
+
+    assets = release.get("assets", [])
+    for asset in assets:
+        if ostag in asset["name"]:
+            break
+    else:
+        raise ValueError(
+            f"could not find ostag {ostag!r} from release {tag_name!r}; "
+            f"see available assets here:\n{release['html_url']}"
+        )
+    download_url = asset["browser_download_url"]
+    # change local download name so it is more unique
+    dst_fname = "-".join([renamed_prefix[repo], tag_name, asset["name"]])
+    tmpdir = None
+    if downloads_dir is None:
+        downloads_dir = Path.home() / "Downloads"
+        if not (downloads_dir.is_dir() and os.access(downloads_dir, os.W_OK)):
+            tmpdir = tempfile.TemporaryDirectory()
+            downloads_dir = Path(tmpdir.name)
+    else:  # check user-defined
+        downloads_dir = Path(downloads_dir)
+        if not downloads_dir.is_dir():
+            raise OSError(
+                f"downloads directory '{downloads_dir}' does not exist"
+            )
+        elif not os.access(downloads_dir, os.W_OK):
+            raise OSError(
+                f"downloads directory '{downloads_dir}' is not writable"
+            )
+    download_pth = downloads_dir / dst_fname
+    if download_pth.is_file() and not force:
+        if not quiet:
+            print(
+                f"using previous download '{download_pth}' (use "
+                f"{'--force' if _is_cli else 'force=True'!r} to re-download)"
+            )
+    else:
+        if not quiet:
+            print(f"downloading to '{download_pth}'")
+        urllib.request.urlretrieve(download_url, download_pth)
+
+    # Open archive and extract files
+    extract = set()
+    chmod = set()
+    items = list()
+    with zipfile.ZipFile(download_pth, "r") as zipf:
+        files = set(zipf.namelist())
+        # print(f"{len(files)=}: {files}")
+        code = False
+        if "code.json" in files:
+            # don't extract this file
+            code = json.loads(zipf.read("code.json").decode())
+            files.remove("code.json")
+        if subset:
+            nosub = False
+            subset_keys = files
+            if code:
+                subset_keys |= set(code.keys())
+            not_found = subset.difference(subset_keys)
+            if not_found:
+                raise ValueError(
+                    f"subset item{'s' if len(not_found) != 1 else ''} "
+                    f"not found: {', '.join(sorted(not_found))}\n"
+                    f"available items are:\n{columns_str(sorted(subset_keys))}"
+                )
+        else:
+            nosub = True
+            subset = set()
+
+        if code:
+
+            def add_item(key, fname, do_chmod):
+                if fname in files:
+                    extract.add(fname)
+                    items.append(f"{fname} ({code[key]['version']})")
+                    if do_chmod:
+                        chmod.add(fname)
+                else:
+                    print(f"file {fname} does not exist")
+                return
+
+            for key in sorted(code):
+                key_in_sub = key in subset
+                if code[key].get("shared_object"):
+                    fname = f"{key}{lib_suffix}"
+                    if nosub or (subset and (key_in_sub or fname in subset)):
+                        add_item(key, fname, do_chmod=False)
+                else:
+                    fname = f"{key}{exe_suffix}"
+                    if nosub or (subset and (key_in_sub or fname in subset)):
+                        add_item(key, fname, do_chmod=True)
+                    # check if double version exists
+                    fname = f"{key}dbl{exe_suffix}"
+                    if (
+                        code[key].get("double_switch", True)
+                        and fname in files
+                        and (
+                            nosub
+                            or (subset and (key_in_sub or fname in subset))
+                        )
+                    ):
+                        add_item(key, fname, do_chmod=True)
+        else:  # release 1.0 did not have code.json
+            for fname in sorted(files):
+                if nosub or (subset and fname in subset):
+                    extract.add(fname)
+                    items.append(fname)
+                    if not fname.endswith(lib_suffix):
+                        chmod.add(fname)
+        if not quiet:
+            print(
+                f"extracting {len(extract)} "
+                f"file{'s' if len(extract) != 1 else ''} to '{bindir}'"
+            )
+        zipf.extractall(bindir, members=extract)
+
+    # If this is a TemporaryDirectory, then delete the directory and files
+    del tmpdir
+
+    if ostag in ["linux", "mac"]:
+        for fname in chmod:
+            pth = bindir / fname
+            pth.chmod(pth.stat().st_mode | 0o111)
+
+    # Show listing
+    if not quiet:
+        print(columns_str(items))
+
+        if not subset:
+            unexpected = extract.difference(files)
+            if unexpected:
+                print(f"unexpected remaining {len(unexpected)} files:")
+                print(columns_str(sorted(unexpected)))
+
+
+def cli_main():
+    """Command-line interface."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "bindir",
+        help="directory to extract executables; use '?' to help choose",
+    )
+    parser.add_argument(
+        "--repo",
+        choices=available_repos,
+        default="executables",
+        help="name of GitHub repository; default is 'executables'",
+    )
+    parser.add_argument(
+        "--release-id",
+        default="latest",
+        help="GitHub release ID (default: latest)",
+    )
+    parser.add_argument(
+        "--ostag",
+        choices=available_ostags,
+        help="operating system tag; default is to automatically choose",
+    )
+    parser.add_argument("--subset", help="subset of executables")
+    parser.add_argument(
+        "--downloads-dir",
+        help="manually specify directory to download archives",
+    )
+    parser.add_argument(
+        "--force", action="store_true", help="force re-download"
+    )
+    parser.add_argument(
+        "--quiet", action="store_true", help="show fewer messages"
+    )
+    args = vars(parser.parse_args())
+    if args["subset"]:
+        args["subset"] = set(args["subset"].replace(",", " ").split())
+    # print(args)
+    try:
+        run_main(**args, _is_cli=True)
+    except KeyboardInterrupt:
+        sys.exit(f" cancelling {sys.argv[0]}")
+    except (KeyError, OSError, RuntimeError, ValueError) as err:
+        sys.exit(err)
+
+
+if __name__ == "__main__":
+    """Run command-line interface, if run as a script."""
+    cli_main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,6 +77,10 @@ doc =
 flopy.mf6.data = dfn/*.dfn
 flopy.plot = mplstyle/*.mplstyle
 
+[options.entry_points]
+console_scripts =
+    get-modflow = flopy.utils.get_modflow:cli_main
+
 [flake8]
 exclude =
     .git


### PR DESCRIPTION
This new features adds a console program with FloPy `get-modflow` (or `get-modflow.exe` for Windows), which automates installing MODFLOW and related programs from GitHub releases hosted at https://github.com/MODFLOW-USGS/executables or https://github.com/MODFLOW-USGS/modflow6-nightly-build

Features:

- Easy way to install MODFLOW and related programs on Windows, Mac or Linux
- The utility can be used as a console program installed with FloPy, or as a flopy module (`flopy.utils.get_modflow_main`)
- The script can be downloaded separately from FloPy with CC0 license, and run as any basic Python script

Here is what `get-modflow --help` currently shows:
```
usage: get-modflow [-h] [--repo {executables,modflow6-nightly-build}] [--release-id RELEASE_ID]
                   [--ostag {linux,mac,win32,win64}] [--subset SUBSET] [--downloads-dir DOWNLOADS_DIR] [--force]
                   [--quiet]
                   bindir

Download and install USGS MODFLOW and related programs.

positional arguments:
  bindir                directory to extract executables; use '?' to help choose

optional arguments:
  -h, --help            show this help message and exit
  --repo {executables,modflow6-nightly-build}
                        name of GitHub repository; default is 'executables'
  --release-id RELEASE_ID
                        GitHub release ID (default: latest)
  --ostag {linux,mac,win32,win64}
                        operating system tag; default is to automatically choose
  --subset SUBSET       subset of executables
  --downloads-dir DOWNLOADS_DIR
                        manually specify directory to download archives
  --force               force re-download
  --quiet               show fewer messages
```

For example, if flopy is installed in a conda environment named "test", install the executables to that environment:
```
(test) C:\Users\mtoews>get-modflow ?
select a directory to extract executables:
 1: C:\Users\mtoews\AppData\Local\miniforge3\envs\test\Scripts
 2: C:\Users\mtoews\AppData\Local\Microsoft\WindowsApps
> 1
fetched release '8.0' from MODFLOW-USGS/executables
using previous download 'C:\Users\mtoews\Downloads\modflow_executables-8.0-win64.zip' (use '--force' to re-download)
file prms.exe does not exist
extracting 25 files to 'C:\Users\mtoews\AppData\Local\miniforge3\envs\test\Scripts'
crt.exe (1.3.1)         mflgrdbl.exe (2.0.0)    sutra.exe (3.0)
gridgen.exe (1.0.02)    mfnwt.exe (1.2.0)       swtv4.exe (4.00.05)
gsflow.exe (2.2.0)      mfnwtdbl.exe (1.2.0)    triangle.exe (1.6)
libmf6.dll (6.3.0)      mfusg.exe (1.5)         vs2dt.exe (3.3)
mf2000.exe (1.19.01)    mfusgdbl.exe (1.5)      zbud6.exe (6.3.0)
mf2005.exe (1.12.00)    mp6.exe (6.0.1)         zonbud3.exe (3.01)
mf2005dbl.exe (1.12.00) mp7.exe (7.2.001)       zonbudusg.exe (1.5)
mf6.exe (6.3.0)         mt3dms.exe (5.3.0)
mflgr.exe (2.0.0)       mt3dusgs.exe (1.1.0)
(test) C:\Users\mtoews>where mf6
C:\Users\mtoews\AppData\Local\miniforge3\envs\test\Scripts\mf6.exe
```
----
The documentation is in draft form at the moment, to gather feedback.