### PR TITLE
update(countour_array): added routine to mask errant triangles

### DIFF
--- a/flopy/discretization/grid.py
+++ b/flopy/discretization/grid.py
@@ -493,8 +493,12 @@ class Grid:
                 for ix in range(0, len(verts)):
                     xv0, yv0 = verts[ix - 1]
                     xv1, yv1 = verts[ix]
-                    idx0 = np.unique(np.where((xverts == xv0) & (yverts == yv0))[0])
-                    idx1 = np.unique(np.where((xverts == xv1) & (yverts == yv1))[0])
+                    idx0 = np.unique(
+                        np.where((xverts == xv0) & (yverts == yv0))[0]
+                    )
+                    idx1 = np.unique(
+                        np.where((xverts == xv1) & (yverts == yv1))[0]
+                    )
                     mask = np.isin(idx0, idx1)
                     conn += [i for i in idx0[mask]]
 

--- a/flopy/discretization/grid.py
+++ b/flopy/discretization/grid.py
@@ -3,8 +3,8 @@ import os
 
 import numpy as np
 
+from ..plot.plotutil import UnstructuredPlotUtilities
 from ..utils import geometry
-from ..utils.gridutil import get_lni
 
 
 class CachedData:
@@ -184,6 +184,7 @@ class Grid:
         self._iverts = None
         self._verts = None
         self._laycbd = None
+        self._neighbors = None
 
     ###################################
     # access to basic grid properties
@@ -361,10 +362,6 @@ class Grid:
         self._idomain = idomain
 
     @property
-    def nlay(self):
-        raise NotImplementedError("must define nlay in child class")
-
-    @property
     def ncpl(self):
         raise NotImplementedError("must define ncpl in child class")
 
@@ -466,6 +463,51 @@ class Grid:
     @property
     def cross_section_vertices(self):
         return self.xyzvertices[0], self.xyzvertices[1]
