### PR TITLE
fix(get-modflow): fix code.json handling

### DIFF
--- a/autotest/test_get_modflow.py
+++ b/autotest/test_get_modflow.py
@@ -140,7 +140,7 @@ def test_select_bindir(bindir, tmpdir):
         pytest.skip(f"{expected_path} is not writable")
     selected = select_bindir(f":{bindir}")
 
-    if system() != 'Darwin':
+    if system() != "Darwin":
         assert selected == expected_path
     else:
         # for some reason sys.prefix can return different python
@@ -162,6 +162,7 @@ def test_script_help():
 
 @flaky
 @requires_github
+@pytest.mark.slow
 def test_script_options(tmpdir, downloads_dir):
     bindir = tmpdir / "bin1"
     assert not bindir.exists()
@@ -213,7 +214,7 @@ def test_script_options(tmpdir, downloads_dir):
         pytest.skip(f"GitHub {rate_limit_msg}")
     assert len(stderr) == returncode == 0
     files = [item.stem for item in bindir.iterdir() if item.is_file()]
-    assert sorted(files) == ["mfnwt", "mfnwtdbl", "mp6"]
+    assert sorted(files) == ["mfnwt", "mp6"]
 
     # similar as before, but also specify a ostag
     bindir = tmpdir / "bin3"
@@ -234,11 +235,12 @@ def test_script_options(tmpdir, downloads_dir):
         pytest.skip(f"GitHub {rate_limit_msg}")
     assert len(stderr) == returncode == 0
     files = [item.name for item in bindir.iterdir() if item.is_file()]
-    assert sorted(files) == ["mfnwt.exe", "mfnwtdbl.exe"]
+    assert sorted(files) == ["mfnwt.exe"]
 
 
 @flaky
 @requires_github
+@pytest.mark.slow
 @pytest.mark.parametrize("repo", repo_options.keys())
 def test_script(tmpdir, repo, downloads_dir):
     bindir = str(tmpdir)
@@ -260,6 +262,7 @@ def test_script(tmpdir, repo, downloads_dir):
 
 @flaky
 @requires_github
+@pytest.mark.slow
 @pytest.mark.parametrize("repo", repo_options.keys())
 def test_python_api(tmpdir, repo, downloads_dir):
     bindir = str(tmpdir)

--- a/autotest/test_get_modflow.py
+++ b/autotest/test_get_modflow.py
@@ -33,7 +33,6 @@ repo_options = {
     "executables": [
         "crt",
         "gridgen",
-        "gsflow",
         "mf2000",
         "mf2005",
         "mf2005dbl",

--- a/flopy/utils/get_modflow.py
+++ b/flopy/utils/get_modflow.py
@@ -452,6 +452,16 @@ def run_main(
             subset = set(subset.replace(",", " ").split())
         elif not isinstance(subset, set):
             subset = set(subset)
+        subset = set(
+            [
+                (
+                    f"{e}{lib_suffix}"
+                    if e.startswith("lib")
+                    else f"{e}{exe_suffix}"
+                )
+                for e in subset
+            ]
+        )
 
     # Open archive and extract files
     extract = set()

--- a/flopy/utils/get_modflow.py
+++ b/flopy/utils/get_modflow.py
@@ -179,7 +179,7 @@ def get_release(repo, tag="latest", quiet=False) -> dict:
     release = json.loads(result.decode())
     tag_name = release["tag_name"]
     if not quiet:
-        print(f"fetched release {tag_name!r} from {owner}/{repo}")
+        print(f"fetched release {tag_name!r} info from {owner}/{repo}")
 
     return release
 
@@ -444,7 +444,7 @@ def run_main(
             )
     else:
         if not quiet:
-            print(f"downloading to '{download_pth}'")
+            print(f"downloading '{download_url}' to '{download_pth}'")
         urllib.request.urlretrieve(download_url, download_pth)
 
     if subset:
@@ -485,10 +485,10 @@ def run_main(
     with zipfile.ZipFile(download_pth, "r") as zipf:
         if repo == "modflow6":
             # modflow6 release contains the whole repo with an internal bindir
-            inner_bin = asset_stem + "/bin"
             for pth in zipf.namelist():
-                if pth.startswith(inner_bin) and not pth.endswith("bin/"):
-                    full_path[Path(pth).name] = pth
+                p = Path(pth)
+                if p.parent.name == "bin":
+                    full_path[p.name] = pth
             files = set(full_path.keys())
         else:
             # assume all files to be extracted


### PR DESCRIPTION
The recent addition of `code.json` to the [`executables` repo distribution](https://github.com/MODFLOW-USGS/executables/releases/tag/9.0) seemed to trip up executable naming/suffix handling when `--subset` is provided. This PR fixes that and makes `--subset` work by exact rather than substring matching, so the user must specify e.g. `mfnwt` and `mfnwtdbl` separately to get both. ~~Also sets execute permissions on the `libmf6` shared library.~~