### PR TITLE
fix(csvfile): default csvfile to retain all characters in column names

### DIFF
--- a/flopy/utils/observationfile.py
+++ b/flopy/utils/observationfile.py
@@ -505,7 +505,9 @@ class CsvFile:
 
     """
 
-    def __init__(self, csvfile, delimiter=",", deletechars="", replace_space=""):
+    def __init__(
+        self, csvfile, delimiter=",", deletechars="", replace_space=""
+    ):
 
         self.file = open(csvfile, "r")
         self.delimiter = delimiter
@@ -518,7 +520,9 @@ class CsvFile:
         self.floattype = "f8"
         self.dtype = _build_dtype(self._header, self.floattype)
 
-        self.data = self.read_csv(self.file, self.dtype, delimiter, replace_space)
+        self.data = self.read_csv(
+            self.file, self.dtype, delimiter, replace_space
+        )
 
     @property
     def obsnames(self):
@@ -570,7 +574,7 @@ class CsvFile:
             dtype=dtype,
             delimiter=delimiter,
             deletechars=deletechars,
-            replace_space=replace_space
+            replace_space=replace_space,
         )
         if len(arr.shape) == 0:
             arr = arr.reshape((1,))

--- a/flopy/utils/observationfile.py
+++ b/flopy/utils/observationfile.py
@@ -496,13 +496,21 @@ class CsvFile:
     delimiter : str
         optional delimiter for the csv or formatted text file,
         defaults to ","
+    deletechars : str
+        optional string containing characters that should be deleted
+        from the column names, defaults to ""
+    replace_space : str
+        optional string containing the character that will be used to replace
+        the space with in any column names, defaults to ""
 
     """
 
-    def __init__(self, csvfile, delimiter=","):
+    def __init__(self, csvfile, delimiter=",", deletechars="", replace_space=""):
 
         self.file = open(csvfile, "r")
         self.delimiter = delimiter
+        self.deletechars = deletechars
+        self.replace_space = replace_space
 
         # read header line
         line = self.file.readline()
@@ -510,7 +518,7 @@ class CsvFile:
         self.floattype = "f8"
         self.dtype = _build_dtype(self._header, self.floattype)
 
-        self.data = self.read_csv(self.file, self.dtype, delimiter)
+        self.data = self.read_csv(self.file, self.dtype, delimiter, replace_space)
 
     @property
     def obsnames(self):
@@ -535,7 +543,7 @@ class CsvFile:
         return len(self.obsnames)
 
     @staticmethod
-    def read_csv(fobj, dtype, delimiter=","):
+    def read_csv(fobj, dtype, delimiter=",", deletechars="", replace_space=""):
         """
 
         Parameters
@@ -546,12 +554,24 @@ class CsvFile:
         delimiter : str
             optional delimiter for the csv or formatted text file,
             defaults to ","
+        deletechars : str
+            optional string containing characters that should be deleted
+            from the column names, defaults to ""
+        replace_space : str
+            optional string containing the character that will be used to replace
+            the space with in any column names, defaults to ""
 
         Returns
         -------
         np.recarray
         """
-        arr = np.genfromtxt(fobj, dtype=dtype, delimiter=delimiter)
+        arr = np.genfromtxt(
+            fobj,
+            dtype=dtype,
+            delimiter=delimiter,
+            deletechars=deletechars,
+            replace_space=replace_space
+        )
         if len(arr.shape) == 0:
             arr = arr.reshape((1,))
         return arr.view(np.recarray)


### PR DESCRIPTION
* The CsvFile load routine used default np.genfromtxt arguments, including those that would remove spaces, dashes, parentheses and others.  This caused problems if these characters were used in obs names, for example.  This PR changes default behavior so that these characters are not removed.