### PR TITLE
fix(flopy performance): FloPy performance modifications + best practices documented

### DIFF
--- a/examples/Tutorials/modflow6data/tutorial08_mf6_data.py
+++ b/examples/Tutorials/modflow6data/tutorial08_mf6_data.py
@@ -202,7 +202,7 @@ print(spd_record[1])
 
 spd_record[0]["filename"] = "well_package_sp1.txt"
 spd_record[0]["binary"] = True
-spd_record[1]["filename"] = "well_package_sp2.txt"
+spd_record[1]["filename"] = "well_package_sp2.bin"
 wel.stress_period_data.set_record(spd_record)
 
 # The changes can be verified by calling get_record again.
@@ -211,6 +211,65 @@ spd_record = wel.stress_period_data.get_record()
 print(f"New filename for stress period 1:  {spd_record[0]['filename']}")
 print(f"New binary flag for stress period 1:  {spd_record[0]['binary']}")
 print(f"New filename for stress period 2:  {spd_record[1]['filename']}")
+
+# ## Optimizing FloPy Performance
+#
+# By default FloPy will perform a number of verification checks on your data
+# when FloPy loads or saves that data.  For large datasets turning these
+# verification checks off can significantly improve FloPy's performance.
+# Additionally, storing files externally can help minimize the amount of data
+# FloPy reads/writes when loading and saving a simulation.  The following
+# steps will help you optimize FloPy's performance for large datasets.
+#
+# 1) Turn off FloPy verification checks and FloPy's option to automatically
+# update "maxbound" to match your data.  This can be turned off on an existing
+# simulation.
+
+sim.simulation_data.auto_set_sizes = False
+sim.simulation_data.verify_data = False
+sim.write_simulation()
+
+# These options can also be turned off when loading an existing simulation
+# from files.
+
+sim2 = flopy.mf6.MFSimulation.load(
+    sim_ws=workspace,
+    auto_set_sizes=False,
+    verify_data=False,
+)
+
+# 2) Whenever possible save large datasets to external binary files.  Binary
+# files are more compact and the data will be read and written significantly
+# faster.  See MODFLOW-6 documentation for which packages and data support
+# binary files.
+
+# store all well period data in external binary files
+spd_record[0]["binary"] = True
+spd_record[1]["binary"] = True
+wel.stress_period_data.set_record(spd_record)
+
+# 3) For datasets that do not support binary files, save them to
+# external text files.  When loading a simulation, FloPy will always parse
+# MODFLOW-6 package files, but will not parse external text files when
+# auto_set_sizes and verify data are both set to False.  Additionally, if
+# write_simulation is later called, external files will not be re-written
+# unless either the data or the file path has changed.
+
+# store lak period data in external text files
+period = {0: {"filename": "lak_sp1.txt", "data": [(0, "STAGE", 10.0)]},
+          1: {"filename": "lak_sp2.txt", "data": [(0, "STAGE", 15.0)]}}
+lakpd = [(0, -2.0, 1)]
+lakecn = [(0, 0, (0, 1, 0), "HORIZONTAL", 1.0, -5.0, 0.0, 10.0, 10.0)]
+lak = flopy.mf6.ModflowGwflak(
+    gwf,
+    pname="lak-1",
+    nlakes=1,
+    noutlets=0,
+    ntables=0,
+    packagedata=lakpd,
+    connectiondata=lakecn,
+    perioddata=period,
+)
 
 try:
     temp_dir.cleanup()

--- a/examples/Tutorials/modflow6data/tutorial08_mf6_data.py
+++ b/examples/Tutorials/modflow6data/tutorial08_mf6_data.py
@@ -12,7 +12,7 @@
 #     name: python3
 # ---
 
-# # MODFLOW 6: Data Storage Information - How and Where to Store MODFLOW-6 Data
+# # MODFLOW 6: Data Storage Information and Performance Optimization
 #
 # This tutorial shows the different options for storing MODFLOW data in FloPy.
 # Interaction with a FloPy MODFLOW 6 model is different from other models,
@@ -31,7 +31,8 @@
 # >       Simulation --> Model --> Package (--> Package) --> DATA
 #
 #
-# This tutorial focuses on the different storage options for MODFLOW data.
+# This tutorial focuses on the different storage options for MODFLOW data and
+# how to optimize data storage read/write speed.
 
 # ## Introduction to Data Storage Information
 # MODFLOW array and list data can either be stored internally or externally in
@@ -222,21 +223,27 @@ print(f"New filename for stress period 2:  {spd_record[1]['filename']}")
 # steps will help you optimize FloPy's performance for large datasets.
 #
 # 1) Turn off FloPy verification checks and FloPy's option to automatically
