### PR TITLE
fix(get_modflow): misc

### DIFF
--- a/autotest/test_binaryfile.py
+++ b/autotest/test_binaryfile.py
@@ -1,8 +1,8 @@
 import numpy as np
 import pytest
+from autotest.conftest import get_example_data_path
 from matplotlib import pyplot as plt
 from matplotlib.axes import Axes
-import numpy as np
 
 import flopy
 from flopy.modflow import Modflow
@@ -14,8 +14,6 @@ from flopy.utils import (
     Util2d,
 )
 from flopy.utils.binaryfile import get_headfile_precision
-
-from autotest.conftest import get_example_data_path
 
 
 @pytest.fixture
@@ -152,30 +150,60 @@ def test_headu_file(tmpdir, example_data_path):
 
 
 def test_get_headfile_precision(example_data_path):
-    precision = get_headfile_precision(str(example_data_path / "freyberg" / "freyberg.githds"))
-    assert precision == 'single'
+    precision = get_headfile_precision(
+        str(example_data_path / "freyberg" / "freyberg.githds")
+    )
+    assert precision == "single"
 
     precision = get_headfile_precision(
-        str(example_data_path / "mf6" / "create_tests" / "test005_advgw_tidal" / "expected_output" / "AdvGW_tidal.hds"))
-    assert precision == 'double'
+        str(
+            example_data_path
+            / "mf6"
+            / "create_tests"
+            / "test005_advgw_tidal"
+            / "expected_output"
+            / "AdvGW_tidal.hds"
+        )
+    )
+    assert precision == "double"
 
 
 _example_data_path = get_example_data_path()
 
 
-@pytest.mark.parametrize("path", [str(p) for p in [
-    _example_data_path / "mf2005_test" / "swiex1.gitzta",
-    _example_data_path / "mp6" / "EXAMPLE.BUD",
-    _example_data_path / "mfusg_test" / "01A_nestedgrid_nognc" / "output" / "flow.cbc",
-]])
+@pytest.mark.parametrize(
+    "path",
+    [
+        str(p)
+        for p in [
+            _example_data_path / "mf2005_test" / "swiex1.gitzta",
+            _example_data_path / "mp6" / "EXAMPLE.BUD",
+            _example_data_path
+            / "mfusg_test"
+            / "01A_nestedgrid_nognc"
+            / "output"
+            / "flow.cbc",
+        ]
+    ],
+)
 def test_budgetfile_detect_precision_single(path):
     file = CellBudgetFile(path, precision="auto")
     assert file.realtype == np.float32
 
 
-@pytest.mark.parametrize("path", [str(p) for p in [
-    _example_data_path / "mf6" / "test006_gwf3" / "expected_output" / "flow_adj.cbc",
-]])
+@pytest.mark.parametrize(
+    "path",
+    [
+        str(p)
+        for p in [
+            _example_data_path
+            / "mf6"
+            / "test006_gwf3"
+            / "expected_output"
+            / "flow_adj.cbc",
+        ]
+    ],
+)
 def test_budgetfile_detect_precision_double(path):
     file = CellBudgetFile(path, precision="auto")
     assert file.realtype == np.float64

--- a/autotest/test_conftest.py
+++ b/autotest/test_conftest.py
@@ -86,10 +86,7 @@ def test_get_project_root_path():
     assert root.is_dir()
 
     contents = [p.name for p in root.glob("*")]
-    assert (
-        "autotest" in contents
-        and "README.md" in contents
-    )
+    assert "autotest" in contents and "README.md" in contents
 
 
 def test_get_paths():
@@ -101,11 +98,7 @@ def test_get_paths():
 
 def test_get_example_data_path():
     parts = get_example_data_path().parts
-    assert (
-        parts[-3] == "flopy"
-        and parts[-2] == "examples"
-        and parts[-1] == "data"
-    )
+    assert parts[-2:] == ("examples", "data")
 
 
 # requiring/excluding executables & platforms

