### PR TITLE
Debug Codecov

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Run tests
         working-directory: ./autotest
         run: |
-          pytest -v -n=auto --smoke --cov=flopy --cov-report=xml --durations=0 --keep-failed=.failed
+          pytest -v -n=auto --smoke --durations=0 --keep-failed=.failed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -172,22 +172,9 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: failed-${{ matrix.os }}-${{ matrix.python-version }}
+          name: failed-smoke-${{ matrix.os }}-${{ matrix.python-version }}
           path: |
             ./autotest/.failed/**
-
-      - name: Print coverage
-        working-directory: ./autotest
-        run: |
-          coverage report
-
-      - name: Upload coverage
-        if:
-          github.repository_owner == 'modflowpy' && github.event_name == 'push'
-        uses: codecov/codecov-action@v2.1.0
-        with:
-          directory: ./autotest
-          file: coverage.xml
 
   test:
     name: Test
@@ -275,11 +262,11 @@ jobs:
 
       - name: Upload coverage
         if:
-          github.repository_owner == 'modflowpy' && github.event_name == 'push'
-        uses: codecov/codecov-action@v2.1.0
+          github.repository_owner == 'modflowpy' && (github.event_name == 'push' || github.event_name == 'pull_request')
+        uses: codecov/codecov-action@v3
         with:
-          directory: ./autotest
-          file: coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./autotest/coverage.xml
 
   test_windows:
     name: Test Windows
@@ -361,8 +348,8 @@ jobs:
 
       - name: Upload coverage
         if:
-          github.repository_owner == 'modflowpy' && github.event_name == 'push'
-        uses: codecov/codecov-action@v2.1.0
+          github.repository_owner == 'modflowpy' && (github.event_name == 'push' || github.event_name == 'pull_request')
+        uses: codecov/codecov-action@v3
         with:
-          directory: ./autotest
-          file: coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./autotest/coverage.xml

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -63,10 +63,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run tests
+      - name: Run regression tests
         working-directory: ./autotest
         run: |
-          pytest -v -m="regression" -n=auto --cov=flopy --cov-report=xml --durations=0 --keep-failed=.failed
+          pytest -v -m="regression" -n=auto --durations=0 --keep-failed=.failed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -77,19 +77,6 @@ jobs:
           name: failed-${{ matrix.os }}-${{ matrix.python-version }}
           path: |
             ./autotest/.failed/**
-
-      - name: Print coverage report
-        working-directory: ./autotest
-        run: |
-          coverage report
-
-      - name: Upload coverage
-        if:
-          github.repository_owner == 'modflowpy' && github.event_name == 'push'
-        uses: codecov/codecov-action@v2.1.0
-        with:
-          directory: ./autotest
-          file: coverage.xml
 
   examples:
     name: Example scripts & notebooks
@@ -149,10 +136,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run tests
+      - name: Run example tests
         working-directory: ./autotest
         run: |
-          pytest -v -m="example" -n=auto --cov=flopy --cov-report=xml --durations=0 --keep-failed=.failed
+          pytest -v -m="example" -n=auto --durations=0 --keep-failed=.failed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -163,19 +150,6 @@ jobs:
           name: failed-${{ matrix.os }}-${{ matrix.python-version }}
           path: |
             ./autotest/.failed/**
-
-      - name: Print coverage report
-        working-directory: ./autotest
-        run: |
-          coverage report
-
-      - name: Upload coverage
-        if:
-          github.repository_owner == 'modflowpy' && github.event_name == 'push'
-        uses: codecov/codecov-action@v2.1.0
-        with:
-          directory: ./autotest
-          file: coverage.xml
 
   benchmark:
     name: Benchmarks
@@ -244,7 +218,7 @@ jobs:
       - name: Run benchmarks
         working-directory: ./autotest
         run: |
-          pytest -v --durations=0 --cov=flopy --cov-report=xml --benchmark-only --benchmark-autosave --benchmark-compare --benchmark-compare-fail=mean:25% --keep-failed=.failed
+          pytest -v --durations=0 --benchmark-only --benchmark-autosave --benchmark-compare --benchmark-compare-fail=mean:25% --keep-failed=.failed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -262,19 +236,6 @@ jobs:
           name: benchmark-${{ matrix.os }}-${{ matrix.python-version }}
           path: |
             ./autotest/.benchmarks/**/*.json
