### PR TITLE
ci: lint after post-release reset version update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -376,6 +376,9 @@ jobs:
           version="$major_version.$minor_version.$((patch_version + 1))"
           python scripts/update_version.py -v "$version"
           
+          # lint Python files
+          python scripts/pull_request_prepare.py
+          
           # commit and push reset branch
           git config core.sharedRepository true
           git config user.name "github-actions[bot]"

--- a/flopy/version.py
+++ b/flopy/version.py
@@ -3,4 +3,4 @@
 major = 3
 minor = 3
 micro = 7
-__version__ = '{}.{}.{}'.format(major, minor, micro)
+__version__ = "{}.{}.{}".format(major, minor, micro)


### PR DESCRIPTION
The [post-release PR to reset the `develop` branch](https://github.com/modflowpy/flopy/pull/1656) neglected to rerun the linter after resetting version files. Do so manually and update `release.yml` to do so in future