--- a/autotest/test_geospatial_util.py
+++ b/autotest/test_geospatial_util.py
@@ -490,4 +490,3 @@ def test_mixed_collection(
                 is_equal = gi2 == gi1[ix]
 
             assert is_equal, "GeoSpatialCollection conversion error"
-

--- a/autotest/test_grid.py
+++ b/autotest/test_grid.py
@@ -4,7 +4,7 @@ from warnings import warn
 import matplotlib
 import numpy as np
 import pytest
-from autotest.conftest import requires_pkg, requires_exe
+from autotest.conftest import requires_exe, requires_pkg
 from autotest.test_dis_cases import case_dis, case_disv
 from autotest.test_grid_cases import GridCases
 from flaky import flaky
@@ -347,14 +347,15 @@ def test_structured_neighbors(example_data_path):
     neighbors = modelgrid.neighbors(k, i, j)
     for neighbor in neighbors:
         if (
-                neighbor != (k, i + 1, j)
-                and neighbor != (k, i - 1, j)
-                and neighbor != (k, i, j + 1)
-                and neighbor != (k, i, j - 1)
+            neighbor != (k, i + 1, j)
+            and neighbor != (k, i - 1, j)
+            and neighbor != (k, i, j + 1)
+            and neighbor != (k, i, j - 1)
         ):
             raise AssertionError(
                 "modelgid.neighbors not returning proper values"
             )
+
 
 def test_vertex_neighbors(example_data_path):
     ws = str(example_data_path / "mf6" / "test003_gwfs_disv")
@@ -365,10 +366,10 @@ def test_vertex_neighbors(example_data_path):
     neighbors = modelgrid.neighbors(node)
     for neighbor in neighbors:
         if (
-                neighbor != node + 1
-                and neighbor != node - 1
-                and neighbor != node + 10
-                and neighbor != node - 10
+            neighbor != node + 1
+            and neighbor != node - 1
+            and neighbor != node + 10
+            and neighbor != node - 10
         ):
             raise AssertionError(
                 "modelgid.neighbors not returning proper values"
@@ -1009,7 +1010,7 @@ def test_get_lni_unstructured(grid):
                     list(grid.ncpl)
                     if not isinstance(grid.ncpl, int)
                     else [grid.ncpl for _ in range(grid.nlay)]
-        )
+                )
             )
         )
         assert csum[layer] + i == nn

--- a/autotest/test_gridintersect.py
+++ b/autotest/test_gridintersect.py
@@ -1253,6 +1253,7 @@ def test_rasters(example_data_path):
 
 # %% test raster sampling methods
 
+
 @pytest.mark.slow
 def test_raster_sampling_methods(example_data_path):
     ws = str(example_data_path / "options")

--- a/autotest/test_obs.py
+++ b/autotest/test_obs.py
@@ -16,7 +16,6 @@ from flopy.modflow import (
     ModflowLpf,
     ModflowPcg,
 )
-
 from flopy.utils.observationfile import Mf6Obs
 
 

--- a/autotest/test_plot.py
+++ b/autotest/test_plot.py
@@ -2,7 +2,7 @@ import os
 
 import numpy as np
 import pytest
-from autotest.conftest import requires_pkg, requires_exe
+from autotest.conftest import requires_exe, requires_pkg
 from flaky import flaky
 from matplotlib import pyplot as plt
 from matplotlib import rcParams

--- a/autotest/test_postprocessing.py
+++ b/autotest/test_postprocessing.py
@@ -2,8 +2,8 @@ import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
-
 from autotest.conftest import requires_exe
