### PR TITLE
fix(setuptools): only include flopy and flopy.* packages (not autotest)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -82,6 +82,11 @@ doc =
 flopy.mf6.data = dfn/*.dfn
 flopy.plot = mplstyle/*.mplstyle
 
+[options.packages.find]
+include =
+    flopy
+    flopy.*
+
 [options.entry_points]
 console_scripts =
     get-modflow = flopy.utils.get_modflow:cli_main


### PR DESCRIPTION
Since #1458, `autotest` was installed along side `flopy` in a Python's site-packages directory. This was done via [automatic/custom discovery](https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#custom-discovery) since `autotest/__init__.py` was added to create a new module. However, it does not make sense to install `autotest`. This is fixed by specifying an `include` list option, which implicitly excludes `autotest` (or potentially any other directory with `__init__.py`).