### PR TITLE
ci: misc

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,53 +11,57 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
         python-version: [ 3.7, 3.8, 3.9, "3.10" ]
         exclude:
           # avoid shutil.copytree infinite recursion bug
           # https://github.com/python/cpython/pull/17098
           - python-version: '3.8.0'
-        include:
-          - os: ubuntu-latest
-            path: ~/.cache/pip
-          - os: macos-latest
-            path: ~/Library/Caches/pip
     defaults:
       run:
-        shell: bash
+        shell: bash -l {0}
     timeout-minutes: 90
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2.3.4
-
-      - name: Cache Python
-        uses: actions/cache@v3
-        with:
-          path: ${{ matrix.path }}
-          key: ${{ matrix.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('setup.cfg') }}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.python-version }}-pip-
+        uses: actions/checkout@v3
 
       - name: Setup Python
+        if: runner.os != 'Windows'
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Get branch name
-        uses: nelonoel/branch-name@v1.0.1
+          cache: 'pip'
+          cache-dependency-path: setup.cfg
 
       - name: Install Python dependencies
+        if: runner.os != 'Windows'
         run: |
           python -m pip install --upgrade pip
-          pip install .
-          pip install ".[test, optional]"
+          pip3 install .
+          pip3 install ".[test, optional]"
+
+      - name: Setup Micromamba
+        if: runner.os == 'Windows'
+        uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: etc/environment.yml
+          extra-specs: |
+            python=${{ matrix.python-version }}
+          channels: conda-forge
+          cache-downloads: true
+          cache-env: true
+
+      - name: Install extra Python dependencies
+        if: runner.os == 'Windows'
+        run: |
+          python -m pip install --upgrade pip
+          pip3 install https://github.com/modflowpy/pymake/zipball/master
+          pip3 install xmipy
+          pip3 install .
 
       - name: Install Modflow executables
         uses: modflowpy/install-modflow-action@v1
-        with:
-          path: ~/.local/bin
-          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run benchmarks
         working-directory: ./autotest
@@ -82,87 +86,9 @@ jobs:
           path: |
             ./autotest/.benchmarks/**/*.json
 
-  benchmark_windows:
-    name: Benchmarks (Windows)
-    runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [ 3.7, 3.8, 3.9, "3.10" ]
-        exclude:
-          # avoid shutil.copytree infinite recursion bug
-          # https://github.com/python/cpython/pull/17098
-          - python-version: '3.8.0'
-    defaults:
-      run:
-        shell: pwsh
-    timeout-minutes: 90
-
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2.3.4
-
-      - name: Get branch name
-        uses: nelonoel/branch-name@v1.0.1
-
-      - name: Cache Miniconda
-        uses: actions/cache@v3
-        with:
-          path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.run-type }}-${{ hashFiles('etc/environment.yml') }}
-
-      # Standard python fails on windows without GDAL installation
-      # Using custom bash shell ("shell: bash -l {0}") with Miniconda
-      - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2.1.1
-        with:
-          python-version: ${{ matrix.python-version }}
-          channels: conda-forge
-          auto-update-conda: true
-          activate-environment: flopy
-          use-only-tar-bz2: true
-
-      - name: Install Python dependencies
-        run: |
-          conda env update --name flopy --file etc/environment.yml
-          python -m pip install --upgrade pip
-          pip install https://github.com/modflowpy/pymake/zipball/master
-          pip install xmipy
-          pip install .
-
-      - name: Install Modflow executables
-        uses: modflowpy/install-modflow-action@v1
-        with:
-          path: C:\Users\runneradmin\.local\bin
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Run benchmarks
-        working-directory: ./autotest
-        run: |
-          md -Force .benchmarks
-          pytest -v --durations=0 --benchmark-only --benchmark-json .benchmarks/${{ runner.os }}_python${{ matrix.python-version }}.json --keep-failed=.failed
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload failed benchmark artifact
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: failed-benchmark-${{ runner.os }}-${{ matrix.python-version }}-${{ github.run_id }}
-          path: |
-            ./autotest/.failed/**
-
-      - name: Upload benchmark result artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: benchmarks-${{ runner.os }}-${{ matrix.python-version }}-${{ github.run_id }}
-          path: |
-            ./autotest/.benchmarks/**/*.json
-
   post_benchmark:
     needs:
       - benchmark