+
 from flopy.mf6 import (
     MFSimulation,
     ModflowGwf,

--- a/autotest/test_seawat.py
+++ b/autotest/test_seawat.py
@@ -195,10 +195,7 @@ def test_seawat2_henry(tmpdir):
 
 def swt4_namfiles():
     return [
-        str(p)
-        for p in (get_example_data_path() / "swtv4_test").rglob(
-            "*.nam"
-        )
+        str(p) for p in (get_example_data_path() / "swtv4_test").rglob("*.nam")
     ]
 
 

--- a/autotest/test_usg.py
+++ b/autotest/test_usg.py
@@ -387,12 +387,7 @@ def test_flat_array_to_util3d_usg(tmpdir, freyberg_usg_model_path):
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "fpth",
-    [
-        str(p)
-        for p in (get_example_data_path() / "mfusg_test").rglob(
-            "*.nam"
-        )
-    ],
+    [str(p) for p in (get_example_data_path() / "mfusg_test").rglob("*.nam")],
 )
 def test_load_usg(tmpdir, fpth):
     namfile = Path(fpth)

--- a/autotest/test_zonbud_utility.py
+++ b/autotest/test_zonbud_utility.py
@@ -2,7 +2,7 @@ import os
 
 import numpy as np
 import pytest
-from autotest.conftest import requires_pkg, requires_exe
+from autotest.conftest import requires_exe, requires_pkg
 
 from flopy.mf6 import MFSimulation
 from flopy.utils import ZoneBudget, ZoneBudget6, ZoneFile6

--- a/docs/get_modflow.md
+++ b/docs/get_modflow.md
@@ -67,23 +67,21 @@ Other auto-select options are only available if the current user can write files
  - `:prev` - if this utility was run by FloPy more than once, the first option will be the previously used `bindir` path selection
  - `:flopy` - special option that will create and install programs for FloPy
  - `:python` - use Python's bin (or Scripts) directory
- - `:local` - use `$HOME/.local/bin`
+ - `:home` - use `$HOME/.local/bin`
  - `:system` - use `/usr/local/bin`
  - `:windowsapps` - use `%LOCALAPPDATA%\Microsoft\WindowsApps`
 
 ## Selecting a distribution
 
