### PR TITLE
fix(mfpackage): modify maxbound evaluation

### DIFF
--- a/flopy/mf6/mfpackage.py
+++ b/flopy/mf6/mfpackage.py
@@ -4,6 +4,7 @@ import errno
 import inspect
 import os
 import sys
+from re import S
 
 import numpy as np
 
@@ -2022,7 +2023,13 @@ class MFPackage(PackageContainer, PackageInterface):
                                 data = None
                             if data is not None:
                                 new_size = len(dataset.get_data())
-                        if size_def.get_data() != new_size >= 0:
+
+                        if size_def.get_data() is None:
+                            current_size = 0
+                        else:
+                            current_size = size_def.get_data()
+
+                        if new_size > current_size:
                             # store current size
                             size_def.set_data(new_size)
 


### PR DESCRIPTION
Modified the way `maxbound` is evaluated relative to the size of the `stress_period_data` data. If `maxbound` is defined to be something other than `None` when a package is initialized the value is only modified if the sized of the `stress_period_data` exceeds the specified `maxbound` value. This change was precipitated by the need to set a `maxbound` value larger than the largest size of `stress_period_data` for use with the MODFLOW API.

This change also simplifies the three value boolean check that was used previously.