### PR TITLE
ModpathFile performance profiling, misc fixes

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -233,7 +233,7 @@ jobs:
       - name: Run tests
         working-directory: ./autotest
         run: |
-          pytest -v test_performance.py --cov=flopy --cov-report=xml --durations=0 --benchmark-autosave  --keep-failed .failed
+          pytest -v --cov=flopy --cov-report=xml --durations=0 --benchmark-only --benchmark-autosave  --keep-failed=.failed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -250,7 +250,7 @@ jobs:
         with:
           name: benchmark-${{ matrix.os }}-${{ matrix.python-version }}
           path: |
-            ./autotest/.benchmark/**/*.json
+            ./autotest/.benchmarks/**/*.json
 
       - name: Print coverage report
         working-directory: ./autotest
@@ -490,7 +490,7 @@ jobs:
       - name: Run tests
         working-directory: ./autotest
         run: |
-          pytest -v test_performance.py --cov=flopy --cov-report=xml --durations=0 --benchmark-autosave --keep-failed=.failed
+          pytest -v --cov=flopy --cov-report=xml --durations=0 --benchmark-only --benchmark-autosave --keep-failed=.failed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -507,7 +507,7 @@ jobs:
         with:
           name: benchmark-${{ matrix.os }}-${{ matrix.python-version }}
           path: |
-            ./autotest/.benchmark/**/*.json
+            ./autotest/.benchmarks/**/*.json
 
       - name: Print coverage report
         working-directory: ./autotest

--- a/.gitignore
+++ b/.gitignore
@@ -33,14 +33,17 @@ MANIFEST
 pip-log.txt
 pip-delete-this-directory.txt
 
-# test coverage / benchmarking reports
+# test coverage reports
 htmlcov/
 .tox/
-**/.benchmarks
 .coverage
 .cache
 nosetests.xml
 coverage.xml
+
+# benchmarking/profiling reports
+**/.benchmarks
+**/.profile
 
 # Translations
 *.mo

--- a/autotest/pytest.ini
+++ b/autotest/pytest.ini
@@ -1,11 +1,13 @@
 [pytest]
 python_files =
-    *_test*.py
     test_*.py
+    profile_*.py
+    *_test*.py
+    *_profile*.py
 markers =
-    unit: tests for a single function or purpose
-    integration: tests for systems in combination
-    regression: compare multiple runs or versions
     slow: tests that don't complete in a few seconds
-    example: example scripts, tutorials and notebooks
-    meta: run only by other tests (e.g., to test fixtures)
+    example: exercise scripts, tutorials and notebooks
+    regression: tests that compare multiple results
+    benchmark: test that gather runtime statistics
+    profile: tests measuring performance in detail
+    meta: run by other tests (e.g. testing fixtures)

--- a/autotest/regression/test_mf6.py
+++ b/autotest/regression/test_mf6.py
@@ -22,7 +22,6 @@ from flopy.utils.datautil import PyListUtil
 
 @requires_exe("mf6")
 @pytest.mark.regression
-@pytest.mark.skipif(sys.version_info == (3, 7), reason="IndexError: list index out of range on Python 3.7")
 def test_np001(tmpdir, example_data_path):
     pytest.importorskip("pymake")
     import pymake

--- a/autotest/test_conftest.py
+++ b/autotest/test_conftest.py
@@ -12,7 +12,6 @@ from autotest.conftest import get_project_root_path, get_example_data_path, requ
 
 # temporary directory fixtures
 
-@pytest.mark.unit
 def test_tmpdirs(tmpdir, module_tmpdir):
     # function-scoped temporary directory
     assert isinstance(tmpdir, Path)
@@ -24,14 +23,12 @@ def test_tmpdirs(tmpdir, module_tmpdir):
     assert "autotest" in module_tmpdir.stem
 
 
-@pytest.mark.unit
 def test_function_scoped_tmpdir(tmpdir):
     assert isinstance(tmpdir, Path)
     assert tmpdir.is_dir()
     assert inspect.currentframe().f_code.co_name in tmpdir.stem
 
 
-@pytest.mark.unit
 @pytest.mark.parametrize("name", ["noslash", "forward/slash", "back\\slash"])
 def test_function_scoped_tmpdir_slash_in_name(tmpdir, name):
     assert isinstance(tmpdir, Path)
