### PR TITLE
update_data(contour_array): added routine to mask errant triangles

### DIFF
--- a/autotest/test_grid.py
+++ b/autotest/test_grid.py
@@ -339,6 +339,53 @@ def test_unstructured_xyz_intersect(example_data_path):
             raise AssertionError("Unstructured grid intersection failed")
 
 
+def test_structured_neighbors(example_data_path):
+    ws = str(example_data_path / "freyberg")
+    ml = Modflow.load("freyberg.nam", model_ws=ws)
+    modelgrid = ml.modelgrid
+    k, i, j = 0, 5, 5
+    neighbors = modelgrid.neighbors(k, i, j)
+    for neighbor in neighbors:
+        if (
+                neighbor != (k, i + 1, j)
+                and neighbor != (k, i - 1, j)
+                and neighbor != (k, i, j + 1)
+                and neighbor != (k, i, j - 1)
+        ):
+            raise AssertionError(
+                "modelgid.neighbors not returning proper values"
+            )
+
+def test_vertex_neighbors(example_data_path):
+    ws = str(example_data_path / "mf6" / "test003_gwfs_disv")
+    sim = MFSimulation.load(sim_ws=ws)
+    gwf = sim.get_model("gwf_1")
+    modelgrid = gwf.modelgrid
+    node = 63
+    neighbors = modelgrid.neighbors(node)
+    for neighbor in neighbors:
+        if (
+                neighbor != node + 1
+                and neighbor != node - 1
+                and neighbor != node + 10
+                and neighbor != node - 10
+        ):
+            raise AssertionError(
+                "modelgid.neighbors not returning proper values"
+            )
+
+
+def test_unstructured_neighbors(example_data_path):
+    ws = str(example_data_path / "mf6" / "test006_gwf3")
+    sim = MFSimulation.load(sim_ws=ws)
+    gwf = sim.get_model("gwf_1")
+    modelgrid = gwf.modelgrid
+    truth = [3, 5, 11]
+    neighbors = modelgrid.neighbors(4)
+    if not truth == neighbors:
+        raise AssertionError("modelgid.neighbors not returning proper values")
+
+
 @pytest.mark.parametrize("spc_file", ["grd.spc", "grdrot.spc"])
 def test_structured_from_gridspec(example_data_path, spc_file):
     fn = str(example_data_path / "specfile" / spc_file)
@@ -959,7 +1006,7 @@ def test_get_lni_unstructured(grid):
                     list(grid.ncpl)
                     if not isinstance(grid.ncpl, int)
                     else [grid.ncpl for _ in range(grid.nlay)]
-                )
+        )
             )
         )
         assert csum[layer] + i == nn

--- a/flopy/discretization/grid.py
+++ b/flopy/discretization/grid.py
@@ -3,6 +3,7 @@ import os
 
 import numpy as np
 
+from ..plot.plotutil import UnstructuredPlotUtilities
 from ..utils import geometry
 from ..utils.gridutil import get_lni
 
@@ -184,6 +185,7 @@ class Grid:
         self._iverts = None
         self._verts = None
         self._laycbd = None
+        self._neighbors = None
 
     ###################################
     # access to basic grid properties
@@ -466,6 +468,55 @@ class Grid:
     @property
     def cross_section_vertices(self):
         return self.xyzvertices[0], self.xyzvertices[1]
+
+    def neighbors(self, node, **kwargs):
+        """
+        Method to get nearest neighbors of a cell
+
+        Returns
+        -------
+            list : list of cell node numbers
+        """
+        ncpl = self.ncpl
+        if isinstance(ncpl, list):
+            ncpl = self.nnodes
+
+        lay = 0
+        while node >= ncpl:
+            node -= ncpl
+            lay += 1
+
+        if self._neighbors is None:
+            neigh = {}
+            xverts, yverts = self.cross_section_vertices
+            xverts, yverts = UnstructuredPlotUtilities.irregular_shape_patch(
+                xverts, yverts
+            )
+            for nn in range(ncpl):
+                conn = []
+                verts = self.get_cell_vertices(nn)
+                for ix in range(0, len(verts)):
+                    xv0, yv0 = verts[ix - 1]
+                    xv1, yv1 = verts[ix]
+                    idx0 = np.unique(
+                        np.where((xverts == xv0) & (yverts == yv0))[0]
+                    )
+                    idx1 = np.unique(
+                        np.where((xverts == xv1) & (yverts == yv1))[0]
+                    )
+                    mask = np.isin(idx0, idx1)
+                    conn += [i for i in idx0[mask]]
+
+                conn = list(set(conn))
+                conn.pop(conn.index(nn))
+                neigh[nn] = conn
+            self._neighbors = neigh
+
+        neighbors = self._neighbors[node]
+        if lay > 0:
+            neighbors = [i + (ncpl * lay) for i in neighbors]
+
+        return neighbors
 
     def remove_confining_beds(self, array):
         """

--- a/flopy/discretization/grid.py
+++ b/flopy/discretization/grid.py
@@ -473,6 +473,11 @@ class Grid:
         """
         Method to get nearest neighbors of a cell
 
