### PR TITLE
fix(csvfile): correction to read_csv args, close file handle

### DIFF
--- a/autotest/test_mf6.py
+++ b/autotest/test_mf6.py
@@ -945,6 +945,7 @@ def test_output(tmpdir, example_data_path):
 
     bud = ml.oc.output.budget()
     budcsv = ml.oc.output.budgetcsv()
+    assert budcsv.file.closed
     hds = ml.oc.output.head()
     lst = ml.oc.output.list()
 

--- a/flopy/utils/observationfile.py
+++ b/flopy/utils/observationfile.py
@@ -509,20 +509,20 @@ class CsvFile:
         self, csvfile, delimiter=",", deletechars="", replace_space=""
     ):
 
-        self.file = open(csvfile, "r")
-        self.delimiter = delimiter
-        self.deletechars = deletechars
-        self.replace_space = replace_space
+        with open(csvfile, "r") as self.file:
+            self.delimiter = delimiter
+            self.deletechars = deletechars
+            self.replace_space = replace_space
 
-        # read header line
-        line = self.file.readline()
-        self._header = line.rstrip().split(delimiter)
-        self.floattype = "f8"
-        self.dtype = _build_dtype(self._header, self.floattype)
+            # read header line
+            line = self.file.readline()
+            self._header = line.rstrip().split(delimiter)
+            self.floattype = "f8"
+            self.dtype = _build_dtype(self._header, self.floattype)
 
-        self.data = self.read_csv(
-            self.file, self.dtype, delimiter, replace_space
-        )
+            self.data = self.read_csv(
+                self.file, self.dtype, delimiter, deletechars, replace_space
+            )
 
     @property
     def obsnames(self):


### PR DESCRIPTION
This fixes an argument mix-up with CsvFile (from #1587), where `deletechars` was passed as `replace_space`, and `replace_space` was never passed to `np.genfromtxt`.

Also, use a context manager to open/read/close file, as it does not need to be open any longer.