-# update "maxbound" to match your data.  This can be turned off on an existing
-# simulation.
+# update "maxbound".  This can be turned off on an existing
+# simulation by either individually turning off each of these settings.
 
 sim.simulation_data.auto_set_sizes = False
 sim.simulation_data.verify_data = False
 sim.write_simulation()
 
+# or by setting lazy_io to True.
+
+sim.simulation_data.lazy_io = True
+sim.write_simulation()
+
 # These options can also be turned off when loading an existing simulation
-# from files.
+# or creating a new simulation by setting lazy_io to True.
 
 sim2 = flopy.mf6.MFSimulation.load(
     sim_ws=workspace,
-    auto_set_sizes=False,
-    verify_data=False,
+    lazy_io=True,
 )
+
+sim3 = flopy.mf6.MFSimulation(lazy_io=True)
 
 # 2) Whenever possible save large datasets to external binary files.  Binary
 # files are more compact and the data will be read and written significantly

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -1701,13 +1701,9 @@ def run_model(
         if exe_name.lower().endswith(".exe"):
             # try removing .exe suffix
             exe = which(exe_name[:-4])
-            if exe is not None:
-                exe_name = exe_name[:-4]
     if exe is None:
         # try abspath
         exe = which(os.path.abspath(exe_name))
-        if exe is not None:
-            exe_name = os.path.abspath(exe_name)
     if exe is None:
         raise Exception(
             f"The program {exe_name} does not exist or is not executable."

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -1701,9 +1701,13 @@ def run_model(
         if exe_name.lower().endswith(".exe"):
             # try removing .exe suffix
             exe = which(exe_name[:-4])
+            if exe is not None:
+                exe_name = exe_name[:-4]
     if exe is None:
         # try abspath
         exe = which(os.path.abspath(exe_name))
+        if exe is not None:
+            exe_name = os.path.abspath(exe_name)
     if exe is None:
         raise Exception(
             f"The program {exe_name} does not exist or is not executable."

--- a/flopy/mf6/data/mfdataarray.py
+++ b/flopy/mf6/data/mfdataarray.py
@@ -1092,25 +1092,27 @@ class MFArray(MFMultiDimVar):
                 self._set_storage_obj(
                     self._new_storage(shape_ml.get_total_size() != 1, True)
                 )
-        file_access = MFFileAccessArray(
-            self.structure,
-            self._data_dimensions,
-            self._simulation_data,
-            self._path,
-            self._current_key,
-        )
         storage = self._get_storage_obj()
-        self._layer_shape, return_val = file_access.load_from_package(
-            first_line,
-            file_handle,
-            self._layer_shape,
-            storage,
-            self._keyword,
-            pre_data_comments=None,
-        )
         if external_file_info is not None:
             storage.point_to_existing_external_file(
                 external_file_info, storage.layer_storage.get_total_size() - 1
+            )
+            return_val = [False, None]
+        else:
+            file_access = MFFileAccessArray(
+                self.structure,
+                self._data_dimensions,
+                self._simulation_data,
+                self._path,
+                self._current_key,
+            )
+            self._layer_shape, return_val = file_access.load_from_package(
+                first_line,
+                file_handle,
+                self._layer_shape,
+                storage,
+                self._keyword,
+                pre_data_comments=None,
             )
 
         return return_val

--- a/flopy/mf6/data/mfdatalist.py
+++ b/flopy/mf6/data/mfdatalist.py
@@ -1329,19 +1329,21 @@ class MFList(mfdata.MFMultiDimVar, DataListInterface):
             first_line, file_handle, block_header, pre_data_comments=None
         )
         self._resync()
-        file_access = MFFileAccessList(
-            self.structure,
-            self._data_dimensions,
-            self._simulation_data,
-            self._path,
-            self._current_key,
-        )
         storage = self._get_storage_obj()
-        result = file_access.load_from_package(
-            first_line, file_handle, storage, pre_data_comments
-        )
         if external_file_info is not None:
             storage.point_to_existing_external_file(external_file_info, 0)
+            result = [False, None]
+        else:
+            file_access = MFFileAccessList(
+                self.structure,
+                self._data_dimensions,
+                self._simulation_data,
+                self._path,
+                self._current_key,
+            )
+            result = file_access.load_from_package(
+                first_line, file_handle, storage, pre_data_comments
+            )
         return result
 
     def _new_storage(self, stress_period=0):

--- a/flopy/mf6/data/mffileaccess.py
+++ b/flopy/mf6/data/mffileaccess.py
@@ -1356,8 +1356,7 @@ class MFFileAccessList(MFFileAccess):
                             return data_rec
             self.simple_line = (
                 self.simple_line
-                and self.structure.package_type != "sfr"
-                and self.structure.package_type != "uzf"
+                and not self.structure.parent_block.parent_package.advanced_package()
             )
             if self.simple_line:
                 line_len = len(self._last_line_info)

--- a/flopy/mf6/data/mffileaccess.py
+++ b/flopy/mf6/data/mffileaccess.py
@@ -1355,7 +1355,9 @@ class MFFileAccessList(MFFileAccess):
                             storage.data_dimensions.unlock()
                             return data_rec
             self.simple_line = (
-                self.simple_line and self.structure.package_type != "sfr"
+                self.simple_line
+                and self.structure.package_type != "sfr"
+                and self.structure.package_type != "uzf"
             )
             if self.simple_line:
                 line_len = len(self._last_line_info)

--- a/flopy/mf6/data/mfstructure.py
+++ b/flopy/mf6/data/mfstructure.py
@@ -198,7 +198,7 @@ class DfnPackage(Dfn):
         )
         self.dfn_list = package.dfn
 
-    def get_block_structure_dict(self, path, common, model_file):
+    def get_block_structure_dict(self, path, common, model_file, block_parent):
         block_dict = {}
         dataset_items_in_block = {}
         self.dataset_items_needed_dict = {}
@@ -222,7 +222,10 @@ class DfnPackage(Dfn):
             ):
                 # create block
                 current_block = MFBlockStructure(
-                    new_data_item_struct.block_name, path, model_file
+                    new_data_item_struct.block_name,
+                    path,
+                    model_file,
+                    block_parent,
                 )
                 # put block in block_dict
                 block_dict[current_block.name] = current_block
@@ -479,7 +482,7 @@ class DfnFile(Dfn):
         dfn_fp.close()
         return name_dict
 
-    def get_block_structure_dict(self, path, common, model_file):
+    def get_block_structure_dict(self, path, common, model_file, block_parent):
         self.dfn_list = []
         block_dict = {}
         dataset_items_in_block = {}
@@ -525,7 +528,10 @@ class DfnFile(Dfn):
                 ):
                     # create block
                     current_block = MFBlockStructure(
-                        new_data_item_struct.block_name, path, model_file
+                        new_data_item_struct.block_name,
+                        path,
+                        model_file,
+                        block_parent,
                     )
                     # put block in block_dict
                     block_dict[current_block.name] = current_block
