### PR TITLE
fix(ci): update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,5 @@ autotest/.noseids
 *.bak
 
 **.env
+venv
+app


### PR DESCRIPTION
In the release workflow, the [`app` directory](https://github.com/modflowpy/flopy/pull/1649/commits/fee7c58ca0bfc34f52763cf3c593547227b0bb12#diff-a172cedcae47474b615c54d510a5d84a8dea3032e958587430b413538be3f333) was leftover by the `orhun/git-cliff-action` step and was previously included in the automated version/DFN/plugin update commit via `git add -A`.

PR adds `app` to `.gitignore`. Also adds `venv` (convenient to ignore Python3 virtual environment in the project root).