### PR TITLE
fix(get-modflow/ci): use GITHUB_TOKEN to side-step ratelimit

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -104,6 +104,8 @@ jobs:
       working-directory: ./autotest
       run: |
         pytest -v ci_prepare.py
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 #    - name: Add executables directory to path on Windows (bash)
 #      run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,8 @@ jobs:
       working-directory: ./autotest
       run: |
         pytest -v ci_prepare.py
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Add executables directory to path on Linux and MacOS
       run: |

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -54,6 +54,8 @@ jobs:
           mkdir -p $HOME/.local/bin
           get-modflow $HOME/.local/bin
           echo "$HOME/.local/bin" >> $GITHUB_PATH
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run jupytext on tutorials
         working-directory: ./.docs


### PR DESCRIPTION
A few bits extracted from #1458 to fix CI runs on macOS. This implementation requires [GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) to be passed as an environment variable, as done within GitHub Actions. Bad tokens are also handled.

Closes #1059