+
+    def neighbors(self, node, **kwargs):
+        """
+        Method to get nearest neighbors of a cell
+
+        Returns
+        -------
+            list : list of cell node numbers
+        """
+        ncpl = self.ncpl
+        if isinstance(ncpl, list):
+            ncpl = self.nnodes
+
+        lay = 0
+        while node >= ncpl:
+            node -= ncpl
+            lay += 1
+
+        if self._neighbors is None:
+            neigh = {}
+            xverts, yverts = self.cross_section_vertices
+            xverts, yverts = UnstructuredPlotUtilities.irregular_shape_patch(
+                xverts, yverts
+            )
+            for nn in range(ncpl):
+                conn = []
+                verts = self.get_cell_vertices(nn)
+                for ix in range(0, len(verts)):
+                    xv0, yv0 = verts[ix - 1]
+                    xv1, yv1 = verts[ix]
+                    idx0 = np.unique(np.where((xverts == xv0) & (yverts == yv0))[0])
+                    idx1 = np.unique(np.where((xverts == xv1) & (yverts == yv1))[0])
+                    mask = np.isin(idx0, idx1)
+                    conn += [i for i in idx0[mask]]
+
+                conn = list(set(conn))
+                conn.pop(conn.index(nn))
+                neigh[nn] = conn
+            self._neighbors = neigh
+
+        neighbors = self._neighbors[node]
+        if lay > 0:
+            neighbors = [i + (ncpl * lay) for i in neighbors]
+
+        return neighbors
 
     def remove_confining_beds(self, array):
         """
@@ -606,27 +648,6 @@ class Grid:
     @property
     def map_polygons(self):
         raise NotImplementedError("must define map_polygons in child class")
-
-    def get_lni(self, nodes):
-        """
-        Get the layer index and within-layer node index (both 0-based) for the given nodes
-
-        Parameters
-        ----------
-        nodes : node numbers (array-like)
-
-        Returns
-        -------
-            list of tuples (layer index, node index)
-        """
-
-        ncpl = (
-            [self.ncpl for _ in range(self.nlay)]
-            if isinstance(self.ncpl, int)
-            else list(self.ncpl)
-        )
-
-        return get_lni(ncpl, nodes)
 
     def get_plottable_layer_array(self, plotarray, layer):
         raise NotImplementedError(

--- a/flopy/discretization/structuredgrid.py
+++ b/flopy/discretization/structuredgrid.py
@@ -775,7 +775,7 @@ class StructuredGrid(Grid):
         if nn is None:
             nn = self.get_node([(k, i, j)])[0]
 
-        as_nodes = kwargs.pop('as_nodes', False)
+        as_nodes = kwargs.pop("as_nodes", False)
 
         neighbors = super().neighbors(nn)
         if not as_nodes:

--- a/flopy/discretization/unstructuredgrid.py
+++ b/flopy/discretization/unstructuredgrid.py
@@ -101,7 +101,7 @@ class UnstructuredGrid(Grid):
         yoff=0.0,
         angrot=0.0,
         iac=None,
-        ja=None
+        ja=None,
     ):
         super().__init__(
             "unstructured",

--- a/flopy/discretization/unstructuredgrid.py
+++ b/flopy/discretization/unstructuredgrid.py
@@ -6,7 +6,6 @@ import numpy as np
 from matplotlib.path import Path
 
 from ..utils.geometry import is_clockwise
-from ..utils.gridutil import get_lni
 from .grid import CachedData, Grid
 
 
@@ -48,6 +47,10 @@ class UnstructuredGrid(Grid):
         top elevations for all cells in the grid.
     botm : list or ndarray
         bottom elevations for all cells in the grid.
+    iac : list or ndarray
+        optional number of connections per node array
+    ja : list or ndarray
+        optional jagged connection array
 
     Properties
     ----------
@@ -97,6 +100,8 @@ class UnstructuredGrid(Grid):
         xoff=0.0,
         yoff=0.0,
         angrot=0.0,
+        iac=None,
+        ja=None
     ):
         super().__init__(
             "unstructured",
@@ -142,6 +147,9 @@ class UnstructuredGrid(Grid):
             else:
                 msg = f"Length of iverts must equal ncpl ({len(iverts)} {self.ncpl})"
                 assert np.all([cpl == len(iverts) for cpl in self.ncpl]), msg
+
+        self._iac = iac
+        self._ja = ja
 
         return
 
@@ -219,15 +227,11 @@ class UnstructuredGrid(Grid):
             return np.array([list(t)[1:] for t in self._vertices], dtype=float)
 
     @property
-    def ia(self):
-        if self._ia is None:
-            self._set_unstructured_iaja()
-        return self._ia
+    def iac(self):
+        return self._iac
 
     @property
     def ja(self):
-        if self._ja is None:
-            self._set_unstructured_iaja()
         return self._ja
 
     @property
@@ -349,6 +353,25 @@ class UnstructuredGrid(Grid):
             xv *= self.nlay
             yv *= self.nlay
         return xv, yv
+
+    def neighbors(self, node, **kwargs):
+        """
+        Method to get a list of nearest neighbors
+
+        Parameters
+        ----------
+        node : int
+            node number
+
+        Returns
+        -------
+            list of nearest neighbors
+        """
+        nrec = self.iac[node]
+        idx0 = np.sum(self.iac[:node])
+        idx1 = idx0 + nrec
+        neighbors = self.ja[idx0:idx1][1:]
+        return list(neighbors)
 
     def cross_section_lay_ncpl_ncb(self, ncb):
         """
@@ -758,6 +781,63 @@ class UnstructuredGrid(Grid):
             shp = (self.ncpl[layer],)
         return shp
 
