### PR TITLE
refactor(shapefile_utils): remove appdirs dependency

### DIFF
--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -26,7 +26,6 @@ dependencies:
   - pytest-benchmark
 
   # optional
-  - appdirs
   - python-dateutil>=2.4.0
   - affine
   - scipy

--- a/flopy/export/shapefile_utils.py
+++ b/flopy/export/shapefile_utils.py
@@ -6,7 +6,9 @@ import copy
 import json
 import os
 import shutil
+import sys
 import warnings
+from pathlib import Path
 
 import numpy as np
 
@@ -945,26 +947,23 @@ class CRS:
 
 
 class EpsgReference:
-    """
+    r"""
     Sets up a local database of text representations of coordinate reference
     systems, keyed by EPSG code.
 
-    The database is epsgref.json, located in the user's data directory. If
-    optional 'appdirs' package is available, this is in the platform-dependent
-    user directory, otherwise in the user's 'HOME/.flopy' directory.
+    The database is epsgref.json, located in either "%LOCALAPPDATA%\flopy"
+    for Windows users, or $HOME/.local/share/flopy for others.
     """
 
     def __init__(self):
-        appdirs = import_optional_dependency("appdirs", errors="silent")
-        if appdirs is not None:
-            datadir = appdirs.user_data_dir("flopy")
+        if sys.platform.startswith("win"):
+            flopy_appdata = Path(os.path.expandvars(r"%LOCALAPPDATA%\flopy"))
         else:
-            # if appdirs is not installed, use user's home directory
-            datadir = os.path.join(os.path.expanduser("~"), ".flopy")
-        if not os.path.isdir(datadir):
-            os.makedirs(datadir)
+            flopy_appdata = Path.home() / ".local" / "share" / "flopy"
+        if not flopy_appdata.exists():
+            flopy_appdata.mkdir(parents=True, exist_ok=True)
         dbname = "epsgref.json"
-        self.location = os.path.join(datadir, dbname)
+        self.location = str(flopy_appdata / dbname)
 
     def to_dict(self):
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,6 @@ test =
     pytest-xdist
 optional =
     affine
-    appdirs
     descartes
     fiona; platform_system!='Windows'
     geojson


### PR DESCRIPTION
This removes a minor dependency on [apprdirs](https://github.com/ActiveState/appdirs), which was used to determine a user-writable path to write application data. The replacement is to let flopy determine this:

- Windows will use `%LOCALAPPDATA%\flopy`
- Others (macOS, Linux) will use `$HOME/.local/share/flopy`

This is the same directory used by get-modflow to store other metadata and potentially `bin`.

Note that previous logic had a fall-back directory `HOME/.flopy` if appdirs was not available. This directory is no longer used (if it ever was), so it can be cleaned up.