### PR TITLE
test: add marker for mf6 tests

### DIFF
--- a/autotest/pytest.ini
+++ b/autotest/pytest.ini
@@ -12,3 +12,4 @@ markers =
     example: exercise scripts, tutorials and notebooks
     regression: tests that compare multiple results
     meta: run by other tests (e.g. testing fixtures)
+    mf6: tests for the mf6 module

--- a/autotest/regression/test_mf6.py
+++ b/autotest/regression/test_mf6.py
@@ -50,6 +50,8 @@ from flopy.mf6.utils import testutils
 from flopy.utils import CellBudgetFile
 from flopy.utils.datautil import PyListUtil
 
+pytestmark = pytest.mark.mf6
+
 
 @requires_exe("mf6")
 @requires_pkg("pymake")

--- a/autotest/regression/test_mf6_examples.py
+++ b/autotest/regression/test_mf6_examples.py
@@ -7,21 +7,21 @@ from autotest.regression.conftest import is_nested
 
 from flopy.mf6 import MFSimulation
 
+pytestmark = pytest.mark.mf6
+
 
 @requires_exe("mf6")
 @requires_pkg("pymake")
 @pytest.mark.slow
 @pytest.mark.regression
 def test_mf6_example_simulations(tmpdir, mf6_example_namfiles):
-    """
-    MF6 examples parametrized by simulation. Arg `mf6_example_namfiles` is a list
-    of models to run in order provided. Coupled models share the same workspace.
-
-    Parameters
-    ----------
-    tmpdir: function-scoped temporary directory fixture
-    mf6_example_namfiles: ordered list of namfiles for 1+ coupled models
-    """
+    # MF6 examples parametrized by simulation. `mf6_example_namfiles` is a list
+    # of models to run in order provided. Coupled models share the same tempdir
+    #
+    # Parameters
+    # ----------
+    # tmpdir: function-scoped temporary directory fixture
+    # mf6_example_namfiles: ordered list of namfiles for 1+ coupled models
 
     import pymake
 

--- a/autotest/test_binarygrid_util.py
+++ b/autotest/test_binarygrid_util.py
@@ -7,6 +7,8 @@ from matplotlib import pyplot as plt
 from flopy.discretization import StructuredGrid, UnstructuredGrid, VertexGrid
 from flopy.mf6.utils import MfGrdFile
 
+pytestmark = pytest.mark.mf6
+
 
 @pytest.fixture(scope="module")
 def mfgrd_test_path(example_data_path):

--- a/autotest/test_cbc_full3D.py
+++ b/autotest/test_cbc_full3D.py
@@ -41,6 +41,7 @@ def load_mf2005(path, ws_out):
     return ml
 
 