@@ -45,7 +42,6 @@ def test_function_scoped_tmpdir_slash_in_name(tmpdir, name):
            f"{inspect.currentframe().f_code.co_name}[{replaced2}]" in tmpdir.stem
 
 
-@pytest.mark.unit
 class TestClassScopedTmpdir:
     filename = "hello.txt"
 
@@ -61,14 +57,12 @@ class TestClassScopedTmpdir:
         assert Path(class_tmpdir / self.filename).is_file()
 
 
-@pytest.mark.unit
 def test_module_scoped_tmpdir(module_tmpdir):
     assert isinstance(module_tmpdir, Path)
     assert module_tmpdir.is_dir()
     assert Path(inspect.getmodulename(__file__)).stem in module_tmpdir.name
 
 
-@pytest.mark.unit
 def test_session_scoped_tmpdir(session_tmpdir):
     assert isinstance(session_tmpdir, Path)
     assert session_tmpdir.is_dir()
@@ -76,7 +70,6 @@ def test_session_scoped_tmpdir(session_tmpdir):
 
 # misc utilities
 
-@pytest.mark.unit
 def test_get_project_root_path_from_autotest():
     cwd = Path(__file__).parent
     root = get_project_root_path(cwd)
@@ -88,7 +81,6 @@ def test_get_project_root_path_from_autotest():
     assert "autotest" in contents and "examples" in contents and "README.md" in contents
 
 
-@pytest.mark.unit
 def test_get_project_root_path_from_project_root():
     cwd = Path(__file__).parent.parent
     root = get_project_root_path(cwd)
@@ -100,7 +92,6 @@ def test_get_project_root_path_from_project_root():
     assert "autotest" in contents and "examples" in contents and "README.md" in contents
 
 
-@pytest.mark.unit
 @pytest.mark.parametrize("relative_path", ["", "utils", "mf6/utils"])
 def test_get_project_root_path_from_within_flopy_module(relative_path):
     cwd = Path(__file__).parent.parent / "flopy" / Path(relative_path)
@@ -113,7 +104,6 @@ def test_get_project_root_path_from_within_flopy_module(relative_path):
     assert "autotest" in contents and "examples" in contents and "README.md" in contents
 
 
-@pytest.mark.unit
 def test_get_paths():
     example_data = get_example_data_path(__file__)
     project_root = get_project_root_path(__file__)
@@ -121,7 +111,6 @@ def test_get_paths():
     assert example_data.parent.parent == project_root
 
 
-@pytest.mark.unit
 @pytest.mark.parametrize("current_path", [__file__, None])
 def test_get_example_data_path(current_path):
     parts = get_example_data_path(current_path).parts
@@ -130,7 +119,7 @@ def test_get_example_data_path(current_path):
             parts[-1] == "data")
 
 
-# require/exclude executables/platforms
+# requiring/excluding executables & platforms
 
 @requires_exe("mf6")
 def test_mf6():
@@ -175,7 +164,6 @@ class TestMeta:
         assert len(deselected) > 0
 
 
-@pytest.mark.unit
 def test_meta():
     args = [f"{__file__}", "-v", "-s",
             "-k", test_meta_inner.__name__,
@@ -185,35 +173,34 @@ def test_meta():
 
 # CLI arguments --keep (-K) and --keep-failed
 
-HELLO_FNAME = 'hello.txt'
+FILE_NAME = 'hello.txt'
 
 
 @pytest.mark.meta("test_keep")
 def test_keep_function_scoped_tmpdir_inner(tmpdir):
-    with open(tmpdir / HELLO_FNAME, "w") as f:
+    with open(tmpdir / FILE_NAME, "w") as f:
         f.write("hello, function-scoped tmpdir")
 
 
 @pytest.mark.meta("test_keep")
 class TestKeepClassScopedTmpdirInner:
     def test_keep_class_scoped_tmpdir_inner(self, class_tmpdir):
-        with open(class_tmpdir / HELLO_FNAME, "w") as f:
+        with open(class_tmpdir / FILE_NAME, "w") as f:
             f.write("hello, class-scoped tmpdir")
 
 
 @pytest.mark.meta("test_keep")
 def test_keep_module_scoped_tmpdir_inner(module_tmpdir):
-    with open(module_tmpdir / HELLO_FNAME, "w") as f:
+    with open(module_tmpdir / FILE_NAME, "w") as f:
         f.write("hello, module-scoped tmpdir")
 
 
 @pytest.mark.meta("test_keep")
 def test_keep_session_scoped_tmpdir_inner(session_tmpdir):
-    with open(session_tmpdir / HELLO_FNAME, "w") as f:
+    with open(session_tmpdir / FILE_NAME, "w") as f:
         f.write("hello, session-scoped tmpdir")
 
 
-@pytest.mark.unit
 @pytest.mark.parametrize("arg", ["--keep", "-K"])
 def test_keep_function_scoped_tmpdir(tmpdir, arg):
     inner_fn = test_keep_function_scoped_tmpdir_inner.__name__
@@ -222,10 +209,9 @@ def test_keep_function_scoped_tmpdir(tmpdir, arg):
             "-M", "test_keep",
             "-K", tmpdir]
     assert pytest.main(args) == ExitCode.OK
