### PR TITLE
refactor(CrossSectionPlot, GeoSpatialUtil)

### DIFF
--- a/autotest/test_geospatial_util.py
+++ b/autotest/test_geospatial_util.py
@@ -543,3 +543,10 @@ def test_mixed_collection(
                     raise AssertionError(
                         "GeoSpatialCollection conversion error"
                     )
+
+
+@requires_pkg("shapely", "geojson")
+def test_create_linestring_with_single_point_fails():
+    point = [0, 0]
+    with pytest.raises(ValueError):
+        GeoSpatialUtil(point, shapetype="linestring")

--- a/flopy/plot/crosssection.py
+++ b/flopy/plot/crosssection.py
@@ -7,6 +7,7 @@ import numpy as np
 from matplotlib.patches import Polygon
 
 from ..utils import geometry
+from ..utils.geospatial_utils import GeoSpatialUtil
 from . import plotutil
 
 warnings.simplefilter("always", PendingDeprecationWarning)
@@ -135,7 +136,13 @@ class PlotCrossSection:
                     (xcenter[int(line[onkey])], yedge[-1] - eps),
                 ]
         else:
-            verts = line[onkey]
+            ln = line[onkey]
+            gu = GeoSpatialUtil(ln, shapetype="linestring")
+            assert (
+                gu.shapetype == "LineString"
+            )  # unnecessary if GSU guarantees shapetype is same as requested
+
+            verts = gu.points
             xp = []
             yp = []
             for [v1, v2] in verts:

--- a/flopy/utils/geospatial_utils.py
+++ b/flopy/utils/geospatial_utils.py
@@ -75,6 +75,9 @@ class GeoSpatialUtil:
                 )
                 raise AssertionError(err)
 
+            if shapetype == "linestring" and len(np.array(obj).shape) == 1:
+                raise ValueError(f"linestring must have 2 or more coordinates")
+
             self.__geo_interface = {
                 "type": shape_types[shapetype],
                 "coordinates": list(obj),


### PR DESCRIPTION
- accept flopy/shapely linestrings for `CrossSectionPlot` line via `GeoSpatialUtil` as suggested [here](https://github.com/modflowpy/flopy/issues/1436#issuecomment-1183432320)
- make sure at least 2 coordinates provided to create `GeoSpatialUtil` with linestring shapetype