-
-      - name: Print coverage report
-        working-directory: ./autotest
-        run: |
-          coverage report
-
-      - name: Upload coverage
-        if:
-          github.repository_owner == 'modflowpy' && github.event_name == 'push'
-        uses: codecov/codecov-action@v2.1.0
-        with:
-          directory: ./autotest
-          file: coverage.xml
 
   regression_windows:
     name: Regression tests (Windows)
@@ -333,10 +294,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run tests
+      - name: Run regression tests
         working-directory: ./autotest
         run: |
-          pytest -v -n auto -m "regression" --cov=flopy --cov-report=xml --durations=0 --keep-failed=.failed
+          pytest -v -n auto -m "regression" --durations=0 --keep-failed=.failed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -347,19 +308,6 @@ jobs:
           name: failed-${{ matrix.os }}-${{ matrix.python-version }}
           path: |
             ./autotest/.failed/**
-
-      - name: Print coverage report
-        working-directory: ./autotest
-        run: |
-          coverage report
-
-      - name: Upload coverage
-        if:
-          github.repository_owner == 'modflowpy' && github.event_name == 'push'
-        uses: codecov/codecov-action@v2.1.0
-        with:
-          directory: ./autotest
-          file: coverage.xml
 
   examples_windows:
     name: Example scripts & notebooks (Windows)
@@ -418,10 +366,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run tests
+      - name: Run example tests
         working-directory: ./autotest
         run: |
-          pytest -v -n auto -m "example" --cov=flopy --cov-report=xml --durations=0 --keep-failed=.failed
+          pytest -v -n auto -m "example" --durations=0 --keep-failed=.failed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -432,19 +380,6 @@ jobs:
           name: failed-${{ matrix.os }}-${{ matrix.python-version }}
           path: |
             ./autotest/.failed/**
-
-      - name: Print coverage report
-        working-directory: ./autotest
-        run: |
-          coverage report
-
-      - name: Upload coverage
-        if:
-          github.repository_owner == 'modflowpy' && github.event_name == 'push'
-        uses: codecov/codecov-action@v2.1.0
-        with:
-          directory: ./autotest
-          file: coverage.xml
 
   benchmark_windows:
     name: Benchmarks (Windows)
@@ -512,7 +447,7 @@ jobs:
       - name: Run benchmarks
         working-directory: ./autotest
         run: |
-          pytest -v --durations=0 --cov=flopy --cov-report=xml --benchmark-only --benchmark-autosave --benchmark-compare --benchmark-compare-fail=mean:25% --keep-failed=.failed
+          pytest -v --durations=0 --benchmark-only --benchmark-autosave --benchmark-compare --benchmark-compare-fail=mean:25% --keep-failed=.failed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -530,16 +465,3 @@ jobs:
           name: benchmark-${{ runner.os }}-${{ matrix.python-version }}
           path: |
             ./autotest/.benchmarks/**/*.json
-
-      - name: Print coverage report
-        working-directory: ./autotest
-        run: |
-          coverage report
-
-      - name: Upload coverage
-        if:
-          github.repository_owner == 'modflowpy' && github.event_name == 'push'
-        uses: codecov/codecov-action@v2.1.0
-        with:
-          directory: ./autotest
-          file: coverage.xml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Before you submit your Pull Request (PR) consider the following guidelines:
    ```shell
    python pull_request_prepare.py
    ```
