### PR TITLE
fix(ci): don't run benchmarks, examples and regression tests on push

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,7 +1,6 @@
 name: FloPy benchmarks
 
 on:
-  push:
   schedule:
     - cron: '0 8 * * *' # run at 8 AM UTC (12 am PST)
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,7 +1,6 @@
 name: FloPy example script & notebook tests
 
 on:
-  push:
   schedule:
     - cron: '0 8 * * *' # run at 8 AM UTC (12 am PST)
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -1,7 +1,6 @@
 name: FloPy regression tests
 
 on:
-  push:
   schedule:
     - cron: '0 8 * * *' # run at 8 AM UTC (12 am PST)
 


### PR DESCRIPTION
I added the `push` trigger for benchmark, example and regression workflows while testing #1614 and neglected to remove it