### PR TITLE
Hotfix gmg read

### DIFF
--- a/flopy/modflow/mfgmg.py
+++ b/flopy/modflow/mfgmg.py
@@ -363,7 +363,7 @@ class ModflowGmg(Package):
         line = f.readline()
         t = line.strip().split()
         relax = 1.0
-        if ism==4:
+        if ism == 4:
             relax = float(t[0])
 
         if openfile:

--- a/flopy/modflow/mfgmg.py
+++ b/flopy/modflow/mfgmg.py
@@ -362,7 +362,9 @@ class ModflowGmg(Package):
         # dataset 3
         line = f.readline()
         t = line.strip().split()
-        relax = float(t[0])
+        relax = 1.0
+        if ism==4:
+            relax = float(t[0])
 
         if openfile:
             f.close()


### PR DESCRIPTION
There was a tiny bug in MF2005 reading GMG file. RELAX was always being read but should only be if ISC==4. Added default RELAX=1.0 following the logic of other optional variables DUP,DLOW, and CHGLIMIT