+    @classmethod
+    def from_argus_export(cls, fname, nlay=1):
+        """
+        Create a new UnstructuredGrid from an Argus One Trimesh file
+
+        Parameters
+        ----------
+        fname : string
+            File name
+
+        nlay : int
+            Number of layers to create
+
+        Returns
+        -------
+        flopy.discretization.unstructuredgrid.UnstructuredGrid
+
+        """
+        from ..utils.geometry import get_polygon_centroid
+
+        f = open(fname, "r")
+        line = f.readline()
+        ll = line.split()
+        ncells, nverts = ll[0:2]
+        ncells = int(ncells)
+        nverts = int(nverts)
+        verts = np.empty((nverts, 3), dtype=float)
+        xc = np.empty((ncells), dtype=float)
+        yc = np.empty((ncells), dtype=float)
+
+        # read the vertices
+        f.readline()
+        for ivert in range(nverts):
+            line = f.readline()
+            ll = line.split()
+            c, iv, x, y = ll[0:4]
+            verts[ivert, 0] = int(iv) - 1
+            verts[ivert, 1] = x
+            verts[ivert, 2] = y
+
+        # read the cell information and create iverts, xc, and yc
+        iverts = []
+        for icell in range(ncells):
+            line = f.readline()
+            ll = line.split()
+            ivlist = []
+            for ic in ll[2:5]:
+                ivlist.append(int(ic) - 1)
+            if ivlist[0] != ivlist[-1]:
+                ivlist.append(ivlist[0])
+            iverts.append(ivlist)
+            xc[icell], yc[icell] = get_polygon_centroid(verts[ivlist, 1:])
+
+        # close file and return spatial reference
+        f.close()
+        return cls(verts, iverts, xc, yc, ncpl=np.array(nlay * [len(iverts)]))
+
     @staticmethod
     def ncpl_from_ihc(ihc, iac):
         """
@@ -803,63 +883,7 @@ class UnstructuredGrid(Grid):
             ncpl = None
         return ncpl
 
-    # Importing
-
-    @classmethod
-    def from_argus_export(cls, file_path, nlay=1):
-        """
-        Create a new UnstructuredGrid from an Argus One Trimesh file
-
-        Parameters
-        ----------
-        file_path : Path-like
-            Path to trimesh file
-
-        nlay : int
-            Number of layers to create
-
-        Returns
-        -------
-            An UnstructuredGrid
-        """
-
-        from ..utils.geometry import get_polygon_centroid
-
-        with open(file_path, "r") as f:
-            line = f.readline()
-            ll = line.split()
-            ncells, nverts = ll[0:2]
-            ncells = int(ncells)
-            nverts = int(nverts)
-            verts = np.empty((nverts, 3), dtype=float)
-            xc = np.empty((ncells), dtype=float)
-            yc = np.empty((ncells), dtype=float)
-
-            # read the vertices
-            f.readline()
-            for ivert in range(nverts):
-                line = f.readline()
-                ll = line.split()
-                c, iv, x, y = ll[0:4]
-                verts[ivert, 0] = int(iv) - 1
-                verts[ivert, 1] = x
-                verts[ivert, 2] = y
-
-            # read the cell information and create iverts, xc, and yc
-            iverts = []
-            for icell in range(ncells):
-                line = f.readline()
-                ll = line.split()
-                ivlist = []
-                for ic in ll[2:5]:
-                    ivlist.append(int(ic) - 1)
-                if ivlist[0] != ivlist[-1]:
-                    ivlist.append(ivlist[0])
-                iverts.append(ivlist)
-                xc[icell], yc[icell] = get_polygon_centroid(verts[ivlist, 1:])
-
-        return cls(verts, iverts, xc, yc, ncpl=np.array(nlay * [len(iverts)]))
-
+    # initialize grid from a grb file
     @classmethod
     def from_binary_grid_file(cls, file_path, verbose=False):
         """
