### PR TITLE
refactor(make-release): use CITATION.cff for author metadata

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -108,6 +108,12 @@ jobs:
         run: |
           pylint --jobs=2 --errors-only --exit-zero ./flopy
 
+      - name: Check CITATION.cff
+        run: |
+          cffconvert --validate
+          cffconvert -f apalike
+          cffconvert -f bibtex
+
   smoke:
     name: Smoke test
     runs-on: ubuntu-latest

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,85 @@
+cff-version: 1.2.0
+message: If you use this software, please cite both the article from preferred-citation
+  and the software itself.
+type: software
+title: FloPy
+version: 3.3.6
+date-released: '2022-03-08'
+doi: 10.5066/F7BK19FH
+abstract: A Python package to create, run, and post-process MODFLOW-based models.
+repository-artifact: https://pypi.org/project/flopy
+repository-code: https://github.com/modflowpy/flopy
+license: CC0-1.0
+authors:
+- family-names: Bakker
+  given-names: Mark
+  orcid: https://orcid.org/0000-0002-5629-2861
+- family-names: Post
+  given-names: Vincent
+  orcid: https://orcid.org/0000-0002-9463-3081
+- family-names: Hughes
+  given-names: Joseph D.
+  orcid: https://orcid.org/0000-0003-1311-2354
+- family-names: Langevin
+  given-names: Christian D.
+  orcid: https://orcid.org/0000-0001-5610-9759
+- family-names: White
+  given-names: Jeremy T.
+  orcid: https://orcid.org/0000-0002-4950-1469
+- family-names: Leaf
+  given-names: Andrew T.
+  orcid: https://orcid.org/0000-0001-8784-4924
+- family-names: Paulinski
+  given-names: Scott R.
+  orcid: https://orcid.org/0000-0001-6548-8164
+- family-names: Bellino
+  given-names: Jason C.
+  orcid: https://orcid.org/0000-0001-9046-9344
+- family-names: Morway
+  given-names: Eric D.
+  orcid: https://orcid.org/0000-0002-8553-6140
+- given-names: Michael W.
+  family-names: Toews
+  orcid: https://orcid.org/0000-0003-3657-7963
+- family-names: Larsen
+  given-names: Joshua D.
+  orcid: https://orcid.org/0000-0002-1218-800X
+- family-names: Fienen
+  given-names: Michael N.
+  orcid: https://orcid.org/0000-0002-7756-4651
+- family-names: Starn
+  given-names: Jon Jeffrey
+  orcid: https://orcid.org/0000-0001-5909-0010
+- family-names: Brakenhoff
+  given-names: Davíd
+preferred-citation:
+  type: article
+  authors:
+  - family-names: Bakker
+    given-names: Mark
+    orcid: https://orcid.org/0000-0002-5629-2861
+  - family-names: Post
+    given-names: Vincent
+    orcid: https://orcid.org/0000-0002-9463-3081
+  - family-names: Langevin
+    given-names: Christian D.
+    orcid: https://orcid.org/0000-0001-5610-9759
+  - family-names: Hughes
+    given-names: Joseph D.
+    orcid: https://orcid.org/0000-0003-1311-2354
+  - family-names: White
+    given-names: Jeremy T.
+    orcid: https://orcid.org/0000-0002-4950-1469
+  - family-names: Starn
+    given-names: Jon Jeffrey
+    orcid: https://orcid.org/0000-0001-5909-0010
+  - family-names: Fienen
+    given-names: Michael N.
+    orcid: https://orcid.org/0000-0002-7756-4651
+  title: Scripting MODFLOW Model Development Using Python and FloPy
+  doi: 10.1111/gwat.12413
+  journal: Groundwater
+  volume: 54
+  issue: 5
+  year: 2016
+  month: 9

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include CITATION.cff
 include pyproject.toml
 include docs/*.md
 include flopy/mf6/data/dfn/*.dfn

--- a/docs/make_release.md
+++ b/docs/make_release.md
@@ -40,7 +40,7 @@ Instructions for making a FloPy release
 
 ## Update the Software/Code citation for FloPy
 
-1. Update the `author_dict` in `flopy/version.py` for the Software/Code citation for FloPy, if required.
+1. Update the authors in `CITATION.cff` for the Software/Code citation for FloPy, if required.
 
 
 ## Build USGS release notes

--- a/flopy/__init__.py
+++ b/flopy/__init__.py
@@ -19,8 +19,10 @@ assistance is welcomed. Please email the development team if you want to
 contribute.
 
 """
+# See CITATION.cff for authors
+__author__ = "FloPy Team"
 
-from .version import __author__, __author_email__, __version__  # isort:skip
+from .version import __version__  # isort:skip
 from . import (
     discretization,
     export,
@@ -38,6 +40,8 @@ from . import (
 from .mbase import run_model, which
 
 __all__ = [
+    "__author__",
+    "__version__",
     "modflow",
     "mt3d",
     "seawat",

--- a/flopy/version.py
+++ b/flopy/version.py
@@ -5,26 +5,3 @@ major = 3
 minor = 3
 micro = 6
 __version__ = f"{major}.{minor}.{micro}"
-
-__pakname__ = "flopy"
-
-# edit author dictionary as necessary (
-# in order of commits after Bakker and Post
-author_dict = {
-    "Mark Bakker": "mark.bakker@tudelft.nl",
-    "Vincent Post": "Vincent.Post@bgr.de",
-    "Joseph D. Hughes": "jdhughes@usgs.gov",
-    "Christian D. Langevin": "langevin@usgs.gov",
-    "Jeremy T. White": "jwhite@intera.com",
-    "Andrew T. Leaf": "aleaf@usgs.gov",
-    "Scott R. Paulinski": "spaulinski@usgs.gov",
-    "Jason C. Bellino": "jbellino@usgs.gov",
-    "Eric D. Morway": "emorway@usgs.gov",
-    "Michael W. Toews": "M.Toews@gns.cri.nz",
-    "Joshua D. Larsen": "jlarsen@usgs.gov",
-    "Michael N. Fienen": "mnfienen@usgs.gov",
-    "Jon Jeffrey Starn": "jjstarn@usgs.gov",
-    "Davíd Brakenhoff": "d.brakenhoff@artesia-water.nl",
-}
-__author__ = ", ".join(author_dict.keys())
-__author_email__ = ", ".join(s for _, s in author_dict.items())

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
 [options.extras_require]
 lint =
     black
+    cffconvert
     flake8
     isort
     pylint


### PR DESCRIPTION
This PR does a few things:

- Adds a [CITATION.cff](https://citation-file-format.github.io/) file [supported by GitHub](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files) (and others), which contains both a software citation and a preferred citation to the _Groundwater_ article. It also contains author [ORCIDs](https://orcid.org/), which I've hopefully correctly identified from a basic search (except @dbrakenhoff you may want to create one). The lint workflow validates this file, and shows the citation in "apalike" and BibTeX formats.
- Parts of `flopy/version.py` are removed, and this file now just contains version-related information.  `__author_email__` is not widely used (usually it is `__email__`; also individual emails are removed, although these can be retained in CITATION.cff if we want). Moved `__author__` to `flopy/__init__.py`, but use the same "Flopy Team" as specified in `setup.cfg`. This could also be removed, as it isn't really needed (many projects don't use dunder variables like `__author__` anymore).
- Lots in `scripts/make-release.py` is rewritten, using pathlib features, and to add `update_citation_cff`, which updates the version and date-released in CITATION.cff.