### PR TITLE
Update tests after feedback

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,12 +1,39 @@
-# Building and testing FloPy
+# Developing FloPy
 
-This document describes how to set up a development environment for FloPy. Details on how to contribute your code to the repository are found in the separate document [CONTRIBUTING.md](CONTRIBUTING.md).
+This document describes how to set up a FloPy development environment, run the example scripts and notebooks, and use the tests. Testing conventions are also briefly discussed. More etail on how to contribute your code to this repository can be found in [CONTRIBUTING.md](CONTRIBUTING.md).
 
-- [Installation](#installation)
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+
+- [Requirements & installation](#requirements--installation)
+  - [Git](#git)
+  - [Python](#python)
+    - [Python IDEs](#python-ides)
+      - [Visual Studio Code](#visual-studio-code)
+      - [PyCharm](#pycharm)
+  - [MODFLOW executables](#modflow-executables)
+    - [Scripted installation](#scripted-installation)
+    - [Manually installing executables](#manually-installing-executables)
+      - [Linux](#linux)
+      - [Mac](#mac)
 - [Examples](#examples)
+  - [Scripts](#scripts)
+  - [Notebooks](#notebooks)
 - [Tests](#tests)
+  - [Running tests](#running-tests)
+    - [Selecting tests with markers](#selecting-tests-with-markers)
+  - [Debugging tests](#debugging-tests)
+  - [Benchmarking](#benchmarking)
+  - [Writing tests](#writing-tests)
+    - [Keepable temporary directories](#keepable-temporary-directories)
+    - [Locating example data](#locating-example-data)
+    - [Locating the project root](#locating-the-project-root)
+    - [Conditionally skipping tests](#conditionally-skipping-tests)
 
-## Installation
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Requirements & installation
 
 To develop `flopy` you must have the following software installed on your machine:
 
@@ -36,7 +63,7 @@ Note that `flopy` has a number of [optional dependencies](docs/flopy_method_depe
 
     pip install ".[test, lint, optional]"
 
-#### IDE configuration
+#### Python IDEs
 
 ##### Visual Studio Code
 
@@ -65,7 +92,7 @@ A utility script is provided to easily download and install executables: after i
 
 #### Manually installing executables
 
-#### Linux
+##### Linux
 
 To download and extract all executables for Linux (e.g., Ubuntu):
 
@@ -78,7 +105,7 @@ Then add the install location to your `PATH`
 
     export PATH="/path/to/your/install/location:$PATH"
 
-#### Mac
+##### Mac
 
 The same commands should work to download and extract executables for OSX:
 
@@ -155,33 +182,32 @@ The `-n auto` option configures the `pytest-xdist` extension to query your compu
 
 The above will run all regression tests, benchmarks, and example scripts and notebooks, which can take some time (likely ~30 minutes to an hour, depending on your machine). To run only fast tests with benchmarking disabled:
 
-    pytest -v -n auto -m "not slow" --benchmark-disable
+    pytest -v -n auto -m "not slow"
 
 Fast tests should complete in under a minute on most machines.
 
-A marker `slow` is used above to select a subset of tests. These can be applied in boolean combinations with `and` and `not`. A few more `pytest` markers are provided:
+#### Selecting tests with markers
+
+The `slow` marker is used above to select a subset of tests. These can be applied in boolean combinations with `and` and `not`. A few more `pytest` markers are provided:
 
 - `regression`: tests comparing the output of multiple runs
 - `example`: example scripts, tutorials, and notebooks
 
 Most of the `regression` and `example` tests are also `slow`, however there are some other slow tests, especially in `test_export.py`, and some regression tests are fairly fast.
 
-### Benchmarking
-
-Benchmarking is accomplished with the [`pytest-benchmark`](https://pytest-benchmark.readthedocs.io/en/latest/index.html) plugin. If the `--benchmark-disable` flag is not provided when `pytest` is invoked, benchmarking is enabled and some tests will be repeated several times to establish a performance profile. Benchmarked tests can be identified by the `benchmark` fixture used in the test signature. By default, two kinds of tests are benchmarked:
-
-- model-loading tests
-- regression tests
-
-To save benchmarking results to a JSON file, use the `--benchmark-autosave` flag. By default, this will create a `.benchmark` directory in `autotest`.
-
-### Debugging failed tests
+### Debugging tests
 
 To debug a failed test it can be helpful to inspect its output, which is cleaned up automatically by default. To run a failing test and keep its output, use the `--keep` option to provide a save location:
 
     pytest test_export.py --keep exports_scratch
 
 This will retain the test directories created by the test, which allows files to be evaluated for errors. Any tests using the function-scoped `tmpdir` and related fixtures (e.g. `class_tmpdir`, `module_tmpdir`) defined in `conftest.py` are compatible with this mechanism.
+
+### Benchmarking
+
+Performance testing is accomplished with [`pytest-benchmark`](https://pytest-benchmark.readthedocs.io/en/latest/index.html). Performance tests are located in `autotest/test_performance.py`. Test functions request the `benchmark` fixture, which can be used to wrap any function call. Benchmarked tests are run several times (the number of iterations depending on the test's runtime, with faster tests getting more reps) to establish a performance profile. Benchmarking is incompatible with `pytest-xdist` and is disabled when tests are run in parallel. When tests are not run in parallel, benchmarking is enabled by default. Benchmarks can be disabled with the `--benchmark-disable` flag.
+
+Benchmarking results are only printed to stdout by default. To save results to a JSON file, use `--benchmark-autosave`. This will create a `.benchmark` folder in the current working location (if you're running tests, this should appear at `autotest/.benchmark`).
 
 ### Writing tests
 

--- a/autotest/regression/test_lgr.py
+++ b/autotest/regression/test_lgr.py
@@ -10,7 +10,7 @@ from autotest.conftest import requires_exe
 
 @requires_exe("mflgr")
 @pytest.mark.regression
-def test_simplelgr(tmpdir, example_data_path, benchmark):
+def test_simplelgr(tmpdir, example_data_path):
     mflgr_v2_ex3_path = example_data_path / "mflgr_v2" / "ex3"
 
     pytest.importorskip("pymake")
@@ -34,7 +34,7 @@ def test_simplelgr(tmpdir, example_data_path, benchmark):
     assert Path(tpth) == ws, f"dir path is {tpth} not {ws}"
 
     # run the lgr model
-    success, buff = benchmark(lambda: lgr.run_model())
+    success, buff = lgr.run_model()
     assert success, "could not run original modflow-lgr model"
 
     # check that a parent and child were read

--- a/autotest/regression/test_mf6.py
+++ b/autotest/regression/test_mf6.py
@@ -1,5 +1,6 @@
 import copy
 import os
+import sys
 import shutil
 from pathlib import Path
 
@@ -21,8 +22,8 @@ from flopy.utils.datautil import PyListUtil
 
 @requires_exe("mf6")
 @pytest.mark.regression
-@pytest.mark.xfail(reason="IndexError: list index out of range on Python 3.7, investigating")
-def test_np001(tmpdir, example_data_path, benchmark):
+@pytest.mark.skipif(sys.version_info == (3, 7), reason="IndexError: list index out of range on Python 3.7")
+def test_np001(tmpdir, example_data_path):
     pytest.importorskip("pymake")
     import pymake
 
@@ -405,7 +406,7 @@ def test_np001(tmpdir, example_data_path, benchmark):
 
     assert sim.simulation_data.max_columns_of_data == dis_package.ncol.get_data()
     # run simulation from new path with external files
-    benchmark(lambda: sim.run_simulation())
+    sim.run_simulation()
 
     # get expected results
     budget_obj = CellBudgetFile(expected_cbc_file, precision="double")
@@ -434,7 +435,7 @@ def test_np001(tmpdir, example_data_path, benchmark):
     sim.set_sim_path(rename_folder)
     sim.write_simulation()
 
-    benchmark(lambda: sim.run_simulation())
+    sim.run_simulation()
     sim.delete_output_files()
 
     # test error checking
@@ -590,7 +591,7 @@ def test_np001(tmpdir, example_data_path, benchmark):
 
 @requires_exe("mf6")
 @pytest.mark.regression
-def test_np002(tmpdir, example_data_path, benchmark):
+def test_np002(tmpdir, example_data_path):
     pytest.importorskip("pymake")
     import pymake
 
@@ -760,7 +761,7 @@ def test_np002(tmpdir, example_data_path, benchmark):
     assert os.path.isfile(top_data_file)
 
     # run simulation
-    benchmark(lambda: sim.run_simulation())
+    sim.run_simulation()
 
     cell_list = [(0, 0, 0), (0, 0, 3), (0, 0, 4), (0, 0, 9)]
     out_file = str(tmpdir / "inspect_test_np002.csv")
@@ -867,7 +868,7 @@ def test_np002(tmpdir, example_data_path, benchmark):
 
 @requires_exe("mf6")
 @pytest.mark.regression
-def test021_twri(tmpdir, example_data_path, benchmark):
+def test021_twri(tmpdir, example_data_path):
     pytest.importorskip("pymake")
     import pymake
 
@@ -1063,7 +1064,7 @@ def test021_twri(tmpdir, example_data_path, benchmark):
     sim.write_simulation()
 
     # run simulation
-    benchmark(lambda: sim.run_simulation())
+    sim.run_simulation()
 
     sim2 = MFSimulation.load(sim_ws=ws)
     model2 = sim2.get_model()
@@ -1094,7 +1095,7 @@ def test021_twri(tmpdir, example_data_path, benchmark):
 @requires_exe("mf6")
 @pytest.mark.slow
 @pytest.mark.regression
-def test005_create_tests_advgw_tidal(tmpdir, example_data_path, benchmark):
+def test005_create_tests_advgw_tidal(tmpdir, example_data_path):
     pytest.importorskip("pymake")
     import pymake
 
@@ -1721,7 +1722,7 @@ def test005_create_tests_advgw_tidal(tmpdir, example_data_path, benchmark):
 
 @requires_exe("mf6")
 @pytest.mark.regression
-def test004_create_tests_bcfss(tmpdir, example_data_path, benchmark):
+def test004_create_tests_bcfss(tmpdir, example_data_path):
     pytest.importorskip("pymake")
     import pymake
 
@@ -1853,7 +1854,7 @@ def test004_create_tests_bcfss(tmpdir, example_data_path, benchmark):
     sim.write_simulation()
 
     # run simulation
-    benchmark(lambda: sim.run_simulation())
+    sim.run_simulation()
 
     # compare output to expected results
     head_new = os.path.join(str(tmpdir), "bcf2ss.hds")
@@ -1872,7 +1873,7 @@ def test004_create_tests_bcfss(tmpdir, example_data_path, benchmark):
 
 @requires_exe("mf6")
 @pytest.mark.regression
-def test035_create_tests_fhb(tmpdir, example_data_path, benchmark):
+def test035_create_tests_fhb(tmpdir, example_data_path):
     pytest.importorskip("pymake")
     import pymake
 
@@ -1996,7 +1997,7 @@ def test035_create_tests_fhb(tmpdir, example_data_path, benchmark):
     sim.write_simulation()
 
     # run simulation
-    benchmark(lambda: sim.run_simulation())
+    sim.run_simulation()
 
     # compare output to expected results
     head_new = str(tmpdir / "fhb2015_fhb.hds")
@@ -2015,7 +2016,7 @@ def test035_create_tests_fhb(tmpdir, example_data_path, benchmark):
 
 @requires_exe("mf6")
 @pytest.mark.regression
-def test006_create_tests_gwf3_disv(tmpdir, example_data_path, benchmark):
+def test006_create_tests_gwf3_disv(tmpdir, example_data_path):
     pytest.importorskip("shapefile")
     pytest.importorskip("pymake")
     import pymake
@@ -2280,7 +2281,7 @@ def test006_create_tests_gwf3_disv(tmpdir, example_data_path, benchmark):
     sim.write_simulation()
 
     # run simulation
-    benchmark(lambda: sim.run_simulation())
+    sim.run_simulation()
 
     # inspect cells
     cell_list = [(0, 0), (0, 7), (0, 17)]
@@ -2310,7 +2311,7 @@ def test006_create_tests_gwf3_disv(tmpdir, example_data_path, benchmark):
 
 @requires_exe("mf6")
 @pytest.mark.regression
-def test006_create_tests_2models_gnc(tmpdir, example_data_path, benchmark):
+def test006_create_tests_2models_gnc(tmpdir, example_data_path):
     pytest.importorskip("pymake")
     import pymake
 
@@ -2644,14 +2645,14 @@ def test006_create_tests_2models_gnc(tmpdir, example_data_path, benchmark):
     gnc_full_path = os.path.join(rename_folder, "gnc", "file_rename.gnc")
     assert os.path.exists(gnc_full_path)
 
-    benchmark(lambda: sim.run_simulation())
+    sim.run_simulation()
     sim.delete_output_files()
 
 
 @requires_exe("mf6")
 @pytest.mark.slow
 @pytest.mark.regression
-def test050_create_tests_circle_island(tmpdir, example_data_path, benchmark):
+def test050_create_tests_circle_island(tmpdir, example_data_path):
     pytest.importorskip("pymake")
     import pymake
 
@@ -2732,7 +2733,7 @@ def test050_create_tests_circle_island(tmpdir, example_data_path, benchmark):
     sim.write_simulation()
 
     # run simulation
-    benchmark(lambda: sim.run_simulation())
+    sim.run_simulation()
 
     # compare output to expected results
     head_new = str(tmpdir / "ci.output.hds")
@@ -2753,7 +2754,7 @@ def test050_create_tests_circle_island(tmpdir, example_data_path, benchmark):
 @pytest.mark.xfail(reason="possible python3.7/windows incompatibilities in testutils.read_std_array "
                           "https://github.com/modflowpy/flopy/runs/7581629193?check_suite_focus=true#step:11:1753")
 @pytest.mark.regression
-def test028_create_tests_sfr(tmpdir, example_data_path, benchmark):
+def test028_create_tests_sfr(tmpdir, example_data_path):
     pytest.importorskip("pymake")
     import pymake
 
@@ -2999,7 +3000,7 @@ def test028_create_tests_sfr(tmpdir, example_data_path, benchmark):
     sim.write_simulation()
 
     # run simulation
-    benchmark(lambda: sim.run_simulation())
+    sim.run_simulation()
 
     # inspect cells
     cell_list = [(0, 2, 3), (0, 3, 4), (0, 4, 5)]
@@ -3024,7 +3025,7 @@ def test028_create_tests_sfr(tmpdir, example_data_path, benchmark):
 
 @requires_exe("mf6")
 @pytest.mark.regression
-def test_create_tests_transport(tmpdir, example_data_path, benchmark):
+def test_create_tests_transport(tmpdir, example_data_path):
     pytest.importorskip("pymake")
     import pymake
 
@@ -3228,7 +3229,7 @@ def test_create_tests_transport(tmpdir, example_data_path, benchmark):
     sim.write_simulation()
 
     # run simulation
-    benchmark(lambda: sim.run_simulation())
+    sim.run_simulation()
 
     # inspect cells
     cell_list = [
@@ -3265,7 +3266,7 @@ def test_create_tests_transport(tmpdir, example_data_path, benchmark):
 @requires_exe("mf6")
 @pytest.mark.slow
 @pytest.mark.regression
-def test001a_tharmonic(tmpdir, example_data_path, benchmark):
+def test001a_tharmonic(tmpdir, example_data_path):
     pytest.importorskip("shapely")
     pytest.importorskip("pymake")
     import pymake
@@ -3374,7 +3375,7 @@ def test001a_tharmonic(tmpdir, example_data_path, benchmark):
     sim.write_simulation()
 
     # run simulation
-    success, buff = benchmark(lambda: sim.run_simulation())
+    success, buff = sim.run_simulation()
     assert success, f"simulation {sim.name} rerun did not run"
 
     # get expected results
@@ -3397,7 +3398,7 @@ def test001a_tharmonic(tmpdir, example_data_path, benchmark):
 
 @requires_exe("mf6")
 @pytest.mark.regression
-def test003_gwfs_disv(tmpdir, example_data_path, benchmark):
+def test003_gwfs_disv(tmpdir, example_data_path):
     pytest.importorskip("pymake")
     import pymake
 
@@ -3467,7 +3468,7 @@ def test003_gwfs_disv(tmpdir, example_data_path, benchmark):
     sim.write_simulation()
 
     # run simulation
-    success, buff = benchmark(lambda: sim.run_simulation())
+    success, buff = sim.run_simulation()
     assert success, f"simulation {sim.name} rerun did not run"
 
     # get expected results
@@ -3491,7 +3492,7 @@ def test003_gwfs_disv(tmpdir, example_data_path, benchmark):
 @requires_exe("mf6")
 @pytest.mark.slow
 @pytest.mark.regression
-def test005_advgw_tidal(tmpdir, example_data_path, benchmark):
+def test005_advgw_tidal(tmpdir, example_data_path):
     pytest.importorskip("pymake")
     import pymake
 
@@ -3558,7 +3559,7 @@ def test005_advgw_tidal(tmpdir, example_data_path, benchmark):
 
 @requires_exe("mf6")
 @pytest.mark.regression
-def test006_gwf3(tmpdir, example_data_path, benchmark):
+def test006_gwf3(tmpdir, example_data_path):
     pytest.importorskip("pymake")
     import pymake
 
@@ -3653,7 +3654,7 @@ def test006_gwf3(tmpdir, example_data_path, benchmark):
     sim.write_simulation()
 
     # run simulation
-    success, buff = benchmark(lambda: sim.run_simulation())
+    success, buff = sim.run_simulation()
     assert success, f"simulation {sim.name} rerun(2) did not run"
 
     # get expected results
@@ -3743,7 +3744,7 @@ def test006_gwf3(tmpdir, example_data_path, benchmark):
 
 @requires_exe("mf6")
 @pytest.mark.regression
-def test045_lake1ss_table(tmpdir, example_data_path, benchmark):
+def test045_lake1ss_table(tmpdir, example_data_path):
     pytest.importorskip("pymake")
     import pymake
 
@@ -3804,7 +3805,7 @@ def test045_lake1ss_table(tmpdir, example_data_path, benchmark):
     sim.write_simulation()
 
     # run simulation
-    success, buff = benchmark(lambda: sim.run_simulation())
+    success, buff = sim.run_simulation()
     assert success, f"simulation {sim.name} rerun did not run"
 
     # compare output to expected results
@@ -3823,7 +3824,7 @@ def test045_lake1ss_table(tmpdir, example_data_path, benchmark):
 @requires_exe("mf6")
 @pytest.mark.slow
 @pytest.mark.regression
-def test006_2models_mvr(tmpdir, example_data_path, benchmark):
+def test006_2models_mvr(tmpdir, example_data_path):
     pytest.importorskip("pymake")
     import pymake
 
@@ -3939,7 +3940,7 @@ def test006_2models_mvr(tmpdir, example_data_path, benchmark):
     sim.write_simulation()
 
     # run simulation
-    success, buff = benchmark(lambda: sim.run_simulation())
+    success, buff = sim.run_simulation()
     assert success, f"simulation {sim.name} rerun did not run"
 
     cell_list = [(0, 3, 1)]
@@ -4012,7 +4013,7 @@ def test006_2models_mvr(tmpdir, example_data_path, benchmark):
 @requires_exe("mf6")
 @pytest.mark.slow
 @pytest.mark.regression
-def test001e_uzf_3lay(tmpdir, example_data_path, benchmark):
+def test001e_uzf_3lay(tmpdir, example_data_path):
     pytest.importorskip("pymake")
 
     # init paths
@@ -4051,7 +4052,7 @@ def test001e_uzf_3lay(tmpdir, example_data_path, benchmark):
     sim.write_simulation()
 
     # run simulation
-    success, buff = benchmark(lambda: sim.run_simulation())
+    success, buff = sim.run_simulation()
     assert success, f"simulation {sim.name} rerun did not run"
 
     # inspect cells
@@ -4112,7 +4113,7 @@ def test001e_uzf_3lay(tmpdir, example_data_path, benchmark):
 @requires_exe("mf6")
 @pytest.mark.slow
 @pytest.mark.regression
-def test045_lake2tr(tmpdir, example_data_path, benchmark):
+def test045_lake2tr(tmpdir, example_data_path):
     pytest.importorskip("pymake")
     import pymake
 
@@ -4165,7 +4166,7 @@ def test045_lake2tr(tmpdir, example_data_path, benchmark):
     sim.write_simulation()
 
     # run simulation
-    success, buff = benchmark(lambda: sim.run_simulation())
+    success, buff = sim.run_simulation()
     assert success, f"simulation {sim.name} rerun did not run"
 
     # inspect cells
@@ -4186,7 +4187,7 @@ def test045_lake2tr(tmpdir, example_data_path, benchmark):
 
 @requires_exe("mf6")
 @pytest.mark.regression
-def test036_twrihfb(tmpdir, example_data_path, benchmark):
+def test036_twrihfb(tmpdir, example_data_path):
     pytest.importorskip("pymake")
     import pymake
 
@@ -4255,7 +4256,7 @@ def test036_twrihfb(tmpdir, example_data_path, benchmark):
     sim.write_simulation()
 
     # run simulation
-    success, buff = benchmark(lambda: sim.run_simulation())
+    success, buff = sim.run_simulation()
     assert success, f"simulation {sim.name} rerun did not run"
 
     # compare output to expected results
@@ -4271,7 +4272,7 @@ def test036_twrihfb(tmpdir, example_data_path, benchmark):
 @requires_exe("mf6")
 @pytest.mark.slow
 @pytest.mark.regression
-def test027_timeseriestest(tmpdir, example_data_path, benchmark):
+def test027_timeseriestest(tmpdir, example_data_path):
     pytest.importorskip("pymake")
     import pymake
 
@@ -4334,7 +4335,7 @@ def test027_timeseriestest(tmpdir, example_data_path, benchmark):
     sim.write_simulation()
 
     # run simulation
-    success, buff = benchmark(lambda: sim.run_simulation())
+    success, buff = sim.run_simulation()
     assert success, f"simulation {sim.name} rerun did not run"
 
     # compare output to expected results

--- a/autotest/regression/test_mf6_examples.py
+++ b/autotest/regression/test_mf6_examples.py
@@ -11,7 +11,7 @@ from flopy.mf6 import MFSimulation
 @requires_exe("mf6")
 @pytest.mark.slow
 @pytest.mark.regression
-def test_mf6_example_simulations(tmpdir, mf6_example_namfiles, benchmark):
+def test_mf6_example_simulations(tmpdir, mf6_example_namfiles):
     """
     MF6 examples parametrized by simulation. Arg `mf6_example_namfiles` is a list
     of models to run in order provided. Coupled models share the same workspace.
@@ -85,4 +85,4 @@ def test_mf6_example_simulations(tmpdir, mf6_example_namfiles, benchmark):
                 files2=[str(p) for p in headfiles2],
                 outfile=str(cmpdir / "head_compare.dat"))
 
-    benchmark(lambda: run_models())
+    run_models()

--- a/autotest/regression/test_mfnwt.py
+++ b/autotest/regression/test_mfnwt.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 
 import pytest
 
@@ -30,7 +29,7 @@ def get_nfnwt_namfiles():
 @pytest.mark.slow
 @pytest.mark.regression
 @pytest.mark.parametrize("namfile", get_nfnwt_namfiles())
-def test_run_mfnwt_model(tmpdir, namfile, benchmark):
+def test_run_mfnwt_model(tmpdir, namfile):
     pytest.importorskip("pymake")
     import pymake
 
@@ -130,7 +129,7 @@ def test_run_mfnwt_model(tmpdir, namfile, benchmark):
     pthf = str(tmpdir / "flopy")
     m.change_model_ws(pthf)
     m.write_input()
-    success, buff = benchmark(lambda: m.run_model(silent=False))
+    success, buff = m.run_model(silent=False)
     assert success, "base model run did not terminate successfully"
     fn1 = os.path.join(pthf, namfile)
 

--- a/autotest/regression/test_modflow.py
+++ b/autotest/regression/test_modflow.py
@@ -22,7 +22,7 @@ def uzf_example_path(example_data_path):
 @requires_exe("mf2005")
 @pytest.mark.slow
 @pytest.mark.regression
-def test_uzf_unit_numbers(tmpdir, uzf_example_path, benchmark):
+def test_uzf_unit_numbers(tmpdir, uzf_example_path):
     pytest.importorskip("pymake")
     import pymake
 
@@ -69,7 +69,7 @@ def test_uzf_unit_numbers(tmpdir, uzf_example_path, benchmark):
     m.write_input()
 
     # run and compare the output files
-    success, buff = benchmark(lambda: m.run_model(silent=False))
+    success, buff = m.run_model(silent=False)
     assert success, "new model run did not terminate successfully"
     fn1 = join(model_ws2, mfnam)
 
@@ -86,7 +86,7 @@ def test_uzf_unit_numbers(tmpdir, uzf_example_path, benchmark):
 @requires_exe("mf2005")
 @pytest.mark.slow
 @pytest.mark.regression
-def test_unitnums(tmpdir, mf2005_test_path, benchmark):
+def test_unitnums(tmpdir, mf2005_test_path):
     pytest.importorskip("pymake")
     import pymake
 
@@ -113,7 +113,7 @@ def test_unitnums(tmpdir, mf2005_test_path, benchmark):
 
     m.write_input()
 
-    success, buff = benchmark(lambda: m.run_model(silent=False))
+    success, buff = m.run_model(silent=False)
     assert success, "base model run did not terminate successfully"
     fn1 = join(model_ws2, mfnam)
 
@@ -127,7 +127,7 @@ def test_unitnums(tmpdir, mf2005_test_path, benchmark):
 @requires_exe("mf2005")
 @pytest.mark.slow
 @pytest.mark.regression
-def test_gage(tmpdir, example_data_path, benchmark):
+def test_gage(tmpdir, example_data_path):
     pytest.importorskip("pymake")
     import pymake
 
@@ -146,7 +146,7 @@ def test_gage(tmpdir, example_data_path, benchmark):
     )
 
     # run the modflow-2005 model
-    success, buff = mf.run_model(silent=False)
+    success, buff = mf.run_model()
     assert success, "could not run original MODFLOW-2005 model"
 
     files = mf.gage.files
@@ -158,7 +158,7 @@ def test_gage(tmpdir, example_data_path, benchmark):
     mf.write_input()
 
     # run the modflow-2005 model
-    success, buff = benchmark(lambda: mf.run_model(silent=False))
+    success, buff = mf.run_model()
     assert success, "could not run new MODFLOW-2005 model"
 
     # compare the two results
@@ -180,7 +180,7 @@ __example_data_path = get_example_data_path(Path(__file__))
     str(__example_data_path / "pcgn_test" / nf)
     for nf in ["twri.nam", "MNW2.nam"]
 ])
-def test_mf2005pcgn(tmpdir, namfile, benchmark):
+def test_mf2005pcgn(tmpdir, namfile):
     pytest.importorskip("pymake")
     import pymake
 
@@ -209,7 +209,7 @@ def test_mf2005pcgn(tmpdir, namfile, benchmark):
     m.change_model_ws(str(ws2))
     m.write_input()
 
-    success, buff = benchmark(lambda: m.run_model(silent=False))
+    success, buff = m.run_model(silent=False)
     assert success, "new model run did not terminate successfully"
     fn1 = str(ws2 / nf)
 
@@ -228,7 +228,7 @@ def test_mf2005pcgn(tmpdir, namfile, benchmark):
 @pytest.mark.slow
 @pytest.mark.regression
 @pytest.mark.parametrize("namfile", [str(__example_data_path / "secp" / nf) for nf in ["secp.nam"]])
-def test_mf2005gmg(tmpdir, namfile, benchmark):
+def test_mf2005gmg(tmpdir, namfile):
     pytest.importorskip("pymake")
     import pymake
 
@@ -252,7 +252,7 @@ def test_mf2005gmg(tmpdir, namfile, benchmark):
     m.change_model_ws(str(tmpdir))
     m.write_input()
 
-    success, buff = benchmark(lambda: m.run_model(silent=False))
+    success, buff = m.run_model(silent=False)
     assert success, "new model run did not terminate successfully"
     fn1 = str(tmpdir / nf)
 
@@ -270,7 +270,7 @@ def test_mf2005gmg(tmpdir, namfile, benchmark):
 @requires_exe("mf2005")
 @pytest.mark.regression
 @pytest.mark.parametrize("namfile", [str(__example_data_path / "freyberg" / nf) for nf in ["freyberg.nam"]])
-def test_mf2005(tmpdir, namfile, benchmark):
+def test_mf2005(tmpdir, namfile):
     """
     test045 load and write of MODFLOW-2005 GMG example problem
     """
@@ -313,7 +313,7 @@ def test_mf2005(tmpdir, namfile, benchmark):
     # rewrite files
     m.write_input()
 
-    success, buff = benchmark(lambda: m.run_model(silent=False))
+    success, buff = m.run_model()
     assert success, "new model run did not terminate successfully"
     fn1 = str(compth / Path(namfile).name)
 
@@ -348,7 +348,7 @@ mf2005_namfiles = [str(__example_data_path / "mf2005_test" / nf) for nf in [
 @pytest.mark.slow
 @pytest.mark.regression
 @pytest.mark.parametrize("namfile", mf2005_namfiles)
-def test_mf2005fhb(tmpdir, namfile, benchmark):
+def test_mf2005fhb(tmpdir, namfile):
     pytest.importorskip("pymake")
     import pymake
 
@@ -366,7 +366,7 @@ def test_mf2005fhb(tmpdir, namfile, benchmark):
     m.change_model_ws(str(tmpdir), reset_external=True)
     m.write_input()
 
-    success, buff = benchmark(lambda: m.run_model(silent=False))
+    success, buff = m.run_model()
     assert success, "new model run did not terminate successfully"
     fn1 = join(str(tmpdir), Path(namfile).name)
 
@@ -385,7 +385,7 @@ def test_mf2005fhb(tmpdir, namfile, benchmark):
 @pytest.mark.slow
 @pytest.mark.regression
 @pytest.mark.parametrize("namfile", mf2005_namfiles)
-def test_mf2005_lake(tmpdir, namfile, mf2005_test_path, benchmark):
+def test_mf2005_lake(tmpdir, namfile, mf2005_test_path):
     pytest.importorskip("pymake")
     import pymake
 
@@ -416,7 +416,7 @@ def test_mf2005_lake(tmpdir, namfile, mf2005_test_path, benchmark):
     )  # l1b2k_bath wont run without this
     m.write_input()
 
-    success, buff = benchmark(lambda: m.run_model(silent=False))
+    success, buff = m.run_model()
     assert success
     fn1 = join(model_ws2, Path(namfile).name)
 

--- a/autotest/regression/test_str.py
+++ b/autotest/regression/test_str.py
@@ -14,7 +14,7 @@ str_items = {
 
 @requires_exe("mf2005")
 @pytest.mark.regression
-def test_str_fixed_free(tmpdir, example_data_path, benchmark):
+def test_str_fixed_free(tmpdir, example_data_path):
     mf2005_model_path = example_data_path / "mf2005_test"
     pytest.importorskip("pymake")
     import pymake
@@ -100,7 +100,7 @@ def test_str_fixed_free(tmpdir, example_data_path, benchmark):
     m.set_ifrefm()
     m.write_input()
 
-    success, buff = benchmark(lambda: m.run_model())
+    success, buff = m.run_model()
     assert success, "free format model run did not terminate successfully"
 
     # load the free format model

--- a/autotest/regression/test_swi2.py
+++ b/autotest/regression/test_swi2.py
@@ -1,10 +1,9 @@
 import os
 import shutil
-from shutil import which
 
 import pytest
-from autotest.conftest import requires_exe
 
+from autotest.conftest import requires_exe
 from flopy.modflow import Modflow
 
 
@@ -17,7 +16,7 @@ def swi_path(example_data_path):
 @pytest.mark.slow
 @pytest.mark.regression
 @pytest.mark.parametrize("namfile", ["swiex1.nam", "swiex2_strat.nam", "swiex3.nam"])
-def test_mf2005swi2(tmpdir, swi_path, namfile, benchmark):
+def test_mf2005swi2(tmpdir, swi_path, namfile):
     pytest.importorskip("pymake")
     import pymake
 
@@ -43,7 +42,7 @@ def test_mf2005swi2(tmpdir, swi_path, namfile, benchmark):
     )  # l1b2k_bath wont run without this
     m.write_input()
 
-    success, buff = benchmark(lambda: m.run_model(silent=False))
+    success, buff = m.run_model()
     assert success, "base model run did not terminate successfully"
     fn1 = os.path.join(model_ws2, namfile)
 

--- a/autotest/regression/test_wel.py
+++ b/autotest/regression/test_wel.py
@@ -17,7 +17,7 @@ from flopy.modflow import (
 
 @requires_exe("mf2005")
 @pytest.mark.regression
-def test_binary_well(tmpdir, benchmark):
+def test_binary_well(tmpdir):
     pytest.importorskip("pymake")
     import pymake
 
@@ -94,7 +94,7 @@ def test_binary_well(tmpdir, benchmark):
     m.write_input()
 
     # run the new modflow-2005 model
-    success, buff = benchmark(lambda: m.run_model(silent=False))
+    success, buff = m.run_model()
     assert success, "could not run the new MODFLOW-2005 model"
     fn1 = os.path.join(pth, f"{mfnam}.nam")
 

--- a/autotest/test_example_notebooks.py
+++ b/autotest/test_example_notebooks.py
@@ -5,10 +5,9 @@ import pytest
 from autotest.conftest import get_project_root_path
 
 
-def get_notebooks(exclude=None):
+def get_example_notebooks(exclude=None):
     prjroot = get_project_root_path(__file__)
-    nbpaths = []
-    nbpaths += [str(p) for p in (prjroot / "examples" / "FAQ").glob("*.ipynb")]
+    nbpaths = [str(p) for p in (prjroot / "examples" / "FAQ").glob("*.ipynb")]
     nbpaths += [str(p) for p in (prjroot / "examples" / "Notebooks").glob("*.ipynb")]
     nbpaths += [str(p) for p in (prjroot / "examples" / "groundwater_paper" / "Notebooks").glob("*.ipynb")]
     return sorted([p for p in nbpaths if not exclude or not any(e in p for e in exclude)])
@@ -16,8 +15,7 @@ def get_notebooks(exclude=None):
 
 @pytest.mark.slow
 @pytest.mark.example
-@pytest.mark.parametrize("notebook", get_notebooks(exclude=["mf6_lgr"]))  # TODO: figure out why this one fails
+@pytest.mark.parametrize("notebook", get_example_notebooks(exclude=["mf6_lgr"]))  # TODO: figure out why this one fails
 def test_notebooks(notebook):
     arg = ("jupytext", "--from ipynb", "--execute", notebook)
-    print(" ".join(arg))
     assert os.system(" ".join(arg)) == 0, f"could not run {notebook}"

--- a/autotest/test_example_scripts.py
+++ b/autotest/test_example_scripts.py
@@ -8,7 +8,7 @@ import pytest
 from autotest.conftest import get_project_root_path
 
 
-def get_scripts(exclude=None):
+def get_example_scripts(exclude=None):
     prjroot = get_project_root_path(__file__)
 
     # sort to appease pytest-xdist: all workers must collect identically ordered sets of tests
@@ -21,10 +21,10 @@ def get_scripts(exclude=None):
 
 @pytest.mark.slow
 @pytest.mark.example
-@pytest.mark.parametrize("script", get_scripts())
-def test_scripts_and_tutorials(script, benchmark):
+@pytest.mark.parametrize("script", get_example_scripts())
+def test_scripts(script):
     proc = Popen(("python", Path(script).name), stdout=PIPE, stderr=PIPE, cwd=Path(script).parent)
-    stdout, stderr = benchmark(lambda: proc.communicate())
+    stdout, stderr = proc.communicate()
     if stdout: print(stdout.decode("utf-8"))
 
     allowed_patterns = [

--- a/autotest/test_export.py
+++ b/autotest/test_export.py
@@ -8,7 +8,6 @@ import math
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
-from flaky import flaky
 
 import flopy
 from autotest.conftest import (

--- a/autotest/test_generate_classes.py
+++ b/autotest/test_generate_classes.py
@@ -1,10 +1,13 @@
-from autotest.conftest import ci_only, excludes_branch
+import pytest
 
+from autotest.conftest import excludes_branch
 from flopy.mf6.utils import generate_classes
 
 
-@ci_only
+@pytest.mark.skip(reason="TODO: use external copy of the repo, otherwise files are rewritten")
 @excludes_branch("master")
-def test_generate_classes_from_dfn(tmpdir):
+def test_generate_classes_from_dfn():
+    # maybe compute hashes of files before/after
+    # generation to make sure they don't change?
+
     generate_classes(branch="develop", backup=False)
-    # TODO: what to check?

--- a/autotest/test_performance.py
+++ b/autotest/test_performance.py
@@ -1,0 +1,75 @@
+import inspect
+
+import numpy as np
+import pytest
+
+from flopy.modflow import Modflow, ModflowDis, ModflowRch, ModflowWel, ModflowSfr2
+
+
+def _build_model(ws, name):
+    m = Modflow(name, model_ws=ws)
+
+    size = 100
+    nlay = 10
+    nper = 10
+    nsfr = int((size ** 2) / 5)
+
+    dis = ModflowDis(
+        m,
+        nper=nper,
+        nlay=nlay,
+        nrow=size,
+        ncol=size,
+        top=nlay,
+        botm=list(range(nlay)),
+    )
+
+    rch = ModflowRch(
+        m, rech={k: 0.001 - np.cos(k) * 0.001 for k in range(nper)}
+    )
+
+    ra = ModflowWel.get_empty(size ** 2)
+    well_spd = {}
+    for kper in range(nper):
+        ra_per = ra.copy()
+        ra_per["k"] = 1
+        ra_per["i"] = (
+            (np.ones((size, size)) * np.arange(size))
+                .transpose()
+                .ravel()
+                .astype(int)
+        )
+        ra_per["j"] = list(range(size)) * size
+        well_spd[kper] = ra
+    wel = ModflowWel(m, stress_period_data=well_spd)
+
+    # SFR package
+    rd = ModflowSfr2.get_empty_reach_data(nsfr)
+    rd["iseg"] = range(len(rd))
+    rd["ireach"] = 1
+    sd = ModflowSfr2.get_empty_segment_data(nsfr)
+    sd["nseg"] = range(len(sd))
+    sfr = ModflowSfr2(reach_data=rd, segment_data=sd, model=m)
+
+    return m
+
+
+@pytest.mark.slow
+def test_model_init_time(tmpdir, benchmark):
+    name = inspect.getframeinfo(inspect.currentframe()).function
+    benchmark(lambda: _build_model(ws=str(tmpdir), name=name))
+
+
+@pytest.mark.slow
+def test_model_write_time(tmpdir, benchmark):
+    name = inspect.getframeinfo(inspect.currentframe()).function
+    model = _build_model(ws=str(tmpdir), name=name)
+    benchmark(lambda: model.write_input())
+
+
+@pytest.mark.slow
+def test_model_load_time(tmpdir, benchmark):
+    name = inspect.getframeinfo(inspect.currentframe()).function
+    model = _build_model(ws=str(tmpdir), name=name)
+    model.write_input()
+    benchmark(lambda: Modflow.load(f"{name}.nam", model_ws=str(tmpdir), check=False))

--- a/autotest/test_specific_discharge.py
+++ b/autotest/test_specific_discharge.py
@@ -12,12 +12,9 @@
 # - the model is a very small synthetic test case that just contains enough
 #   things to allow for the functions to be thoroughly tested
 
-import os
-
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
-from flaky import flaky
 from matplotlib.quiver import Quiver
 
 import flopy.utils.binaryfile as bf

--- a/autotest/test_str.py
+++ b/autotest/test_str.py
@@ -1,4 +1,5 @@
 import matplotlib
+
 from autotest.conftest import requires_exe
 
 from flopy.modflow import Modflow
@@ -14,7 +15,7 @@ str_items = {
 }
 
 
-@requires_exe("mf2005'")
+@requires_exe("mf2005")
 def test_str_issue1164(tmpdir, example_data_path):
     mf2005_model_path = example_data_path / "mf2005_test"
     m = Modflow.load(


### PR DESCRIPTION
This is followup to #1458 including small fixes and tidying, updates to the benchmarking approach as well as developer documentation updates. Planning to add CI updates discussed yesterday in subsequent PRs.

### Minor fixes

A few tests were accidentally skipped, now included. `conftest.py` has been cleaned up, removing unused fixtures added during development.

### Benchmarking & dev docs

Benchmarking is scoped back to include only the original set of performance tests (1458 included regression tests too) as testing model performance is probably not a flopy concern- only loading/writing models, etc.

Performance tests are moved back to their own file as well: `test_performance.py` now has what used to live in `t064_test_performance.py`.

The benchmarking section in `DEVELOPER.md` is updated to reflect `pytest-benchmark` and `pytest-xdist` incompatibility (when tests are run in parallel, benchmarking is disabled- this was described incorrectly in 1458).

Also used [`doctoc`](https://www.npmjs.com/package/doctoc) to generate a table of contents for `DEVELOPER.md`. (This can be used to generate TOC from markdown files, with `npm` installed use `npm install -g doctoc` to install it globally, then run `doctoc <file>`. It will insert HTML comments surrounding an automatically edited region, then subsequent runs are idempotent, updating if the file has changed or leaving it untouched if not.)