-    assert Path(tmpdir / f"{inner_fn}0" / HELLO_FNAME).is_file()
+    assert Path(tmpdir / f"{inner_fn}0" / FILE_NAME).is_file()
 
 
-@pytest.mark.unit
 @pytest.mark.parametrize("arg", ["--keep", "-K"])
 def test_keep_class_scoped_tmpdir(tmpdir, arg):
     args = [__file__, "-v", "-s",
@@ -233,10 +219,9 @@ def test_keep_class_scoped_tmpdir(tmpdir, arg):
             "-M", "test_keep",
             "-K", tmpdir]
     assert pytest.main(args) == ExitCode.OK
-    assert Path(tmpdir / f"{TestKeepClassScopedTmpdirInner.__name__}0" / HELLO_FNAME).is_file()
+    assert Path(tmpdir / f"{TestKeepClassScopedTmpdirInner.__name__}0" / FILE_NAME).is_file()
 
 
-@pytest.mark.unit
 @pytest.mark.parametrize("arg", ["--keep", "-K"])
 def test_keep_module_scoped_tmpdir(tmpdir, arg):
     args = [__file__, "-v", "-s",
@@ -246,10 +231,9 @@ def test_keep_module_scoped_tmpdir(tmpdir, arg):
     assert pytest.main(args) == ExitCode.OK
     this_file_path = Path(__file__)
     this_test_dir = (tmpdir / f"{str(this_file_path.parent.name)}.{str(this_file_path.stem)}0")
-    assert HELLO_FNAME in [f.name for f in this_test_dir.glob('*')]
+    assert FILE_NAME in [f.name for f in this_test_dir.glob('*')]
 
 
-@pytest.mark.unit
 @pytest.mark.parametrize("arg", ["--keep", "-K"])
 def test_keep_session_scoped_tmpdir(tmpdir, arg, request):
     args = [__file__, "-v", "-s",
@@ -257,18 +241,17 @@ def test_keep_session_scoped_tmpdir(tmpdir, arg, request):
             "-M", "test_keep",
             "-K", tmpdir]
     assert pytest.main(args) == ExitCode.OK
-    assert Path(tmpdir / f"{request.session.name}0" / HELLO_FNAME).is_file()
+    assert Path(tmpdir / f"{request.session.name}0" / FILE_NAME).is_file()
 
 
 @pytest.mark.meta("test_keep_failed")
 def test_keep_failed_function_scoped_tmpdir_inner(tmpdir):
-    with open(tmpdir / HELLO_FNAME, "w") as f:
+    with open(tmpdir / FILE_NAME, "w") as f:
         f.write("hello, function-scoped tmpdir")
 
     assert False, "oh no"
 
 
-@pytest.mark.unit
 @pytest.mark.parametrize("keep", [True, False])
 def test_keep_failed_function_scoped_tmpdir(tmpdir, keep):
     inner_fn = test_keep_failed_function_scoped_tmpdir_inner.__name__
@@ -278,5 +261,5 @@ def test_keep_failed_function_scoped_tmpdir(tmpdir, keep):
     if keep: args += ["--keep-failed", tmpdir]
     assert pytest.main(args) == ExitCode.TESTS_FAILED
 
-    kept_file = Path(tmpdir / f"{inner_fn}0" / HELLO_FNAME).is_file()
+    kept_file = Path(tmpdir / f"{inner_fn}0" / FILE_NAME).is_file()
     assert kept_file if keep else not kept_file

--- a/autotest/test_modflow.py
+++ b/autotest/test_modflow.py
@@ -1,4 +1,5 @@
 import glob
+import inspect
 import os
 import shutil
 from pathlib import Path
@@ -1254,3 +1255,72 @@ def test_load_with_list_reader(tmpdir):
 
     originalwelra = m.wel.stress_period_data[0].copy()
     assert np.array_equal(originalwelra, m2.wel.stress_period_data[0])
+
+
+def get_basic_modflow_model(ws, name):
+    m = Modflow(name, model_ws=ws)
+
+    size = 100
+    nlay = 10
+    nper = 10
+    nsfr = int((size ** 2) / 5)
+
+    dis = ModflowDis(
+        m,
+        nper=nper,
+        nlay=nlay,
+        nrow=size,
+        ncol=size,
+        top=nlay,
+        botm=list(range(nlay)),
+    )
+
+    rch = ModflowRch(
+        m, rech={k: 0.001 - np.cos(k) * 0.001 for k in range(nper)}
+    )
+
+    ra = ModflowWel.get_empty(size ** 2)
+    well_spd = {}
+    for kper in range(nper):
+        ra_per = ra.copy()
+        ra_per["k"] = 1
+        ra_per["i"] = (
+            (np.ones((size, size)) * np.arange(size))
+                .transpose()
+                .ravel()
+                .astype(int)
+        )
+        ra_per["j"] = list(range(size)) * size
+        well_spd[kper] = ra
+    wel = ModflowWel(m, stress_period_data=well_spd)
+
+    # SFR package
+    rd = ModflowSfr2.get_empty_reach_data(nsfr)
+    rd["iseg"] = range(len(rd))
+    rd["ireach"] = 1
+    sd = ModflowSfr2.get_empty_segment_data(nsfr)
+    sd["nseg"] = range(len(sd))
+    sfr = ModflowSfr2(reach_data=rd, segment_data=sd, model=m)
+
+    return m
+
+
+@pytest.mark.slow
+def test_model_init_time(tmpdir, benchmark):
+    name = inspect.getframeinfo(inspect.currentframe()).function
+    benchmark(lambda: get_basic_modflow_model(ws=str(tmpdir), name=name))
+
+
+@pytest.mark.slow
+def test_model_write_time(tmpdir, benchmark):
+    name = inspect.getframeinfo(inspect.currentframe()).function
+    model = get_basic_modflow_model(ws=str(tmpdir), name=name)
+    benchmark(lambda: model.write_input())
+
+
+@pytest.mark.slow
+def test_model_load_time(tmpdir, benchmark):
+    name = inspect.getframeinfo(inspect.currentframe()).function
+    model = get_basic_modflow_model(ws=str(tmpdir), name=name)
+    model.write_input()
+    benchmark(lambda: Modflow.load(f"{name}.nam", model_ws=str(tmpdir), check=False))

--- a/autotest/test_scripts.py
+++ b/autotest/test_scripts.py
@@ -1,14 +1,12 @@
 """Test scripts."""
 import sys
-import time
 import urllib
 from subprocess import PIPE, Popen
 from urllib.error import HTTPError
 
 import pytest
-from flaky import flaky
 
-import flopy
+from flopy.utils import get_modflow_main
 from autotest.conftest import (
     get_project_root_path,
     requires_github,
@@ -51,16 +49,7 @@ def test_script_usage():
 rate_limit_msg = "rate limit exceeded"
 
 
-def delay_rerun(*args):
-    # github releases API is sometimes inconsistent,
-    # need to retry in case "latest" can't be found
-    time.sleep(2)
-    return True
-
-
-@flaky(max_runs=3, rerun_filter=delay_rerun)
 @requires_github
-@pytest.mark.slow
 def test_get_modflow_script(tmp_path, downloads_dir):
     # exit if extraction directory does not exist
     bindir = tmp_path / "bin1"
@@ -130,9 +119,7 @@ def test_get_modflow_script(tmp_path, downloads_dir):
     assert sorted(files) == ["mfnwt.exe", "mfnwtdbl.exe"]
 
 
-@flaky(max_runs=3, rerun_filter=delay_rerun)
 @requires_github
-@pytest.mark.slow
 def test_get_nightly_script(tmp_path, downloads_dir):
     bindir = tmp_path / "bin1"
     bindir.mkdir()
@@ -150,12 +137,10 @@ def test_get_nightly_script(tmp_path, downloads_dir):
     assert len(files) >= 4
 
 
-@flaky(max_runs=3, rerun_filter=delay_rerun)
 @requires_github
-@pytest.mark.slow
 def test_get_modflow(tmpdir):
     try:
-        flopy.utils.get_modflow_main(tmpdir)
+        get_modflow_main(tmpdir)
     except HTTPError as err:
         if err.code == 403:
             pytest.skip(f"GitHub {rate_limit_msg}")
@@ -194,12 +179,10 @@ def test_get_modflow(tmpdir):
     assert all(exe in actual for exe in expected)
 
 
-@flaky(max_runs=3, rerun_filter=delay_rerun)
 @requires_github
-@pytest.mark.slow
 def test_get_nightly(tmpdir):
     try:
-        flopy.utils.get_modflow_main(tmpdir, repo="modflow6-nightly-build")
+        get_modflow_main(tmpdir, repo="modflow6-nightly-build")
     except urllib.error.HTTPError as err:
         if err.code == 403:
             pytest.skip(f"GitHub {rate_limit_msg}")

--- a/autotest/test_seawat.py
+++ b/autotest/test_seawat.py
@@ -237,7 +237,6 @@ def test_seawat_load_and_write(tmpdir, namfile, binary):
         assert success
 
 
-@pytest.mark.unit
 def test_vdf_vsc(tmpdir):
     nlay = 3
     nrow = 4


### PR DESCRIPTION
Performance profiling for `ModpathFile` methods (results [here](https://github.com/modflowpy/flopy/issues/1479)) and a few unrelated fixes and updates

## Performance profiling

Test cases are added to `autotest/test_modpathfile.py` to profile `ModpathFile.get_destination_pathline_data()` and `ModpathFile.get_destination_endpoint_data()`.

More generally this PR adds profiling support to `pytest` with a `--profile` (short `-P`) flag and a `profile` marker. Using the `--profile` flag runs only test functions marked with `@pytest.mark.profile`. Profiling functions do not run when the `--profile` flag is not provided (normal testing and profiling are mutually exclusive). By default, results are only printed to `stdout`. Results can be saved to disk with the `--profile-autosave` flag. This will create a folder `.profile` in the current working directory (i.e. `autotest/.profile`).

Two files are saved for each profiling function in `test_modpathfile.py`:

- `<test case name>.txt`
- `<test case name>.dmp`

The first is plain-text human-readable output. The second is for ingest by [`pstats`](https://docs.python.org/3/library/profile.html#module-pstats). The `*.dmp` files can also be inspected by [`snakeviz`](https://github.com/jiffyclub/snakeviz/) (available via `pip` or conda), which produces an interactive HTML viewer. For instance:

```shell
snakeviz .profile/profile_get_destination_pathline_data.backward.river.dmp
```

To allow defining profiling functions separately from test cases, `pytest.ini` is updated to match `profile_*.py` and `*_profile*.py` files. `DEVELOPER.md` is updated to reflect all above.

## Miscellaneous

- Moved performance tests from `test_performance.py` to files named by module under test (model init, load and write benchmarks are now in `test_modflow.py`, `PathlineFile` benchmarks are now in `test_modpathfile.py`)
- Fixed benchmark save location in `daily.yml` CI and in the dev docs (was `.benchmark` but correct name is `.benchmarks`)
- Unskipped `regression/test_mf6.py::test_np001`, which was mistakenly marked to skip Python 3.7.
- Added `**/.benchmarks` and `**/.profile` to `.gitignore`
- Fixed `pytest --smoke` (short `-P`) flag to select correct subset of tests (previously only deselected slow tests, now deselects slow, example and regression tests)
- Removed `unit` and `integration` markers from `pytest.ini` pending demonstrated need for this distinction
- Removed retries from tests for `get-modflow` utility (hopefully resolved by #1480)