### PR TITLE
fix: example scripts and notebooks

### DIFF
--- a/autotest/regression/test_mf6.py
+++ b/autotest/regression/test_mf6.py
@@ -245,7 +245,10 @@ def test_np001(tmpdir, example_data_path):
         model,
         budget_filerecord=[("np001_mod 1.cbc",)],
         head_filerecord=[("np001_mod 1.hds",)],
-        saverecord={0: [("HEAD", "ALL"), ("BUDGET", "ALL")], 1: [],},
+        saverecord={
+            0: [("HEAD", "ALL"), ("BUDGET", "ALL")],
+            1: [],
+        },
         printrecord=[("HEAD", "ALL")],
     )
     empty_sp_text = oc_package.saverecord.get_file_entry(1)
@@ -572,7 +575,11 @@ def test_np001(tmpdir, example_data_path):
 
     # test loading and re-writing empty stress period
     test_sim = MFSimulation.load(
-        test_ex_name, "mf6", "mf6", spath, write_headers=False,
+        test_ex_name,
+        "mf6",
+        "mf6",
+        spath,
+        write_headers=False,
     )
     wel = test_sim.get_model().get_package("wel_2")
     wel._filename = "np001_spd_test.wel"
@@ -868,7 +875,10 @@ def test_np002(tmpdir, example_data_path):
     sim.write_simulation()
     sim.run_simulation()
     sim2 = MFSimulation.load(
-        sim_name=test_ex_name, version="mf6", exe_name="mf6", sim_ws=ws,
+        sim_name=test_ex_name,
+        version="mf6",
+        exe_name="mf6",
+        sim_ws=ws,
     )
     md2 = sim2.get_model()
     ghb2 = md2.get_package("ghb")
@@ -1449,7 +1459,15 @@ def test005_create_tests_advgw_tidal(tmpdir, example_data_path):
             ("rv2-upper", "RIV", "riv2_upper"),
             ("rv-2-7-4", "RIV", (0, 6, 3)),
             ("rv2-8-5", "RIV", (0, 6, 4)),