@@ -1982,13 +1988,14 @@ class MFBlockStructure:
 
     """
 
-    def __init__(self, name, path, model_block):
+    def __init__(self, name, path, model_block, parent_package):
         # initialize
         self.data_structures = {}
         self.block_header_structure = []
         self.name = name
         self.path = path + (self.name,)
         self.model_block = model_block
+        self.parent_package = parent_package
 
     def repeating(self):
         if len(self.block_header_structure) > 0:
@@ -2093,11 +2100,19 @@ class MFInputFileStructure:
         self.read_as_arrays = False
 
         self.blocks, self.header = dfn_file.get_block_structure_dict(
-            self.path, common, model_file
+            self.path,
+            common,
+            model_file,
+            self,
         )
+        self.has_packagedata = "packagedata" in self.blocks
+        self.has_perioddata = "period" in self.blocks
         self.multi_package_support = "multi-package" in self.header
         self.dfn_list = dfn_file.dfn_list
         self.sub_package = self._sub_package()
+
+    def advanced_package(self):
+        return self.has_packagedata and self.has_perioddata
 
     def _sub_package(self):
         mfstruct = MFStructure()

--- a/flopy/mf6/mfmodel.py
+++ b/flopy/mf6/mfmodel.py
@@ -1650,6 +1650,7 @@ class MFModel(PackageContainer, ModelInterface):
             if (
                 package_struct is not None
                 and not package_struct.multi_package_support
+                and not isinstance(package.parent_file, MFPackage)
             ):
                 # package of this type already exists, replace it
                 self.remove_package(package.package_type)

--- a/flopy/mf6/mfpackage.py
+++ b/flopy/mf6/mfpackage.py
@@ -856,11 +856,6 @@ class MFBlock:
                             f'        opening external file "{file_name}"...'
                         )
                     external_file_info = arr_line
-                    file_name = datautil.clean_filename(arr_line[1])
-                    fd_block = open(os.path.join(root_path, file_name), "r")
-                    # read first line of external file
-                    line = fd_block.readline()
-                    arr_line = datautil.PyListUtil.split_data_line(line)
                 except:
                     type_, value_, traceback_ = sys.exc_info()
                     message = f'Error reading external file specified in line "{line}"'
@@ -1252,8 +1247,8 @@ class MFBlock:
 
     def _add_missing_block_headers(self, repeating_dataset):
         for key in repeating_dataset.get_active_key_list():
-            data = repeating_dataset.get_data(key)
-            if not self.header_exists(key[0]) and data is not None:
+            has_data = repeating_dataset.has_data(key)
+            if not self.header_exists(key[0]) and has_data:
                 self._build_repeating_header([key[0]])
 
     def header_exists(self, key, data_path=None):

--- a/flopy/mf6/modflow/mfsimulation.py
+++ b/flopy/mf6/modflow/mfsimulation.py
@@ -215,9 +215,9 @@ class MFSimulationData:
     wrap_multidim_arrays : bool
         Whether to wrap line for multi-dimensional arrays at the end of a
         row/column/layer
-    float_precision : int
+    _float_precision : int
         Number of decimal points to write for a floating point number
-    float_characters : int
+    _float_characters : int
         Number of characters a floating point number takes up
     write_headers: bool
         When true flopy writes a header to each package file indicating that
@@ -241,8 +241,8 @@ class MFSimulationData:
         self.constant_formatting = ["constant", ""]
         self._max_columns_of_data = 20
         self.wrap_multidim_arrays = True
-        self.float_precision = 8
-        self.float_characters = 15
+        self._float_precision = 8
+        self._float_characters = 15
         self.write_headers = True
         self._sci_note_upper_thres = 100000
         self._sci_note_lower_thres = 0.001
@@ -284,6 +284,48 @@ class MFSimulationData:
             self._max_columns_of_data = val
             self.max_columns_user_set = True
 
+    @property
+    def float_precision(self):
+        """
+        Gets precision of floating point numbers.
+        """
+        return self._float_precision
+
+    @float_precision.setter
+    def float_precision(self, value):
+        """
+        Sets precision of floating point numbers.
+
+        Parameters
+        ----------
+            value: float
+                floating point precision
+
+        """
+        self._float_precision = value
+        self._update_str_format()
+
+    @property
+    def float_characters(self):
+        """
+        Gets max characters used in floating point numbers.
+        """
+        return self._float_characters
+
+    @float_characters.setter
+    def float_characters(self, value):
+        """
+        Sets max characters used in floating point numbers.
+
+        Parameters
+        ----------
+            value: float
+                floating point max characters
+
+        """
+        self._float_characters = value
+        self._update_str_format()
+
     def set_sci_note_upper_thres(self, value):
         """
         Sets threshold number where any number larger than threshold