-   Note: Pull Requests must pass isort import and black format checks run on the [GitHub actions](https://github.com/modflowpy/flopy/actions) (*linting*) before they will be accepted. isort can be installed using [`pip`](https://pypi.org/project/isort/) and [`conda`](https://anaconda.org/conda-forge/isort). The black formatter can also be installed using [`pip`](https://pypi.org/project/black/) and [`conda`](https://anaconda.org/conda-forge/black). If the Pull Request fails the *linting* job in the [flopy continuous integration](https://github.com/modflowpy/flopy/actions/workflows/ci.yml) workflow, make sure the latest versions of isort and black are installed.
+   Note: Pull Requests must pass isort import and black format checks run on the [GitHub actions](https://github.com/modflowpy/flopy/actions) (*linting*) before they will be accepted. isort can be installed using [`pip`](https://pypi.org/project/isort/) and [`conda`](https://anaconda.org/conda-forge/isort). The black formatter can also be installed using [`pip`](https://pypi.org/project/black/) and [`conda`](https://anaconda.org/conda-forge/black). If the Pull Request fails the *linting* job in the [flopy continuous integration](https://github.com/modflowpy/flopy/actions/workflows/commit.yml) workflow, make sure the latest versions of isort and black are installed.
    
 6. Run the full FloPy test suite and ensure that all tests pass:
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -435,13 +435,13 @@ The [`act`](https://github.com/nektos/act) tool uses Docker to run containerized
 With Docker installed and running, run `act -l` from the project root to see available CI workflows. To run all workflows and jobs, just run `act`. To run a particular workflow use `-W`:
 
 ```shell
-act -W .github/workflows/ci.yml
+act -W .github/workflows/commit.yml
 ```
 
 To run a particular job within a workflow, add the `-j` option:
 
 ```shell
-act -W .github/workflows/ci.yml -j build
+act -W .github/workflows/commit.yml -j build
 ```
 
 **Note:** GitHub API rate limits are easy to exceed, especially with job matrices. Authenticated GitHub users have a much higher rate limit: use `-s GITHUB_TOKEN=<your token>` when invoking `act` to provide a personal access token. Note that this will log your token in shell history &mdash; leave the value blank for a prompt to enter it more securely.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <img src="https://raw.githubusercontent.com/modflowpy/flopy/master/examples/images/flopy3.png" alt="flopy3" style="width:50;height:20">
 
 ### Version 3.3.6 &mdash; release candidate
-[![flopy continuous integration](https://github.com/modflowpy/flopy/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/modflowpy/flopy/actions/workflows/ci.yml)
+[![flopy continuous integration](https://github.com/modflowpy/flopy/actions/workflows/commit.yml/badge.svg?branch=develop)](https://github.com/modflowpy/flopy/actions/workflows/commit.yml)
 [![Read the Docs](https://github.com/modflowpy/flopy/actions/workflows/rtd.yml/badge.svg?branch=develop)](https://github.com/modflowpy/flopy/actions/workflows/rtd.yml)
 
 [![codecov](https://codecov.io/gh/modflowpy/flopy/branch/develop/graph/badge.svg)](https://codecov.io/gh/modflowpy/flopy)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 coverage:
-  precision: 3
+  precision: 2
   round: down
   range: "50...100"
   status:

--- a/release/make-release.py
+++ b/release/make-release.py
@@ -283,9 +283,9 @@ def update_readme_markdown(vmajor, vminor, vmicro):
         elif "[flopy continuous integration]" in line:
             line = (
                 "[![flopy continuous integration](https://github.com/"
-                "modflowpy/flopy/actions/workflows/ci.yml/badge.svg?"
+                "modflowpy/flopy/actions/workflows/commit.yml/badge.svg?"
                 "branch={})](https://github.com/modflowpy/flopy/actions/"
-                "workflows/ci.yml)".format(branch)
+                "workflows/commit.yml)".format(branch)
             )
         elif "[Read the Docs]" in line:
             line = (


### PR DESCRIPTION
Upload coverage reports on `pull_request` as well as `push` events to fix inaccurate codecov bot comments on PRs.

Also:
- don't measure & upload coverage for smoke tests, regression & example tests, and benchmarks
    * smoke tests and benchmarks are subsets of the standard test suite
    * example scripts/notebooks are not included in coverage measurements (only the `flopy` module is)
    * excluding regression tests [does not seem to change coverage appreciably](https://app.codecov.io/gh/modflowpy/flopy/compare/1496/overview) (as seems appropriate &mdash; ideally the standard test suite should exercise everything?) and I can plan to add a few cases to make up any omissions
- decrease coverage precision from 3 to 2 decimal places to avoid small/spurious deltas
- update to `codecov-action@v3`