### PR TITLE
Update pytest framework

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -18,6 +18,7 @@ jobs:
     defaults:
       run:
         shell: bash
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repo
@@ -50,13 +51,13 @@ jobs:
         run: |
           twine check --strict dist/*
 
-
   lint:
     name: Lint
     runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repo
@@ -106,14 +107,13 @@ jobs:
         run: |
           pylint --jobs=2 --errors-only --exit-zero ./flopy
 
-
-
   smoke:
     name: Smoke
     runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repo
@@ -185,7 +185,6 @@ jobs:
           directory: ./autotest
           file: coverage.xml
 
-
   test:
     name: Test
     needs: smoke
@@ -204,6 +203,7 @@ jobs:
             path: ~/.cache/pip
           - os: macos-latest
             path: ~/Library/Caches/pip
+    timeout-minutes: 45
 
     steps:
       - name: Checkout repo
@@ -290,6 +290,7 @@ jobs:
     defaults:
       run:
         shell: pwsh
+    timeout-minutes: 45
 
     steps:
       - name: Checkout repo
@@ -302,7 +303,7 @@ jobs:
         uses: actions/cache@v2.1.0
         with:
           path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.run-type }}-${{ hashFiles('etc/environment.yml', 'flopy') }}
+          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.run-type }}-${{ hashFiles('etc/environment.yml') }}
 
       # Standard python fails on windows without GDAL installation
       # Using custom bash shell ("shell: bash -l {0}") with Miniconda

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -25,6 +25,7 @@ jobs:
     defaults:
       run:
         shell: bash
+    timeout-minutes: 90
 
     steps:
       - name: Checkout repo
@@ -90,7 +91,6 @@ jobs:
           file: coverage.xml
 
   examples:
-
     name: Example scripts & notebooks
     runs-on: ${{ matrix.os }}
     strategy:
@@ -110,6 +110,7 @@ jobs:
     defaults:
       run:
         shell: bash
+    timeout-minutes: 90
 
     steps:
       - name: Checkout repo
@@ -194,6 +195,7 @@ jobs:
     defaults:
       run:
         shell: bash
+    timeout-minutes: 90
 
     steps:
       - name: Checkout repo
@@ -230,14 +232,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run tests
+      - name: Load cached benchmark results (for comparison)
+        uses: actions/cache@v2.1.0
+        with:
+          path: ./autotest/.benchmarks
+          key: benchmark-${{ matrix.os }}-${{ matrix.python-version }} }}
+
+      - name: Run benchmarks
         working-directory: ./autotest
         run: |
-          pytest -v --cov=flopy --cov-report=xml --durations=0 --benchmark-only --benchmark-autosave  --keep-failed=.failed
+          pytest -v --durations=0 \
+            --cov=flopy --cov-report=xml \
+            --benchmark-only --benchmark-autosave --benchmark-compare --benchmark-compare-fail=mean:25% \
+            --keep-failed=.failed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload failed test outputs
+      - name: Upload failed benchmark outputs
         uses: actions/upload-artifact@v2
         if: failure()
         with:
@@ -279,6 +290,7 @@ jobs:
     defaults:
       run:
         shell: pwsh
+    timeout-minutes: 90
 
     steps:
       - name: Checkout repo
@@ -291,7 +303,7 @@ jobs:
         uses: actions/cache@v2.1.0
         with:
           path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.run-type }}-${{ hashFiles('etc/environment.yml', 'flopy') }}
+          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.run-type }}-${{ hashFiles('etc/environment.yml') }}
 
       # Standard python fails on windows without GDAL installation
       # Using custom bash shell ("shell: bash -l {0}") with Miniconda
@@ -362,6 +374,7 @@ jobs:
     defaults:
       run:
         shell: pwsh
+    timeout-minutes: 90
 
     steps:
       - name: Checkout repo
@@ -374,7 +387,7 @@ jobs:
         uses: actions/cache@v2.1.0
         with:
           path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.run-type }}-${{ hashFiles('etc/environment.yml', 'flopy') }}
+          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.run-type }}-${{ hashFiles('etc/environment.yml') }}
 
       # Standard python fails on windows without GDAL installation
       # Using custom bash shell ("shell: bash -l {0}") with Miniconda
@@ -409,7 +422,6 @@ jobs:
           pytest -v -n auto -m "example" --cov=flopy --cov-report=xml --durations=0 --keep-failed=.failed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 
       - name: Upload failed test outputs
         uses: actions/upload-artifact@v2
@@ -446,6 +458,7 @@ jobs:
     defaults:
       run:
         shell: pwsh
+    timeout-minutes: 90
 
     steps:
       - name: Checkout repo
@@ -458,7 +471,7 @@ jobs:
         uses: actions/cache@v2.1.0
         with:
           path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.run-type }}-${{ hashFiles('etc/environment.yml', 'flopy') }}
+          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.run-type }}-${{ hashFiles('etc/environment.yml') }}
 
       # Standard python fails on windows without GDAL installation
       # Using custom bash shell ("shell: bash -l {0}") with Miniconda
@@ -487,14 +500,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run tests
+      - name: Load cached benchmark results (for comparison)
+        uses: actions/cache@v2.1.0
+        with:
+          path: ./autotest/.benchmarks
+          key: benchmark-${{ runner.os }}-${{ matrix.python-version }} }}
+
+      - name: Run benchmarks
         working-directory: ./autotest
         run: |
-          pytest -v --cov=flopy --cov-report=xml --durations=0 --benchmark-only --benchmark-autosave --keep-failed=.failed
+          pytest -v --durations=0 \
+            --cov=flopy --cov-report=xml \
+            --benchmark-only --benchmark-autosave --benchmark-compare --benchmark-compare-fail=mean:25% \
+            --keep-failed=.failed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload failed test outputs
+      - name: Upload failed benchmark outputs
         uses: actions/upload-artifact@v2
         if: failure()
         with:
@@ -505,7 +527,7 @@ jobs:
       - name: Upload benchmark results
         uses: actions/upload-artifact@v2
         with:
-          name: benchmark-${{ matrix.os }}-${{ matrix.python-version }}
+          name: benchmark-${{ runner.os }}-${{ matrix.python-version }}
           path: |
             ./autotest/.benchmarks/**/*.json
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -192,8 +192,6 @@ Markers are a `pytest` feature that can be used to select subsets of tests. Mark
 - `slow`: tests that don't complete in a few seconds
 - `example`: exercise scripts, tutorials and notebooks
 - `regression`: tests that compare multiple results
