### PR TITLE
fix(multiple): miscellanous fixes/enhancements

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,6 +1,7 @@
 name: FloPy benchmarks
 
 on:
+  push:
   schedule:
     - cron: '0 8 * * *' # run at 8 AM UTC (12 am PST)
 
@@ -19,7 +20,7 @@ jobs:
           - python-version: '3.8.0'
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash
     timeout-minutes: 90
 
     steps:
@@ -37,9 +38,9 @@ jobs:
       - name: Install Python dependencies
         if: runner.os != 'Windows'
         run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install .
-          python3 -m pip install ".[test, optional]"
+          pip install --upgrade pip
+          pip install .
+          pip install ".[test, optional]"
 
       - name: Setup Micromamba
         if: runner.os == 'Windows'
@@ -54,6 +55,7 @@ jobs:
 
       - name: Install extra Python dependencies
         if: runner.os == 'Windows'
+        shell: bash -l {0}
         run: |
           pip install --upgrade pip
           pip install https://github.com/modflowpy/pymake/zipball/master
@@ -64,6 +66,17 @@ jobs:
         uses: modflowpy/install-modflow-action@v1
 
       - name: Run benchmarks
+        if: runner.os != 'Windows'
+        working-directory: ./autotest
+        run: |
+          mkdir -p .benchmarks
+          pytest -v --durations=0 --benchmark-only --benchmark-json .benchmarks/${{ matrix.os }}_python${{ matrix.python-version }}.json --keep-failed=.failed
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run benchmarks
+        if: runner.os == 'Windows'
+        shell: bash -l {0}
         working-directory: ./autotest
         run: |
           mkdir -p .benchmarks

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,9 +37,9 @@ jobs:
       - name: Install Python dependencies
         if: runner.os != 'Windows'
         run: |
-          python -m pip install --upgrade pip
-          pip3 install .
-          pip3 install ".[test, optional]"
+          python3 -m pip install --upgrade pip
+          python3 -m pip install .
+          python3 -m pip install ".[test, optional]"
 
       - name: Setup Micromamba
         if: runner.os == 'Windows'
@@ -55,10 +55,10 @@ jobs:
       - name: Install extra Python dependencies
         if: runner.os == 'Windows'
         run: |
-          python -m pip install --upgrade pip
-          pip3 install https://github.com/modflowpy/pymake/zipball/master
-          pip3 install xmipy
-          pip3 install .
+          pip install --upgrade pip
+          pip install https://github.com/modflowpy/pymake/zipball/master
+          pip install xmipy
+          pip install .
 
       - name: Install Modflow executables
         uses: modflowpy/install-modflow-action@v1
@@ -109,7 +109,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python -m pip install --upgrade pip
+          pip install --upgrade pip
           pip install numpy pandas matplotlib seaborn
 
       - name: Download all artifacts

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -157,7 +157,7 @@ jobs:
           - python-version: '3.8.0'
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash
     timeout-minutes: 45
     steps:
 
@@ -175,9 +175,9 @@ jobs:
       - name: Install Python dependencies
         if: runner.os != 'Windows'
         run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install .
-          python3 -m pip install ".[test, optional]"
+          pip install --upgrade pip
+          pip install .
+          pip install ".[test, optional]"
 
       - name: Setup Micromamba
         if: runner.os == 'Windows'
@@ -191,6 +191,7 @@ jobs:
           cache-env: true
 
       - name: Install Python dependencies
+        shell: bash -l {0}
         if: runner.os == 'Windows'
         run: |
           pip install --upgrade pip
@@ -202,9 +203,21 @@ jobs:
         uses: modflowpy/install-modflow-action@v1
 
       - name: Run tests
+        if: runner.os != 'Windows'
         working-directory: ./autotest
         run: |
           pytest -v -m="not example and not regression" -n=auto --cov=flopy --cov-report=xml --durations=0 --keep-failed=.failed
