### PR TITLE
test: mark LGR test flaky

### DIFF
--- a/autotest/regression/test_lgr.py
+++ b/autotest/regression/test_lgr.py
@@ -2,12 +2,14 @@ import shutil
 from os.path import dirname, join
 from pathlib import Path
 
+from flaky import flaky
 import pytest
 from autotest.conftest import requires_exe, requires_pkg
 
 import flopy
 
 
+@flaky
 @requires_exe("mflgr")
 @requires_pkg("pymake")
 @pytest.mark.regression


### PR DESCRIPTION
`autotest/regression/test_lgr.py::test_simplelgr` failed on Windows CI last night, marked it `@flaky` for an automatic retry