### PR TITLE
CI: fix benchmark steps, disable dependency caching

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -24,13 +24,14 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2.3.4
 
-      - name: Cache python
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-3.7-pip-${{ hashFiles('setup.cfg') }}
-          restore-keys: |
-            ${{ runner.os }}-3.7-pip-
+      # Caching disabled until hashFiles issue resolved: https://github.com/actions/runner/issues/1840
+      # - name: Cache python
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ~/.cache/pip
+      #     key: ${{ runner.os }}-3.7-pip-${{ hashFiles('setup.cfg') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-3.7-pip-
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -63,13 +64,14 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2.3.4
 
-      - name: Cache python
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-3.7-pip-${{ hashFiles('setup.cfg') }}
-          restore-keys: |
-            ${{ runner.os }}-3.7-pip-
+      # Caching disabled until hashFiles issue resolved: https://github.com/actions/runner/issues/1840
+      # - name: Cache python
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ~/.cache/pip
+      #     key: ${{ runner.os }}-3.7-pip-${{ hashFiles('setup.cfg') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-3.7-pip-
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -119,13 +121,14 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2.3.4
 
-      - name: Cache python
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-3.7-pip-${{ hashFiles('setup.cfg') }}
-          restore-keys: |
-            ${{ runner.os }}-3.7-pip-
+      # Caching disabled until hashFiles issue resolved: https://github.com/actions/runner/issues/1840
+      # - name: Cache python
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ~/.cache/pip
+      #     key: ${{ runner.os }}-3.7-pip-${{ hashFiles('setup.cfg') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-3.7-pip-
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -141,13 +144,14 @@ jobs:
           pip install .
           pip install ".[test, optional]"
 
-      - name: Cache Modflow executables
-        uses: actions/cache@v3
-        with:
-          path: $HOME/.local/bin
-          key: ${{ runner.os }}-${{ hashFiles('flopy/utils/get_modflow.py') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ hashFiles('flopy/utils/get_modflow.py') }}
+      # Caching disabled until hashFiles issue resolved: https://github.com/actions/runner/issues/1840
+      # - name: Cache Modflow executables
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: $HOME/.local/bin
+      #     key: ${{ runner.os }}-${{ hashFiles('flopy/utils/get_modflow.py') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-${{ hashFiles('flopy/utils/get_modflow.py') }}
 
       - name: Install Modflow executables
         run: |
@@ -209,13 +213,14 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2.3.4
 
-      - name: Cache python
-        uses: actions/cache@v3
-        with:
-          path: ${{ matrix.path }}
-          key: ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('setup.cfg') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.python-version }}-pip-
+      # Caching disabled until hashFiles issue resolved: https://github.com/actions/runner/issues/1840
+      # - name: Cache python
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ${{ matrix.path }}
+      #     key: ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('setup.cfg') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-${{ matrix.python-version }}-pip-
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -231,13 +236,14 @@ jobs:
           pip install .
           pip install ".[test, optional]"
 
-      - name: Cache Modflow executables
-        uses: actions/cache@v3
-        with:
-          path: $HOME/.local/bin
-          key: ${{ runner.os }}-${{ hashFiles('flopy/utils/get_modflow.py') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ hashFiles('flopy/utils/get_modflow.py') }}
+      # Caching disabled until hashFiles issue resolved: https://github.com/actions/runner/issues/1840
+      # - name: Cache Modflow executables
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: $HOME/.local/bin
+      #     key: ${{ runner.os }}-${{ hashFiles('flopy/utils/get_modflow.py') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-${{ hashFiles('flopy/utils/get_modflow.py') }}
 
       - name: Install Modflow executables
         run: |
@@ -299,11 +305,12 @@ jobs:
       - name: Get branch name
         uses: nelonoel/branch-name@v1.0.1
 
-      - name: Cache Miniconda
-        uses: actions/cache@v2.1.0
-        with:
-          path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.run-type }}-${{ hashFiles('etc/environment.yml') }}
+      # Caching disabled until hashFiles issue resolved: https://github.com/actions/runner/issues/1840
+      # - name: Cache Miniconda
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ~/conda_pkgs_dir
+      #     key: ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.run-type }}-${{ hashFiles('etc/environment.yml') }}
 
       # Standard python fails on windows without GDAL installation
       # Using custom bash shell ("shell: bash -l {0}") with Miniconda

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -31,13 +31,14 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2.3.4
 
-      - name: Cache python
-        uses: actions/cache@v3
-        with:
-          path: ${{ matrix.path }}
-          key: ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('setup.cfg') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.python-version }}-pip-
+      # Caching disabled until hashFiles issue resolved: https://github.com/actions/runner/issues/1840
+      # - name: Cache python
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ${{ matrix.path }}
+      #     key: ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('setup.cfg') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-${{ matrix.python-version }}-pip-
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -116,13 +117,14 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2.3.4
 