+        Parameters
+        ----------
+        node : int
+            model grid node number
+
         Returns
         -------
             list : list of cell node numbers

--- a/flopy/discretization/structuredgrid.py
+++ b/flopy/discretization/structuredgrid.py
@@ -743,6 +743,45 @@ class StructuredGrid(Grid):
     ###############
     ### Methods ###
     ###############
+    def neighbors(self, *args, **kwargs):
+        """
+
+        Parameters
+        ----------
+        cellid
+
+        Returns
+        -------
+
+        """
+        nn = None
+        if kwargs:
+            if "node" in kwargs:
+                nn = kwargs.pop("node")
+            else:
+                k = kwargs.pop("k", 0)
+                i = kwargs.pop("i")
+                j = kwargs.pop("j")
+
+        if len(args) > 0:
+            if len(args) == 1:
+                nn = args[0]
+            elif len(args) == 2:
+                k = 0
+                i, j = args[0:2]
+            else:
+                k, i, j = args[0:3]
+
+        if nn is None:
+            nn = self.get_node([(k, i, j)])[0]
+
+        as_nodes = kwargs.pop("as_nodes", False)
+
+        neighbors = super().neighbors(nn)
+        if not as_nodes:
+            neighbors = self.get_lrc(neighbors)
+        return neighbors
+
     def intersect(self, x, y, z=None, local=False, forgive=False):
         """
         Get the row and column of a point with coordinates x and y

--- a/flopy/discretization/structuredgrid.py
+++ b/flopy/discretization/structuredgrid.py
@@ -745,14 +745,28 @@ class StructuredGrid(Grid):
     ###############
     def neighbors(self, *args, **kwargs):
         """
+        Method to get nearest neighbors for a cell
 
         Parameters
         ----------
-        cellid
+        *args
+            lay (int), row (int), column (int)
+            or
+            node (int)
+
+        **kwargs
+            k : int
+                layer number
+            i : int
+                row number
+            j : int
+                column number
+            as_node : bool
+                flag to return neighbors as node numbers
 
         Returns
         -------
-
+            list of neighboring cells
         """
         nn = None
         if kwargs:

--- a/flopy/mf6/mfmodel.py
+++ b/flopy/mf6/mfmodel.py
@@ -459,6 +459,8 @@ class MFModel(PackageContainer, ModelInterface):
                 xoff=self._modelgrid.xoffset,
                 yoff=self._modelgrid.yoffset,
                 angrot=self._modelgrid.angrot,
+                iac=dis.iac,
+                ja=dis.ja,
             )
         elif self.get_grid_type() == DiscretizationType.DISL:
             dis = self.get_package("disl")

--- a/flopy/modflow/mf.py
+++ b/flopy/modflow/mf.py
@@ -294,6 +294,8 @@ class Modflow(BaseModel):
                 xoff=self._modelgrid.xoffset,
                 yoff=self._modelgrid.yoffset,
                 angrot=self._modelgrid.angrot,
+                iac=self.disu.iac,
+                ja=self.disu.ja,
             )
             print(
                 "WARNING: Model grid functionality limited for unstructured "


### PR DESCRIPTION
* added `tri_mask` **kwarg to contour_array to check triangle elements against grid cell nearest neighbors and mask triangles that do not conform to nearest neighbor requirements. `tri_mask` is only needed when holes are present or a modelgrid has concave boundaries. 
* added neighbors() method to Grid, StructuredGrid, and UnstructuredGrid that returns a cells nearest neighbors 
* updated UnstructuredGrid to optionally include iac, ja arrays
* updated MFModel and Modflow to provide iac and ja arrays during UnstructuredGrid construction
* added tests for neighbors routine