### PR TITLE
fixBug: not reading comma separated data correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,5 @@ autotest/.noseids
 .docs/_notebooks
 
 *.bak
+
+**.env

--- a/autotest/test_datautil.py
+++ b/autotest/test_datautil.py
@@ -1,3 +1,13 @@
+from flopy.utils.datautil import PyListUtil
+
+
 def test_split_data_line():
-    # TODO: try to reproduce this: https://github.com/modflowpy/flopy/runs/7581629193?check_suite_focus=true#step:11:1753
-    pass
+    # fixes: https://github.com/modflowpy/flopy/runs/7581629193?check_suite_focus=true#step:11:1753
+
+    line = "13,14,15, 16,  17,"
+    spl = PyListUtil.split_data_line(line)
+    exp = ["13", "14", "15", "16", "17"]
+    assert len(spl) == len(exp)
+    # whitespace is not removed, todo: can it be?
+    # or is it needed to support Modflow input file format?
+    assert all(any([e in s for s in spl]) for e in exp)

--- a/flopy/utils/datautil.py
+++ b/flopy/utils/datautil.py
@@ -329,6 +329,7 @@ class PyListUtil:
                 if alt_split_len > max_split_size:
                     max_split_size = len(alt_split)
                     max_split_type = delimiter
+                    max_split_list = alt_split
                 elif alt_split_len == max_split_size:
                     if (
                         max_split_type not in PyListUtil.delimiter_list


### PR DESCRIPTION
To test:
```python
from flopy.utils.datautil import PyListUtil
line = '13,14'
```
PyListUtil.split_data_line(line)