-      - name: Cache python
-        uses: actions/cache@v3
-        with:
-          path: ${{ matrix.path }}
-          key: ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('setup.cfg') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.python-version }}-pip-
+      # Caching disabled until hashFiles issue resolved: https://github.com/actions/runner/issues/1840
+      # - name: Cache python
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ${{ matrix.path }}
+      #     key: ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('setup.cfg') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-${{ matrix.python-version }}-pip-
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -201,13 +203,14 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2.3.4
 
-      - name: Cache python
-        uses: actions/cache@v3
-        with:
-          path: ${{ matrix.path }}
-          key: ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('setup.cfg') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.python-version }}-pip-
+      # Caching disabled until hashFiles issue resolved: https://github.com/actions/runner/issues/1840
+      # - name: Cache python
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ${{ matrix.path }}
+      #     key: ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('setup.cfg') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-${{ matrix.python-version }}-pip-
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -233,18 +236,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Load cached benchmark results (for comparison)
-        uses: actions/cache@v2.1.0
+        uses: actions/cache@v3
         with:
           path: ./autotest/.benchmarks
-          key: benchmark-${{ matrix.os }}-${{ matrix.python-version }} }}
+          key: benchmark-${{ matrix.os }}-${{ matrix.python-version }}
 
       - name: Run benchmarks
         working-directory: ./autotest
         run: |
-          pytest -v --durations=0 \
-            --cov=flopy --cov-report=xml \
-            --benchmark-only --benchmark-autosave --benchmark-compare --benchmark-compare-fail=mean:25% \
-            --keep-failed=.failed
+          pytest -v --durations=0 --cov=flopy --cov-report=xml --benchmark-only --benchmark-autosave --benchmark-compare --benchmark-compare-fail=mean:25% --keep-failed=.failed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -299,11 +299,12 @@ jobs:
       - name: Get branch name
         uses: nelonoel/branch-name@v1.0.1
 
-      - name: Cache Miniconda
-        uses: actions/cache@v2.1.0
-        with:
-          path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.run-type }}-${{ hashFiles('etc/environment.yml') }}
+      # Caching disabled until hashFiles issue resolved: https://github.com/actions/runner/issues/1840
+      # - name: Cache Miniconda
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ~/conda_pkgs_dir
+      #     key: ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.run-type }}-${{ hashFiles('etc/environment.yml') }}
 
       # Standard python fails on windows without GDAL installation
       # Using custom bash shell ("shell: bash -l {0}") with Miniconda
@@ -383,11 +384,12 @@ jobs:
       - name: Get branch name
         uses: nelonoel/branch-name@v1.0.1
 
-      - name: Cache Miniconda
-        uses: actions/cache@v2.1.0
-        with:
-          path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.run-type }}-${{ hashFiles('etc/environment.yml') }}
+      # Caching disabled until hashFiles issue resolved: https://github.com/actions/runner/issues/1840
+      # - name: Cache Miniconda
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ~/conda_pkgs_dir
+      #     key: ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.run-type }}-${{ hashFiles('etc/environment.yml') }}
 
       # Standard python fails on windows without GDAL installation
       # Using custom bash shell ("shell: bash -l {0}") with Miniconda
@@ -467,11 +469,12 @@ jobs:
       - name: Get branch name
         uses: nelonoel/branch-name@v1.0.1
 
-      - name: Cache Miniconda
-        uses: actions/cache@v2.1.0
-        with:
-          path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.run-type }}-${{ hashFiles('etc/environment.yml') }}
+      # Caching disabled until hashFiles issue resolved: https://github.com/actions/runner/issues/1840
+      # - name: Cache Miniconda
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ~/conda_pkgs_dir
+      #     key: ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.run-type }}-${{ hashFiles('etc/environment.yml') }}
 
       # Standard python fails on windows without GDAL installation
       # Using custom bash shell ("shell: bash -l {0}") with Miniconda
@@ -501,18 +504,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Load cached benchmark results (for comparison)
-        uses: actions/cache@v2.1.0
+        uses: actions/cache@v3
         with:
           path: ./autotest/.benchmarks
-          key: benchmark-${{ runner.os }}-${{ matrix.python-version }} }}
+          key: benchmark-${{ runner.os }}-${{ matrix.python-version }}
 
       - name: Run benchmarks
         working-directory: ./autotest
         run: |
-          pytest -v --durations=0 \
-            --cov=flopy --cov-report=xml \
-            --benchmark-only --benchmark-autosave --benchmark-compare --benchmark-compare-fail=mean:25% \
-            --keep-failed=.failed
+          pytest -v --durations=0 --cov=flopy --cov-report=xml --benchmark-only --benchmark-autosave --benchmark-compare --benchmark-compare-fail=mean:25% --keep-failed=.failed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Fixes multiline command syntax error in Windows benchmark job. Also disables dependency caching (pip, conda and modflow executables) pending resolution of GitHub actions [`hashFiles()` timeouts](https://github.com/actions/runner/issues/1840).