@@ -917,90 +941,4 @@ class UnstructuredGrid(Grid):
             raise TypeError(
                 f"{os.path.basename(file_path)} binary grid file "
                 "does not include vertex data"
-            )
-
-    @classmethod
-    def from_gridspec(cls, file_path):
-        """
-        Create an UnstructuredGrid from a grid specification file.
-
-        Parameters
-        ----------
-        file_path : Path-like
-            Path to the grid specification file
-
-        Returns
-        -------
-            An UnstructuredGrid
-        """
-
-        with open(file_path, "r") as file:
-
-            def split_line():
-                return file.readline().strip().split()
-
-            header = split_line()
-            if not (len(header) == 1 and header[0] == "UNSTRUCTURED") or (
-                len(header) == 2 and header == ["UNSTRUCTURED", "GWF"]
-            ):
-                raise ValueError(f"Invalid GSF file, no header")
-
-            nnodes = int(split_line()[0])
-            verts_declared = int(split_line()[0])
-
-            vertices = []
-            zverts = []
-
-            for i in range(verts_declared):
-                x, y, z = split_line()
-                vertices.append([i, float(x), float(y)])
-                zverts.append(float(z))
-
-            iverts = []
-            xcenters = []
-            ycenters = []
-            layers = []
-            top = []
-            bot = []
-
-            for nn in range(nnodes):
-                line = split_line()
-
-                xc = float(line[1])
-                yc = float(line[2])
-                lay = float(line[4])
-
-                # make sure number of vertices provided and declared are equal
-                verts_declared = int(line[5])
-                verts_provided = len(line) - 6
-                if verts_declared != verts_provided:
-                    raise ValueError(
-                        f"Cell {nn} declares {verts_declared} vertices but provides {verts_provided}"
-                    )
-
-                verts = [
-                    int(vert) - 1 for vert in line[6 : 6 + verts_declared]
-                ]
-                elevs = [
-                    zverts[int(line[i]) - 1]
-                    for i in range(6, 6 + verts_declared)
-                ]
-
-                xcenters.append(xc)
-                ycenters.append(yc)
-                layers.append(lay)
-                iverts.append(verts)
-                top.append(max(elevs))
-                bot.append(min(elevs))
-
-            _, ncpl = np.unique(layers, return_counts=True)
-
-            return cls(
-                vertices=vertices,
-                iverts=iverts,
-                xcenters=np.array(xcenters),
-                ycenters=np.array(ycenters),
-                ncpl=ncpl,
-                top=np.array(top),
-                botm=np.array(bot),
             )

--- a/flopy/mf6/mfmodel.py
+++ b/flopy/mf6/mfmodel.py
@@ -460,8 +460,7 @@ class MFModel(PackageContainer, ModelInterface):
                 yoff=self._modelgrid.yoffset,
                 angrot=self._modelgrid.angrot,
                 iac=dis.iac,
-                ja=dis.ja
-
+                ja=dis.ja,
             )
         elif self.get_grid_type() == DiscretizationType.DISL:
             dis = self.get_package("disl")

--- a/flopy/mf6/mfmodel.py
+++ b/flopy/mf6/mfmodel.py
@@ -949,7 +949,9 @@ class MFModel(PackageContainer, ModelInterface):
                         continue
                     budget_array = np.array(
                         bud.get_data(
-                            kstpkper=kstp_kper, text=rec_name, full3D=True,
+                            kstpkper=kstp_kper,
+                            text=rec_name,
+                            full3D=True,
                         )[0]
                     )
                     if len(budget_array.shape) == 4:
@@ -1745,7 +1747,11 @@ class MFModel(PackageContainer, ModelInterface):
                 else:
                     package_rel_path = package.filename
                 self.name_file.packages.update_record(
-                    [f"{pkg_type}6", package_rel_path, package.package_name,],
+                    [
+                        f"{pkg_type}6",
+                        package_rel_path,
+                        package.package_name,
+                    ],
                     0,
                 )
         if package_struct is not None:

--- a/flopy/mf6/mfmodel.py
+++ b/flopy/mf6/mfmodel.py
@@ -459,6 +459,9 @@ class MFModel(PackageContainer, ModelInterface):
                 xoff=self._modelgrid.xoffset,
                 yoff=self._modelgrid.yoffset,
                 angrot=self._modelgrid.angrot,
+                iac=dis.iac,
+                ja=dis.ja
+
             )
         elif self.get_grid_type() == DiscretizationType.DISL:
             dis = self.get_package("disl")
