### PR TITLE
refactor(docs/examples): correction to authors, use Path.cwd()

### DIFF
--- a/.docs/conf.py
+++ b/.docs/conf.py
@@ -13,6 +13,8 @@
 import os
 import sys
 
+import yaml
+
 # add flopy root directory to the python path
 sys.path.insert(0, os.path.abspath(".."))
 from flopy import __author__, __version__
@@ -29,6 +31,10 @@ for line in lines:
         if "release candidate" in line:
             rc_text = "release candidate"
         break
+
+# -- get authors
+with open("../CITATION.cff") as f:
+    citation = yaml.safe_load(f.read())
 
 # -- update version number in main.rst
 rst_name = "main.rst"
@@ -62,9 +68,10 @@ with open(rst_name, "w") as f:
                 "post-processing.  Members of the team\n"
                 "currently include:\n\n"
             )
-            authors = __author__.split(sep=",")
-            for author in authors:
-                line += f" * {author.strip()}\n"
+            parts = ["given-names", "name-particle", "family-names", "name"]
+            for author in citation["authors"]:
+                name = " ".join([author[pt] for pt in parts if pt in author])
+                line += f" * {name}\n"
             line += " * and others\n\n"
             f.write(line)
         elif line.startswith(tag_end):
@@ -90,14 +97,14 @@ if not on_rtd:
     os.system(" ".join(cmd))
 
 # -- Project information -----------------------------------------------------
-project = "flopy Documentation"
-copyright = f"2021, {__author__}"
+project = "FloPy Documentation"
+copyright = f"2022, {__author__}"
 author = __author__
 
 # The version.
 version = __version__
 release = __version__
-language = None
+language = "en"
 
 # -- General configuration ---------------------------------------------------
 

--- a/examples/Notebooks/flopy3_mfusg_freyberg.ipynb
+++ b/examples/Notebooks/flopy3_mfusg_freyberg.ipynb
@@ -34,11 +34,10 @@
    "outputs": [],
    "source": [
     "from pathlib import Path\n",
-    "import os\n",
     "import flopy\n",
     "\n",
     "root_name = \"freyberg.usg\"\n",
-    "model_ws = Path(os.getcwd()).parent / \"data\" / root_name.replace('.', '_')"
+    "model_ws = Path.cwd().parent / \"data\" / root_name.replace('.', '_')"
    ]
   },
   {

--- a/examples/Notebooks/flopy3_modpath6_example.ipynb
+++ b/examples/Notebooks/flopy3_modpath6_example.ipynb
@@ -86,7 +86,7 @@
     "temp_dir = TemporaryDirectory()\n",
     "model_ws = temp_dir.name\n",
     "\n",
-    "model_path = Path(os.getcwd()).parent / \"data\" / \"mp6\"\n",
+    "model_path = Path.cwd().parent / \"data\" / \"mp6\"\n",
     "mffiles = list(model_path.glob(\"EXAMPLE.*\"))\n",
     "\n",
     "m = flopy.modflow.Modflow.load(\"EXAMPLE.nam\", model_ws=model_path)\n",

--- a/examples/Tutorials/modflow6output/tutorial01_mf6_output.py
+++ b/examples/Tutorials/modflow6output/tutorial01_mf6_output.py
@@ -46,7 +46,7 @@ def get_project_root_path(path=None):
         The path to the project root
     """
 
-    cwd = Path(path) if path is not None else Path(os.getcwd())
+    cwd = Path(path) if path is not None else Path.cwd()
     if cwd.name == "autotest":
         # we're in top-level autotest folder
         return cwd.parent
@@ -62,7 +62,7 @@ def get_project_root_path(path=None):
         # we're somewhere inside examples folder
         parts = cwd.parts[0 : cwd.parts.index("examples")]
         return Path(*parts)
-    elif cwd.parts.count("flopy") >= 2:
+    elif cwd.parts.count("flopy") >= 1:
         # we're somewhere inside the project or flopy module
         tries = [1]
         if "CI" in os.environ:

--- a/examples/common/notebook_utils.py
+++ b/examples/common/notebook_utils.py
@@ -1,20 +1,18 @@
 import os
 import sys
+from pathlib import Path
 
 import numpy as np
 
 try:
     import flopy
-except:
+except ImportError:
     fpth = os.path.abspath(os.path.join("..", "..", ".."))
     sys.path.append(fpth)
     import flopy
 
-from pathlib import Path
-
-
 def get_project_root_path() -> Path:
-    return Path(os.getcwd()).parent.parent
+    return Path.cwd().parent.parent
 
 
 def run(ws):

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,10 +84,14 @@ optional =
 doc =
     %(optional)s
     ipython[kernel]
+    jupytext
     nbsphinx
     nbsphinx-link
     pydata-sphinx-theme
-    rtds_action
+    PyYAML
+    recommonmark
+    rtds-action
+    sphinx-rtd-theme
 
 [options.package_data]
 flopy.mf6.data = dfn/*.dfn


### PR DESCRIPTION
This PR does several things related to docs/examples:

- Online docs needed updating to use authors from CITATION.cff instead of `__authors__` metadata
- Update dependencies for `doc` extras (i.e. `pip install -e .[doc]`) to make a complete build
- Fix-up an issue with `get_project_root_path` only in `examples/Tutorials/modflow6output/tutorial01_mf6_output.py`
- Use [`Path.cwd()`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.cwd) instead of `Path(os.getcwd())`
- Sphinx now considers `language = None` to be invalid, so specify "en"
- Update copyright year for docs