+@pytest.mark.mf6
 def load_mf6(path, ws_out):
     sim = MFSimulation.load(
         sim_name=Path(path).name,
@@ -118,6 +119,7 @@ def cbc_eval(cbcobj, nnodes, shape3d, modelgrid):
     cobj_mg.close()
 
 
+@pytest.mark.mf6
 @pytest.mark.parametrize("path", mf6_paths)
 def test_cbc_full3D_mf6(tmpdir, path):
     sim = load_mf6(path, str(tmpdir))

--- a/autotest/test_copy.py
+++ b/autotest/test_copy.py
@@ -4,6 +4,7 @@ import copy
 import inspect
 
 import numpy as np
+import pytest
 
 from flopy.datbase import DataInterface, DataType
 from flopy.mbase import ModelInterface
@@ -226,6 +227,7 @@ def test_mf2005_copy(example_data_path):
     assert not model_is_copy(m, m_c)
 
 
+@pytest.mark.mf6
 def test_mf6_copy(example_data_path):
     sim = MFSimulation.load(
         "mfsim.nam",

--- a/autotest/test_export.py
+++ b/autotest/test_export.py
@@ -616,6 +616,7 @@ def test_export_contourf(tmpdir, example_data_path):
             )
 
 
+@pytest.mark.mf6
 @requires_pkg("shapefile", "shapely")
 def test_export_contours(tmpdir, example_data_path):
     from shapefile import Reader
@@ -643,6 +644,7 @@ def test_export_contours(tmpdir, example_data_path):
         assert len(shapes) == 65
 
 
+@pytest.mark.mf6
 @requires_pkg("shapely")
 def test_mf6_grid_shp_export(tmpdir):
     nlay = 2
@@ -1110,6 +1112,7 @@ def test_vtk_export_packages(tmpdir, example_data_path):
     assert os.path.exists(filetocheck)
 
 
+@pytest.mark.mf6
 @requires_pkg("vtk")
 def test_vtk_mf6(tmpdir, example_data_path):
     # test mf6
@@ -1372,6 +1375,7 @@ def test_vtk_unstructured(tmpdir, example_data_path):
     assert np.allclose(np.ravel(top), top2), "Field data not properly written"
 
 
+@pytest.mark.mf6
 @requires_pkg("vtk")
 def test_vtk_vertex(tmpdir, example_data_path):
     from vtkmodules.util.numpy_support import vtk_to_numpy
@@ -1530,6 +1534,7 @@ def load_iverts(fname, closed=False):
     return iverts, np.array(xc), np.array(yc)
 
 
+@pytest.mark.mf6
 @requires_pkg("vtk")
 def test_vtk_export_model_without_packages_names(tmpdir):
     from vtkmodules.util.numpy_support import vtk_to_numpy
@@ -1587,6 +1592,7 @@ def test_vtk_export_model_without_packages_names(tmpdir):
     assert np.allclose(cell_types, cell_types_answer), errmsg
 
 
+@pytest.mark.mf6
 @requires_pkg("vtk")
 def test_vtk_export_disv1_model(tmpdir):
     from vtkmodules.util.numpy_support import vtk_to_numpy
@@ -1659,6 +1665,7 @@ def test_vtk_export_disv1_model(tmpdir):
     assert np.allclose(cell_types, cell_types_answer), errmsg
 
 
+@pytest.mark.mf6
 @requires_pkg("vtk")
 def test_vtk_export_disv2_model(tmpdir):
     from vtkmodules.util.numpy_support import vtk_to_numpy
@@ -1896,6 +1903,7 @@ def test_vtk_export_disu2_grid(tmpdir, example_data_path):
     assert np.allclose(cell_types, cell_types_answer), errmsg
 
 
+@pytest.mark.mf6
 @requires_pkg("vtk", "shapefile")
 def test_vtk_export_disu_model(tmpdir):
     from vtkmodules.util.numpy_support import vtk_to_numpy

--- a/autotest/test_generate_classes.py
+++ b/autotest/test_generate_classes.py
@@ -4,6 +4,7 @@ from autotest.conftest import excludes_branch
 from flopy.mf6.utils import generate_classes
 
 
+@pytest.mark.mf6
 @pytest.mark.skip(
     reason="TODO: use external copy of the repo, otherwise files are rewritten"
 )

--- a/autotest/test_lake_connections.py
+++ b/autotest/test_lake_connections.py
@@ -2,7 +2,7 @@ import os
 
 import numpy as np
 import pytest
-from autotest.conftest import requires_pkg
+from autotest.conftest import requires_exe, requires_pkg
 
 from flopy.discretization import StructuredGrid
 from flopy.mf6 import (
@@ -22,6 +22,8 @@ from flopy.mf6 import (
 from flopy.mf6.utils import get_lak_connections
 from flopy.modflow import Modflow
 from flopy.utils import Raster
+
+pytestmark = pytest.mark.mf6
 
 
 def export_ascii_grid(modelgrid, file_path, v, nodata=0.0):
@@ -136,6 +138,7 @@ def get_lake_connection_data(
     return lakeconnectiondata, nlakecon
 
 
+@requires_exe("mf6")
 def test_base_run(tmpdir, example_data_path):
     mpath = example_data_path / "mf6-freyberg"
     sim = MFSimulation().load(
@@ -177,6 +180,7 @@ def test_base_run(tmpdir, example_data_path):
     )
 
 
+@requires_exe("mf6")
 @requires_pkg("rasterio")
 def test_lake(tmpdir, example_data_path):
     mpath = example_data_path / "mf6-freyberg"
@@ -295,9 +299,8 @@ def test_lake(tmpdir, example_data_path):
 
     assert success, f"could not run {sim.name} with lake"
 
-    return
 
-
+@requires_exe("mf6")
 def test_embedded_lak_ex01(tmpdir, example_data_path):
     nper = 1
     nlay, nrow, ncol = 5, 17, 17
@@ -497,6 +500,7 @@ def test_embedded_lak_ex01(tmpdir, example_data_path):
     assert success, f"could not run {sim.name}"
 
 
+@requires_exe("mf6")
 def test_embedded_lak_prudic(example_data_path):
     lakebed_leakance = 1.0  # Lakebed leakance ($ft^{-1}$)
     nlay = 8  # Number of layers
@@ -599,6 +603,7 @@ def test_embedded_lak_prudic(example_data_path):
     ), "idomain not updated correctly with lakibd"
 
 
+@requires_exe("mf6")
 def test_embedded_lak_prudic_mixed(example_data_path):
     lakebed_leakance = 1.0  # Lakebed leakance ($ft^{-1}$)
     nlay = 8  # Number of layers

--- a/autotest/test_modpathfile.py
+++ b/autotest/test_modpathfile.py
@@ -23,6 +23,8 @@ from flopy.mf6 import (
 from flopy.modpath import Modpath7
 from flopy.utils import EndpointFile, PathlineFile
 
+pytestmark = pytest.mark.mf6
+
 
 def __create_simulation(
     ws,

--- a/autotest/test_mp6.py
+++ b/autotest/test_mp6.py
@@ -48,6 +48,8 @@ from flopy.utils import EndpointFile, PathlineFile
 from flopy.utils.flopy_io import loadtxt
 from flopy.utils.recarray_utils import ra_slice
 
+pytestmark = pytest.mark.mf6
+
 MP6_TEST_PATH = get_example_data_path(__file__) / "mp6"
 
 

--- a/autotest/test_mp7.py
+++ b/autotest/test_mp7.py
@@ -32,6 +32,8 @@ from flopy.modpath import (
 )
 from flopy.utils import EndpointFile
 
+pytestmark = pytest.mark.mf6
+
 ex01b_mf6_model_name = "ex01b_mf6"
 
 

--- a/autotest/test_plot.py
+++ b/autotest/test_plot.py
@@ -2,7 +2,7 @@ import os
 
 import numpy as np
 import pytest
-from autotest.conftest import requires_pkg
+from autotest.conftest import is_in_ci, requires_pkg
 from flaky import flaky
 from matplotlib import pyplot as plt
 from matplotlib import rcParams
@@ -47,12 +47,10 @@ def test_map_view():
     modelmap = flopy.plot.PlotMapView(model=m)
     pc = modelmap.plot_grid()
     check_vertices()
-    plt.close()
 
     modelmap = flopy.plot.PlotMapView(modelgrid=m.modelgrid)
     pc = modelmap.plot_grid()
     check_vertices()
-    plt.close()
 
     mf = flopy.modflow.Modflow()
 
@@ -73,11 +71,11 @@ def test_map_view():
     verts = [[101.0, 201.0], [119.0, 209.0]]
     modelxsect = flopy.plot.PlotCrossSection(model=mf, line={"line": verts})
     patchcollection = modelxsect.plot_grid()
-    plt.close()
 
 
+@pytest.mark.mf6
 @pytest.mark.xfail(reason="sometimes get wrong collection type")
-def test_map_view_boundary_conditions(example_data_path):
+def test_map_view_bc_gwfs_disv(example_data_path):
     mpath = example_data_path / "mf6" / "test003_gwfs_disv"
     sim = MFSimulation.load(sim_ws=str(mpath))
     ml6 = sim.get_model("gwf_1")
@@ -93,8 +91,11 @@ def test_map_view_boundary_conditions(example_data_path):
         assert isinstance(
             col, (QuadMesh, PathCollection)
         ), f"Unexpected collection type: {type(col)}"
-    plt.close()
 
+
+@pytest.mark.mf6
+@pytest.mark.xfail(reason="sometimes get wrong collection type")
+def test_map_view_bc_lake2tr(example_data_path):
     mpath = example_data_path / "mf6" / "test045_lake2tr"
     sim = MFSimulation.load(sim_ws=str(mpath))
     ml6 = sim.get_model("lakeex2a")
@@ -110,8 +111,11 @@ def test_map_view_boundary_conditions(example_data_path):
         assert isinstance(
             col, (QuadMesh, PathCollection)
         ), f"Unexpected collection type: {type(col)}"
-    plt.close()
 
+
+@pytest.mark.mf6
+@pytest.mark.xfail(reason="sometimes get wrong collection type")
+def test_map_view_bc_2models_mvr(example_data_path):
     mpath = example_data_path / "mf6" / "test006_2models_mvr"
     sim = MFSimulation.load(sim_ws=str(mpath))
     ml6 = sim.get_model("parent")
@@ -134,14 +138,18 @@ def test_map_view_boundary_conditions(example_data_path):
         assert isinstance(
             col, (QuadMesh, PathCollection)
         ), f"Unexpected collection type: {type(col)}"
-    plt.close()
 
+
+@pytest.mark.mf6
+@pytest.mark.xfail(reason="sometimes get wrong collection type")
+def test_map_view_bc_UZF_3lay(example_data_path):
     mpath = example_data_path / "mf6" / "test001e_UZF_3lay"
     sim = MFSimulation.load(sim_ws=str(mpath))
     ml6 = sim.get_model("gwf_1")
 
     mapview = flopy.plot.PlotMapView(model=ml6)
     mapview.plot_bc("UZF")
+    ax = mapview.ax
 
     if len(ax.collections) == 0:
         raise AssertionError("Boundary condition was not drawn")
@@ -150,13 +158,13 @@ def test_map_view_boundary_conditions(example_data_path):
         assert isinstance(
             col, (QuadMesh, PathCollection)
         ), f"Unexpected collection type: {type(col)}"
-    plt.close()
 
 
+@pytest.mark.mf6
 @pytest.mark.xfail(
     reason="sometimes get LineCollections instead of PatchCollections"
 )
-def test_cross_section_boundary_conditions(example_data_path):
+def test_cross_section_bc_gwfs_disv(example_data_path):
     mpath = example_data_path / "mf6" / "test003_gwfs_disv"
     sim = MFSimulation.load(sim_ws=str(mpath))
     ml6 = sim.get_model("gwf_1")
@@ -170,8 +178,13 @@ def test_cross_section_boundary_conditions(example_data_path):
         assert isinstance(
             col, PatchCollection
         ), f"Unexpected collection type: {type(col)}"
-    plt.close()
 
+
+@pytest.mark.mf6
+@pytest.mark.xfail(
+    reason="sometimes get LineCollections instead of PatchCollections"
+)
+def test_cross_section_bc_lake2tr(example_data_path):
     mpath = example_data_path / "mf6" / "test045_lake2tr"
     sim = MFSimulation.load(sim_ws=str(mpath))
     ml6 = sim.get_model("lakeex2a")
@@ -186,8 +199,13 @@ def test_cross_section_boundary_conditions(example_data_path):
         assert isinstance(
             col, PatchCollection
         ), f"Unexpected collection type: {type(col)}"
-    plt.close()
 
+
+@pytest.mark.mf6
+@pytest.mark.xfail(
+    reason="sometimes get LineCollections instead of PatchCollections"
+)
+def test_cross_section_bc_2models_mvr(example_data_path):
     mpath = example_data_path / "mf6" / "test006_2models_mvr"
     sim = MFSimulation.load(sim_ws=str(mpath))
     ml6 = sim.get_model("parent")
@@ -201,8 +219,13 @@ def test_cross_section_boundary_conditions(example_data_path):
         assert isinstance(
             col, PatchCollection
         ), f"Unexpected collection type: {type(col)}"
-    plt.close()
 
+
+@pytest.mark.mf6
+@pytest.mark.xfail(
+    reason="sometimes get LineCollections instead of PatchCollections"
+)
+def test_cross_section_bc_UZF_3lay(example_data_path):
     mpath = example_data_path / "mf6" / "test001e_UZF_3lay"
     sim = MFSimulation.load(sim_ws=str(mpath))
     ml6 = sim.get_model("gwf_1")
@@ -217,7 +240,6 @@ def test_cross_section_boundary_conditions(example_data_path):
         assert isinstance(
             col, PatchCollection
         ), f"Unexpected collection type: {type(col)}"
-    plt.close()
 
 
 def test_map_view_tricontour_nan():
@@ -255,9 +277,8 @@ def test_map_view_tricontour_nan():
         if not np.allclose(lev, levels[ix]):
             raise AssertionError("TriContour NaN catch Failed")
 
-    plt.close()
 
-
+@pytest.mark.mf6
 def test_vertex_model_dot_plot(example_data_path):
     rcParams["figure.max_open_warning"] = 36
 
@@ -269,7 +290,6 @@ def test_vertex_model_dot_plot(example_data_path):
     ax = disv_ml.plot()
     assert isinstance(ax, list)
     assert len(ax) == 36
-    plt.close("all")
 
 
 # occasional _tkinter.TclError: Can't find a usable tk.tcl (or init.tcl)
@@ -285,19 +305,41 @@ def test_model_dot_plot(tmpdir, example_data_path):
     ax = ml.plot()
     assert isinstance(ax, list), "ml.plot() ax is is not a list"
     assert len(ax) == 18, f"number of axes ({len(ax)}) is not equal to 18"
-    plt.close("all")
+
+
+def test_dataset_dot_plot(tmpdir, example_data_path):
+    import matplotlib.pyplot as plt
+
+    loadpth = example_data_path / "mf2005_test"
+    ml = flopy.modflow.Modflow.load(
+        "ibs2k.nam", "mf2k", model_ws=str(loadpth), check=False
+    )
 
     # plot specific dataset
     ax = ml.bcf6.hy.plot()
     assert isinstance(ax, list), "ml.bcf6.hy.plot() ax is is not a list"
     assert len(ax) == 2, f"number of hy axes ({len(ax)}) is not equal to 2"
 
+
+def test_dataset_dot_plot_nlay_ne_plottable(tmpdir, example_data_path):
+    import matplotlib.pyplot as plt
+
+    loadpth = example_data_path / "mf2005_test"
+    ml = flopy.modflow.Modflow.load(
+        "ibs2k.nam", "mf2k", model_ws=str(loadpth), check=False
+    )
     # special case where nlay != plottable
     ax = ml.bcf6.vcont.plot()
     assert isinstance(
         ax, plt.Axes
     ), "ml.bcf6.vcont.plot() ax is is not of type plt.Axes"
-    plt.close("all")
+
+
+def test_model_dot_plot_export(tmpdir, example_data_path):
+    loadpth = example_data_path / "mf2005_test"
+    ml = flopy.modflow.Modflow.load(
+        "ibs2k.nam", "mf2k", model_ws=str(loadpth), check=False
+    )
 
     fh = os.path.join(tmpdir, "ibs2k")
     ml.plot(mflay=0, filename_base=fh, file_extension="png")
@@ -311,7 +353,6 @@ def test_model_dot_plot(tmpdir, example_data_path):
         t = f.split("_")
         if len(t) < 3:
             raise AssertionError("Plot filenames not written correctly")
-    plt.close("all")
 
 
 @requires_pkg("pandas")
@@ -363,10 +404,9 @@ def test_pathline_plot_xc(tmpdir, example_data_path):
     if len(pth._paths) != 6:
         raise AssertionError()
 
-    plt.close()
 
-
-def test_plotting_with_quasi3d_layers(tmpdir):
+@pytest.fixture
+def quasi3d_model(tmpdir):
     mf = Modflow("model_mf", model_ws=str(tmpdir), exe_name="mf2005")
 
     # Model domain and grid definition
@@ -429,34 +469,57 @@ def test_plotting_with_quasi3d_layers(tmpdir):
 
     assert success, "test_plotting_with_quasi3d_layers() failed"
 
+    return mf
+
+
+def test_map_plot_with_quasi3d_layers(quasi3d_model):
     # read output
-    hf = HeadFile(os.path.join(mf.model_ws, f"{mf.name}.hds"))
+    hf = HeadFile(
+        os.path.join(quasi3d_model.model_ws, f"{quasi3d_model.name}.hds")
+    )
     head = hf.get_data(totim=1.0)
-    cbb = CellBudgetFile(os.path.join(mf.model_ws, f"{mf.name}.cbc"))
+    cbb = CellBudgetFile(
+        os.path.join(quasi3d_model.model_ws, f"{quasi3d_model.name}.cbc")
+    )
     frf = cbb.get_data(text="FLOW RIGHT FACE", totim=1.0)[0]
     fff = cbb.get_data(text="FLOW FRONT FACE", totim=1.0)[0]
     flf = cbb.get_data(text="FLOW LOWER FACE", totim=1.0)[0]
 
     # plot a map
     plt.figure()
-    mv = PlotMapView(model=mf, layer=1)
+    mv = PlotMapView(model=quasi3d_model, layer=1)
     mv.plot_grid()
     mv.plot_array(head)
     mv.contour_array(head)
     mv.plot_ibound()
     mv.plot_bc("wel")
     mv.plot_vector(frf, fff)
-    plt.savefig(os.path.join(str(tmpdir), "plt01.png"))
-    plt.close()
+    plt.savefig(os.path.join(str(quasi3d_model.model_ws), "plt01.png"))
+
+
+def test_cross_section_with_quasi3d_layers(quasi3d_model):
+    # read output
+    hf = HeadFile(
+        os.path.join(quasi3d_model.model_ws, f"{quasi3d_model.name}.hds")
+    )
+    head = hf.get_data(totim=1.0)
+    cbb = CellBudgetFile(
+        os.path.join(quasi3d_model.model_ws, f"{quasi3d_model.name}.cbc")
+    )
+    frf = cbb.get_data(text="FLOW RIGHT FACE", totim=1.0)[0]
+    fff = cbb.get_data(text="FLOW FRONT FACE", totim=1.0)[0]
+    flf = cbb.get_data(text="FLOW LOWER FACE", totim=1.0)[0]
 
     # plot a cross-section
     plt.figure()
-    cs = PlotCrossSection(model=mf, line={"row": int((nrow - 1) / 2)})
+    cs = PlotCrossSection(
+        model=quasi3d_model,
+        line={"row": int((quasi3d_model.modelgrid.nrow - 1) / 2)},
+    )
     cs.plot_grid()
     cs.plot_array(head)
     cs.contour_array(head)
     cs.plot_ibound()
     cs.plot_bc("wel")
     cs.plot_vector(frf, fff, flf, head=head)
-    plt.savefig(os.path.join(str(tmpdir), "plt02.png"))
-    plt.close()
+    plt.savefig(os.path.join(str(quasi3d_model.model_ws), "plt02.png"))

--- a/autotest/test_postprocessing.py
+++ b/autotest/test_postprocessing.py
@@ -30,6 +30,7 @@ def mf6_freyberg_path(example_data_path):
     return example_data_path / "mf6-freyberg"
 
 
+@pytest.mark.mf6
 def test_faceflows(tmpdir, mf6_freyberg_path):
     sim = MFSimulation.load(
         sim_name="freyberg",
@@ -96,6 +97,7 @@ def test_faceflows(tmpdir, mf6_freyberg_path):
     return
 
 
+@pytest.mark.mf6
 def test_flowja_residuals(tmpdir, mf6_freyberg_path):
     sim = MFSimulation.load(
         sim_name="freyberg",
@@ -142,6 +144,7 @@ def test_flowja_residuals(tmpdir, mf6_freyberg_path):
     plt.close("all")
 
 
+@pytest.mark.mf6
 def test_structured_faceflows_3d(tmpdir):
     name = "mymodel"
     sim = MFSimulation(sim_name=name, sim_ws=str(tmpdir), exe_name="mf6")

--- a/autotest/test_specific_discharge.py
+++ b/autotest/test_specific_discharge.py
@@ -485,6 +485,7 @@ def specific_discharge_comprehensive(tmpdir):
     plt.close()
 
 
+@pytest.mark.mf6
 @pytest.mark.xfail(
     reason="occasional Unexpected collection type: <class 'matplotlib.collections.LineCollection'>"
 )

--- a/autotest/test_structured_faceflows.py
+++ b/autotest/test_structured_faceflows.py
@@ -3,6 +3,8 @@ import pytest
 
 from flopy.mf6.utils import get_residuals, get_structured_faceflows
 
+pytestmark = pytest.mark.mf6
+
 
 def test_get_faceflows_empty():
     flowja = np.zeros(10, dtype=np.float64)

--- a/autotest/test_zonbud_utility.py
+++ b/autotest/test_zonbud_utility.py
@@ -282,6 +282,7 @@ def test_read_zone_file(tmpdir):
         raise AssertionError("zone file read failed")
 
 
+@pytest.mark.mf6
 @requires_pkg("pandas")
 def test_zonebudget_6(tmpdir, example_data_path):
     import pandas as pd
@@ -341,6 +342,7 @@ def test_zonebudget_6(tmpdir, example_data_path):
     assert list(df)[0] == "test_alias", "Alias testing failed"
 
 
+@pytest.mark.mf6
 def test_zonebudget6_from_output_method(tmpdir, example_data_path):
     exe_name = "mf6"
     zb_exe_name = "zbud6"


### PR DESCRIPTION
Introduce `mf6` marker to `pytest.ini` and add it to all tests using `flopy.mf6`. The marker is applied separately to some test cases with `@pytest.mark.mf6` and to some entire files with `pytestmark = pytest.mark.mf6`. Modflow6 tests can be selected with `pytest -m "mf6"` and queried with `pytest --collect-only --quiet -m "mf6"`.

Also:

- un-`xfail` external-path related tests in `test_modflow.py` (marked in error)
- skip `test_modflow.py::test_single_mflist_entry_load` on Windows CI to avoid [errors](https://github.com/modflowpy/flopy/runs/8096439002?check_suite_focus=true#step:8:1753) when changing workspace between drives and resetting external path [with `os.path.relpath`](https://bugs.python.org/issue7195)
- add fixture to make sure plots are closed when tests are run interactively, or optionally show them with `--show-plots`