+          coverage report
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run tests
+        if: runner.os == 'Windows'
+        shell: bash -l {0}
+        working-directory: ./autotest
+        run: |
+          pytest -v -m="not example and not regression" -n=auto --cov=flopy --cov-report=xml --durations=0 --keep-failed=.failed
+          coverage report
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -215,11 +228,6 @@ jobs:
           name: failed-${{ matrix.os }}-${{ matrix.python-version }}
           path: |
             ./autotest/.failed/**
-
-      - name: Print coverage
-        working-directory: ./autotest
-        run: |
-          coverage report
 
       - name: Upload coverage
         if:

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -4,8 +4,8 @@ on:
     branches:
       - master
       - develop
-      - 'release*'
-      - 'ci-diagnose'
+      - release*
+      - ci-diagnose*
   pull_request:
     branches:
       - master
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python -m pip install --upgrade pip
+          pip install --upgrade pip
           pip install build twine
           pip install .
           python -c "import flopy; print(f'{flopy.__version__}')"
@@ -120,7 +120,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python -m pip install --upgrade pip
+          pip install --upgrade pip
           pip install .
           pip install ".[test, optional]"
 
@@ -175,9 +175,9 @@ jobs:
       - name: Install Python dependencies
         if: runner.os != 'Windows'
         run: |
-          python -m pip install --upgrade pip
-          pip3 install .
-          pip3 install ".[test, optional]"
+          python3 -m pip install --upgrade pip
+          python3 -m pip install .
+          python3 -m pip install ".[test, optional]"
 
       - name: Setup Micromamba
         if: runner.os == 'Windows'
@@ -193,10 +193,10 @@ jobs:
       - name: Install Python dependencies
         if: runner.os == 'Windows'
         run: |
-          python -m pip install --upgrade pip
-          pip3 install https://github.com/modflowpy/pymake/zipball/master
-          pip3 install xmipy
-          pip3 install .
+          pip install --upgrade pip
+          pip install https://github.com/modflowpy/pymake/zipball/master
+          pip install xmipy
+          pip install .
 
       - name: Install Modflow executables
         uses: modflowpy/install-modflow-action@v1

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,6 +1,7 @@
 name: FloPy example script & notebook tests
 
 on:
+  push:
   schedule:
     - cron: '0 8 * * *' # run at 8 AM UTC (12 am PST)
 
@@ -19,7 +20,7 @@ jobs:
           - python-version: '3.8.0'
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash
     timeout-minutes: 90
     steps:
       - name: Checkout repo
@@ -36,9 +37,9 @@ jobs:
       - name: Install Python dependencies
         if: runner.os != 'Windows'
         run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install .
-          python3 -m pip install ".[test, optional]"
+          pip install --upgrade pip
+          pip install .
+          pip install ".[test, optional]"
 
       - name: Setup Micromamba
         if: runner.os == 'Windows'
@@ -53,6 +54,7 @@ jobs:
 
       - name: Install extra Python dependencies
         if: runner.os == 'Windows'
+        shell: bash -l {0}
         run: |
           pip install --upgrade pip
           pip install https://github.com/modflowpy/pymake/zipball/master
@@ -63,6 +65,16 @@ jobs:
         uses: modflowpy/install-modflow-action@v1
 
       - name: Run example tests
+        if: runner.os != 'Windows'
+        working-directory: ./autotest
+        run: |
+          pytest -v -m="example" -n=auto --durations=0 --keep-failed=.failed
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run example tests
+        if: runner.os == 'Windows'
+        shell: bash -l {0}
         working-directory: ./autotest
         run: |
           pytest -v -m="example" -n=auto --durations=0 --keep-failed=.failed

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -36,9 +36,9 @@ jobs:
       - name: Install Python dependencies
         if: runner.os != 'Windows'
         run: |
-          python -m pip install --upgrade pip
-          pip3 install .
-          pip3 install ".[test, optional]"
+          python3 -m pip install --upgrade pip
+          python3 -m pip install .
+          python3 -m pip install ".[test, optional]"
 
       - name: Setup Micromamba
         if: runner.os == 'Windows'
@@ -54,10 +54,10 @@ jobs:
       - name: Install extra Python dependencies
         if: runner.os == 'Windows'
         run: |
-          python -m pip install --upgrade pip
-          pip3 install https://github.com/modflowpy/pymake/zipball/master
-          pip3 install xmipy
-          pip3 install .
+          pip install --upgrade pip
+          pip install https://github.com/modflowpy/pymake/zipball/master
+          pip install xmipy
+          pip install .
 
       - name: Install Modflow executables
         uses: modflowpy/install-modflow-action@v1

--- a/.github/workflows/mf6.yml
+++ b/.github/workflows/mf6.yml
@@ -7,9 +7,12 @@ on:
     branches:
       - master
       - develop
-      - 'release*'
+      - release*
+      - ci-diagnose*
   pull_request:
-    branches: [master, develop]
+    branches:
+      - master
+      - develop
 
 jobs:
 
@@ -35,11 +38,11 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip3 install https://github.com/modflowpy/pymake/zipball/master
-        pip3 install https://github.com/Deltares/xmipy/zipball/develop
-        pip3 install https://github.com/MODFLOW-USGS/modflowapi/zipball/develop
-        pip3 install .[test,optional]
+        pip install --upgrade pip
+        pip install https://github.com/modflowpy/pymake/zipball/master
+        pip install https://github.com/Deltares/xmipy/zipball/develop
+        pip install https://github.com/MODFLOW-USGS/modflowapi/zipball/develop
+        pip install .[test,optional]
 
     - name: Install gfortran
       uses: modflowpy/install-gfortran-action@v1

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -36,9 +36,9 @@ jobs:
       - name: Install Python dependencies
         if: runner.os != 'Windows'
         run: |
-          python -m pip install --upgrade pip
-          pip3 install .
-          pip3 install ".[test, optional]"
+          python3 -m pip install --upgrade pip
+          python3 -m pip install .
+          python3 -m pip install ".[test, optional]"
 
       - name: Setup Micromamba
         if: runner.os == 'Windows'
@@ -54,10 +54,10 @@ jobs:
       - name: Install extra Python dependencies
         if: runner.os == 'Windows'
         run: |
-          python -m pip install --upgrade pip
-          pip3 install https://github.com/modflowpy/pymake/zipball/master
-          pip3 install xmipy
-          pip3 install .
+          pip install --upgrade pip
+          pip install https://github.com/modflowpy/pymake/zipball/master
+          pip install xmipy
+          pip install .
 
       - name: Install Modflow executables
         uses: modflowpy/install-modflow-action@v1

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -1,6 +1,7 @@
 name: FloPy regression tests
 
 on:
+  push:
   schedule:
     - cron: '0 8 * * *' # run at 8 AM UTC (12 am PST)
 
@@ -19,7 +20,7 @@ jobs:
           - python-version: '3.8.0'
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash
     timeout-minutes: 90
     steps:
       - name: Checkout repo
@@ -36,9 +37,9 @@ jobs:
       - name: Install Python dependencies
         if: runner.os != 'Windows'
         run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install .
-          python3 -m pip install ".[test, optional]"
+          pip install --upgrade pip
+          pip install .
+          pip install ".[test, optional]"
 
       - name: Setup Micromamba
         if: runner.os == 'Windows'
@@ -53,6 +54,7 @@ jobs:
 
       - name: Install extra Python dependencies
         if: runner.os == 'Windows'
+        shell: bash -l {0}
         run: |
           pip install --upgrade pip
           pip install https://github.com/modflowpy/pymake/zipball/master
@@ -63,6 +65,16 @@ jobs:
         uses: modflowpy/install-modflow-action@v1
 
       - name: Run regression tests
+        if: runner.os != 'Windows'
+        working-directory: ./autotest
+        run: |
+          pytest -v -m="regression" -n=auto --durations=0 --keep-failed=.failed
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run regression tests
+        if: runner.os == 'Windows'
+        shell: bash -l {0}
         working-directory: ./autotest
         run: |
           pytest -v -m="regression" -n=auto --durations=0 --keep-failed=.failed

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - master
       - develop
-      - 'release*'
-      - 'ci-pytest'
+      - release*
+      - ci-diagnose*
   pull_request:
-    branches: [master, develop]
+    branches:
+      - master
+      - develop
 
 jobs:
 
@@ -41,7 +43,7 @@ jobs:
 
       - name: Upgrade pip
         run: |
-          python -m pip install --upgrade pip
+          pip install --upgrade pip
 
       - name: Install prerequisites
         run: |

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -480,7 +480,7 @@ class BaseModel(ModelInterface):
             return self.get_package("BCF6").hdry
         if self.get_package("UPW") is not None:
             return self.get_package("UPW").hdry
-        return None
+        return -1e30
 
     @property
     def hnoflo(self):
@@ -488,7 +488,7 @@ class BaseModel(ModelInterface):
             bas6 = self.get_package("BAS6")
             return bas6.hnoflo
         except AttributeError:
-            return None
+            return 1e30
 
     @property
     def laycbd(self):

--- a/flopy/plot/crosssection.py
+++ b/flopy/plot/crosssection.py
@@ -258,7 +258,7 @@ class PlotCrossSection:
         self._polygons = {}
 
         if model is None:
-            self._masked_values = [1e30, -1e-30]
+            self._masked_values = [1e30, -1e30]
         else:
             self._masked_values = [model.hnoflo, model.hdry]
 

--- a/flopy/plot/map.py
+++ b/flopy/plot/map.py
@@ -70,7 +70,7 @@ class PlotMapView:
             self._extent = None
 
         if model is None:
-            self._masked_values = [1e30, -1e-30]
+            self._masked_values = [1e30, -1e30]
         else:
             self._masked_values = [model.hnoflo, model.hdry]
 


### PR DESCRIPTION
- update commit-triggered CI to run on any branch starting with prefix `ci-diagnose*`
- fix Python usage in cross-platform CI jobs
  - `python` isn't aliased to Python3 on Mac when `bash -l {0}` is the default shell, causing [Python2 to be used](https://github.com/modflowpy/flopy/actions/runs/3367930152/jobs/5585909218#step:4:14)
  - use `shell: bash -l {0}` only [as required for Micromamba](https://github.com/mamba-org/provision-with-micromamba#important), otherwise `shell: bash`
- fix default values for `hnoflo` and `hdry` introduced in #1610
  - correct `hdry` default from `-1e-30` to `-1e30`
  - add defaults to `BaseModel` (fix [notebook errors](https://github.com/modflowpy/flopy/actions/runs/3367943010/jobs/5585933660#step:8:412) caused by `None` passed to numpy)
  - this caused the MODFLOW 6 nightly build [to fail](https://github.com/MODFLOW-USGS/modflow6-nightly-build/actions/runs/3366732118) &mdash; maybe worth switching that repo's dependency to FloPy `master` branch or a published release so issues that get past this repo's `develop` CI don't break the nightly distribution?