### PR TITLE
refactor(export_contours): refactor, test and example for flopy.export.utils.export_contours

### DIFF
--- a/flopy/export/utils.py
+++ b/flopy/export/utils.py
@@ -1611,7 +1611,6 @@ def export_array(
 
 
 def export_contours(
-    modelgrid,
     filename,
     contours,
     fieldname="level",
@@ -1624,8 +1623,6 @@ def export_contours(
 
     Parameters
     ----------
-    modelgrid : flopy.discretization.Grid
-        flopy modelgrid instance
     filename : str
         path of output shapefile
     contours : matplotlib.contour.QuadContourSet or list of them
@@ -1648,11 +1645,6 @@ def export_contours(
 
     if not isinstance(contours, list):
         contours = [contours]
-
-    if epsg is None:
-        epsg = modelgrid.epsg
-    if prj is None:
-        prj = modelgrid.proj4
 
     geoms = []
     level = []
@@ -1813,7 +1805,7 @@ def export_array_contours(
         levels = np.arange(imin, imax, interval)
     ax = plt.subplots()[-1]
     ctr = contour_array(modelgrid, ax, a, levels=levels)
-    export_contours(modelgrid, filename, ctr, fieldname, epsg, prj, **kwargs)
+    export_contours(filename, ctr, fieldname, epsg, prj, **kwargs)
     plt.close()
 
 


### PR DESCRIPTION
- add test case for `export_contours` function (previously only filled contours version `export_contourf` was tested)
- remove `modelgrid` from `flopy.export.utils.export_contours` signature
    - follow `export_contourf` convention
    - `epsg` and `prj` are already optional params
- mention contour export functions in `flopy3.3_PlotMapView.ipynb` ([cell 15](https://github.com/modflowpy/flopy/blob/eb06b9edfa21be80e6aac02c9a8d2e4211ace7e6/examples/Notebooks/flopy3.3_PlotMapView.ipynb))

Motivated by #1527