### PR TITLE
fix(quotes+exe_path+nam_file): fixes for quoted strings, exe path, and nam file

### DIFF
--- a/autotest/regression/test_mf6.py
+++ b/autotest/regression/test_mf6.py
@@ -1379,7 +1379,7 @@ def test005_create_tests_advgw_tidal(tmpdir, example_data_path):
 
     obs_dict = {
         ("ghb_obs.csv", "binary"): [
-            ("ghb-2-6-10", "GHB", (1, 5, 9)),
+            ("ghb- 2-6-10", "GHB", (1, 5, 9)),
             ("ghb-3-6-10", "GHB", (2, 5, 9)),
         ],
         "ghb_flows.csv": [
@@ -1743,6 +1743,7 @@ def test005_create_tests_advgw_tidal(tmpdir, example_data_path):
             # there should be only one
             assert not found_obs
             found_obs = True
+            assert value[0][0] == "ghb- 2-6-10"
     assert found_flows and found_obs
 
     # clean up

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -1702,6 +1702,9 @@ def run_model(
             # try removing .exe suffix
             exe = which(exe_name[:-4])
     if exe is None:
+        # try abspath
+        exe = which(os.path.abspath(exe_name))
+    if exe is None:
         raise Exception(
             f"The program {exe_name} does not exist or is not executable."
         )

--- a/flopy/mf6/mfmodel.py
+++ b/flopy/mf6/mfmodel.py
@@ -146,7 +146,10 @@ class MFModel(PackageContainer, ModelInterface):
             raise FlopyException(excpt_str)
 
         self.name_file = package_obj(
-            self, filename=self.model_nam_file, pname=self.name
+            self,
+            filename=self.model_nam_file,
+            pname=self.name,
+            _internal_package=True,
         )
 
     def __init_subclass__(cls):
@@ -1644,7 +1647,10 @@ class MFModel(PackageContainer, ModelInterface):
             package.package_type
         )
         if add_to_package_list and path in self._package_paths:
-            if not package_struct.multi_package_support:
+            if (
+                package_struct is not None
+                and not package_struct.multi_package_support
+            ):
                 # package of this type already exists, replace it
                 self.remove_package(package.package_type)
                 if (
@@ -1685,6 +1691,15 @@ class MFModel(PackageContainer, ModelInterface):
         self._package_paths[path] = 1
 
         if package.package_type.lower() == "nam":
+            if not package.internal_package:
+                excpt_str = (
+                    "Unable to register nam file.  Do not create your own nam "
+                    "files.  Nam files are automatically created and managed "
+                    "for you by FloPy."
+                )
+                print(excpt_str)
+                raise FlopyException(excpt_str)
+
             return path, self.structure.name_file_struct_obj
 
         package_extension = package.package_type
@@ -1853,6 +1868,7 @@ class MFModel(PackageContainer, ModelInterface):
             pname=dict_package_name,
             loading_package=True,
             parent_file=parent_package,
+            _internal_package=True,
         )
         try:
             package.load(strict)
@@ -1865,6 +1881,7 @@ class MFModel(PackageContainer, ModelInterface):
                 pname=dict_package_name,
                 loading_package=True,
                 parent_file=parent_package,
+                _internal_package=True,
             )
             package.load(strict)
 

--- a/flopy/mf6/mfpackage.py
+++ b/flopy/mf6/mfpackage.py
@@ -1594,6 +1594,10 @@ class MFPackage(PackageContainer, PackageInterface):
         else:
             self.model_or_sim = parent
             self.parent_file = None
+        if "_internal_package" in kwargs and kwargs["_internal_package"]:
+            self.internal_package = True
+        else:
+            self.internal_package = False
         self._data_list = []
         self._package_type = package_type
         if self.model_or_sim.type == "Model" and package_type.lower() != "nam":

--- a/flopy/mf6/modflow/mfsimulation.py
+++ b/flopy/mf6/modflow/mfsimulation.py
@@ -336,8 +336,7 @@ class MFSimulation(PackageContainer):
     version : str
         Version of MODFLOW 6 executable
     exe_name : str
-        Relative path to MODFLOW 6 executable from the simulation
-        working folder.
+        Path to MODFLOW 6 executable
     sim_ws : str
         Path to MODFLOW 6 simulation working folder.  This is the folder
         containing the simulation name file.
@@ -432,6 +431,7 @@ class MFSimulation(PackageContainer):
             continue_=continue_,
             nocheck=nocheck,
             memory_print_option=memory_print_option,
+            _internal_package=True,
         )
 
         # try to build directory structure
@@ -1902,6 +1902,14 @@ class MFSimulation(PackageContainer):
                 # added during ims package registration
                 self._add_package(package, path)
         if package.package_type.lower() == "nam":
+            if not package.internal_package:
+                excpt_str = (
+                    "Unable to register nam file.  Do not create your own nam "
+                    "files.  Nam files are automatically created and managed "
+                    "for you by FloPy."
+                )
+                print(excpt_str)
+                raise FlopyException(excpt_str)
             return path, self.structure.name_file_struct_obj
         elif package.package_type.lower() == "tdis":
             self._tdis_file = package

--- a/flopy/utils/datautil.py
+++ b/flopy/utils/datautil.py
@@ -358,8 +358,8 @@ class PyListUtil:
                 if item and item[0] in PyListUtil.quote_list:
                     # starts with a quote, handle quoted text
                     if item[-1] in PyListUtil.quote_list:
-                        # if quoted on both ends, keep quotes
-                        arr_fixed_line.append(item)
+                        # if quoted on both ends, remove quotes
+                        arr_fixed_line.append(item[1:-1])
                     else:
                         arr_fixed_line.append(item[1:])
                         # loop until trailing quote found


### PR DESCRIPTION
Quotes properly removed when loading files with quoted strings (#1643).  If all else fails trying to find exe_path, abs_path is used (#1633).  Proper error message given when user attempts to create namefile (#1617).