-By default the distribution from the [executables repository](https://github.com/MODFLOW-USGS/executables) is installed. This includes the MODFLOW 6 binary `mf6` and over 20 other related programs. The utility can also install from the main [MODFLOW 6 repo](https://github.com/MODFLOW-USGS/modflow6) or the [nightly build](https://github.com/MODFLOW-USGS/modflow6-nightly-build). To select a distribution, specify a repository name with the `--repo` command line option or the `repo` function argument. Valid names are:
-
-- `executables` (default)
-- `modflow6`
-- `modflow6-nightly-build`
-
-The `modflow6-nightly-build` distribution contains only:
+By default the distribution from the [executables repository](https://github.com/MODFLOW-USGS/executables) is installed. This includes the MODFLOW 6 binary `mf6` and over 20 other related programs. The utility can also install from the main [MODFLOW 6 repo](https://github.com/MODFLOW-USGS/modflow6) or the [nightly build](https://github.com/MODFLOW-USGS/modflow6-nightly-build) distributions, which contain only:
 
 - `mf6`
 - `mf5to6`
 - `zbud6`
 - `libmf6.dylib`
 
-The `modflow6` release archive contains the entire repository with an internal `bin` directory, whose contents are as above. These are copied to the selected `bindir` after the archive is unzipped in the download location.
+To select a distribution, specify a repository name with the `--repo` command line option or the `repo` function argument. Valid names are:
+
+- `executables` (default)
+- `modflow6`
+- `modflow6-nightly-build`

--- a/flopy/utils/get_modflow.py
+++ b/flopy/utils/get_modflow.py
@@ -13,12 +13,15 @@ import sys
 import tempfile
 import urllib
 import urllib.request
+import warnings
 import zipfile
 from importlib.util import find_spec
 from pathlib import Path
 
 __all__ = ["run_main"]
 __license__ = "CC0"
+
+from typing import Dict, List, Tuple
 
 owner = "MODFLOW-USGS"
 # key is the repo name, value is the renamed file prefix for the download
@@ -40,8 +43,15 @@ if spec is not None:
     )
 del spec
 
+# local flopy install location (selected with :flopy)
+flopy_appdata_path = (
+    Path(os.path.expandvars(r"%LOCALAPPDATA%\flopy"))
+    if sys.platform.startswith("win")
+    else Path.home() / ".local" / "share" / "flopy"
+)
 
-def get_ostag():
+
+def get_ostag() -> str:
     """Determine operating system tag from sys.platform."""
     if sys.platform.startswith("linux"):
         return "linux"
@@ -52,11 +62,29 @@ def get_ostag():
     raise ValueError(f"platform {sys.platform!r} not supported")
 
 
-def get_request(url):
-    """Get urllib.request.Request, with headers.
+def get_suffixes(ostag) -> Tuple[str, str]:
+    if ostag in ["win32", "win64"]:
+        return ".exe", ".dll"
+    elif ostag == "linux":
+        return "", ".so"
+    elif ostag == "mac":
+        return "", ".dylib"
+    else:
+        raise KeyError(
+            f"unrecognized ostag {ostag!r}; choose one of {available_ostags}"
+        )
+
+
+def get_request(url, params={}):
+    """Get urllib.request.Request, with parameters and headers.
 
     This bears GITHUB_TOKEN if it is set as an environment variable.
     """
+    if isinstance(params, dict):
+        if len(params) > 0:
+            url += "?" + urllib.parse.urlencode(params)
+    else:
+        raise TypeError("data must be a dict")
     headers = {}
     github_token = os.environ.get("GITHUB_TOKEN")
     if github_token:
@@ -64,10 +92,17 @@ def get_request(url):
     return urllib.request.Request(url, headers=headers)
 
 
-def get_avail_releases(api_url):
+def get_releases(repo, quiet=False, per_page=None) -> List[str]:
     """Get list of available releases."""
-    req_url = f"{api_url}/releases"
-    request = get_request(req_url)
+    req_url = f"https://api.github.com/repos/{owner}/{repo}/releases"
+
+    params = {}
+    if per_page is not None:
+        if per_page < 1 or per_page > 100:
+            raise ValueError("per_page must be between 1 and 100")
+        params["per_page"] = per_page
+
+    request = get_request(req_url, params=params)
     num_tries = 0
     while True:
         num_tries += 1
@@ -89,12 +124,67 @@ def get_avail_releases(api_url):
             raise RuntimeError(f"cannot retrieve data from {req_url}") from err
 
     releases = json.loads(result.decode())
+    if not quiet:
+        print(f"found {len(releases)} releases for {owner}/{repo}")
+
     avail_releases = ["latest"]
     avail_releases.extend(release["tag_name"] for release in releases)
     return avail_releases
 
 
-def columns_str(items, line_chars=79):
+def get_release(repo, tag="latest", quiet=False) -> dict:
+    """Get info about a particular release."""
+    api_url = f"https://api.github.com/repos/{owner}/{repo}"
+    req_url = (
+        f"{api_url}/releases/latest"
+        if tag == "latest"
+        else f"{api_url}/releases/tags/{tag}"
+    )
+    request = get_request(req_url)
+    releases = None
+    num_tries = 0
+
+    while True:
+        num_tries += 1
+        try:
+            with urllib.request.urlopen(request, timeout=10) as resp:
+                result = resp.read()
+                remaining = int(resp.headers["x-ratelimit-remaining"])
+                if remaining <= 10:
+                    warnings.warn(
+                        f"Only {remaining} GitHub API requests remaining "
+                        "before rate-limiting"
+                    )
+                break
+        except urllib.error.HTTPError as err:
+            if err.code == 401 and os.environ.get("GITHUB_TOKEN"):
+                raise ValueError("GITHUB_TOKEN env is invalid") from err
+            elif err.code == 403 and "rate limit exceeded" in err.reason:
+                raise ValueError(
+                    f"use GITHUB_TOKEN env to bypass rate limit ({err})"
+                ) from err
+            elif err.code == 404:
+                if releases is None:
+                    releases = get_releases(repo, quiet)
+                if tag not in releases:
+                    raise ValueError(
+                        f"Release {tag} not found (choose from {', '.join(releases)})"
+                    )
+            elif err.code == 503 and num_tries < max_http_tries:
+                # GitHub sometimes returns this error for valid URLs, so retry
+                warnings.warn(f"URL request {num_tries} did not work ({err})")
+                continue
+            raise RuntimeError(f"cannot retrieve data from {req_url}") from err
+
+    release = json.loads(result.decode())
+    tag_name = release["tag_name"]
+    if not quiet:
+        print(f"fetched release {tag_name!r} from {owner}/{repo}")
+
+    return release
+
+
+def columns_str(items, line_chars=79) -> str:
     """Return str of columns of items, similar to 'ls' command."""
     item_chars = max(len(item) for item in items)
     num_cols = line_chars // item_chars
@@ -110,6 +200,88 @@ def columns_str(items, line_chars=79):
             " ".join(item.ljust(item_chars) for item in row_items).rstrip()
         )
     return "\n".join(lines)
+
+
+def get_bindir_options(previous=None) -> Dict[str, Tuple[Path, str]]:
+    """Generate install location options based on platform and filesystem access."""
+    options = {}  # key is an option name, value is (optpath, optinfo)
+    if previous is not None and os.access(previous, os.W_OK):
+        # Make previous bindir as the first option
+        options[":prev"] = (previous, "previously selected bindir")
+    if within_flopy:  # don't check is_dir() or access yet
+        options[":flopy"] = (flopy_appdata_path / "bin", "used by FloPy")
+    # Python bin (same for standard or conda varieties)
+    py_bin = Path(sys.prefix) / (
+        "Scripts" if get_ostag().startswith("win") else "bin"
+    )
+    if py_bin.is_dir() and os.access(py_bin, os.W_OK):
+        options[":python"] = (py_bin, "used by Python")
+    home_local_bin = Path.home() / ".local" / "bin"
+    if home_local_bin.is_dir() and os.access(home_local_bin, os.W_OK):
+        options[":home"] = (home_local_bin, "user-specific bindir")
+    local_bin = Path("/usr") / "local" / "bin"
+    if local_bin.is_dir() and os.access(local_bin, os.W_OK):
+        options[":system"] = (local_bin, "system local bindir")
+    # Windows user
+    windowsapps_dir = Path(
+        os.path.expandvars(r"%LOCALAPPDATA%\Microsoft\WindowsApps")
+    )
+    if windowsapps_dir.is_dir() and os.access(windowsapps_dir, os.W_OK):
+        options[":windowsapps"] = (windowsapps_dir, "User App path")
+
+    # any other possible OS-specific hard-coded locations?
+    if not options:
+        raise RuntimeError("could not find any installable folders")
+
+    return options
+
+
+def select_bindir(bindir, previous=None, quiet=False, is_cli=False) -> Path:
+    """Resolve an install location if provided, or prompt interactive user to select one."""
+    options = get_bindir_options(previous)
+
+    if len(bindir) > 1:  # auto-select mode
+        # match one option that starts with input, e.g. :Py -> :python
+        sel = list(opt for opt in options if opt.startswith(bindir.lower()))
+        if len(sel) != 1:
+            opt_avail = ", ".join(
+                f"'{opt}' for '{optpath}'"
+                for opt, (optpath, _) in options.items()
+            )
+            raise ValueError(
+                f"invalid option '{bindir}', choose from: {opt_avail}"
+            )
+        if not quiet:
+            print(f"auto-selecting option {sel[0]!r} for '{bindir}'")
+        return Path(options[sel[0]][0]).resolve()
+    else:
+        if not is_cli:
+            opt_avail = ", ".join(
+                f"'{opt}' for '{optpath}'"
+                for opt, (optpath, _) in options.items()
+            )
+            raise ValueError(f"specify the option, choose from: {opt_avail}")
+
+        ioptions = dict(enumerate(options.keys(), 1))
+        print("select a number to extract executables to a directory:")
+        for iopt, opt in ioptions.items():
+            optpath, optinfo = options[opt]
+            print(f" {iopt}: '{optpath}' -- {optinfo} ('{opt}')")
+        num_tries = 0
+        while True:
+            num_tries += 1
+            res = input("> ")
+            try:
+                opt = ioptions[int(res)]
+                print(f"selecting option {opt!r}")
+                return Path(options[opt][0]).resolve()
+            except (KeyError, ValueError):
+                if num_tries < 2:
+                    print("invalid option, try choosing option again")
+                else:
+                    raise RuntimeError(
+                        "invalid option, too many attempts"
+                    ) from None
 
 
 def run_main(
@@ -159,14 +331,10 @@ def run_main(
     if within_flopy:
         meta_list = []
         # Store metadata and possibly 'bin' in a user-writable path
-        if sys.platform.startswith("win"):
-            flopy_appdata = Path(os.path.expandvars(r"%LOCALAPPDATA%\flopy"))
-        else:
-            flopy_appdata = Path.home() / ".local" / "share" / "flopy"
-        if not flopy_appdata.exists():
-            flopy_appdata.mkdir(parents=True, exist_ok=True)
-        flopy_bin = flopy_appdata / "bin"
-        meta_path = flopy_appdata / "get_modflow.json"
+        if not flopy_appdata_path.exists():
+            flopy_appdata_path.mkdir(parents=True, exist_ok=True)
+        flopy_bin = flopy_appdata_path / "bin"
+        meta_path = flopy_appdata_path / "get_modflow.json"
         meta_path_exists = meta_path.exists()
         if meta_path_exists:
             del_meta_path = False
@@ -194,155 +362,37 @@ def run_main(
     if ostag is None:
         ostag = get_ostag()
 
-    exe_suffix = ""
-    if ostag in ["win32", "win64"]:
-        exe_suffix = ".exe"
-        lib_suffix = ".dll"
-    elif ostag == "linux":
-        lib_suffix = ".so"
-    elif ostag == "mac":
-        lib_suffix = ".dylib"
-    else:
-        raise KeyError(
-            f"unrecognized ostag {ostag!r}; choose one of {available_ostags}"
-        )
+    exe_suffix, lib_suffix = get_suffixes(ostag)
 
-    if isinstance(bindir, Path):
-        pass
-    elif bindir.startswith(":"):
-        options = {}  # key is an option name, value is (optpath, optinfo)
-        if prev_bindir is not None and os.access(prev_bindir, os.W_OK):
-            # Make previous bindir as the first option
-            options[":prev"] = (prev_bindir, "previously selected bindir")
-        if within_flopy:  # don't check is_dir() or access yet
-            options[":flopy"] = (flopy_bin, "used by FloPy")
-        # Python bin (same for standard or conda varieties)
-        py_bin = Path(sys.prefix) / (
-            "Scripts" if ostag.startswith("win") else "bin"
+    # select bindir if path not provided
+    if bindir.startswith(":"):
+        bindir = select_bindir(
+            bindir, previous=prev_bindir, quiet=quiet, is_cli=_is_cli
         )
-        if py_bin.is_dir() and os.access(py_bin, os.W_OK):
-            options[":python"] = (py_bin, "used by Python")
-        home_local_bin = Path.home() / ".local" / "bin"
-        if home_local_bin.is_dir() and os.access(home_local_bin, os.W_OK):
-            options[":home"] = (home_local_bin, "user-specific bindir")
-        local_bin = Path("/usr") / "local" / "bin"
-        if local_bin.is_dir() and os.access(local_bin, os.W_OK):
-            options[":system"] = (local_bin, "system local bindir")
-        # Windows user
-        windowsapps_dir = Path(
-            os.path.expandvars(r"%LOCALAPPDATA%\Microsoft\WindowsApps")
-        )
-        if windowsapps_dir.is_dir() and os.access(windowsapps_dir, os.W_OK):
-            options[":windowsapps"] = (windowsapps_dir, "User App path")
-            options.append(windowsapps_dir)
-        # any other possible OS-specific hard-coded locations?
-        if not options:
-            raise RuntimeError("could not find any installable folders")
-        opt_avail = ", ".join(
-            f"'{opt}' for '{optpath}'" for opt, (optpath, _) in options.items()
-        )
-        if len(bindir) > 1:  # auto-select mode
-            # match one option that starts with input, e.g. :Py -> :python
-            sel = list(
-                opt for opt in options if opt.startswith(bindir.lower())
-            )
-            if len(sel) != 1:
-                if bindir == ":flopy":
-                    raise ValueError("option ':flopy' is only for flopy")
-                raise ValueError(f"invalid option, choose from: {opt_avail}")
-            bindir = options[sel[0]][0]
-            if not quiet:
-                print(f"auto-selecting option {sel[0]!r} for '{bindir}'")
-        elif not _is_cli:
-            raise ValueError(f"specify the option, choose from: {opt_avail}")
-        else:
-            ioptions = dict(enumerate(options.keys(), 1))
-            print("select a number to extract executables to a directory:")
-            for iopt, opt in ioptions.items():
-                optpath, optinfo = options[opt]
-                print(f" {iopt}: '{optpath}' -- {optinfo} ('{opt}')")
-            num_tries = 0
-            while True:
-                num_tries += 1
-                res = input("> ")
-                try:
-                    opt = ioptions[int(res)]
-                    print(f"selecting option {opt!r}")
-                    bindir = options[opt][0]
-                    break
-                except (KeyError, ValueError):
-                    if num_tries < 2:
-                        print("invalid option, try choosing option again")
-                    else:
-                        raise RuntimeError(
-                            "invalid option, too many attempts"
-                        ) from None
-
+    elif not isinstance(bindir, (str, Path)):
+        raise ValueError(f"Invalid bindir option (expected string or Path)")
     bindir = Path(bindir).resolve()
-    if bindir == flopy_bin and not flopy_bin.exists():
-        # special case option that can create non-existing directory
-        flopy_bin.mkdir(parents=True, exist_ok=True)
+
+    # make sure bindir exists
+    if bindir == flopy_bin:
+        if not within_flopy:
+            raise ValueError("option ':flopy' is only for flopy")
+        elif not flopy_bin.exists():
+            # special case option that can create non-existing directory
+            flopy_bin.mkdir(parents=True, exist_ok=True)
     if not bindir.is_dir():
         raise OSError(f"extraction directory '{bindir}' does not exist")
     elif not os.access(bindir, os.W_OK):
         raise OSError(f"extraction directory '{bindir}' is not writable")
 
+    # make sure repo option is valid
     if repo not in available_repos:
         raise KeyError(
             f"repo {repo!r} not supported; choose one of {available_repos}"
         )
-    api_url = f"https://api.github.com/repos/{owner}/{repo}"
 
-    if release_id == "latest":
-        req_url = f"{api_url}/releases/latest"
-    else:
-        req_url = f"{api_url}/releases/tags/{release_id}"
-    request = get_request(req_url)
-    avail_releases = None
-    num_tries = 0
-    while True:
-        num_tries += 1
-        try:
-            with urllib.request.urlopen(request, timeout=10) as resp:
-                result = resp.read()
-                remaining = int(resp.headers["x-ratelimit-remaining"])
-                if remaining <= 10:
-                    print(
-                        f"Only {remaining} GitHub API requests remaining "
-                        "before rate-limiting"
-                    )
-                break
-        except urllib.error.HTTPError as err:
-            if err.code == 401 and os.environ.get("GITHUB_TOKEN"):
-                raise ValueError("GITHUB_TOKEN env is invalid") from err
-            elif err.code == 403 and "rate limit exceeded" in err.reason:
-                raise ValueError(
-                    f"use GITHUB_TOKEN env to bypass rate limit ({err})"
-                ) from err
-            elif err.code == 404:
-                if avail_releases is None:
-                    avail_releases = get_avail_releases(api_url)
-                if release_id in avail_releases:
-                    if num_tries < max_http_tries:
-                        # GitHub sometimes returns 404 for valid URLs, so retry
-                        print(f"URL request {num_tries} did not work ({err})")
-                        continue
-                else:
-                    raise ValueError(
-                        f"Release {release_id!r} not found -- "
-                        f"choose from {avail_releases}"
-                    ) from err
-            elif err.code == 503 and num_tries < max_http_tries:
-                # GitHub sometimes returns this error for valid URLs, so retry
-                print(f"URL request {num_tries} did not work ({err})")
-                continue
-            raise RuntimeError(f"cannot retrieve data from {req_url}") from err
-
-    release = json.loads(result.decode())
-    tag_name = release["tag_name"]
-    if not quiet:
-        print(f"fetched release {tag_name!r} from {owner}/{repo}")
-
+    # get the selected release
+    release = get_release(repo, release_id, quiet)
     assets = release.get("assets", [])
 
     # Windows 64-bit asset in modflow6 repo release has no OS tag
@@ -354,7 +404,7 @@ def run_main(
                 break
         else:
             raise ValueError(
-                f"could not find ostag {ostag!r} from release {tag_name!r}; "
+                f"could not find ostag {ostag!r} from release {release['tag_name']!r}; "
                 f"see available assets here:\n{release['html_url']}"
             )
     asset_name = asset["name"]
@@ -363,10 +413,12 @@ def run_main(
         asset_pth = Path(asset_name)
         asset_stem = asset_pth.stem
         asset_suffix = asset_pth.suffix
-        dst_fname = "-".join([repo, tag_name, ostag]) + asset_suffix
+        dst_fname = "-".join([repo, release["tag_name"], ostag]) + asset_suffix
     else:
         # change local download name so it is more unique
-        dst_fname = "-".join([renamed_prefix[repo], tag_name, asset_name])
+        dst_fname = "-".join(
+            [renamed_prefix[repo], release["tag_name"], asset_name]
+        )
     tmpdir = None
     if downloads_dir is None:
         downloads_dir = Path.home() / "Downloads"
@@ -413,7 +465,7 @@ def run_main(
             "bindir": str(bindir),
             "owner": owner,
             "repo": repo,
-            "release_id": tag_name,
+            "release_id": release["tag_name"],
             "name": asset_name,
             "updated_at": asset["updated_at"],
             "extracted_at": datetime.now().isoformat(),
@@ -558,8 +610,8 @@ def run_main(
             print("skipping writing flopy metadata for pytest")
             return
         meta_list.append(meta)
-        if not flopy_appdata.exists():
-            flopy_appdata.mkdir(parents=True, exist_ok=True)
+        if not flopy_appdata_path.exists():
+            flopy_appdata_path.mkdir(parents=True, exist_ok=True)
         try:
             meta_path.write_text(json.dumps(meta_list, indent=4) + "\n")
         except OSError as err:
@@ -623,7 +675,7 @@ Examples:
     else:
         bindir_help += (
             "Option ':python' is Python's bin directory. "
-            "Option ':local' is '$HOME/.local/bin'. "
+            "Option ':home' is '$HOME/.local/bin'. "
             "Option ':system' is '/usr/local/bin'."
         )
     parser.add_argument("bindir", help=bindir_help)


### PR DESCRIPTION
A few minor fixes for `get-modflow` following up on https://github.com/modflowpy/flopy/pull/1573

- `:local` -> `:home` for `~/.local/bin` bindir option
- remove test asserts checking for downloaded zip file
- make sure user-local bindir exists before tests run
- remove stale `append` invocations on a `dict`

Also a bit of refactoring:

- update `get_releases` function signature to accept `repo` instead of full API URL
- factor out `get_release` function (planning to use this from  `modflow6` test framework)
- factor out function to (auto-)select `bindir` if a `:`-prefixed option is used
- use parametrization to combine previously separate test functions
- add tests for refactored functions

Finally, miscellaneous:

- fix test case missed in https://github.com/modflowpy/flopy/pull/1586