-            ("rv-2-9-6", "RIV", (0, 5, 5,),),
+            (
+                "rv-2-9-6",
+                "RIV",
+                (
+                    0,
+                    5,
+                    5,
+                ),
+            ),
         ],
         "riv_flowsA.csv": [
             ("riv1-3-1", "RIV", (0, 2, 0)),
@@ -2396,10 +2414,14 @@ def test006_create_tests_2models_gnc(tmpdir, example_data_path):
         sim, time_units="DAYS", nper=1, perioddata=tdis_rc
     )
     model_1 = ModflowGwf(
-        sim, modelname=model_name_1, model_nam_file=f"{model_name_1}.nam",
+        sim,
+        modelname=model_name_1,
+        model_nam_file=f"{model_name_1}.nam",
     )
     model_2 = ModflowGwf(
-        sim, modelname=model_name_2, model_nam_file=f"{model_name_2}.nam",
+        sim,
+        modelname=model_name_2,
+        model_nam_file=f"{model_name_2}.nam",
     )
     ims_package = ModflowIms(
         sim,
@@ -3123,7 +3145,10 @@ def test_create_tests_transport(tmpdir, example_data_path):
 
     # build MODFLOW 6 files
     sim = MFSimulation(
-        sim_name=name, version="mf6", exe_name="mf6", sim_ws=str(tmpdir),
+        sim_name=name,
+        version="mf6",
+        exe_name="mf6",
+        sim_ws=str(tmpdir),
     )
     # create tdis package
     tdis = ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
@@ -3131,7 +3156,11 @@ def test_create_tests_transport(tmpdir, example_data_path):
     # create gwf model
     gwfname = f"gwf_{name}"
     newtonoptions = ["NEWTON", "UNDER_RELAXATION"]
-    gwf = ModflowGwf(sim, modelname=gwfname, newtonoptions=newtonoptions,)
+    gwf = ModflowGwf(
+        sim,
+        modelname=gwfname,
+        newtonoptions=newtonoptions,
+    )
 
     # create iterative model solution and register the gwf model with it
     imsgwf = ModflowIms(
@@ -3673,7 +3702,10 @@ def test006_gwf3(tmpdir, example_data_path):
     # compare output to expected results
     head_new = os.path.join(str(tmpdir), "flow.hds")
     assert pymake.compare_heads(
-        None, None, files1=expected_head_file_a, files2=head_new,
+        None,
+        None,
+        files1=expected_head_file_a,
+        files2=head_new,
     )
 
     budget_fjf = np.array(
@@ -3717,7 +3749,10 @@ def test006_gwf3(tmpdir, example_data_path):
     # compare output to expected results
     head_new = os.path.join(save_folder, "flow.hds")
     assert pymake.compare_heads(
-        None, None, files1=expected_head_file_b, files2=head_new,
+        None,
+        None,
+        files1=expected_head_file_b,
+        files2=head_new,
     )
 
     budget_fjf = np.array(
@@ -3749,7 +3784,10 @@ def test006_gwf3(tmpdir, example_data_path):
     assert success, f"simulation {sim.name} rerun(3) did not run"
 
     # get expected results
-    budget_obj = CellBudgetFile(expected_cbc_file_b, precision="double",)
+    budget_obj = CellBudgetFile(
+        expected_cbc_file_b,
+        precision="double",
+    )
     budget_fjf_valid = np.array(
         budget_obj.get_data(text="    FLOW JA FACE", full3D=True)
     )
@@ -3759,7 +3797,10 @@ def test006_gwf3(tmpdir, example_data_path):
     # compare output to expected results
     head_new = os.path.join(save_folder, "flow.hds")
     assert pymake.compare_heads(
-        None, None, files1=expected_head_file_b, files2=head_new,
+        None,
+        None,
+        files1=expected_head_file_b,
+        files2=head_new,
     )
 
     budget_fjf = np.array(
@@ -3802,7 +3843,10 @@ def test045_lake1ss_table(tmpdir, example_data_path):
 
     # load simulation
     sim = MFSimulation.load(
-        sim_name=model_name, exe_name="mf6", sim_ws=pth, verify_data=True,
+        sim_name=model_name,
+        exe_name="mf6",
+        sim_ws=pth,
+        verify_data=True,
     )
 
     # make temp folder to save simulation
@@ -3900,15 +3944,24 @@ def test006_2models_mvr(tmpdir, example_data_path):
     # compare output to expected results
     head_new = str(ws / "model1.hds")
     assert pymake.compare_heads(
-        None, None, files1=expected_head_file_a, files2=head_new,
+        None,
+        None,
+        files1=expected_head_file_a,
+        files2=head_new,
     )
 
     head_new = str(ws / "model2.hds")
     assert pymake.compare_heads(
-        None, None, files1=expected_head_file_aa, files2=head_new,
+        None,
+        None,
+        files1=expected_head_file_aa,
+        files2=head_new,
     )
 
-    budget_obj = CellBudgetFile(expected_cbc_file_a, precision="double",)
+    budget_obj = CellBudgetFile(
+        expected_cbc_file_a,
+        precision="double",
+    )
     budget_obj.list_records()
 
     # test getting models
@@ -3978,12 +4031,18 @@ def test006_2models_mvr(tmpdir, example_data_path):
     # compare output to expected results
     head_new = os.path.join(save_folder, "model1.hds")
     assert pymake.compare_heads(
-        None, None, files1=expected_head_file_b, files2=head_new,
+        None,
+        None,
+        files1=expected_head_file_b,
+        files2=head_new,
     )
 
     head_new = os.path.join(save_folder, "model2.hds")
     assert pymake.compare_heads(
-        None, None, files1=expected_head_file_bb, files2=head_new,
+        None,
+        None,
+        files1=expected_head_file_bb,
+        files2=head_new,
     )
 
     # test load_only
@@ -4120,7 +4179,10 @@ def test001e_uzf_3lay(tmpdir, example_data_path):
 
     ims = ModflowIms(sim, print_option="SUMMARY", complexity="COMPLEX")
     sim.register_ims_package(
-        ims, ["GwF_1",],
+        ims,
+        [
+            "GwF_1",
+        ],
     )
     sim.write_simulation()
 
@@ -4159,7 +4221,11 @@ def test045_lake2tr(tmpdir, example_data_path):
     # compare output to expected results
     head_new = str(tmpdir / "lakeex2a.hds")
     assert pymake.compare_heads(
-        None, None, files1=expected_head_file_a, files2=head_new, htol=10.0,
+        None,
+        None,
+        files1=expected_head_file_a,
+        files2=head_new,
+        htol=10.0,
     )
 
     # change some settings
@@ -4191,7 +4257,11 @@ def test045_lake2tr(tmpdir, example_data_path):
     # compare output to expected results
     head_new = str(save_folder / "lakeex2a.hds")
     assert pymake.compare_heads(
-        None, None, files1=expected_head_file_b, files2=head_new, htol=10.0,
+        None,
+        None,
+        files1=expected_head_file_b,
+        files2=head_new,
+        htol=10.0,
     )
 
 
@@ -4230,7 +4300,10 @@ def test036_twrihfb(tmpdir, example_data_path):
     # compare output to expected results
     head_new = str(tmpdir / "twrihfb2015_output.hds")
     assert pymake.compare_heads(
-        None, None, files1=expected_head_file_a, files2=head_new,
+        None,
+        None,
+        files1=expected_head_file_a,
+        files2=head_new,
     )
 
     # change some settings
@@ -4269,7 +4342,10 @@ def test036_twrihfb(tmpdir, example_data_path):
     # compare output to expected results
     head_new = str(save_folder / "twrihfb2015_output.hds")
     assert pymake.compare_heads(
-        None, None, files1=expected_head_file_b, files2=head_new,
+        None,
+        None,
+        files1=expected_head_file_b,
+        files2=head_new,
     )
 
 
@@ -4345,5 +4421,9 @@ def test027_timeseriestest(tmpdir, example_data_path):
     # compare output to expected results
     head_new = os.path.join(str(save_folder), "timeseriestest.hds")
     assert pymake.compare_heads(
-        None, None, files1=expected_head_file_b, files2=head_new, htol=10.0,
+        None,
+        None,
+        files1=expected_head_file_b,
+        files2=head_new,
+        htol=10.0,
     )

--- a/autotest/test_example_scripts.py
+++ b/autotest/test_example_scripts.py
@@ -42,7 +42,7 @@ def test_scripts(script):
 
     assert returncode == 0
 
-    allowed_patterns = ["findfont", "warning", "loose"]
+    allowed_patterns = ["findfont", "warning", "loose", "match_original"]
 
     assert (
         not stderr

--- a/examples/scripts/flopy_henry.py
+++ b/examples/scripts/flopy_henry.py
@@ -216,6 +216,6 @@ if __name__ == "__main__":
         try:
             with TemporaryDirectory() as workspace:
                 run(workspace, quiet)
-        except PermissionError:
+        except (PermissionError, NotADirectoryError):
             # can occur on windows: https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryDirectory
             pass

--- a/examples/scripts/flopy_lake_example.py
+++ b/examples/scripts/flopy_lake_example.py
@@ -155,13 +155,9 @@ if __name__ == "__main__":
     if workspace is not None:
         run(workspace, quiet)
     else:
-        temp_dir = TemporaryDirectory()
-        workspace = temp_dir.name
-
-        run(workspace, quiet)
-
         try:
-            temp_dir.cleanup()
-        except:
-            # prevent permission errors on windows
+            with TemporaryDirectory() as workspace:
+                run(workspace, quiet)
+        except (PermissionError, NotADirectoryError):
+            # can occur on windows: https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryDirectory
             pass

--- a/examples/scripts/flopy_swi2_ex1.py
+++ b/examples/scripts/flopy_swi2_ex1.py
@@ -283,6 +283,6 @@ if __name__ == "__main__":
         try:
             with TemporaryDirectory() as workspace:
                 run(workspace, quiet)
-        except PermissionError:
+        except (PermissionError, NotADirectoryError):
             # can occur on windows: https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryDirectory
             pass

--- a/examples/scripts/flopy_swi2_ex2.py
+++ b/examples/scripts/flopy_swi2_ex2.py
@@ -489,13 +489,9 @@ if __name__ == "__main__":
     if workspace is not None:
         run(workspace, quiet)
     else:
-        temp_dir = TemporaryDirectory()
-        workspace = temp_dir.name
-
-        run(workspace, quiet)
-
         try:
-            temp_dir.cleanup()
-        except:
-            # prevent permission errors on windows
+            with TemporaryDirectory() as workspace:
+                run(workspace, quiet)
+        except (PermissionError, NotADirectoryError):
+            # can occur on windows: https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryDirectory
             pass

--- a/examples/scripts/flopy_swi2_ex3.py
+++ b/examples/scripts/flopy_swi2_ex3.py
@@ -327,13 +327,9 @@ if __name__ == "__main__":
     if workspace is not None:
         run(workspace, quiet)
     else:
-        temp_dir = TemporaryDirectory()
-        workspace = temp_dir.name
-
-        run(workspace, quiet)
-
         try:
-            temp_dir.cleanup()
-        except:
-            # prevent permission errors on windows
+            with TemporaryDirectory() as workspace:
+                run(workspace, quiet)
+        except (PermissionError, NotADirectoryError):
+            # can occur on windows: https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryDirectory
             pass

--- a/examples/scripts/flopy_swi2_ex4.py
+++ b/examples/scripts/flopy_swi2_ex4.py
@@ -602,6 +602,6 @@ if __name__ == "__main__":
         try:
             with TemporaryDirectory() as workspace:
                 run(workspace, quiet)
-        except PermissionError:
+        except (PermissionError, NotADirectoryError):
             # can occur on windows: https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryDirectory
             pass

--- a/examples/scripts/flopy_swi2_ex5.py
+++ b/examples/scripts/flopy_swi2_ex5.py
@@ -642,6 +642,6 @@ if __name__ == "__main__":
         try:
             with TemporaryDirectory() as workspace:
                 run(workspace, quiet)
-        except PermissionError:
+        except (PermissionError, NotADirectoryError):
             # can occur on windows: https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryDirectory
             pass

--- a/flopy/plot/crosssection.py
+++ b/flopy/plot/crosssection.py
@@ -1546,7 +1546,9 @@ class PlotCrossSection:
                 data.append(plotarray[cell])
 
         if len(rectcol) > 0:
-            patches = PatchCollection(rectcol, match_original, **kwargs)
+            patches = PatchCollection(
+                rectcol, match_original=match_original, **kwargs
+            )
             if not fill_between:
                 patches.set_array(np.array(data))
                 patches.set_clim(vmin, vmax)


### PR DESCRIPTION
Fix example script/notebook [test failures](https://github.com/modflowpy/flopy/actions/runs/3072694989/jobs/4964349538#step:8:509)

- use named `match_original` param when creating `PatchCollection` in `crosssection.py` (avoid usage warning)
- update `test_example_scripts.py` allowed outputs (don't fail on matplotlib warning)
- explicitly provide axis for colorbar in `flopy3.3_PlotMapView.ipynb`
- use filename instead of abs path for plot title in `flopy3.3_PlotMapView.ipynb`
- lint `autotest/regression/test_mf6.py`