-      - benchmark_windows
     name: Process benchmark results
     runs-on: ubuntu-latest
     defaults:
@@ -172,20 +98,14 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2.3.4
-
-      - name: Cache Python
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-3.7-pip-${{ hashFiles('setup.cfg') }}
-          restore-keys: |
-            ${{ runner.os }}-3.7-pip-
+        uses: actions/checkout@v3
 
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: 3.7
+          cache: 'pip'
+          cache-dependency-path: setup.cfg
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -20,20 +20,14 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2.3.4
-
-      - name: Cache Python
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-3.7-pip-${{ hashFiles('setup.cfg') }}
-          restore-keys: |
-            ${{ runner.os }}-3.7-pip-
+        uses: actions/checkout@v3
 
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: 3.7
+          cache: 'pip'
+          cache-dependency-path: setup.cfg
 
       - name: Install Python dependencies
         run: |
@@ -59,20 +53,14 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2.3.4
-
-      - name: Cache Python
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-3.7-pip-${{ hashFiles('setup.cfg') }}
-          restore-keys: |
-            ${{ runner.os }}-3.7-pip-
+        uses: actions/checkout@v3
 
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: 3.7
+          cache: 'pip'
+          cache-dependency-path: setup.cfg
 
       - name: Install Python dependencies
         run: |
@@ -121,23 +109,14 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2.3.4
-
-      - name: Cache Python
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-3.7-pip-${{ hashFiles('setup.cfg') }}
-          restore-keys: |
-            ${{ runner.os }}-3.7-pip-
+        uses: actions/checkout@v3
 
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: 3.7
-
-      - name: Get branch name
-        uses: nelonoel/branch-name@v1.0.1
+          cache: 'pip'
+          cache-dependency-path: setup.cfg
 
       - name: Install Python dependencies
         run: |
@@ -147,9 +126,6 @@ jobs:
 
       - name: Install Modflow executables
         uses: modflowpy/install-modflow-action@v1
-        with:
-          path: ~/.local/bin
-          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run smoke tests
         working-directory: ./autotest
@@ -173,49 +149,57 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
         python-version: [ 3.7, 3.8, 3.9, "3.10" ]
         exclude:
           # avoid shutil.copytree infinite recursion bug
           # https://github.com/python/cpython/pull/17098
           - python-version: '3.8.0'
-        include:
-          - os: ubuntu-latest
-            path: ~/.cache/pip
-          - os: macos-latest
-            path: ~/Library/Caches/pip
+    defaults:
+      run:
+        shell: bash -l {0}
     timeout-minutes: 45
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2.3.4
 
-      - name: Cache Python
-        uses: actions/cache@v3
-        with:
-          path: ${{ matrix.path }}
-          key: ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('setup.cfg') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.python-version }}-pip-
+      - name: Checkout repo
+        uses: actions/checkout@v3
 
       - name: Setup Python
+        if: runner.os != 'Windows'
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Get branch name
-        uses: nelonoel/branch-name@v1.0.1
+          cache: 'pip'
+          cache-dependency-path: setup.cfg
 
       - name: Install Python dependencies
+        if: runner.os != 'Windows'
         run: |
           python -m pip install --upgrade pip
-          pip install .
-          pip install ".[test, optional]"
+          pip3 install .
+          pip3 install ".[test, optional]"
+
+      - name: Setup Micromamba
+        if: runner.os == 'Windows'
+        uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: etc/environment.yml
+          extra-specs: |
+            python=${{ matrix.python-version }}
+          channels: conda-forge
+          cache-downloads: true
+          cache-env: true
+
+      - name: Install Python dependencies
+        if: runner.os == 'Windows'
+        run: |
+          python -m pip install --upgrade pip
+          pip3 install https://github.com/modflowpy/pymake/zipball/master
+          pip3 install xmipy
+          pip3 install .
 
       - name: Install Modflow executables
         uses: modflowpy/install-modflow-action@v1
-        with:
-          path: ~/.local/bin
-          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tests
         working-directory: ./autotest