@@ -315,9 +357,9 @@ class MFSimulationData:
     def _update_str_format(self):
         """
         Update floating point formatting strings."""
-        self.reg_format_str = f"{{:.{self.float_precision}E}}"
+        self.reg_format_str = f"{{:.{self._float_precision}E}}"
         self.sci_format_str = (
-            f"{{:{self.float_characters}.{self.float_precision}f}}"
+            f"{{:{self._float_characters}.{self._float_precision}f}}"
         )
 
 
@@ -600,6 +642,7 @@ class MFSimulation(PackageContainer):
         load_only=None,
         verify_data=False,
         write_headers=True,
+        auto_set_sizes=True,
     ):
         """
         Load an existing model.
@@ -636,7 +679,9 @@ class MFSimulation(PackageContainer):
         write_headers: bool
             When true flopy writes a header to each package file indicating
             that it was created by flopy
-
+        auto_set_sizes : bool
+            Automatically calculate the maximum size of arrays and use that
+            number to populate the maxbound fields
         Returns
         -------
         sim : MFSimulation object
@@ -657,6 +702,7 @@ class MFSimulation(PackageContainer):
         )
         verbosity_level = instance.simulation_data.verbosity_level
         instance.simulation_data.verify_data = verify_data
+        instance.simulation_data.auto_set_sizes = auto_set_sizes
 
         if verbosity_level.value >= VerbosityLevel.normal.value:
             print("loading simulation...")


### PR DESCRIPTION
FloPy modifications to improve external file performance and best practices documented for optimizing performance for models with large datasets.  Specifically,

1) Reading and writing external binary files are now significantly faster than reading and writing external text files.

2) FloPy can be configured to no longer parse external files during load or save, unless they are specifically requested or modified.   In order to configure FloPy for this, turn FloPy's verification checks and auto-update "maxbound" value off:

   sim.simulation_data.auto_set_sizes = False
   sim.simulation_data.verify_data = False