### PR TITLE
fix(test markers): add missing markers for exes required

### DIFF
--- a/autotest/test_cbc_full3D.py
+++ b/autotest/test_cbc_full3D.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from autotest.conftest import get_example_data_path
+from autotest.conftest import get_example_data_path, requires_exe
 
 from flopy.mf6 import MFSimulation, ModflowGwfoc
 from flopy.modflow import Modflow
@@ -119,6 +119,7 @@ def cbc_eval(cbcobj, nnodes, shape3d, modelgrid):
     cobj_mg.close()
 
 
+@requires_exe("mf6")
 @pytest.mark.mf6
 @pytest.mark.parametrize("path", mf6_paths)
 def test_cbc_full3D_mf6(tmpdir, path):
@@ -142,6 +143,7 @@ def test_cbc_full3D_mf6(tmpdir, path):
     cbc_eval(cbc, nnodes, shape3d, gwf.modelgrid)
 
 
+@requires_exe("mf2005")
 @pytest.mark.parametrize("path", mf2005_paths)
 def test_cbc_full3D_mf2005(tmpdir, path):
     ml = load_mf2005(path, str(tmpdir))

--- a/autotest/test_export.py
+++ b/autotest/test_export.py
@@ -1905,6 +1905,7 @@ def test_vtk_export_disu2_grid(tmpdir, example_data_path):
 
 
 @pytest.mark.mf6
+@requires_exe("mf6", "gridgen")
 @requires_pkg("vtk", "shapefile")
 def test_vtk_export_disu_model(tmpdir):
     from vtkmodules.util.numpy_support import vtk_to_numpy

--- a/autotest/test_grid.py
+++ b/autotest/test_grid.py
@@ -4,7 +4,7 @@ from warnings import warn
 import matplotlib
 import numpy as np
 import pytest
-from autotest.conftest import requires_pkg
+from autotest.conftest import requires_pkg, requires_exe
 from autotest.test_dis_cases import case_dis, case_disv
 from autotest.test_grid_cases import GridCases
 from flaky import flaky
@@ -773,6 +773,7 @@ def test_unstructured_complete_grid_ctor():
 
 
 @requires_pkg("shapely")
+@requires_exe("triangle")
 def test_triangle_unstructured_grid(tmpdir):
     maximum_area = 30000.0
     extent = (214270.0, 221720.0, 4366610.0, 4373510.0)
@@ -805,6 +806,7 @@ def test_triangle_unstructured_grid(tmpdir):
 
 
 @requires_pkg("shapely", "scipy")
+@requires_exe("triangle")
 def test_voronoi_vertex_grid(tmpdir):
     xmin = 0.0
     xmax = 2.0
@@ -832,6 +834,7 @@ def test_voronoi_vertex_grid(tmpdir):
 
 
 @flaky
+@requires_exe("triangle")
 @requires_pkg("shapely", "scipy")
 @parametrize_with_cases("grid_info", cases=GridCases, prefix="voronoi")
 def test_voronoi_grid(request, tmpdir, grid_info):

--- a/autotest/test_modpathfile.py
+++ b/autotest/test_modpathfile.py
@@ -235,6 +235,7 @@ def mp7_large(module_tmpdir):
     )
 
 
+@requires_exe("mf6")
 def test_pathline_file_sorts_in_ctor(tmpdir, module_tmpdir, mp7_small):
     sim, forward_model_name, backward_model_name, nodew, nodesr = mp7_small
     ws = tmpdir / "ws"

--- a/autotest/test_mp6.py
+++ b/autotest/test_mp6.py
@@ -809,6 +809,7 @@ def make_mp_model(nm, m, ws, use_pandas):
     return mp
 
 
+@requires_exe("mf2005")
 @parametrize_with_cases("ml", cases=Mp6Cases2)
 def test_mp_wpandas_wo_pandas(ml):
     """

--- a/autotest/test_mp7.py
+++ b/autotest/test_mp7.py
@@ -841,6 +841,7 @@ def test_endpoint_output(tmpdir):
     # assert not np.allclose(t0, t1), msg
 
 
+@requires_exe("mf6")
 def test_pathline_plotting(tmpdir):
     ml = Mp7Cases.mf6(tmpdir)
     success, buff = ml.run_model()

--- a/autotest/test_mt3d.py
+++ b/autotest/test_mt3d.py
@@ -17923,6 +17923,7 @@ def test_mt3dms_load_when_nam_dne():
         Mt3dms.load("nonexistent.nam")
 
 
+@requires_exe("mf2005")
 def test_mt3d_ssm_with_nodata_in_1st_sp(tmpdir):
     nlay, nrow, ncol = 3, 5, 5
     perlen = np.zeros((10), dtype=float) + 10
@@ -18032,6 +18033,7 @@ def test_mt3d_ssm_with_nodata_in_1st_sp(tmpdir):
     assert np.allclose(conca, concb)
 
 
+@requires_exe("mf2005")
 def test_none_spdtype(tmpdir):
     # ensure that -1 and None work as valid list entries in the
     # stress period dictionary

--- a/autotest/test_obs.py
+++ b/autotest/test_obs.py
@@ -268,6 +268,7 @@ def test_obs_single_time(tmpdir):
     assert data["obs02"][0] == 20.0, "obs02[0] != 20.0"
 
 
+@requires_exe("mf2005")
 def test_obs_create_and_write(tmpdir, example_data_path):
     """
     test041 create and write of MODFLOW-2005 OBS example problem

