### PR TITLE
feat(contours): use standard contours for StructuredGrid map view plots

### DIFF
--- a/autotest/test_export.py
+++ b/autotest/test_export.py
@@ -631,10 +631,9 @@ def test_export_contourf(tmpdir, example_data_path):
 
     with Reader(filename) as r:
         shapes = r.shapes()
-        if len(shapes) != 65:
-            raise AssertionError(
-                "multipolygons were skipped in contourf routine"
-            )
+        # expect 65 with standard mpl contours (structured grids), 86 with tricontours
+        assert len(shapes) >= 65, "multipolygons were skipped in contourf routine"
+
 
 
 @pytest.mark.mf6
@@ -662,7 +661,9 @@ def test_export_contours(tmpdir, example_data_path):
 
     with Reader(filename) as r:
         shapes = r.shapes()
-        assert len(shapes) == 65
+        # expect 65 with standard mpl contours (structured grids), 86 with tricontours
+        assert len(shapes) >= 65
+
 
 
 @pytest.mark.mf6

--- a/autotest/test_plot.py
+++ b/autotest/test_plot.py
@@ -242,7 +242,7 @@ def test_cross_section_bc_UZF_3lay(example_data_path):
         ), f"Unexpected collection type: {type(col)}"
 
 
-def test_map_view_tricontour_nan():
+def test_map_view_contour(tmpdir):
     arr = np.random.rand(10, 10) * 100
     arr[-1, :] = np.nan
     delc = np.array([10] * 10, dtype=float)
@@ -272,10 +272,12 @@ def test_map_view_tricontour_nan():
 
     pmv = PlotMapView(modelgrid=grid, layer=0)
     contours = pmv.contour_array(a=arr)
+    plt.savefig(tmpdir / "map_view_contour.png")
 
-    for ix, lev in enumerate(contours.levels):
-        if not np.allclose(lev, levels[ix]):
-            raise AssertionError("TriContour NaN catch Failed")
+    # if we ever revert from standard contours to tricontours, restore this nan check
+    # for ix, lev in enumerate(contours.levels):
+    #     if not np.allclose(lev, levels[ix]):
+    #         raise AssertionError("TriContour NaN catch Failed")
 
 
 @pytest.mark.mf6


### PR DESCRIPTION
- switch from matplotlib `tricontour` to `contour` for `StructuredGrid` map view plots
  - requested in #1605
  - moved from #1614
  - code rearranged a bit to separate the tri / contours cases