### PR TITLE
ci: don't upgrade pip on Windows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -56,7 +56,6 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash -l {0}
         run: |
-          pip install --upgrade pip
           pip install xmipy
           pip install .
 

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -193,7 +193,6 @@ jobs:
         shell: bash -l {0}
         if: runner.os == 'Windows'
         run: |
-          pip install --upgrade pip
           pip install xmipy
           pip install .
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -55,7 +55,6 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash -l {0}
         run: |
-          pip install --upgrade pip
           pip install xmipy
           pip install .
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -55,7 +55,6 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash -l {0}
         run: |
-          pip install --upgrade pip
           pip install xmipy
           pip install .
 


### PR DESCRIPTION
An issue has emerged where `pip install --upgrade pip` [fails on Windows CI runs](https://github.com/modflowpy/flopy/actions/runs/4054542779/jobs/6976552910). This only occurs for Python 3.10.

I'm not entirely clear on the root cause, but this PR sidesteps the problem by removing the `pip` upgrade on Windows runners. Presumably it isn't necessary since a fairly recent `pip` is installed with the Micromamba environment.