### PR TITLE
refactor(get_lrc, get_node): use numpy methods, add examples

### DIFF
--- a/autotest/test_gridintersect.py
+++ b/autotest/test_gridintersect.py
@@ -1195,10 +1195,7 @@ def test_rasters(example_data_path):
     ws = str(example_data_path / "options")
     raster_name = "dem.img"
 
-    try:
-        rio = Raster.load(os.path.join(ws, "dem", raster_name))
-    except:
-        return
+    rio = Raster.load(os.path.join(ws, "dem", raster_name))
 
     ml = Modflow.load(
         "sagehen.nam", version="mfnwt", model_ws=os.path.join(ws, "sagehen")
@@ -1254,14 +1251,12 @@ def test_rasters(example_data_path):
 # %% test raster sampling methods
 
 @pytest.mark.slow
+@requires_pkg("rasterstats")
 def test_raster_sampling_methods(example_data_path):
     ws = str(example_data_path / "options")
     raster_name = "dem.img"
 
-    try:
-        rio = Raster.load(os.path.join(ws, "dem", raster_name))
-    except:
-        return
+    rio = Raster.load(os.path.join(ws, "dem", raster_name))
 
     ml = Modflow.load(
         "sagehen.nam", version="mfnwt", model_ws=os.path.join(ws, "sagehen")


### PR DESCRIPTION
This PR replaces internal processing of `get_lrc` and `get_node` to use NumPy's [`unravel_index`](https://numpy.org/doc/stable/reference/generated/numpy.unravel_index.html) and [`ravel_multi_index`](https://numpy.org/doc/stable/reference/generated/numpy.ravel_multi_index.html). There is a minor speed bump, and the methods also check the bounds of the inputs, raising ValueError if they are outside the L/R/C/node range.

Also add docstring examples and minor formatting to adhere to the [numpydoc style guide](https://numpydoc.readthedocs.io/en/latest/format.html).