@@ -233,89 +217,6 @@ jobs:
             ./autotest/.failed/**
 
       - name: Print coverage
-        working-directory: ./autotest
-        run: |
-          coverage report
-
-      - name: Upload coverage
-        if:
-          github.repository_owner == 'modflowpy' && (github.event_name == 'push' || github.event_name == 'pull_request')
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./autotest/coverage.xml
-
-  test_windows:
-    name: Test Windows
-    needs: smoke
-    runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [ 3.7, 3.8, 3.9, "3.10" ]
-        exclude:
-          # avoid shutil.copytree infinite recursion bug
-          # https://github.com/python/cpython/pull/17098
-          - python-version: '3.8.0'
-    defaults:
-      run:
-        shell: pwsh
-    timeout-minutes: 45
-
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2.3.4
-
-      - name: Get branch name
-        uses: nelonoel/branch-name@v1.0.1
-
-      - name: Cache Miniconda
-        uses: actions/cache@v3
-        with:
-          path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-${{ matrix.python-version }}-miniconda-${{ hashFiles('etc/environment.yml') }}
-
-      # Standard python fails on windows without GDAL installation
-      # Using custom bash shell ("shell: bash -l {0}") with Miniconda
-      - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2.1.1
-        with:
-          python-version: ${{ matrix.python-version }}
-          channels: conda-forge
-          auto-update-conda: true
-          activate-environment: flopy
-          use-only-tar-bz2: true
-
-      - name: Install Python dependencies
-        run: |
-          conda env update --name flopy --file etc/environment.yml
-          python -m pip install --upgrade pip
-          pip install https://github.com/modflowpy/pymake/zipball/master
-          pip install xmipy
-          pip install .
-
-      - name: Install Modflow executables
-        uses: modflowpy/install-modflow-action@v1
-        with:
-          path: C:\Users\runneradmin\.local\bin
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Run tests
-        working-directory: ./autotest
-        run: |
-          pytest -v -m "not regression and not example" -n=auto --cov=flopy --cov-report=xml --durations=0 --keep-failed=.failed
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload failed test outputs
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: failed-${{ runner.os }}-${{ matrix.python-version }}
-          path: |
-            ./autotest/.failed/**
-
-      - name: Print coverage report
         working-directory: ./autotest
         run: |
           coverage report

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -11,52 +11,56 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
         python-version: [ 3.7, 3.8, 3.9, "3.10" ]
         exclude:
           # avoid shutil.copytree infinite recursion bug
           # https://github.com/python/cpython/pull/17098
           - python-version: '3.8.0'
-        include:
-          - os: ubuntu-latest
-            path: ~/.cache/pip
-          - os: macos-latest
-            path: ~/Library/Caches/pip
     defaults:
       run:
-        shell: bash
+        shell: bash -l {0}
     timeout-minutes: 90
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2.3.4
-
-      - name: Cache Python
-        uses: actions/cache@v3
-        with:
-          path: ${{ matrix.path }}
-          key: ${{ matrix.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('setup.cfg') }}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.python-version }}-pip-
+        uses: actions/checkout@v3
 
       - name: Setup Python
+        if: runner.os != 'Windows'
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Get branch name
-        uses: nelonoel/branch-name@v1.0.1
+          cache: 'pip'
+          cache-dependency-path: setup.cfg
 
       - name: Install Python dependencies
+        if: runner.os != 'Windows'
         run: |
           python -m pip install --upgrade pip
-          pip install .
-          pip install ".[test, optional]"
+          pip3 install .
+          pip3 install ".[test, optional]"
+
+      - name: Setup Micromamba
+        if: runner.os == 'Windows'
+        uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: etc/environment.yml
+          extra-specs: |
+            python=${{ matrix.python-version }}
+          channels: conda-forge
+          cache-downloads: true
+          cache-env: true
+
+      - name: Install extra Python dependencies
+        if: runner.os == 'Windows'
+        run: |
+          python -m pip install --upgrade pip
+          pip3 install https://github.com/modflowpy/pymake/zipball/master
+          pip3 install xmipy
+          pip3 install .
 
       - name: Install Modflow executables
         uses: modflowpy/install-modflow-action@v1
-        with:
-          path: ~/.local/bin
-          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run example tests
         working-directory: ./autotest
@@ -72,71 +76,3 @@ jobs:
           name: failed-example-${{ matrix.os }}-${{ matrix.python-version }}
           path: |
             ./autotest/.failed/**
-
-  examples_windows:
-    name: Example scripts & notebooks (Windows)
-    runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [ 3.7, 3.8, 3.9, "3.10" ]
-        exclude:
-          # avoid shutil.copytree infinite recursion bug
-          # https://github.com/python/cpython/pull/17098
-          - python-version: '3.8.0'
-    defaults:
-      run:
-        shell: pwsh
-    timeout-minutes: 90
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2.3.4
-
-      - name: Get branch name
-        uses: nelonoel/branch-name@v1.0.1
-
-      - name: Cache Miniconda
-        uses: actions/cache@v3
-        with:
-          path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.run-type }}-${{ hashFiles('etc/environment.yml') }}
-
-      # Standard python fails on windows without GDAL installation
-      # Using custom bash shell ("shell: bash -l {0}") with Miniconda
-      - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2.1.1
-        with:
-          python-version: ${{ matrix.python-version }}
-          channels: conda-forge
-          auto-update-conda: true
-          activate-environment: flopy
-          use-only-tar-bz2: true
-
-      - name: Install Python dependencies
-        run: |
-          conda env update --name flopy --file etc/environment.yml
-          python -m pip install --upgrade pip
-          pip install https://github.com/modflowpy/pymake/zipball/master
-          pip install xmipy
-          pip install .
-
-      - name: Install Modflow executables
-        uses: modflowpy/install-modflow-action@v1
-        with:
-          path: C:\Users\runneradmin\.local\bin
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Run example tests
-        working-directory: ./autotest
-        run: |
-          pytest -v -n auto -m "example" --durations=0 --keep-failed=.failed
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload failed test outputs
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: failed-example-${{ runner.os }}-${{ matrix.python-version }}
-          path: |
-            ./autotest/.failed/*

--- a/.github/workflows/mf6.yml
+++ b/.github/workflows/mf6.yml
@@ -21,72 +21,66 @@ jobs:
     defaults:
       run:
         shell: bash
-
     steps:
-    # check out repo
-    - name: Checkout flopy repo
-      uses:  actions/checkout@v2.3.4
 
-    - name: Get branch name
-      uses: nelonoel/branch-name@v1.0.1
+    - name: Checkout flopy repo
+      uses: actions/checkout@v3
 
     - name: Setup Python
-      uses: actions/setup-python@v2.2.2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
+        cache: 'pip'
+        cache-dependency-path: setup.cfg
 
-    - name: Upgrade pip
+    - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-
-    - name: Install prerequisites
-      run: |
-        pip install https://github.com/modflowpy/pymake/zipball/master
-        pip install https://github.com/Deltares/xmipy/zipball/develop
-        pip install https://github.com/MODFLOW-USGS/modflowapi/zipball/develop
-
-    - name: Install flopy and dependencies
-      run: |
-        pip install .[test,optional]
+        pip3 install https://github.com/modflowpy/pymake/zipball/master
+        pip3 install https://github.com/Deltares/xmipy/zipball/develop
+        pip3 install https://github.com/MODFLOW-USGS/modflowapi/zipball/develop
+        pip3 install .[test,optional]
 
     - name: Install gfortran
       uses: modflowpy/install-gfortran-action@v1
 
-    - name: Clone MODFLOW 6 repo
-      run: |
-        git clone https://github.com/MODFLOW-USGS/modflow6.git modflow6
+    - name: Checkout MODFLOW 6
+      uses: actions/checkout@v3
+      with:
+        repository: MODFLOW-USGS/modflow6
+        path: modflow6
 
     - name: Update flopy MODFLOW 6 classes
-      working-directory: ./modflow6/autotest
+      working-directory: modflow6/autotest
       run: |
         python update_flopy.py
 
     - name: Install meson
       run: |
-        pip install meson ninja
+        pip3 install meson ninja
 
     - name: Setup modflow
-      working-directory: ./modflow6
+      working-directory: modflow6
       run: |
         meson setup builddir --buildtype=debugoptimized --prefix=$(pwd) --libdir=bin
 
     - name: Build modflow
-      working-directory: ./modflow6
+      working-directory: modflow6
       run: |
         meson compile -C builddir
 
     - name: Install modflow
-      working-directory: ./modflow6
+      working-directory: modflow6
       run: |
         meson install -C builddir
 
     - name: Get executables
-      working-directory: ./modflow6/autotest
+      working-directory: modflow6/autotest
       run: |
         pytest -v --durations=0 get_exes.py
 
     - name: Run tests
-      working-directory: ./modflow6/autotest
+      working-directory: modflow6/autotest
       run: |
         pytest -v -n auto -k "test_gw" --durations=0 --cov=flopy --cov-report=xml
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -11,52 +11,56 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
         python-version: [ 3.7, 3.8, 3.9, "3.10" ]
         exclude:
           # avoid shutil.copytree infinite recursion bug
           # https://github.com/python/cpython/pull/17098
           - python-version: '3.8.0'
-        include:
-          - os: ubuntu-latest
-            path: ~/.cache/pip
-          - os: macos-latest
-            path: ~/Library/Caches/pip
     defaults:
       run:
-        shell: bash
+        shell: bash -l {0}
     timeout-minutes: 90
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2.3.4
-
-      - name: Cache Python
-        uses: actions/cache@v3
-        with:
-          path: ${{ matrix.path }}
-          key: ${{ matrix.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('setup.cfg') }}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.python-version }}-pip-
+        uses: actions/checkout@v3
 
       - name: Setup Python
+        if: runner.os != 'Windows'
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Get branch name
-        uses: nelonoel/branch-name@v1.0.1
+          cache: 'pip'
+          cache-dependency-path: setup.cfg
 
       - name: Install Python dependencies
+        if: runner.os != 'Windows'
         run: |
           python -m pip install --upgrade pip
-          pip install .
-          pip install ".[test, optional]"
+          pip3 install .
+          pip3 install ".[test, optional]"
+
+      - name: Setup Micromamba
+        if: runner.os == 'Windows'
+        uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: etc/environment.yml
+          extra-specs: |
+            python=${{ matrix.python-version }}
+          channels: conda-forge
+          cache-downloads: true
+          cache-env: true
+
+      - name: Install extra Python dependencies
+        if: runner.os == 'Windows'
+        run: |
+          python -m pip install --upgrade pip
+          pip3 install https://github.com/modflowpy/pymake/zipball/master
+          pip3 install xmipy
+          pip3 install .
 
       - name: Install Modflow executables
         uses: modflowpy/install-modflow-action@v1
-        with:
-          path: ~/.local/bin
-          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run regression tests
         working-directory: ./autotest
@@ -70,73 +74,5 @@ jobs:
         if: failure()
         with:
           name: failed-regression-${{ matrix.os }}-${{ matrix.python-version }}
-          path: |
-            ./autotest/.failed/**
-
-  regression_windows:
-    name: Regression tests (Windows)
-    runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [ 3.7, 3.8, 3.9, "3.10" ]
-        exclude:
-          # avoid shutil.copytree infinite recursion bug
-          # https://github.com/python/cpython/pull/17098
-          - python-version: '3.8.0'
-    defaults:
-      run:
-        shell: pwsh
-    timeout-minutes: 90
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2.3.4
-
-      - name: Get branch name
-        uses: nelonoel/branch-name@v1.0.1
-
-      - name: Cache Miniconda
-        uses: actions/cache@v3
-        with:
-          path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.run-type }}-${{ hashFiles('etc/environment.yml') }}
-
-      # Standard python fails on windows without GDAL installation
-      # Using custom bash shell ("shell: bash -l {0}") with Miniconda
-      - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2.1.1
-        with:
-          python-version: ${{ matrix.python-version }}
-          channels: conda-forge
-          auto-update-conda: true
-          activate-environment: flopy
-          use-only-tar-bz2: true
-
-      - name: Install Python dependencies
-        run: |
-          conda env update --name flopy --file etc/environment.yml
-          python -m pip install --upgrade pip
-          pip install https://github.com/modflowpy/pymake/zipball/master
-          pip install xmipy
-          pip install .
-
-      - name: Install Modflow executables
-        uses: modflowpy/install-modflow-action@v1
-        with:
-          path: C:\Users\runneradmin\.local\bin
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Run regression tests
-        working-directory: ./autotest
-        run: |
-          pytest -v -n auto -m "regression" --durations=0 --keep-failed=.failed
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload failed test outputs
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: failed-regression-${{ runner.os }}-${{ matrix.python-version }}
           path: |
             ./autotest/.failed/**

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout flopy repo
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
 
       - name: Output repo information
         run: |
@@ -33,9 +33,11 @@ jobs:
           echo $GITHUB_EVENT_NAME
 
       - name: Setup Python
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
+          cache: 'pip'
+          cache-dependency-path: setup.cfg
 
       - name: Upgrade pip
         run: |
@@ -49,13 +51,8 @@ jobs:
         run: |
           pip install .[doc]
 
-      - name: Install executables and add to PATH
-        run: |
-          mkdir -p $HOME/.local/bin
-          get-modflow $HOME/.local/bin
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install MODFLOW executables
+        uses: modflowpy/install-modflow-action@v1
 
       - name: Run jupytext on tutorials
         working-directory: ./.docs

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -62,9 +62,9 @@ Alternatively, with Anaconda or Miniconda:
     conda env create -f etc/environment.yml
     conda activate flopy
 
-Note that `flopy` has a number of [optional dependencies](docs/flopy_method_dependencies.md), as well as dependencies required for linting, testing, and building documentation. All required, linting, testing and optional dependencies are included in the Conda environment in `etc/environment.yml`. Only core dependencies are included in the PyPI package &mdash; to install extra testing, linting and optional packages with pip, use
+The `flopy` package has a number of [optional dependencies](docs/flopy_method_dependencies.md), as well as extra dependencies required for linting, testing, and building documentation. Extra dependencies are listed in the `test`, `lint`, `optional`, and `doc` groups under the `options.extras_require` section in `setup.cfg`. Core, linting, testing and optional dependencies are included in the Conda environment in `etc/environment.yml`. Only core dependencies are included in the PyPI package &mdash; to install extra dependency groups with pip, use `pip install ".[<group>]"`. For instance, to install all extra dependency groups:
 
-    pip install ".[test, lint, optional]"
+    pip install ".[test, lint, optional, doc]"
 
 #### Python IDEs
 

--- a/autotest/test_get_modflow.py
+++ b/autotest/test_get_modflow.py
@@ -1,5 +1,6 @@
 """Test get-modflow utility."""
 import os
+import platform
 import sys
 from os.path import expandvars
 from pathlib import Path
@@ -138,7 +139,17 @@ def test_select_bindir(bindir, tmpdir):
     if not os.access(expected_path, os.W_OK):
         pytest.skip(f"{expected_path} is not writable")
     selected = select_bindir(f":{bindir}")
-    assert selected == expected_path
+
+    if system() != 'Darwin':
+        assert selected == expected_path
+    else:
+        # for some reason sys.prefix can return different python
+        # installs when invoked here and get_modflow.py on macOS
+        #   https://github.com/modflowpy/flopy/actions/runs/3331965840/jobs/5512345032#step:8:1835
+        #
+        # work around by just comparing the end of the bin path
+        # should be .../Python.framework/Versions/<version>/bin
+        assert selected.parts[-4:] == expected_path.parts[-4:]
 
 
 def test_script_help():


### PR DESCRIPTION
Miscellaneous CI updates:

- bump `actions/checkout` to `v3`
- use `actions/setup-python`'s built-in caching
- remove optional inputs from `modflowpy/install-modflow-action` usages
- replace `conda-incubator/setup-miniconda` with `mamba-org/provision-with-micromamba` (faster)
- mention `doc` extra dependency group in `DEVELOPER.md` (per [discussion here](https://github.com/modflowpy/flopy/pull/1602#discussion_r1004894208))
- merge previously separate Windows jobs into combined job matrix
- fix [issue in `get-modflow` tests](https://github.com/modflowpy/flopy/actions/runs/3331965840/jobs/5512345032#step:8:1835) caused by `sys.prefix` returning different Python install locations on Mac CI runners (possibly introduced with the [rolling upgrade to macOS 12](https://github.blog/changelog/2022-10-03-github-actions-jobs-running-on-macos-latest-are-now-running-on-macos-12/)?)

There were also a few recent [failures in Windows CI](https://github.com/modflowpy/flopy/actions/runs/3327365727/jobs/5502093331#step:8:33) caused by a [dependency issue](https://github.com/pytest-dev/pytest/issues/10420) in the `pytest-benchmark` plugin. It's now [been fixed](https://github.com/ionelmc/pytest-benchmark/issues/226) and [a new version published to PyPI](https://github.com/ionelmc/pytest-benchmark/issues/226#issuecomment-1291158690) and [conda forge](https://github.com/conda-forge/pytest-benchmark-feedstock), so with fresh CI caches we shouldn't see this anymore