-- `benchmark`: test that gather runtime statistics
-- `profile`: tests measuring performance in detail
 
 Markers can be used with the `-m <marker>` option. For example, to run only fast tests:
 
@@ -221,9 +219,20 @@ This will retain the test directories created by the test, which allows files to
 
 There is also a `--keep-failed <dir>` option which preserves the outputs of failed tests in the given location, however this option is only compatible with function-scoped temporary directories (the `tmpdir` fixture defined in `conftest.py`).
 
-### Benchmarking
+### Performance testing
 
-Benchmarking is accomplished with [`pytest-benchmark`](https://pytest-benchmark.readthedocs.io/en/latest/index.html). Any test function can be turned into a benchmark by requesting the `benchmark` fixture (i.e. declaring a `benchmark` argument), which can be used to wrap any function call. For instance:
+Performance testing is accomplished with [`pytest-benchmark`](https://pytest-benchmark.readthedocs.io/en/latest/index.html).
+
+To allow optional separation of performance from correctness concerns, performance test files may be named either as typical test files or may match any of the following patterns:
+
+- `benchmark_*.py`
+- `profile_*.py`
+- `*_profile*.py`.
+- `*_benchmark*.py`
+
+#### Benchmarking
+
+Any test function can be turned into a benchmark by requesting the `benchmark` fixture (i.e. declaring a `benchmark` argument), which can be used to wrap any function call. For instance:
 
 ```python
 def test_benchmark(benchmark):
@@ -251,25 +260,27 @@ Rather than alter an existing function call to use this syntax, a lambda can be 
 
 ```python
 def test_benchmark(benchmark):
-    def sleep_1s():
+    def sleep_s(s):
         import time
-        time.sleep(1)
+        time.sleep(s)
         return True
         
-    assert benchmark(lambda: sleep_1s())
+    assert benchmark(lambda: sleep_s(1))
 ```
 
 This can be convenient when the function call is complicated or passes many arguments.
 
-To control the number of repetitions and rounds (repetitions of repetitions) use `benchmark.pedantic`, e.g. `benchmark.pedantic(some_function(), iterations=1, rounds=1)`.
+Benchmarked functions are repeated several times (the number of iterations depending on the test's runtime, with faster tests generally getting more reps) to compute summary statistics. To control the number of repetitions and rounds (repetitions of repetitions) use `benchmark.pedantic`, e.g. `benchmark.pedantic(some_function(), iterations=1, rounds=1)`.
 
-Benchmarked functions are repeated several times (the number of iterations depending on the test's runtime, with faster tests generally getting more reps) to compute summary statistics. Benchmarking is incompatible with `pytest-xdist` and is disabled automatically when tests are run in parallel. When tests are not run in parallel, benchmarking is enabled by default. Benchmarks can be disabled with the `--benchmark-disable` flag.
+Benchmarking is incompatible with `pytest-xdist` and is disabled automatically when tests are run in parallel. When tests are not run in parallel, benchmarking is enabled by default. Benchmarks can be disabled with the `--benchmark-disable` flag.
 
-Benchmark results are only printed to stdout by default. To save results to a JSON file, use `--benchmark-autosave`. This will create a `.benchmarks` folder in the current working location (if you're running tests, this should appear at `autotest/.benchmarks`).
+Benchmark results are only printed to `stdout` by default. To save results to a JSON file, use `--benchmark-autosave`. This will create a `.benchmarks` folder in the current working location (if you're running tests, this should be `autotest/.benchmarks`).
 
-### Profiling
+#### Profiling
 
-Profiling is [distinct](https://stackoverflow.com/a/39381805/6514033) from benchmarking in considering program behavior in detail, while benchmarking just invokes functions repeatedly and computes summary statistics. Profiling test files may be named either as typical test files or matching `profile_*.py` or `*_profile*.py`. Functions marked with the `profile` marker are considered profiling tests and will not run unless `pytest` is invoked with the `--profile` (short `-P`) flag.
+Profiling is [distinct](https://stackoverflow.com/a/39381805/6514033) from benchmarking in evaluating a program's call stack in detail, while benchmarking just invokes a function repeatedly and computes summary statistics. Profiling is also accomplished with `pytest-benchmark`: use the `--benchmark-cprofile` option when running tests which use the `benchmark` fixture described above. The option's value is the column to sort results by. For instance, to sort by total time, use `--benchmark-cprofile="tottime"`. See the `pytest-benchmark` [docs](https://pytest-benchmark.readthedocs.io/en/stable/usage.html#commandline-options) for more information.
+
+By default, `pytest-benchmark` will only print profiling results to `stdout`. If the `--benchmark-autosave` flag is provided, performance profile data will be included in the JSON files written to the `.benchmarks` save directory as described in the benchmarking section above.
 
 ### Writing tests
 

--- a/autotest/pytest.ini
+++ b/autotest/pytest.ini
@@ -2,12 +2,12 @@
 python_files =
     test_*.py
     profile_*.py
+    benchmark_*.py
     *_test*.py
     *_profile*.py
+    *_benchmark*.py
 markers =
     slow: tests that don't complete in a few seconds
     example: exercise scripts, tutorials and notebooks
     regression: tests that compare multiple results
-    benchmark: test that gather runtime statistics
-    profile: tests measuring performance in detail
     meta: run by other tests (e.g. testing fixtures)

--- a/autotest/regression/test_lgr.py
+++ b/autotest/regression/test_lgr.py
@@ -47,7 +47,7 @@ def test_simplelgr(tmpdir, example_data_path):
     # get the namefiles of the parent and child
     namefiles = lgr.get_namefiles()
     assert (
-        len(namefiles) == 2
+            len(namefiles) == 2
     ), f"get_namefiles returned {len(namefiles)} items instead of 2"
 
     tpth = dirname(namefiles[0])

--- a/autotest/regression/test_mf6.py
+++ b/autotest/regression/test_mf6.py
@@ -350,7 +350,7 @@ def test_np001(tmpdir, example_data_path):
     sim.set_all_data_external()
     sim.write_simulation()
     assert (
-        sim.simulation_data.max_columns_of_data == dis_package.ncol.get_data()
+            sim.simulation_data.max_columns_of_data == dis_package.ncol.get_data()
     )
     # test package file with relative path to simulation path
     wel_path = os.path.join(ws, "well_folder", f"{model_name}.wel")
@@ -462,12 +462,12 @@ def test_np001(tmpdir, example_data_path):
     summary = ".".join(chk[0].summary_array.desc)
     assert "drn_1 package: invalid BC index" in summary
     assert (
-        "npf package: vertical hydraulic conductivity values below "
-        "checker threshold of 1e-11" in summary
+            "npf package: vertical hydraulic conductivity values below "
+            "checker threshold of 1e-11" in summary
     )
     assert (
-        "npf package: horizontal hydraulic conductivity values above "
-        "checker threshold of 100000.0" in summary
+            "npf package: horizontal hydraulic conductivity values above "
+            "checker threshold of 100000.0" in summary
     )
     data_invalid = False
     try:
@@ -502,10 +502,10 @@ def test_np001(tmpdir, example_data_path):
         for line in fd:
             line_lst = line.strip().split()
             if (
-                len(line) > 2
-                and line_lst[0] == "0"
-                and line_lst[1] == "0"
-                and line_lst[2] == "0"
+                    len(line) > 2
+                    and line_lst[0] == "0"
+                    and line_lst[1] == "0"
+                    and line_lst[2] == "0"
             ):
                 found_cellid = True
     assert found_cellid
@@ -810,12 +810,12 @@ def test_np002(tmpdir, example_data_path):
     chk = sim.check()
     summary = ".".join(chk[0].summary_array.desc)
     assert (
-        "sto package: specific storage values below "
-        "checker threshold of 1e-06" in summary
+            "sto package: specific storage values below "
+            "checker threshold of 1e-06" in summary
     )
     assert (
-        "sto package: specific yield values above "
-        "checker threshold of 0.5" in summary
+            "sto package: specific yield values above "
+            "checker threshold of 0.5" in summary
     )
     assert "Not a number" in summary
     model.remove_package("chd_2")
@@ -1471,10 +1471,10 @@ def test005_create_tests_advgw_tidal(tmpdir, example_data_path):
             col_max = 6
         for col in range(0, col_max):
             if (
-                (row == 3 and col == 5)
-                or (row == 2 and col == 4)
-                or (row == 1 and col == 3)
-                or (row == 0 and col == 2)
+                    (row == 3 and col == 5)
+                    or (row == 2 and col == 4)
+                    or (row == 1 and col == 3)
+                    or (row == 0 and col == 2)
             ):
                 mult = 0.5
             else:
@@ -1578,10 +1578,10 @@ def test005_create_tests_advgw_tidal(tmpdir, example_data_path):
             col_min = 6
         for col in range(col_min, 10):
             if (
-                (row == 0 and col == 9)
-                or (row == 1 and col == 8)
-                or (row == 2 and col == 7)
-                or (row == 3 and col == 6)
+                    (row == 0 and col == 9)
+                    or (row == 1 and col == 8)
+                    or (row == 2 and col == 7)
+                    or (row == 3 and col == 6)
             ):
                 mult = 0.5
             else:
@@ -1943,9 +1943,9 @@ def test035_create_tests_fhb(tmpdir, example_data_path):
     )
     time = model.modeltime
     assert (
-        time.steady_state[0] == False
-        and time.steady_state[1] == False
-        and time.steady_state[2] == False
+            time.steady_state[0] == False
+            and time.steady_state[1] == False
+            and time.steady_state[2] == False
     )
     wel_period = {0: [((0, 1, 0), "flow")]}
     wel_package = ModflowGwfwel(
@@ -3514,10 +3514,10 @@ def test005_advgw_tidal(tmpdir, example_data_path):
     model = sim.get_model(model_name)
     time = model.modeltime
     assert (
-        time.steady_state[0] == True
-        and time.steady_state[1] == False
-        and time.steady_state[2] == False
-        and time.steady_state[3] == False
+            time.steady_state[0] == True
+            and time.steady_state[1] == False
+            and time.steady_state[2] == False
+            and time.steady_state[3] == False
     )
     ghb = model.get_package("ghb")
     obs = ghb.obs
@@ -3976,14 +3976,14 @@ def test006_2models_mvr(tmpdir, example_data_path):
             model = sim.get_model(model_name)
             for package in model_package_check:
                 assert (
-                    package in model.package_type_dict
-                    or package in sim.package_type_dict
-                ) == (package in load_only or f"{package}6" in load_only)
+                               package in model.package_type_dict
+                               or package in sim.package_type_dict
+                       ) == (package in load_only or f"{package}6" in load_only)
         assert (len(sim._exchange_files) > 0) == (
-            "gwf6-gwf6" in load_only or "gwf-gwf" in load_only
+                "gwf6-gwf6" in load_only or "gwf-gwf" in load_only
         )
         assert (len(sim._ims_files) > 0) == (
-            "ims6" in load_only or "ims" in load_only
+                "ims6" in load_only or "ims" in load_only
         )
 
     # load package by name
@@ -4012,7 +4012,6 @@ def test006_2models_mvr(tmpdir, example_data_path):
 @pytest.mark.slow
 @pytest.mark.regression
 def test001e_uzf_3lay(tmpdir, example_data_path):
-
     # init paths
     test_ex_name = "test001e_UZF_3lay"
     model_name = "gwf_1"
@@ -4073,7 +4072,7 @@ def test001e_uzf_3lay(tmpdir, example_data_path):
         model = sim.get_model()
         for package in model_package_check:
             assert (package in model.package_type_dict) == (
-                package in load_only or f"{package}6" in load_only
+                    package in load_only or f"{package}6" in load_only
             )
     # test running a runnable load_only case
     sim = MFSimulation.load(

--- a/autotest/test_binarygrid_util.py
+++ b/autotest/test_binarygrid_util.py
@@ -3,6 +3,8 @@ import numpy as np
 import pytest
 from matplotlib import pyplot as plt
 
+from flaky import flaky
+
 from flopy.discretization import StructuredGrid, UnstructuredGrid, VertexGrid
 from flopy.mf6.utils import MfGrdFile
 
@@ -81,6 +83,7 @@ def test_mfgrddisv_MfGrdFile(mfgrd_test_path):
     assert isinstance(mg, VertexGrid), f"invalid grid type ({type(mg)})"
 
 
+@flaky
 def test_mfgrddisv_modelgrid(mfgrd_test_path):
     fn = mfgrd_test_path / "flow.disv.grb"
     mg = VertexGrid.from_binary_grid_file(fn, verbose=True)

--- a/autotest/test_example_scripts.py
+++ b/autotest/test_example_scripts.py
@@ -1,7 +1,6 @@
 import re
 from functools import reduce
 from os import linesep
-from pathlib import Path
 
 import pytest
 

--- a/autotest/test_grid.py
+++ b/autotest/test_grid.py
@@ -894,8 +894,12 @@ def test_voronoi_grid(tmpdir, grid_info):
     voronoi_grid.plot(ax=ax)
     plt.savefig(os.path.join(str(tmpdir), f"{name}.png"))
 
+    # TODO: why does this sometimes happen on CI
+    #  could be a rounding error as described here:
+    #  https://github.com/modflowpy/flopy/issues/1492#issuecomment-1210596349
+
     # ensure proper number of cells
-    almost_right = (ncpl == 538 and gridprops["ncpl"] == 535)  # TODO: why does this sometimes happen on CI
+    almost_right = (ncpl == 538 and gridprops["ncpl"] == 535)
     assert ncpl == gridprops["ncpl"] or almost_right
 
     # ensure that all cells have 3 or more points

--- a/autotest/test_lgr.py
+++ b/autotest/test_lgr.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from flaky import flaky
 from autotest.conftest import requires_exe
 
 import flopy
@@ -160,6 +161,9 @@ def singleModel(
     return mf
 
 
+# occasional forrtl: error (65): floating invalid
+# https://github.com/w-bonelli/flopy/runs/7744805897?check_suite_focus=true#step:8:1832
+@flaky
 @requires_exe("mflgr")
 def test_simple_lgrmodel_from_scratch(tmpdir):
     # coordinates and extend Mother

--- a/autotest/test_mf6.py
+++ b/autotest/test_mf6.py
@@ -355,39 +355,32 @@ def test_mf6(tmpdir):
     return
 
 
-@requires_exe("mf6")
 def test_mf6_string_to_file_path():
     import platform
 
     if platform.system().lower() == "windows":
         unc_path = r"\\server\path\path"
         new_path = MFFileMgmt.string_to_file_path(unc_path)
-        if not unc_path == new_path:
-            raise AssertionError("UNC path error")
+        assert unc_path == new_path, "UNC path error"
 
         abs_path = r"C:\Users\some_user\path"
         new_path = MFFileMgmt.string_to_file_path(abs_path)
-        if not abs_path == new_path:
-            raise AssertionError("Absolute path error")
+        assert abs_path == new_path, "Absolute path error"
 
         rel_path = r"..\path\some_path"
         new_path = MFFileMgmt.string_to_file_path(rel_path)
-        if not rel_path == new_path:
-            raise AssertionError("Relative path error")
+        assert rel_path == new_path, "Relative path error"
 
     else:
         abs_path = "/mnt/c/some_user/path"
         new_path = MFFileMgmt.string_to_file_path(abs_path)
-        if not abs_path == new_path:
-            raise AssertionError("Absolute path error")
+        assert abs_path == new_path, "Absolute path error"
 
         rel_path = "../path/some_path"
         new_path = MFFileMgmt.string_to_file_path(rel_path)
-        if not rel_path == new_path:
-            raise AssertionError("Relative path error")
+        assert rel_path == new_path, "Relative path error"
 
 
-@requires_exe("mf6")
 def test_mf6_subdir(tmpdir):
     sim = MFSimulation(sim_ws=str(tmpdir))
     tdis = ModflowTdis(sim)
@@ -1187,7 +1180,6 @@ def test_multi_model(tmpdir):
     sim.run_simulation()
 
 
-@requires_exe("mf6")
 def test_binary_read(tmpdir):
     test_ex_name = "binary_read"
     nlay = 3
@@ -1232,8 +1224,7 @@ def test_binary_read(tmpdir):
         binfile, data_shape, data_size, np.float64, modelgrid
     )[0]
 
-    if not np.allclose(arr, arr2):
-        raise AssertionError("Binary read for layered Structured failed")
+    assert np.allclose(arr, arr2), "Binary read for layered Structured failed"
 
     binfile = str(tmpdir / "structured_flat.hds")
     with open(binfile, "wb") as foo:
@@ -1244,8 +1235,7 @@ def test_binary_read(tmpdir):
         binfile, data_shape, data_size, np.float64, modelgrid
     )[0]
 
-    if not np.allclose(arr, arr2):
-        raise AssertionError("Binary read for flat Structured failed")
+    assert np.allclose(arr, arr2), "Binary read for flat Structured failed"
 
     ncpl = nrow * ncol
     data_shape = (nlay, ncpl)
@@ -1264,8 +1254,7 @@ def test_binary_read(tmpdir):
         binfile, data_shape, data_size, np.float64, modelgrid
     )[0]
 
-    if not np.allclose(arr, arr2):
-        raise AssertionError("Binary read for layered Vertex failed")
+    assert np.allclose(arr, arr2), "Binary read for layered Vertex failed"
 
     binfile = str(tmpdir / "vertex_flat.hds")
     with open(binfile, "wb") as foo:
@@ -1276,8 +1265,7 @@ def test_binary_read(tmpdir):
         binfile, data_shape, data_size, np.float64, modelgrid
     )[0]
 
-    if not np.allclose(arr, arr2):
-        raise AssertionError("Binary read for flat Vertex failed")
+    assert np.allclose(arr, arr2), "Binary read for flat Vertex failed"
 
     nlay = 3
     ncpl = [50, 100, 150]

--- a/autotest/test_plot.py
+++ b/autotest/test_plot.py
@@ -255,7 +255,9 @@ def test_vertex_model_dot_plot(example_data_path):
     plt.close("all")
 
 
-@flaky  # occasional _tkinter.TclError: Can't find a usable tk.tcl
+# occasional _tkinter.TclError: Can't find a usable tk.tcl (or init.tcl)
+# similar: https://github.com/microsoft/azure-pipelines-tasks/issues/16426
+@flaky
 def test_model_dot_plot(tmpdir, example_data_path):
     import matplotlib.pyplot as plt
 

--- a/autotest/test_scripts.py
+++ b/autotest/test_scripts.py
@@ -4,6 +4,7 @@ import urllib
 from urllib.error import HTTPError
 
 import pytest
+from flaky import flaky
 
 from flopy.utils import get_modflow_main
 from autotest.conftest import (
@@ -37,6 +38,7 @@ def test_script_usage():
 rate_limit_msg = "rate limit exceeded"
 
 
+@flaky
 @requires_github
 def test_get_modflow_script(tmp_path, downloads_dir):
     # exit if extraction directory does not exist
@@ -107,6 +109,7 @@ def test_get_modflow_script(tmp_path, downloads_dir):
     assert sorted(files) == ["mfnwt.exe", "mfnwtdbl.exe"]
 
 
+@flaky
 @requires_github
 def test_get_nightly_script(tmp_path, downloads_dir):
     bindir = tmp_path / "bin1"
@@ -125,6 +128,7 @@ def test_get_nightly_script(tmp_path, downloads_dir):
     assert len(files) >= 4
 
 
+@flaky
 @requires_github
 def test_get_modflow(tmpdir):
     try:
@@ -167,6 +171,7 @@ def test_get_modflow(tmpdir):
     assert all(exe in actual for exe in expected)
 
 
+@flaky
 @requires_github
 def test_get_nightly(tmpdir):
     try:

--- a/autotest/test_usg.py
+++ b/autotest/test_usg.py
@@ -312,9 +312,10 @@ def test_usg_lak(tmpdir, mfusg_rch_evt_model_path):
     assert success
 
 
+# occasional forrtl: error (72): floating overflow
+@flaky
 @requires_exe("mfusg")
 @pytest.mark.slow
-@flaky(max_runs=3)  # occasional forrtl: error (72): floating overflow
 def test_freyburg_usg(tmpdir, freyberg_usg_model_path):
     # test mfusg model with rch nrchop 3 / freyburg.usg
     print("testing usg nrchop 3: freyburg.usg.nam")


### PR DESCRIPTION
Pytest framework changes include:

* use `pytest-benchmark`'s [builtin profiling capability](https://pytest-benchmark.readthedocs.io/en/stable/usage.html#commandline-options) instead of manual implementation
* update `DEVELOPER.md` to reflect above
* remove `requires_exe("mf6")` from `test_mf6.py` tests that don't run models/simulations
* add `@requires_spatial_reference` marker to `conftest.py` (for tests depending on [spatialreference.org](spatialreference.org))
* split `test_export.py::test_polygon_from_ij` into network-bound and non-network-bound cases (and use marker above)
* try both `importlib.import_module` and `pkg_resources.get_distribution` in `@requires_pkg` marker
    * #1486 only used latter, which caused some tests to be unintentionally skipped due to differences between package name and import name, e.g. `pymake` vs `mfpymake`
* mark `test_lgr.py::test_simple_lgr_model_from_scratch` as flaky (occasional forrtl error (65): floating invalid)
* add comments to flaky tests with links to potentially similar issues
* remove unneeded markers from `pytest.ini` (`profile`, `benchmark`)
* match profiling/benchmarking test files in `pytest.ini`
    * `profile_*.py`
    * `benchmark_*.py`
    * `*_profile*.py`
    * `*_benchmark*.py`
* mark `get-modflow` script tests as [flaky](https://github.com/modflowpy/flopy/pull/1489#issuecomment-1209777379) again due to [internal github API egress issues](https://github.com/orgs/community/discussions/8535)
* various tidying/cleanup

CI changes include:

* add timeouts to CI jobs (10min for build, lint, & smoke, 45min for test, 90min for daily jobs)
* fix benchmark artifact names (previously Windows benchmark artifacts were saved as `benchmark--<python version>` because `matrix.os` was incorrectly used with no job matrix, now fixed with `runner.os` so that all benchmark artifacts are named as `benchmark-<platform>-<python version>`)
* cache benchmark results in daily CI and compare with prior runs (a performance regression failure condition is introduced such that if any benchmark sees an avg increase > 25%, the benchmark job is failed)