--- a/autotest/test_plot.py
+++ b/autotest/test_plot.py
@@ -2,7 +2,7 @@ import os
 
 import numpy as np
 import pytest
-from autotest.conftest import requires_pkg
+from autotest.conftest import requires_pkg, requires_exe
 from flaky import flaky
 from matplotlib import pyplot as plt
 from matplotlib import rcParams
@@ -352,6 +352,7 @@ def test_model_dot_plot_export(tmpdir, example_data_path):
 
 
 @requires_pkg("pandas")
+@requires_exe("mf2005")
 def test_pathline_plot_xc(tmpdir, example_data_path):
     # test with multi-layer example
     load_ws = example_data_path / "mp6"
@@ -465,6 +466,7 @@ def quasi3d_model(tmpdir):
     return mf
 
 
+@requires_exe("mf2005")
 def test_map_plot_with_quasi3d_layers(quasi3d_model):
     # read output
     hf = HeadFile(
@@ -490,6 +492,7 @@ def test_map_plot_with_quasi3d_layers(quasi3d_model):
     plt.savefig(os.path.join(str(quasi3d_model.model_ws), "plt01.png"))
 
 
+@requires_exe("mf2005")
 def test_cross_section_with_quasi3d_layers(quasi3d_model):
     # read output
     hf = HeadFile(

--- a/autotest/test_postprocessing.py
+++ b/autotest/test_postprocessing.py
@@ -3,6 +3,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
+from autotest.conftest import requires_exe
 from flopy.mf6 import (
     MFSimulation,
     ModflowGwf,
@@ -31,6 +32,7 @@ def mf6_freyberg_path(example_data_path):
 
 
 @pytest.mark.mf6
+@requires_exe("mf6")
 def test_faceflows(tmpdir, mf6_freyberg_path):
     sim = MFSimulation.load(
         sim_name="freyberg",
@@ -98,6 +100,7 @@ def test_faceflows(tmpdir, mf6_freyberg_path):
 
 
 @pytest.mark.mf6
+@requires_exe("mf6")
 def test_flowja_residuals(tmpdir, mf6_freyberg_path):
     sim = MFSimulation.load(
         sim_name="freyberg",
@@ -145,6 +148,7 @@ def test_flowja_residuals(tmpdir, mf6_freyberg_path):
 
 
 @pytest.mark.mf6
+@requires_exe("mf6")
 def test_structured_faceflows_3d(tmpdir):
     name = "mymodel"
     sim = MFSimulation(sim_name=name, sim_ws=str(tmpdir), exe_name="mf6")

--- a/autotest/test_sfr.py
+++ b/autotest/test_sfr.py
@@ -664,6 +664,7 @@ def test_assign_layers(tmpdir):
     assert np.array_equal(l, np.array([1, 1]))
 
 
+@requires_exe("mf2005")
 @requires_pkg("pandas")
 def test_SfrFile(tmpdir, sfr_examples_path, mf2005_model_path):
     common_names = [
@@ -894,6 +895,7 @@ def test_sfrloadcheck(tmpdir, mf2005_model_path, i, case):
         assert "segment elevations vs. model grid" in chk.warnings
 
 
+@requires_exe("mfnwt")
 @pytest.mark.parametrize("isfropt, icalc", get_test_matrix())
 def test_isfropt_icalc(tmpdir, example_data_path, isfropt, icalc):
     pth = example_data_path / "sfr_test"

--- a/autotest/test_uzf.py
+++ b/autotest/test_uzf.py
@@ -583,6 +583,7 @@ def test_load_write_wel_option_line(tmpdir, options_path):
     assert wel.iunitramp == 20
 
 
+@requires_exe("mfnwt")
 def test_uzf_negative_iuzfopt(tmpdir):
     ml = Modflow(
         modelname="uzf_neg",

--- a/autotest/test_zonbud_utility.py
+++ b/autotest/test_zonbud_utility.py
@@ -2,7 +2,7 @@ import os
 
 import numpy as np
 import pytest
-from autotest.conftest import requires_pkg
+from autotest.conftest import requires_pkg, requires_exe
 
 from flopy.mf6 import MFSimulation
 from flopy.utils import ZoneBudget, ZoneBudget6, ZoneFile6
@@ -283,6 +283,7 @@ def test_read_zone_file(tmpdir):
 
 
 @pytest.mark.mf6
+@requires_exe("mf6")
 @requires_pkg("pandas")
 def test_zonebudget_6(tmpdir, example_data_path):
     import pandas as pd
@@ -343,6 +344,7 @@ def test_zonebudget_6(tmpdir, example_data_path):
 
 
 @pytest.mark.mf6
+@requires_exe("mf6")
 def test_zonebudget6_from_output_method(tmpdir, example_data_path):
     exe_name = "mf6"
     zb_exe_name = "zbud6"


### PR DESCRIPTION
Some markers to skip tests based on executable availability were missing. (Noticed while setting up a fresh environment and running the tests before installing exes.)