### PR TITLE
feat(get_modflow): support modflow6 repo releases

### DIFF
--- a/autotest/test_get_modflow.py
+++ b/autotest/test_get_modflow.py
@@ -1,7 +1,6 @@
 """Test get-modflow utility."""
 import sys
 import urllib
-from os.path import splitext
 from pathlib import Path
 from platform import system
 from typing import List

--- a/docs/get_modflow.md
+++ b/docs/get_modflow.md
@@ -1,12 +1,25 @@
 # Install MODFLOW and related programs
 
-This method describes how to install USGS MODFLOW and related programs for Windows, Mac or Linux using a "get modflow" utility. If FloPy is installed, the utility is available in the Python environment as a `get-modflow` command. The same utility is also available as a Python script `get_modflow.py`, described later.
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-The utility uses a [GitHub releases API](https://docs.github.com/en/rest/releases) to download versioned archives of programs that have been compiled with modern Intel Fortran compilers. The utility is able to match the binary archive to the operating system, and extract the console programs to a user-defined directory. A prompt can also be used to assist where to install programs.
+
+- [Command-line interface](#command-line-interface)
+  - [Using the `get-modflow` command](#using-the-get-modflow-command)
+  - [Using `get_modflow.py` as a script](#using-get_modflowpy-as-a-script)
+- [FloPy module](#flopy-module)
+- [Where to install?](#where-to-install)
+- [Selecting a distribution](#selecting-a-distribution)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+FloPy includes a `get-modflow` utility to install USGS MODFLOW and related programs for Windows, Mac or Linux. If FloPy is installed, the utility is available in the Python environment as a `get-modflow` command. The script `flopy/utils/get_modflow.py` has no dependencies and can be invoked independently.
+
+The utility uses the [GitHub releases API](https://docs.github.com/en/rest/releases) to download versioned archives containing executables compiled with [Intel Fortran](https://www.intel.com/content/www/us/en/developer/tools/oneapi/fortran-compiler.html). The utility is able to match the binary archive to the operating system and extract the console programs to a user-defined directory. A prompt can also be used to help the user choose where to install programs.
 
 ## Command-line interface
 
-### Using `get-modflow` from FloPy
+### Using the `get-modflow` command
 
 When FloPy is installed, a `get-modflow` (or `get-modflow.exe` for Windows) program is installed, which is usually installed to the PATH (depending on the Python setup). From a console:
 
@@ -57,3 +70,20 @@ Other auto-select options are only available if the current user can write files
  - `:local` - use `$HOME/.local/bin`
  - `:system` - use `/usr/local/bin`
  - `:windowsapps` - use `%LOCALAPPDATA%\Microsoft\WindowsApps`
+
+## Selecting a distribution
+
+By default the distribution from the [executables repository](https://github.com/MODFLOW-USGS/executables) is installed. This includes the MODFLOW 6 binary `mf6` and over 20 other related programs. The utility can also install from the main [MODFLOW 6 repo](https://github.com/MODFLOW-USGS/modflow6) or the [nightly build](https://github.com/MODFLOW-USGS/modflow6-nightly-build). To select a distribution, specify a repository name with the `--repo` command line option or the `repo` function argument. Valid names are:
+
+- `executables` (default)
+- `modflow6`
+- `modflow6-nightly-build`
+
+The `modflow6-nightly-build` distribution contains only:
+
+- `mf6`
+- `mf5to6`
+- `zbud6`
+- `libmf6.dylib`
+
+The `modflow6` release archive contains the entire repository with an internal `bin` directory, whose contents are as above. These are copied to the selected `bindir` after the archive is unzipped in the download location.


### PR DESCRIPTION
Supports installing releases from the main modflow6 repository. Updates the `repo` option to accept `modflow6` so the user can select any of the following:

- `executables` (default)
- `modflow6`
- `modflow6-nightly-build`

The `modflow6` repo's release archive contains most of the repository, not just binaries, so instead of unzipping directly to `bindir` like the other 2 options, there is an extra step to unzip in the download location before copying binaries to `bindir`.

Adds a section describing repo selection to the docs. Also adds a table of contents.

#### Motivation

Besides covering the bases as far as distributions go, this is a step towards replacing the `pymake` dependency in modflow6 tests (currently `pymake` is used to download the latest mf6 release, among other things)