### PR TITLE
fix(parsenamefile): only do lowercase comparison when parent dir exists

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -81,5 +81,7 @@ preferred-citation:
   journal: Groundwater
   volume: 54
   issue: 5
+  start: 733
+  end: 739
   year: 2016
   month: 9

--- a/autotest/regression/conftest.py
+++ b/autotest/regression/conftest.py
@@ -80,7 +80,10 @@ def pytest_generate_tests(metafunc):
             )
 
         def simulation_name_from_model_namfiles(mnams):
-            namfile = next(iter(mnams), None)
+            try:
+                namfile = next(iter(mnams), None)
+            except TypeError:
+                namfile = None
             if namfile is None:
                 pytest.skip("No namfiles (expected ordered collection)")
             namfile = Path(namfile)


### PR DESCRIPTION
This PR fixes a bug with parsenamefile, where it attempts to find case-insensitive filename matches from a parent directory, e.g. this change:
```diff
--- a/examples/data/mt3d_test/mf2005mt3d/P07/p7mf2005.nam
+++ b/examples/data/mt3d_test/mf2005mt3d/P07/p7mf2005.nam
@@ -7 +7 @@
-LIST         7       P7.LST
+LIST         7       ..\other\P7.LST
```
will raise errors with `pytest test_mt3d.py::test_mf2005_p07`:
```
../flopy/modflow/mf.py:733: in load
    ext_unit_dict = mfreadnam.parsenamefile(
...
>               fls = os.listdir(dn)
E               FileNotFoundError: [Errno 2] No such file or directory: '/data/mtoews/src/flopy/examples/data/mt3d_test/mf2005mt3d/P07/../other'

../flopy/utils/mfreadnam.py:167: FileNotFoundError
```
The fix was to only check other files if the parent directory exists. Much of this module was rewritten using pathlib.

---

Other minor/unrelated changes are cobbled in this PR:
- skip `simulation_name_from_model_namfiles` (I'm getting `TypeError: 'NotSetType' object is not iterable` / `ValueError: regression/test_mf6_examples.py::test_mf6_example_simulations: error raised while trying to determine id of parameter 'mf6_example_namfiles' at position 0` errors locally, so this was my best solution)
- minor add start/end pages for preferred-citation in CITATION.cff