### PR TITLE
Update(rasters.py, map.py): speed improvement updates for `resample_to_grid()`

### DIFF
--- a/autotest/test_gridintersect.py
+++ b/autotest/test_gridintersect.py
@@ -1252,7 +1252,7 @@ def test_rasters(example_data_path):
 
 # %% test raster sampling methods
 
-
+@requires_pkg("rasterstats")
 @pytest.mark.slow
 def test_raster_sampling_methods(example_data_path):
     ws = str(example_data_path / "options")
@@ -1283,7 +1283,7 @@ def test_raster_sampling_methods(example_data_path):
     methods = {
         "min": 2088.52343,
         "max": 2103.54882,
-        "mean": 2097.05035,
+        "mean": 2097.05054,
         "median": 2097.36254,
         "mode": 2088.52343,
         "nearest": 2097.81079,

--- a/autotest/test_gridintersect.py
+++ b/autotest/test_gridintersect.py
@@ -1252,7 +1252,6 @@ def test_rasters(example_data_path):
 
 # %% test raster sampling methods
 
-@requires_pkg("rasterstats")
 @pytest.mark.slow
 def test_raster_sampling_methods(example_data_path):
     ws = str(example_data_path / "options")

--- a/docs/flopy_method_dependencies.md
+++ b/docs/flopy_method_dependencies.md
@@ -25,7 +25,7 @@ Additional dependencies to use optional FloPy helper methods are listed below.
 | `.generate_classes()` in `flopy.mf6.utils`                                           | [**pymake**](https://github.com/modflowpy/pymake)                  |
 | `GridIntersect()` in `flopy.utils.gridintersect`                                     | **shapely**                                                        |
 | `GridIntersect().plot_polygon()` in `flopy.utils.gridintersect`                      | **shapely** and **descartes**                                      |
-| `Raster()` in `flopy.utils.Raster`                                                   | **rasterio**, **affine**, and **scipy**                            |
+| `Raster()` in `flopy.utils.Raster`                                                   | **rasterio**, **rasterstats**, **affine**, and **scipy**                            |
 | `Raster().sample_polygon()` in `flopy.utils.Raster`                                  | **shapely**                                                        |
 | `Raster().crop()` in `flopy.utils.Raster`                                            | **shapely**                                                        |
 | `.array_at_verts()` in `flopy.discretization.structuredgrid` `StructuredGrid` class  | **scipy.interpolate**                                              |

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -40,6 +40,7 @@ dependencies:
   - geos
   - geojson
   - vtk
+  - rasterstats
 
   # MODFLOW API dependencies
   - bmipy

--- a/flopy/plot/map.py
+++ b/flopy/plot/map.py
@@ -134,6 +134,9 @@ class PlotMapView:
         vmin = kwargs.pop("vmin", None)
         vmax = kwargs.pop("vmax", None)
 
+        if "cmap" not in kwargs:
+            kwargs["cmap"] = "viridis"
+
         # set matplotlib kwargs
         collection.set_clim(vmin=vmin, vmax=vmax)
         collection.set(**kwargs)
@@ -560,64 +563,6 @@ class PlotMapView:
         ax = kwargs.pop("ax", self.ax)
         patch_collection = plotutil.plot_shapefile(obj, ax, **kwargs)
         return patch_collection
-
-    def plot_cvfd(self, verts, iverts, **kwargs):
-        """
-        Plot a cvfd grid.  The vertices must be in the same
-        coordinates as the rotated and offset grid.
-
-        Parameters
-        ----------
-        verts : ndarray
-            2d array of x and y points.
-        iverts : list of lists
-            should be of len(ncells) with a list of vertex number for each cell
-
-        kwargs : dictionary
-            Keyword arguments passed to plotutil.plot_cvfd()
-
-        """
-        warnings.warn(
-            "plot_cvfd will be deprecated and will be removed in version "
-            "3.3.5. Use plot_grid or plot_array",
-            PendingDeprecationWarning,
-        )
-        a = kwargs.pop("a", None)
-        if a is None:
-            return self.plot_grid(**kwargs)
-        else:
-            return self.plot_array(a, **kwargs)
-
-    def contour_array_cvfd(self, vertc, a, masked_values=None, **kwargs):
-        """
-        Contour a cvfd array.  If the array is three-dimensional,
-        then the method will contour the layer tied to this class (self.layer).
-        The vertices must be in the same coordinates as the rotated and
-        offset grid.
-
-        Parameters
-        ----------
-        vertc : np.ndarray
-            Array with of size (nc, 2) with centroid location of cvfd
-        a : numpy.ndarray
-            Array to plot.
-        masked_values : iterable of floats, ints
-            Values to mask.
-        **kwargs : dictionary
-            keyword arguments passed to matplotlib.pyplot.pcolormesh
-
-        Returns
-        -------
-        contour_set : matplotlib.pyplot.contour
-
-        """
-        warnings.warn(
-            "contour_cvfd will be deprecated and removed in version 3.3.5. "
-            " Use contour_array",
-            PendingDeprecationWarning,
-        )
-
-        return self.contour_array(a, masked_values=masked_values, **kwargs)
 
     def plot_vector(
         self,

--- a/flopy/utils/rasters.py
+++ b/flopy/utils/rasters.py
@@ -1,9 +1,12 @@
-import queue
-import threading
+import rasterstats
+import warnings
 
 import numpy as np
 
+from .geometry import Polygon
 from .utl_import import import_optional_dependency
+
+warnings.simplefilter("always", DeprecationWarning)
 
 
 class Raster:
@@ -341,7 +344,7 @@ class Raster:
         band : int
             raster band to re-sample
         method : str
-            scipy interpolation methods
+            resampling methods
 
             ``linear`` for bi-linear interpolation
 
@@ -357,11 +360,13 @@ class Raster:
 
             ``max`` for maximum sampling
 
+            `'mode'` for majority sampling
+
         multithread : bool
-            boolean flag indicating if multithreading should be used with
-            the ``mean`` and ``median`` sampling methods
+            DEPRECATED boolean flag indicating if multithreading should be
+            used with the ``mean`` and ``median`` sampling methods
         thread_pool : int
-            number of threads to use for mean and median sampling
+            DEPRECATED number of threads to use for mean and median sampling
         extrapolate_edges : bool
             boolean flag indicating if areas without data should be filled
             using the ``nearest`` interpolation method. This option
@@ -371,9 +376,15 @@ class Raster:
         -------
             np.array
         """
+        if multithread:
+            warnings.warn(
+                "multithread option has been deprecated and will be removed "
+                "in flopy version 3.3.8"
+            )
+
         import_optional_dependency("scipy")
+        rasterstats = import_optional_dependency("rasterstats")
         from scipy.interpolate import griddata
-        from scipy.stats import mode
 
         method = method.lower()
         if method in ("linear", "nearest", "cubic"):
@@ -407,82 +418,24 @@ class Raster:
             )
 
         elif method in ("median", "mean", "min", "max", "mode"):
-            # these methods are slow and could use a speed up
-            ncpl = modelgrid.ncpl
+            # these methods are slow and could use speed ups
             data_shape = modelgrid.xcellcenters.shape
-            if isinstance(ncpl, (list, np.ndarray)):
-                ncpl = ncpl[0]
 
-            data = np.zeros((ncpl,), dtype=float)
+            if method == "mode":
+                method = "majority"
+            xv, yv = modelgrid.cross_section_vertices
+            polygons = [list(zip(x, yv[ix])) for ix, x in enumerate(xv)]
+            polygons = [Polygon(p) for p in polygons]
+            rstr = self.get_array(band, masked=False)
+            affine = self._meta["transform"]
+            nodata = self.nodatavals[0]
+            zs = rasterstats.zonal_stats(
+                polygons, rstr, affine=affine, stats=[method], nodata=nodata
+            )
+            data = np.array(
+                [z[method] if z[method] is not None else np.nan for z in zs]
+            )
 
-            if multithread:
-                q = queue.Queue()
-                container = threading.BoundedSemaphore(thread_pool)
-
-                # determine the number of thread pairs required to
-                # fill the grid
-                nthreadpairs = int(ncpl / thread_pool)
-                if ncpl % thread_pool != 0:
-                    nthreadpairs += 1
-
-                # iterate over the tread pairs
-                for idx in range(nthreadpairs):
-                    i0 = idx * thread_pool
-                    nthreads = thread_pool
-                    if i0 + thread_pool > ncpl:
-                        nthreads = ncpl - i0
-                    i1 = i0 + nthreads
-                    threads = []
-                    for node in range(i0, i1):
-                        t = threading.Thread(
-                            target=self.__threaded_resampling,
-                            args=(modelgrid, node, band, method, container, q),
-                        )
-                        threads.append(t)
-
-                    # start the threads
-                    for thread in threads:
-                        thread.daemon = True
-                        thread.start()
-
-                    # wait until all threads are terminated
-                    for thread in threads:
-                        thread.join()
-
-                    for idx in range(nthreads):
-                        node, val = q.get()
-                        data[node] = val
-
-            else:
-                for node in range(ncpl):
-                    verts = modelgrid.get_cell_vertices(node)
-                    rstr_data = self.sample_polygon(
-                        verts, band, convert=False
-                    ).astype(float)
-                    msk = np.in1d(rstr_data, self.nodatavals)
-                    rstr_data[msk] = np.nan
-
-                    if rstr_data.size == 0:
-                        val = self.nodatavals[0]
-                    else:
-                        if method == "median":
-                            val = np.nanmedian(rstr_data)
-                        elif method == "mean":
-                            val = np.nanmean(rstr_data)
-                        elif method == "max":
-                            val = np.nanmax(rstr_data)
-                        elif method == "mode":
-                            val = mode(
-                                rstr_data, axis=None, nan_policy="omit"
-                            ).mode
-                            if len(val) == 0:
-                                val = np.nan
-                            else:
-                                val = val[0]
-                        else:
-                            val = np.nanmin(rstr_data)
-
-                    data[node] = val
         else:
             raise TypeError(f"{method} method not supported")
 
@@ -525,63 +478,6 @@ class Raster:
         data[np.isnan(data)] = self.nodatavals[0]
 
         return data
-
-    def __threaded_resampling(
-        self, modelgrid, node, band, method, container, q
-    ):
-        """
-        Threaded resampling handler to speed up bottlenecks
-
-        Parameters
-        ----------
-        modelgrid : flopy.discretization.Grid object
-            flopy grid to sample to
-        node : int
-            node number
-        band : int
-            raster band to sample from
-        method : str
-            resampling method
-        container : threading.BoundedSemaphore
-        q : queue.Queue
-
-        Returns
-        -------
-            None
-        """
-        container.acquire()
-
-        import_optional_dependency("scipy")
-        from scipy.stats import mode
-
-        verts = modelgrid.get_cell_vertices(node)
-        rstr_data = self.sample_polygon(verts, band, convert=False).astype(
-            float
-        )
-        msk = np.in1d(rstr_data, self.nodatavals)
-        rstr_data[msk] = np.nan
-
-        if rstr_data.size == 0:
-            val = self.nodatavals[0]
-
-        else:
-            if method == "median":
-                val = np.nanmedian(rstr_data)
-            elif method == "mean":
-                val = np.nanmean(rstr_data)
-            elif method == "max":
-                val = np.nanmax(rstr_data)
-            elif method == "mode":
-                val = mode(rstr_data, axis=None, nan_policy="omit").mode
-                if len(val) == 0:
-                    val = np.nan
-                else:
-                    val = val[0]
-            else:
-                val = np.nanmin(rstr_data)
-
-        q.put((node, val))
-        container.release()
 
     def crop(self, polygon, invert=False):
         """
@@ -774,7 +670,7 @@ class Raster:
 
             geom = GeoSpatialUtil(polygon, shapetype="Polygon")
 
-            polygon = geom.points[0]
+            polygon = list(geom.points[0])
 
         # step 2: create a grid of centoids
         xc = self.xcenters

--- a/flopy/utils/rasters.py
+++ b/flopy/utils/rasters.py
@@ -1,4 +1,3 @@
-import rasterstats
 import warnings
 
 import numpy as np

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,7 @@ optional =
     pyshp
     python-dateutil >=2.4.0
     rasterio; platform_system!='Windows'
-	rasterstats; platform_system!='Windows'
+    rasterstats; platform_system!='Windows'
     scipy
     shapely
     vtk

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,6 +67,7 @@ optional =
     pyshp
     python-dateutil >=2.4.0
     rasterio; platform_system!='Windows'
+	rasterstats; platform_system!='Windows'
     scipy
     shapely
     vtk


### PR DESCRIPTION
Updates to map.py: 
* remove deprecated code that was tagged for removal in flopy version 3.3.5
* explicitly set default cmap to viridis in plot_array()

Updates to rasters.py:
* Major update to geostatistical sampling routine within resample_to_grid()
* Update takes advantage of the `rasterstats` package to perform zonal statistics, which provides over a 100x speed up to min, max, mean, med, mode sampling routine
* begin deprecation of multithread and thread_pool input parameters as they are no longer used
* Update introduces another optional dependency (`rasterstats` package) to FloPy