### PR TITLE
refactor(get_lni): simplify get_lni signature & behavior

### DIFF
--- a/autotest/test_grid.py
+++ b/autotest/test_grid.py
@@ -885,21 +885,21 @@ def test_unstructured_iverts(grid):
 @parametrize_with_cases("grid", cases=GridCases, prefix="structured")
 def test_get_lni_structured(grid):
     for nn in range(0, grid.nnodes):
-        layer, i = grid.get_lni(nn)
+        layer, i = grid.get_lni([nn])[0]
         assert layer * grid.ncpl + i == nn
 
 
 @parametrize_with_cases("grid", cases=GridCases, prefix="vertex")
 def test_get_lni_vertex(grid):
     for nn in range(0, grid.nnodes):
-        layer, i = grid.get_lni(nn)
+        layer, i = grid.get_lni([nn])[0]
         assert layer * grid.ncpl + i == nn
 
 
 @parametrize_with_cases("grid", cases=GridCases, prefix="unstructured")
 def test_get_lni_unstructured(grid):
     for nn in range(0, grid.nnodes):
-        layer, i = grid.get_lni(nn)
+        layer, i = grid.get_lni([nn])[0]
         csum = [0] + list(
             np.cumsum(
                 (

--- a/autotest/test_headufile.py
+++ b/autotest/test_headufile.py
@@ -114,9 +114,9 @@ def test_get_ts_multiple_nodes(mfusg_model):
     nodes = [500, 300, 182, 65]
     multi_hds = head_file.get_ts(idx=nodes)
     for i, node in enumerate(nodes):
-        li, ni = get_lni(grid.ncpl, node)
+        layer, nn = get_lni(grid.ncpl, [node])[0]
         assert (
-            multi_hds[0, i + 1] == head[li][ni]
+            multi_hds[0, i + 1] == head[layer][nn]
         ), "head from 'get_ts' != head from 'get_data'"
 
 
@@ -131,9 +131,9 @@ def test_get_ts_all_nodes(mfusg_model):
     nodes = list(range(0, grid.nnodes))
     multi_hds = head_file.get_ts(idx=nodes)
     for node in nodes:
-        li, ni = get_lni(grid.ncpl, node)
+        layer, nn = get_lni(grid.ncpl, [node])[0]
         assert (
-            multi_hds[0, node + 1] == head[li][ni]
+            multi_hds[0, node + 1] == head[layer][nn]
         ), "head from 'get_ts' != head from 'get_data'"
 
 
@@ -155,7 +155,7 @@ def test_get_lni(mfusg_model):
         return exp
 
     nodes = list(range(0, grid.nnodes))
+    lni = get_lni(grid.ncpl, nodes)
     expected = get_expected()
-    for node in nodes:
-        layer, nn = get_lni(grid.ncpl, node)
+    for layer, nn in lni:
         assert expected[layer][nn] == head[layer][nn]

--- a/flopy/discretization/grid.py
+++ b/flopy/discretization/grid.py
@@ -607,19 +607,17 @@ class Grid:
     def map_polygons(self):
         raise NotImplementedError("must define map_polygons in child class")
 
-    def get_lni(self, *nodes):
+    def get_lni(self, nodes):
         """
-        Get the layer index and within-layer node index (both 0-based).
-        if no nodes are specified, all are returned in ascending order.
+        Get the layer index and within-layer node index (both 0-based) for the given nodes
 
         Parameters
         ----------
-        nodes : the node numbers (zero or more ints)
+        nodes : node numbers (array-like)
 
         Returns
         -------
-            A tuple (layer index, node index), or a
-            list of such if multiple nodes provided
+            list of tuples (layer index, node index)
         """
 
         ncpl = (
@@ -628,7 +626,7 @@ class Grid:
             else list(self.ncpl)
         )
 
-        return get_lni(ncpl, *nodes)
+        return get_lni(ncpl, nodes)
 
     def get_plottable_layer_array(self, plotarray, layer):
         raise NotImplementedError(

--- a/flopy/utils/binaryfile.py
+++ b/flopy/utils/binaryfile.py
@@ -1969,7 +1969,7 @@ class HeadUFile(BinaryLayerFile):
         result = []
 
         if isinstance(idx, int):
-            layer, nn = get_lni(ncpl, idx)
+            layer, nn = get_lni(ncpl, [idx])[0]
             for i, time in enumerate(times):
                 data = self.get_data(totim=time)
                 value = data[layer][nn]
@@ -1978,8 +1978,8 @@ class HeadUFile(BinaryLayerFile):
             for i, time in enumerate(times):
                 data = self.get_data(totim=time)
                 row = [time]
-                for node in idx:
-                    layer, nn = get_lni(ncpl, node)
+                lni = get_lni(ncpl, idx)
+                for layer, nn in lni:
                     value = data[layer][nn]
                     row += [value]
                 result.append(row)

--- a/flopy/utils/gridutil.py
+++ b/flopy/utils/gridutil.py
@@ -1,34 +1,52 @@
 """
 Grid utilities
 """
-from typing import Iterable, List, Tuple, Union
+from math import floor
+from typing import Collection, Iterable, List, Sequence, Tuple, Union
 
 import numpy as np
 
 
-def get_lni(
-    ncpl: Union[int, Iterable[int]], *nodes
-) -> Union[Tuple[int, int], List[Tuple[int, int]]]:
+def get_lni(ncpl, nodes) -> List[Tuple[int, int]]:
     """
-    Get the layer index and within-layer node index (both 0-based)
-    given node count per layer and node number (grid-scoped index).
-    if no nodes are specified, all are returned in ascending order.
+    Get layer index and within-layer node index (both 0-based).
+
+     | Node count per layer may be an int or array-like of integers.
+    An integer ncpl indicates all layers have the same node count.
+    If an integer ncpl is less than any specified node numbers, the
+    grid is understood to have at least enough layers to contain them.
+
+     | If ncpl is array-like it is understood to describe node count
+    per zero-indexed layer. If ncpl is array-like and no nodes are
+    specified, indices are returned for all nodes in ascending order.
 
     Parameters
     ----------
-    ncpl: node count per layer (int or list of ints)
-    nodes : node numbers (zero or more ints)
+    ncpl: node count per layer (int or array-like of ints)
+    nodes : node numbers (array-like of nodes)
 
     Returns
     -------
-        A tuple (layer index, node index), or a
-        list of such if multiple nodes provided
+        A list of tuples (layer index, node index)
     """
 
-    v = []
-    counts = [ncpl] if isinstance(ncpl, int) else list(ncpl)
+    if not isinstance(ncpl, (int, list, tuple, np.ndarray)):
+        raise ValueError(f"ncpl must be int or array-like")
+    if not isinstance(nodes, (list, tuple, np.ndarray)):
+        raise ValueError(f"nodes must be array-like")
 
-    for nn in nodes if nodes else range(sum(ncpl)):
+    if len(nodes) == 0:
+        return []
+
+    if isinstance(ncpl, int):
+        # infer min number of layers to hold given node numbers
+        layers = range(floor(np.max(nodes) / ncpl) if len(nodes) > 0 else 1)
+        counts = [ncpl for _ in layers]
+    else:
+        counts = list(ncpl)
+
+    tuples = []
+    for nn in nodes if nodes else range(sum(counts)):
         csum = np.cumsum([0] + counts)
         layer = max(0, np.searchsorted(csum, nn) - 1)
         nidx = nn - sum([counts[l] for l in range(0, layer)])
@@ -36,6 +54,6 @@ def get_lni(
         # np.searchsorted assigns the first index of each layer
         # to the previous layer in layer 2+, so correct for it
         correct = layer + 1 < len(csum) and nidx == counts[layer]
-        v.append((layer + 1, 0) if correct else (layer, nidx))
+        tuples.append((layer + 1, 0) if correct else (layer, nidx))
 
-    return v if len(v) > 1 else v[0]
+    return tuples


### PR DESCRIPTION
#1510 added new grid utility function `get_lni(ncpl, *nodes)` to compute layer index and within-layer node index from grid-wise node number. For `ncpl` it expects an `int` or array-like of integers per the convention for unstructured grids.

Originally if the `ncpl` argument to this function was an `int` it was assumed to describe a 1-layer grid. Now an integer value is no longer understood to carry information about the number of layers, and indicates only that all layers have the same node count. If the value is less than any specified node numbers, the grid is presumed to have at least enough layers to contain them.

The function's signature has changed from `get_lni(ncpl, *nodes)` to `get_lni(ncpl, nodes)`, and likewise for `Grid.get_lni(nodes)`. Both now expect array-like `nodes` and just return lists of tuples in corresponding order. This aims to conform to the signature and return value of `StructuredGrid.get_lrc(nodes)` and make the `Grid` API more consistent.