### PR TITLE
test(binaryfile): add tests for head and budget file precision detection

### DIFF
--- a/autotest/test_binaryfile.py
+++ b/autotest/test_binaryfile.py
@@ -2,7 +2,9 @@ import numpy as np
 import pytest
 from matplotlib import pyplot as plt
 from matplotlib.axes import Axes
+import numpy as np
 
+import flopy
 from flopy.modflow import Modflow
 from flopy.utils import (
     BinaryHeader,
@@ -11,6 +13,9 @@ from flopy.utils import (
     HeadUFile,
     Util2d,
 )
+from flopy.utils.binaryfile import get_headfile_precision
+
+from autotest.conftest import get_example_data_path
 
 
 @pytest.fixture
@@ -144,3 +149,33 @@ def test_headu_file(tmpdir, example_data_path):
         assert np.allclose(t1, minmaxtrue[i])
 
     return
+
+
+def test_get_headfile_precision(example_data_path):
+    precision = get_headfile_precision(str(example_data_path / "freyberg" / "freyberg.githds"))
+    assert precision == 'single'
+
+    precision = get_headfile_precision(
+        str(example_data_path / "mf6" / "create_tests" / "test005_advgw_tidal" / "expected_output" / "AdvGW_tidal.hds"))
+    assert precision == 'double'
+
+
+_example_data_path = get_example_data_path(__file__)
+
+
+@pytest.mark.parametrize("path", [str(p) for p in [
+    _example_data_path / "mf2005_test" / "swiex1.gitzta",
+    _example_data_path / "mp6" / "EXAMPLE.BUD",
+    _example_data_path / "mfusg_test" / "01A_nestedgrid_nognc" / "output" / "flow.cbc",
+]])
+def test_budgetfile_detect_precision_single(path):
+    file = CellBudgetFile(path, precision="auto")
+    assert file.realtype == np.float32
+
+
+@pytest.mark.parametrize("path", [str(p) for p in [
+    _example_data_path / "mf6" / "test006_gwf3" / "expected_output" / "flow_adj.cbc",
+]])
+def test_budgetfile_detect_precision_double(path):
+    file = CellBudgetFile(path, precision="auto")
+    assert file.realtype == np.float64

--- a/autotest/test_gridintersect.py
+++ b/autotest/test_gridintersect.py
@@ -1190,6 +1190,7 @@ def test_all_intersections_shapely_no_strtree():
 # %% test rasters
 
 
+@requires_pkg("rasterstats")
 def test_rasters(example_data_path):
     ws = str(example_data_path / "options")
     raster_name = "dem.img"

--- a/autotest/test_lake_connections.py
+++ b/autotest/test_lake_connections.py
@@ -181,7 +181,7 @@ def test_base_run(tmpdir, example_data_path):
 
 
 @requires_exe("mf6")
-@requires_pkg("rasterio")
+@requires_pkg("rasterio", "rasterstats")
 def test_lake(tmpdir, example_data_path):
     mpath = example_data_path / "mf6-freyberg"
     top = Raster.load(str(mpath / "top.asc"))


### PR DESCRIPTION
- add a few test cases for `HeadFile` and `CellBudgetFile` precision detection while attempting to reproduce https://github.com/modflowpy/flopy/issues/1572
- mark tests which need new `rasterstats` optional dependency introduced in https://github.com/modflowpy/flopy/pull/1571