### PR TITLE
fix(mp7-writestoptime) arbitrarily adding 1 to stoptime when writing modpath input file

### DIFF
--- a/flopy/modpath/mp7sim.py
+++ b/flopy/modpath/mp7sim.py
@@ -650,7 +650,7 @@ class Modpath7Sim(Package):
         f.write(f"{self.stoptimeoption}\n")
         if self.stoptimeoption == 3:
             # item 15
-            f.write(f"{self.stoptime + 1:g}\n")
+            f.write(f"{self.stoptime:g}\n")
 
         # item 16
         if self.simulationtype == 3 or self.simulationtype == 4:


### PR DESCRIPTION
- while writing stoptime with stoptimeoption 3, there is an arbitrary +1 to the specified stoptime value
- addresses issue  #1622