@@ -947,9 +950,7 @@ class MFModel(PackageContainer, ModelInterface):
                         continue
                     budget_array = np.array(
                         bud.get_data(
-                            kstpkper=kstp_kper,
-                            text=rec_name,
-                            full3D=True,
+                            kstpkper=kstp_kper, text=rec_name, full3D=True,
                         )[0]
                     )
                     if len(budget_array.shape) == 4:
@@ -1745,11 +1746,7 @@ class MFModel(PackageContainer, ModelInterface):
                 else:
                     package_rel_path = package.filename
                 self.name_file.packages.update_record(
-                    [
-                        f"{pkg_type}6",
-                        package_rel_path,
-                        package.package_name,
-                    ],
+                    [f"{pkg_type}6", package_rel_path, package.package_name,],
                     0,
                 )
         if package_struct is not None:

--- a/flopy/modflow/mf.py
+++ b/flopy/modflow/mf.py
@@ -294,6 +294,8 @@ class Modflow(BaseModel):
                 xoff=self._modelgrid.xoffset,
                 yoff=self._modelgrid.yoffset,
                 angrot=self._modelgrid.angrot,
+                iac=self.disu.iac,
+                ja=self.disu.ja
             )
             print(
                 "WARNING: Model grid functionality limited for unstructured "

--- a/flopy/modflow/mf.py
+++ b/flopy/modflow/mf.py
@@ -295,7 +295,7 @@ class Modflow(BaseModel):
                 yoff=self._modelgrid.yoffset,
                 angrot=self._modelgrid.angrot,
                 iac=self.disu.iac,
-                ja=self.disu.ja
+                ja=self.disu.ja,
             )
             print(
                 "WARNING: Model grid functionality limited for unstructured "

--- a/flopy/plot/map.py
+++ b/flopy/plot/map.py
@@ -182,13 +182,13 @@ class PlotMapView:
 
         # workaround for tri-contour nan issue
         # use -2**31 to allow for 32 bit int arrays
-        plotarray[np.isnan(plotarray)] = -(2 ** 31)
+        plotarray[np.isnan(plotarray)] = -(2**31)
         if masked_values is None:
-            masked_values = [-(2 ** 31)]
+            masked_values = [-(2**31)]
         else:
             masked_values = list(masked_values)
-            if -(2 ** 31) not in masked_values:
-                masked_values.append(-(2 ** 31))
+            if -(2**31) not in masked_values:
+                masked_values.append(-(2**31))
 
         ismasked = None
         if masked_values is not None:
@@ -701,7 +701,7 @@ class PlotMapView:
 
         # normalize
         if normalize:
-            vmag = np.sqrt(u ** 2.0 + v ** 2.0)
+            vmag = np.sqrt(u**2.0 + v**2.0)
             idx = vmag > 0.0
             u[idx] /= vmag[idx]
             v[idx] /= vmag[idx]

--- a/flopy/plot/map.py
+++ b/flopy/plot/map.py
@@ -239,7 +239,7 @@ class PlotMapView:
             for i in range(2):
                 for ix, nodes in enumerate(triangles):
                     neighbors = self.mg.neighbors(nodes[i], as_nodes=True)
-                    isin = np.isin(nodes[i + 1:], neighbors)
+                    isin = np.isin(nodes[i + 1 :], neighbors)
                     if not np.alltrue(isin):
                         mask[ix] = True
 


### PR DESCRIPTION
* added `tri_mask` **kwarg to contour_array to check triangle elements against grid cell nearest neighbors and mask triangles that do not conform to nearest neighbor requirements. `tri_mask` is only needed when holes are present or a modelgrid has concave boundaries. 
* added neighbors() method to Grid, StructuredGrid, and UnstructuredGrid that returns a cells nearest neighbors 
* updated UnstructuredGrid to optionally include iac, ja arrays
* updated MFModel and Modflow to provide iac and ja arrays during UnstructuredGrid construction
* added tests for neighbors routine