### PR TITLE
refactor: run pyupgrade and adjust a few f-strings

### DIFF
--- a/.docs/conf.py
+++ b/.docs/conf.py
@@ -23,7 +23,7 @@ from flopy import __author__, __version__
 on_rtd = os.environ.get("READTHEDOCS") == "True"
 
 # -- determine if this version is a release candidate
-with open("../README.md", "r") as f:
+with open("../README.md") as f:
     lines = f.readlines()
 rc_text = ""
 for line in lines:
@@ -38,7 +38,7 @@ with open("../CITATION.cff") as f:
 
 # -- update version number in main.rst
 rst_name = "main.rst"
-with open(rst_name, "r") as f:
+with open(rst_name) as f:
     lines = f.readlines()
 with open(rst_name, "w") as f:
     for line in lines:
@@ -51,7 +51,7 @@ with open(rst_name, "w") as f:
 
 # -- update authors in introduction.rst
 rst_name = "introduction.rst"
-with open(rst_name, "r") as f:
+with open(rst_name) as f:
     lines = f.readlines()
 tag_start = "FloPy Development Team"
 tag_end = "How to Cite"

--- a/autotest/regression/test_mf6.py
+++ b/autotest/regression/test_mf6.py
@@ -533,7 +533,7 @@ def test_np001(function_tmpdir, example_data_path):
     mpath = sim.simulation_data.mfpath.get_model_path(model.name)
     spath = sim.simulation_data.mfpath.get_sim_path()
     found_cellid = False
-    with open(os.path.join(mpath, "np001_mod.wel"), "r") as fd:
+    with open(os.path.join(mpath, "np001_mod.wel")) as fd:
         for line in fd:
             line_lst = line.strip().split()
             if (
@@ -561,7 +561,7 @@ def test_np001(function_tmpdir, example_data_path):
     found_begin = False
     found_end = False
     text_between_begin_and_end = False
-    with open(os.path.join(mpath, "file_rename.wel"), "r") as fd:
+    with open(os.path.join(mpath, "file_rename.wel")) as fd:
         for line in fd:
             if line.strip().lower() == "begin period  2":
                 found_begin = True
@@ -587,7 +587,7 @@ def test_np001(function_tmpdir, example_data_path):
     found_begin = False
     found_end = False
     text_between_begin_and_end = False
-    with open(os.path.join(mpath, "np001_spd_test.wel"), "r") as fd:
+    with open(os.path.join(mpath, "np001_spd_test.wel")) as fd:
         for line in fd:
             if line.strip().lower() == "begin period  2":
                 found_begin = True

--- a/autotest/test_binarygrid_util.py
+++ b/autotest/test_binarygrid_util.py
@@ -116,7 +116,7 @@ def test_mfgrddisv_modelgrid(mfgrd_test_path):
         f"does not equal {nvert}"
     )
 
-    cellxy = np.column_stack((mg.xyzcellcenters[:2]))
+    cellxy = np.column_stack(mg.xyzcellcenters[:2])
     errmsg = (
         f"shape of flow.disv centroids {cellxy.shape} not equal to (218, 2)."
     )

--- a/autotest/test_get_modflow.py
+++ b/autotest/test_get_modflow.py
@@ -123,9 +123,9 @@ def test_get_release(repo):
 
     if repo == "modflow6":
         # can remove if modflow6 releases follow asset name conventions followed in executables and nightly build repos
-        assert set([a.rpartition("_")[2] for a in actual_assets]) >= set(
-            [a for a in expected_assets if not a.startswith("win")]
-        )
+        assert {a.rpartition("_")[2] for a in actual_assets} >= {
+            a for a in expected_assets if not a.startswith("win")
+        }
     else:
         assert set(actual_assets) >= set(expected_assets)
 

--- a/autotest/test_grid.py
+++ b/autotest/test_grid.py
@@ -501,7 +501,7 @@ def test_unstructured_from_gridspec(example_data_path):
     spec_path = str(model_path / "freyberg.usg.gsf")
     grid = UnstructuredGrid.from_gridspec(spec_path)
 
-    with open(spec_path, "r") as file:
+    with open(spec_path) as file:
         lines = file.readlines()
         split = [line.strip().split() for line in lines]
 
@@ -1019,11 +1019,9 @@ def test_get_lni_unstructured(grid):
         layer, i = grid.get_lni([nn])[0]
         csum = [0] + list(
             np.cumsum(
-                (
-                    list(grid.ncpl)
-                    if not isinstance(grid.ncpl, int)
-                    else [grid.ncpl for _ in range(grid.nlay)]
-                )
+                list(grid.ncpl)
+                if not isinstance(grid.ncpl, int)
+                else [grid.ncpl for _ in range(grid.nlay)]
             )
         )
         assert csum[layer] + i == nn

--- a/autotest/test_gridintersect.py
+++ b/autotest/test_gridintersect.py
@@ -1220,7 +1220,7 @@ def test_polygon_offset_rot_structured_grid_shapely(rtree):
 # %% test rasters
 
 
-@requires_pkg("rasterstats")
+@requires_pkg("rasterstats", "scipy")
 def test_rasters(example_data_path):
     ws = str(example_data_path / "options")
     raster_name = "dem.img"

--- a/autotest/test_lake_connections.py
+++ b/autotest/test_lake_connections.py
@@ -255,11 +255,7 @@ def test_lake(function_tmpdir, example_data_path):
     # mm = flopy.plot.PlotMapView(modelgrid=gwf.modelgrid)
     # mm.plot_array(k11_tm)
 
-    (
-        idomain,
-        pakdata_dict,
-        connectiondata,
-    ) = get_lak_connections(
+    idomain, pakdata_dict, connectiondata = get_lak_connections(
         gwf.modelgrid,
         lakes,
         bedleak=5e-9,
@@ -459,11 +455,7 @@ def test_embedded_lak_ex01(function_tmpdir, example_data_path):
         printrecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
     )
 
-    (
-        idomain,
-        pakdata_dict,
-        connectiondata,
-    ) = get_lak_connections(
+    idomain, pakdata_dict, connectiondata = get_lak_connections(
         gwf.modelgrid,
         lake_map,
         bedleak=0.1,
@@ -559,11 +551,7 @@ def test_embedded_lak_prudic(example_data_path):
     )
 
     # flopy test
-    (
-        idomain_rev,
-        pakdata_dict,
-        connectiondata,
-    ) = get_lak_connections(
+    idomain_rev, pakdata_dict, connectiondata = get_lak_connections(
         model_grid,
         lake_map,
         idomain=idomain,
@@ -668,11 +656,7 @@ def test_embedded_lak_prudic_mixed(example_data_path):
     )
 
     # test mixed lakebed leakance list
-    (
-        _,
-        _,
-        connectiondata,
-    ) = get_lak_connections(
+    _, _, connectiondata = get_lak_connections(
         model_grid,
         lake_map,
         idomain=idomain,

--- a/autotest/test_mf6.py
+++ b/autotest/test_mf6.py
@@ -173,8 +173,8 @@ def get_gwf_model(sim, gwfname, gwfpath, modelshape, chdspd=None, welspd=None):
     # output control
     oc = ModflowGwfoc(
         gwf,
-        budget_filerecord="{}.cbc".format(gwfname),
-        head_filerecord="{}.hds".format(gwfname),
+        budget_filerecord=f"{gwfname}.cbc",
+        head_filerecord=f"{gwfname}.hds",
         headprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("HEAD", "LAST"), ("BUDGET", "LAST")],
         printrecord=[("HEAD", "LAST"), ("BUDGET", "LAST")],
@@ -226,8 +226,8 @@ def get_gwt_model(sim, gwtname, gwtpath, modelshape, sourcerecarray=None):
     # output control
     oc = ModflowGwtoc(
         gwt,
-        budget_filerecord="{}.cbc".format(gwtname),
-        concentration_filerecord="{}.ucn".format(gwtname),
+        budget_filerecord=f"{gwtname}.cbc",
+        concentration_filerecord=f"{gwtname}.ucn",
         concentrationprintrecord=[
             ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
         ],
@@ -1031,6 +1031,7 @@ def test_output_add_observation(function_tmpdir, example_data_path):
         sfr_obs, Mf6Obs
     ), "remove and add observation test (Mf6Output) failed"
 
+@requires_exe("mf6")
 def test_sfr_connections(function_tmpdir, example_data_path):
     '''MODFLOW just warns if any reaches are unconnected
     flopy fails to load model if reach 1 is unconnected, fine with other unconnected'''
@@ -1039,7 +1040,7 @@ def test_sfr_connections(function_tmpdir, example_data_path):
     for test in ['sfr0', 'sfr1']:
         sim_name = "test_sfr"
         model_name = "test_sfr"
-        tdis_name = "{}.tdis".format(sim_name)
+        tdis_name = f"{sim_name}.tdis"
         sim = MFSimulation(
             sim_name=sim_name, version="mf6", exe_name="mf6", sim_ws=sim_ws
         )
@@ -1053,7 +1054,7 @@ def test_sfr_connections(function_tmpdir, example_data_path):
             complexity="SIMPLE",
         )
         model = ModflowGwf(
-            sim, modelname=model_name, model_nam_file="{}.nam".format(model_name)
+            sim, modelname=model_name, model_nam_file=f"{model_name}.nam"
         )
 
         dis = ModflowGwfdis(
@@ -1077,7 +1078,7 @@ def test_sfr_connections(function_tmpdir, example_data_path):
             icelltype=1,
             k=50.0,
         )
-        
+
         cnfile = f'mf6_{test}_connection.txt'
         pkfile = f'mf6_{test}_package.txt'
 
@@ -1115,7 +1116,7 @@ def test_array(function_tmpdir):
     sim_name = "test_array"
     model_name = "test_array"
     out_dir = function_tmpdir
-    tdis_name = "{}.tdis".format(sim_name)
+    tdis_name = f"{sim_name}.tdis"
     sim = MFSimulation(
         sim_name=sim_name, version="mf6", exe_name="mf6", sim_ws=out_dir
     )
@@ -1138,7 +1139,7 @@ def test_array(function_tmpdir):
         number_orthogonalizations=2,
     )
     model = ModflowGwf(
-        sim, modelname=model_name, model_nam_file="{}.nam".format(model_name)
+        sim, modelname=model_name, model_nam_file=f"{model_name}.nam"
     )
 
     dis = ModflowGwfdis(
@@ -1700,7 +1701,7 @@ def test_namefile_creation(tmpdir):
     model = ModflowGwf(
         sim,
         modelname=test_ex_name,
-        model_nam_file="{}.nam".format(test_ex_name),
+        model_nam_file=f"{test_ex_name}.nam",
     )
 
     # try to create simulation name file

--- a/autotest/test_mnw.py
+++ b/autotest/test_mnw.py
@@ -353,7 +353,7 @@ def test_mnw2_create_file(function_tmpdir):
         mnwmax=len(wells),
         mnw=wells,
         itmp=list(
-            (np.ones((len(stress_period_data.index))) * len(wellids)).astype(
+            (np.ones(len(stress_period_data.index)) * len(wellids)).astype(
                 int
             )
         ),

--- a/autotest/test_modpathfile.py
+++ b/autotest/test_modpathfile.py
@@ -66,7 +66,7 @@ def __create_simulation(
     )
 
     # Create the Flopy groundwater flow (gwf) model object
-    model_nam_file = "{}.nam".format(name)
+    model_nam_file = f"{name}.nam"
     gwf = ModflowGwf(
         sim, modelname=name, model_nam_file=model_nam_file, save_flows=True
     )
@@ -113,9 +113,9 @@ def __create_simulation(
     ModflowGwfriv(gwf, stress_period_data={0: rd})
 
     # Create the output control package
-    headfile = "{}.hds".format(name)
+    headfile = f"{name}.hds"
     head_record = [headfile]
-    budgetfile = "{}.cbb".format(name)
+    budgetfile = f"{name}.cbb"
     budget_record = [budgetfile]
     saverecord = [("HEAD", "ALL"), ("BUDGET", "ALL")]
     oc = ModflowGwfoc(

--- a/autotest/test_mp6.py
+++ b/autotest/test_mp6.py
@@ -834,8 +834,8 @@ def test_mp_wpandas_wo_pandas(ml):
     assert success
 
     # read the two files and ensure they are identical
-    with open(mp_pandas.get_package("loc").fn_path, "r") as f:
+    with open(mp_pandas.get_package("loc").fn_path) as f:
         particles_pandas = f.readlines()
-    with open(mp_no_pandas.get_package("loc").fn_path, "r") as f:
+    with open(mp_no_pandas.get_package("loc").fn_path) as f:
         particles_no_pandas = f.readlines()
     assert particles_pandas == particles_no_pandas

--- a/autotest/test_pcg.py
+++ b/autotest/test_pcg.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This simple script tests that the pcg load function works for both free-
 and fixed-format pcg files for mf2005 models.

--- a/autotest/test_zonbud_utility.py
+++ b/autotest/test_zonbud_utility.py
@@ -29,7 +29,7 @@ def zbud_f(loadpth):
 
 
 def read_zonebudget_file(fname):
-    with open(fname, "r") as f:
+    with open(fname) as f:
         lines = f.readlines()
 
     rows = []
@@ -112,8 +112,8 @@ def test_compare2zonebudget(cbc_f, zon_f, zbud_f, rtol):
         zb_arr = zba[zba["totim"] == time]
         fp_arr = fpa[fpa["totim"] == time]
         for name in fp_arr["name"]:
-            r1 = np.where((zb_arr["name"] == name))
-            r2 = np.where((fp_arr["name"] == name))
+            r1 = np.where(zb_arr["name"] == name)
+            r2 = np.where(fp_arr["name"] == name)
             if r1[0].shape[0] < 1 or r2[0].shape[0] < 1:
                 continue
             if r1[0].shape[0] != r2[0].shape[0]:
@@ -167,7 +167,7 @@ def test_zonbud_to_csv(function_tmpdir, cbc_f, zon_f):
     zb = ZoneBudget(str(cbc_f), zon, kstpkper=[(0, 1094), (0, 1096)])
     f_out = os.path.join(str(function_tmpdir), "test.csv")
     zb.to_csv(f_out)
-    with open(f_out, "r") as f:
+    with open(f_out) as f:
         lines = f.readlines()
     assert len(lines) > 0, "No data written to csv file."
 

--- a/examples/groundwater_paper/scripts/uspb_capture.py
+++ b/examples/groundwater_paper/scripts/uspb_capture.py
@@ -99,12 +99,10 @@ nrow2 = nrow // nstep
 ncol2 = ncol // nstep
 
 # open summary file
-fs = open(
-    os.path.join("data", "uspb", "uspb_capture_{}.out".format(nstep)), "w", 0
-)
+fs = open(os.path.join("data", "uspb", f"uspb_capture_{nstep}.out"), "w", 0)
 
 # write some summary information
-fs.write("Problem size: {} rows and {} columns.\n".format(nrow, ncol))
+fs.write(f"Problem size: {nrow} rows and {ncol} columns.\n")
 fs.write(
     "Capture fraction analysis performed every {} rows and columns.\n".format(
         nstep
@@ -141,7 +139,7 @@ for i in range(0, nrow, nstep):
             s0 = time.time()
             cf = cf_model(ml, 3, i, j, baseQ)
             s1 = time.time()
-            line = "  model {} run time: {} seconds\n".format(idx, s1 - s0)
+            line = f"  model {idx} run time: {s1 - s0} seconds\n"
             fs.write(line)
             sys.stdout.write(line)
             idx += 1
@@ -158,9 +156,9 @@ end = time.time()
 ets = end - start
 line = (
     "\n"
-    + "streamflow capture analysis took {} seconds.\n".format(ets)
-    + "streamflow capture analysis took {} minutes.\n".format(ets / 60.0)
-    + "streamflow capture analysis took {} hours.\n".format(ets / 3600.0)
+    + f"streamflow capture analysis took {ets} seconds.\n"
+    + f"streamflow capture analysis took {ets / 60.0} minutes.\n"
+    + f"streamflow capture analysis took {ets / 3600.0} hours.\n"
 )
 fs.write(line)
 sys.stdout.write(line)
@@ -179,7 +177,7 @@ if not os.path.exists(res_pth):
 for idx in range(10):
     fn = os.path.join(
         res_pth,
-        "USPB_capture_fraction_{:02d}_{:02d}.dat".format(nstep, idx + 1),
+        f"USPB_capture_fraction_{nstep:02d}_{idx + 1:02d}.dat",
     )
-    print("saving capture fraction data to...{}".format(os.path.basename(fn)))
+    print(f"saving capture fraction data to...{os.path.basename(fn)}")
     np.savetxt(fn, cf_array[idx, :, :], delimiter=" ")

--- a/examples/groundwater_paper/scripts/uspb_capture_par.py
+++ b/examples/groundwater_paper/scripts/uspb_capture_par.py
@@ -47,7 +47,7 @@ def get_baseQ(model):
         "\nrunning base model to get base head-dependent flow\n\n"
     )
     success, report = model.run_model(silent=True, report=True)
-    sys.stdout.write("Base model run: {}\n".format(report[-3]))
+    sys.stdout.write(f"Base model run: {report[-3]}\n")
 
     # get base model results
     cbcObj = flopy.utils.CellBudgetFile(
@@ -68,7 +68,7 @@ def copy_files(ml, nproc):
     exclude = ["hds", "cbc", "list", "ddn"]
     cf_pths = []
     for idx in range(nproc):
-        cf_pths.append(os.path.join(cf_base, "cf{:02d}".format(idx)))
+        cf_pths.append(os.path.join(cf_base, f"cf{idx:02d}"))
         # create base model in each directory
         if idx == 0:
             ml.model_ws = cf_pths[idx]
@@ -143,13 +143,13 @@ def make_well(pth, k, i, j, Qt):
     f.write("         1         0\n")
     f.write("         0         0 # stress period 0\n")
     f.write("         1         0 # stress period 1\n")
-    f.write("{:10d}{:10d}{:10d}{:10.2f}\n".format(k + 1, i + 1, j + 1, Qt))
+    f.write(f"{k + 1:10d}{i + 1:10d}{j + 1:10d}{Qt:10.2f}\n")
     f.close()
 
 
 def run_model(pth):
     proc = sp.Popen([exe_name, "DG.nam"], stdout=sp.PIPE, cwd=pth)
-    sys.stdout.write("  running {} in {}\n".format(exe_name, pth))
+    sys.stdout.write(f"  running {exe_name} in {pth}\n")
     success = False
     buff = []
     elt = "Normal model termination did not occur"
@@ -173,19 +173,17 @@ def run_model(pth):
 
 # function to create well file, run model, and extract results
 def cf_model(imod, ion, nmax, k, i, j, Qt, base, hdry):
-    pth = os.path.join("data", "uspb", "cf{:02d}".format(imod))
-    sys.stdout.write("\nRunning model number: {}\n".format(imod))
-    sys.stdout.write("  model run: {} of {}\n".format(ion + 1, nmax))
-    sys.stdout.write(
-        "  model number {} working directory: {}\n".format(imod, pth)
-    )
+    pth = os.path.join("data", "uspb", f"cf{imod:02d}")
+    sys.stdout.write(f"\nRunning model number: {imod}\n")
+    sys.stdout.write(f"  model run: {ion + 1} of {nmax}\n")
+    sys.stdout.write(f"  model number {imod} working directory: {pth}\n")
     make_well(pth, k, i, j, Qt)
     success, elt = run_model(pth)
     line = "\nModel run: {} of {} (model number {})\n".format(
         ion + 1, nmax, imod
     )
-    line += "  row {} - col {}\n".format(i + 1, j + 1)
-    line += "  {}\n".format(elt)
+    line += f"  row {i + 1} - col {j + 1}\n"
+    line += f"  {elt}\n"
     # get the results
     v = np.zeros((10), dtype=float)
     if success:
@@ -258,7 +256,7 @@ def doit():
 
     # run first model created to get base model results
     baseQ = get_baseQ(ml)
-    sys.stdout.write("Base head-dependent flux = {}".format(baseQ))
+    sys.stdout.write(f"Base head-dependent flux = {baseQ}")
 
     # modify oc file copy model files
     ml, cf_pths = copy_files(ml, nproc)
@@ -269,13 +267,13 @@ def doit():
 
     # open summary file
     fs = open(
-        os.path.join("data", "uspb", "uspb_capture_{}.out".format(nstep)),
+        os.path.join("data", "uspb", f"uspb_capture_{nstep}.out"),
         "w",
         0,
     )
 
     # write some summary information
-    fs.write("Problem size: {} rows and {} columns.\n".format(nrow, ncol))
+    fs.write(f"Problem size: {nrow} rows and {ncol} columns.\n")
     fs.write(
         "Capture fraction analysis performed every {} rows and columns.\n".format(
             nstep
@@ -341,9 +339,9 @@ def doit():
     ets = end - start
     line = (
         "\n"
-        + "streamflow capture analysis took {} seconds.\n".format(ets)
-        + "streamflow capture analysis took {} minutes.\n".format(ets / 60.0)
-        + "streamflow capture analysis took {} hours.\n".format(ets / 3600.0)
+        + f"streamflow capture analysis took {ets} seconds.\n"
+        + f"streamflow capture analysis took {ets / 60.0} minutes.\n"
+        + f"streamflow capture analysis took {ets / 3600.0} hours.\n"
     )
     fs.write(line)
     sys.stdout.write(line)
@@ -363,7 +361,7 @@ def doit():
     for idx in range(10):
         fn = os.path.join(
             res_pth,
-            "USPB_capture_fraction_{:02d}_{:02d}.dat".format(nstep, idx + 1),
+            f"USPB_capture_fraction_{nstep:02d}_{idx + 1:02d}.dat",
         )
         sys.stdout.write(
             "saving capture fraction data to...{}\n".format(

--- a/flopy/discretization/grid.py
+++ b/flopy/discretization/grid.py
@@ -843,7 +843,7 @@ class Grid:
             return False
         xul, yul = None, None
         header = []
-        with open(namefile, "r") as f:
+        with open(namefile) as f:
             for line in f:
                 if not line.startswith("#"):
                     break

--- a/flopy/discretization/structuredgrid.py
+++ b/flopy/discretization/structuredgrid.py
@@ -1723,7 +1723,7 @@ class StructuredGrid(Grid):
             A StructuredGrid
         """
 
-        with open(file_path, "r") as f:
+        with open(file_path) as f:
             raw = f.readline().strip().split()
             nrow = int(raw[0])
             ncol = int(raw[1])

--- a/flopy/discretization/unstructuredgrid.py
+++ b/flopy/discretization/unstructuredgrid.py
@@ -857,7 +857,7 @@ class UnstructuredGrid(Grid):
 
         from ..utils.geometry import get_polygon_centroid
 
-        with open(file_path, "r") as f:
+        with open(file_path) as f:
             line = f.readline()
             ll = line.split()
             ncells, nverts = ll[0:2]
@@ -966,7 +966,7 @@ class UnstructuredGrid(Grid):
             An UnstructuredGrid
         """
 
-        with open(file_path, "r") as file:
+        with open(file_path) as file:
 
             def split_line():
                 return file.readline().strip().split()

--- a/flopy/export/netcdf.py
+++ b/flopy/export/netcdf.py
@@ -328,7 +328,7 @@ class NetCdf:
                         continue
                 assert (
                     new_vname not in self.nc.variables.keys()
-                ), "var already exists:{0} in {1}".format(
+                ), "var already exists:{} in {}".format(
                     new_vname, ",".join(self.nc.variables.keys())
                 )
                 attrs["max"] = var[:].max()
@@ -1263,7 +1263,7 @@ class NetCdf:
         self.log(f"creating variable: {name}")
         assert (
             precision_str in PRECISION_STRS
-        ), "netcdf.create_variable() error: precision string {0} not in {1}".format(
+        ), "netcdf.create_variable() error: precision string {} not in {}".format(
             precision_str, PRECISION_STRS
         )
 

--- a/flopy/export/utils.py
+++ b/flopy/export/utils.py
@@ -169,12 +169,8 @@ def _add_output_nc_variable(
                     else:
                         a = out_obj.get_data(totim=t)
                 except Exception as e:
-                    estr = (
-                        "error getting data for {0} at time"
-                        " {1}:{2}".format(
-                            var_name + text.decode().strip().lower(), t, str(e)
-                        )
-                    )
+                    nme = var_name + text.decode().strip().lower()
+                    estr = f"error getting data for {nme} at time {t}:{e!s}"
                     if logger:
                         logger.warn(estr)
                     else:
@@ -185,12 +181,8 @@ def _add_output_nc_variable(
                 try:
                     array[i, :, :, :] = a.astype(np.float32)
                 except Exception as e:
-                    estr = (
-                        "error assigning {0} data to array for time"
-                        " {1}:{2}".format(
-                            var_name + text.decode().strip().lower(), t, str(e)
-                        )
-                    )
+                    nme = var_name + text.decode().strip().lower()
+                    estr = f"error assigning {nme} data to array for time {t}:{e!s}"
                     if logger:
                         logger.warn(estr)
                     else:

--- a/flopy/mf6/data/mfdatastorage.py
+++ b/flopy/mf6/data/mfdatastorage.py
@@ -1986,7 +1986,7 @@ class DataStorage:
                 )
                 data_out = self._build_recarray(data, layer, False)
             else:
-                with open(read_file, "r") as fd_read_file:
+                with open(read_file) as fd_read_file:
                     data_out = file_access.read_list_data_from_file(
                         fd_read_file,
                         self,

--- a/flopy/mf6/data/mfstructure.py
+++ b/flopy/mf6/data/mfstructure.py
@@ -2471,7 +2471,7 @@ class MFStructure:
                 dfn_path, tail = os.path.split(os.path.realpath(__file__))
                 dfn_path = os.path.join(dfn_path, "dfn")
                 dfn_file = os.path.join(dfn_path, file)
-                with open(dfn_file, "r") as fd_dfn:
+                with open(dfn_file) as fd_dfn:
                     for line in fd_dfn:
                         if len(line) < 1 or line[0] != "#":
                             break

--- a/flopy/mf6/mfbase.py
+++ b/flopy/mf6/mfbase.py
@@ -525,7 +525,7 @@ class PackageContainer:
         package_abbr = f"{model_type}{package_type}"
         factory = PackageContainer.packages_by_abbr.get(package_abbr)
         if factory is None:
-            package_utl_abbr = "utl{}".format(package_type)
+            package_utl_abbr = f"utl{package_type}"
             factory = PackageContainer.packages_by_abbr.get(package_utl_abbr)
         return factory
 

--- a/flopy/mf6/modflow/mfsimulation.py
+++ b/flopy/mf6/modflow/mfsimulation.py
@@ -1204,7 +1204,7 @@ class MFSimulation(PackageContainer):
 
     def _set_timing_block(self, file_name):
         struct_root = mfstructure.MFStructure()
-        tdis_pkg = "tdis{}".format(struct_root.get_version_string())
+        tdis_pkg = f"tdis{struct_root.get_version_string()}"
         tdis_attr = getattr(self.name_file, tdis_pkg)
         try:
             tdis_attr.set_data(file_name)

--- a/flopy/mf6/utils/createpackages.py
+++ b/flopy/mf6/utils/createpackages.py
@@ -81,7 +81,6 @@ files, the package classes, and updated init.py that createpackages.py created.
 
 """
 import datetime
-import io
 import os
 import textwrap
 from enum import Enum
@@ -485,7 +484,7 @@ def create_packages():
             )
 
     util_path, tail = os.path.split(os.path.realpath(__file__))
-    init_file = io.open(
+    init_file = open(
         os.path.join(util_path, "..", "modflow", "__init__.py"),
         "w",
         newline="\n",
@@ -749,7 +748,7 @@ def create_packages():
         )
 
         # open new Packages file
-        pb_file = io.open(
+        pb_file = open(
             os.path.join(util_path, "..", "modflow", f"mf{package_name}.py"),
             "w",
             newline="\n",
@@ -918,7 +917,7 @@ def create_packages():
                 init_vars,
                 load_txt,
             )
-            md_file = io.open(
+            md_file = open(
                 os.path.join(util_path, "..", "modflow", f"mf{model_name}.py"),
                 "w",
                 newline="\n",

--- a/flopy/mf6/utils/reference.py
+++ b/flopy/mf6/utils/reference.py
@@ -93,7 +93,7 @@ class StructuredSpatialReference:
     def from_namfile_header(cls, namefile):
         # check for reference info in the nam file header
         header = []
-        with open(namefile, "r") as f:
+        with open(namefile) as f:
             for line in f:
                 if not line.startswith("#"):
                     break
@@ -625,7 +625,7 @@ class VertexSpatialReference:
     def from_namfile_header(cls, namefile):
         # check for reference info in the nam file header
         header = []
-        with open(namefile, "r") as f:
+        with open(namefile) as f:
             for line in f:
                 if not line.startswith("#"):
                     break

--- a/flopy/mfusg/mfusgbcf.py
+++ b/flopy/mfusg/mfusgbcf.py
@@ -253,11 +253,9 @@ class MfUsgBcf(ModflowBcf):
 
         # Item 1: ipakcb, HDRY, IWDFLG, WETFCT, IWETIT, IHDWET, IKVFLAG, IKCFLAG
         f_obj.write(
-            (
-                f" {self.ipakcb:9d} {self.hdry:9.3G} {self.iwdflg:9d}"
-                f" {self.wetfct:9.3G} {self.iwetit:9d} {self.ihdwet:9d}"
-                f" {self.ikvflag:9d} {self.ikcflag:9d}\n"
-            )
+            f" {self.ipakcb:9d} {self.hdry:9.3G} {self.iwdflg:9d}"
+            f" {self.wetfct:9.3G} {self.iwetit:9d} {self.ihdwet:9d}"
+            f" {self.ikvflag:9d} {self.ikcflag:9d}\n"
         )
 
         # LAYCON array

--- a/flopy/mfusg/mfusgcln.py
+++ b/flopy/mfusg/mfusgcln.py
@@ -512,11 +512,9 @@ class MfUsgCln(Package):
             f_cln.write("\n")
 
         f_cln.write(
-            (
-                f" {self.ncln:9d} {self.iclnnds:9d} {self.iclncb:9d}"
-                f" {self.iclnhd:9d} {self.iclndd:9d} {self.iclnib:9d}"
-                f" {self.nclngwc:9d} {self.nconduityp:9d}"
-            )
+            f" {self.ncln:9d} {self.iclnnds:9d} {self.iclncb:9d}"
+            f" {self.iclnhd:9d} {self.iclndd:9d} {self.iclnib:9d}"
+            f" {self.nclngwc:9d} {self.nconduityp:9d}"
         )
 
         if self.nrectyp > 0:

--- a/flopy/mfusg/mfusgdisu.py
+++ b/flopy/mfusg/mfusgdisu.py
@@ -477,7 +477,7 @@ class MfUsgDisU(Package):
         vol : array of floats (nodes)
 
         """
-        vol = np.empty((self.nodes))
+        vol = np.empty((self.nodes,))
         for n in range(self.nodes):
             nn = n
             if self.ivsd == -1:
@@ -493,7 +493,7 @@ class MfUsgDisU(Package):
         elevation.
 
         """
-        z = np.empty((self.nodes))
+        z = np.empty((self.nodes,))
         z[:] = (self.top.array - self.bot.array) / 2.0
         return z
 
@@ -831,7 +831,7 @@ class MfUsgDisU(Package):
             self.lenuni,
             self.idsymrd,
         ]:
-            s += "{} ".format(var)
+            s += f"{var} "
         f_dis.write(s + "\n")
 
         # Item 2: LAYCBD
@@ -882,9 +882,9 @@ class MfUsgDisU(Package):
                 f"{self.perlen[t]:14f}{self.nstp[t]:14d}{self.tsmult[t]:10f} "
             )
             if self.steady[t]:
-                f_dis.write(" {0:3s}\n".format("SS"))
+                f_dis.write(" SS\n")
             else:
-                f_dis.write(" {0:3s}\n".format("TR"))
+                f_dis.write(" TR\n")
 
         # Close and return
         f_dis.close()

--- a/flopy/mfusg/mfusggnc.py
+++ b/flopy/mfusg/mfusggnc.py
@@ -178,11 +178,9 @@ class MfUsgGnc(Package):
         f_gnc.write(f"{self.heading}\n")
 
         f_gnc.write(
-            (
-                f" {0:9d} {0:9d} {self.numgnc:9d} {self.numalphaj:9d}"
-                f" {self.i2kn:9d} {self.isymgncn:9d} {self.iflalphan:9d}"
-                f" {self.options}\n"
-            )
+            f" {0:9d} {0:9d} {self.numgnc:9d} {self.numalphaj:9d}"
+            f" {self.i2kn:9d} {self.isymgncn:9d} {self.iflalphan:9d}"
+            f" {self.options}\n"
         )
 
         gdata = self.gncdata.copy()

--- a/flopy/mfusg/mfusglpf.py
+++ b/flopy/mfusg/mfusglpf.py
@@ -359,10 +359,8 @@ class MfUsgLpf(ModflowLpf):
         # Item 1: IBCFCB, HDRY, NPLPF, <IKCFLAG>, OPTIONS
         if self.parent.version == "mfusg" and not self.parent.structured:
             f_obj.write(
-                (
-                    f" {self.ipakcb:9d} {self.hdry:9.5G} {self.nplpf:9d}"
-                    f" {self.ikcflag:9d} {self.options:s}\n"
-                )
+                f" {self.ipakcb:9d} {self.hdry:9.5G} {self.nplpf:9d}"
+                f" {self.ikcflag:9d} {self.options:s}\n"
             )
         else:
             f_obj.write(

--- a/flopy/mfusg/mfusgsms.py
+++ b/flopy/mfusg/mfusgsms.py
@@ -343,7 +343,7 @@ class MfUsgSms(Package):
         if nopt > 0:
             f.write(" ".join(self.options) + "\n")
         f.write(
-            "{0} {1} {2} {3} {4} {5} {6}\n".format(
+            "{} {} {} {} {} {} {}\n".format(
                 self.hclose,
                 self.hiclose,
                 self.mxiter,
@@ -355,7 +355,7 @@ class MfUsgSms(Package):
         )
         if self.nonlinmeth != 0 and nopt == 0:
             f.write(
-                "{0} {1} {2} {3} {4} {5} {6} {7}\n".format(
+                "{} {} {} {} {} {} {} {}\n".format(
                     self.theta,
                     self.akappa,
                     self.gamma,
@@ -368,7 +368,7 @@ class MfUsgSms(Package):
             )
         if self.linmeth == 1 and nopt == 0:
             f.write(
-                "{0} {1} {2} {3} {4} {5} {6} {7}\n".format(
+                "{} {} {} {} {} {} {} {}\n".format(
                     self.iacl,
                     self.norder,
                     self.level,
@@ -381,7 +381,7 @@ class MfUsgSms(Package):
             )
         if self.linmeth == 2 and nopt == 0:
             f.write(
-                "{0} {1} {2} {3} {4} {5}\n".format(
+                "{} {} {} {} {} {}\n".format(
                     self.clin,
                     self.ipc,
                     self.iscl,

--- a/flopy/modflow/mfag.py
+++ b/flopy/modflow/mfag.py
@@ -540,17 +540,17 @@ class ModflowAg(Package):
                                     if rec[f"fracsupmax{i}"] != -1e10:
                                         foo.write(
                                             "{:d}   {:f}   {:f}\n".format(
-                                                rec["segid{}".format(i)],
-                                                rec["fracsup{}".format(i)],
-                                                rec["fracsupmax{}".format(i)],
+                                                rec[f"segid{i}"],
+                                                rec[f"fracsup{i}"],
+                                                rec[f"fracsupmax{i}"],
                                             )
                                         )
 
                                     else:
                                         foo.write(
                                             "{:d}   {:f}\n".format(
-                                                rec["segid{}".format(i)],
-                                                rec["fracsup{}".format(i)],
+                                                rec[f"segid{i}"],
+                                                rec[f"fracsup{i}"],
                                             )
                                         )
 

--- a/flopy/modflow/mfchd.py
+++ b/flopy/modflow/mfchd.py
@@ -167,7 +167,7 @@ class ModflowChd(Package):
         f_chd.write(f"{self.heading}\n")
         f_chd.write(f" {self.stress_period_data.mxact:9d}")
         for option in self.options:
-            f_chd.write("  {}".format(option))
+            f_chd.write(f"  {option}")
         f_chd.write("\n")
         self.stress_period_data.write_transient(f_chd)
         f_chd.close()

--- a/flopy/modflow/mfdis.py
+++ b/flopy/modflow/mfdis.py
@@ -604,7 +604,7 @@ class ModflowDis(Package):
         f_dis.write(f"{self.heading}\n")
         # Item 1: NLAY, NROW, NCOL, NPER, ITMUNI, LENUNI
         f_dis.write(
-            "{0:10d}{1:10d}{2:10d}{3:10d}{4:10d}{5:10d}\n".format(
+            "{:10d}{:10d}{:10d}{:10d}{:10d}{:10d}\n".format(
                 self.nlay,
                 self.nrow,
                 self.ncol,
@@ -632,9 +632,9 @@ class ModflowDis(Package):
                 f"{self.perlen[t]:14f}{self.nstp[t]:14d}{self.tsmult[t]:10f} "
             )
             if self.steady[t]:
-                f_dis.write(" {0:3s}\n".format("SS"))
+                f_dis.write(" SS\n")
             else:
-                f_dis.write(" {0:3s}\n".format("TR"))
+                f_dis.write(" TR\n")
         f_dis.close()
 
     def check(self, f=None, verbose=True, level=1, checktype=None):

--- a/flopy/modflow/mffhb.py
+++ b/flopy/modflow/mffhb.py
@@ -549,7 +549,7 @@ class ModflowFhb(Package):
                 structured=model.structured,
             )
             for n in range(nflw):
-                tds5 = read1d(f, np.zeros((nbdtim + 4)))
+                tds5 = read1d(f, np.zeros((nbdtim + 4,)))
                 ds5[n] = tuple(tds5)
 
             if model.structured:
@@ -626,7 +626,7 @@ class ModflowFhb(Package):
                 structured=model.structured,
             )
             for n in range(nhed):
-                tds7 = read1d(f, np.empty((nbdtim + 4)))
+                tds7 = read1d(f, np.empty((nbdtim + 4,)))
                 ds7[n] = tuple(tds7)
 
             if model.structured:

--- a/flopy/modflow/mfflwob.py
+++ b/flopy/modflow/mfflwob.py
@@ -341,7 +341,6 @@ class ModflowFlwob(Package):
                 line = f"{self.layer[i, j] + 1:10d}"
                 line += f"{self.row[i, j] + 1:10d}"
                 line += f"{self.column[i, j] + 1:10d}"
-                line += " ".format(self.factor[i, j])
                 # note is 10f good enough here?
                 line += f"{self.factor[i, j]:10f}\n"
                 f_fbob.write(line)

--- a/flopy/modflow/mfghb.py
+++ b/flopy/modflow/mfghb.py
@@ -199,7 +199,7 @@ class ModflowGhb(Package):
         f_ghb.write(f"{self.heading}\n")
         f_ghb.write(f"{self.stress_period_data.mxact:10d}{self.ipakcb:10d}")
         for option in self.options:
-            f_ghb.write("  {}".format(option))
+            f_ghb.write(f"  {option}")
         f_ghb.write("\n")
         self.stress_period_data.write_transient(f_ghb)
         f_ghb.close()

--- a/flopy/modflow/mfhfb.py
+++ b/flopy/modflow/mfhfb.py
@@ -185,7 +185,7 @@ class ModflowHfb(Package):
         f_hfb.write(f"{self.heading}\n")
         f_hfb.write(f"{self.nphfb:10d}{self.mxfb:10d}{self.nhfbnp:10d}")
         for option in self.options:
-            f_hfb.write("  {}".format(option))
+            f_hfb.write(f"  {option}")
         f_hfb.write("\n")
         for a in self.hfb_data:
             f_hfb.write(

--- a/flopy/modflow/mflak.py
+++ b/flopy/modflow/mflak.py
@@ -490,7 +490,7 @@ class ModflowLak(Package):
         # dataset 1a
         if len(self.options) > 0:
             for option in self.options:
-                f.write("{} ".format(option))
+                f.write(f"{option} ")
             f.write("\n")
 
         # dataset 1b

--- a/flopy/modflow/mflpf.py
+++ b/flopy/modflow/mflpf.py
@@ -379,7 +379,7 @@ class ModflowLpf(Package):
         # Item 1: IBCFCB, HDRY, NPLPF, <IKCFLAG>, OPTIONS
         if self.parent.version == "mfusg" and self.parent.structured == False:
             f.write(
-                "{0:10d}{1:10.6G}{2:10d}{3:10d} {4:s}\n".format(
+                "{:10d}{:10.6G}{:10d}{:10d} {:s}\n".format(
                     self.ipakcb,
                     self.hdry,
                     self.nplpf,

--- a/flopy/modflow/mfnwt.py
+++ b/flopy/modflow/mfnwt.py
@@ -318,7 +318,7 @@ class ModflowNwt(Package):
         )
         isspecified = False
         for option in self.options:
-            f.write("{0:>10s}".format(option.upper()))
+            f.write(f"{option.upper():>10s}")
             if option.lower() == "specified":
                 isspecified = True
         if isspecified:

--- a/flopy/modflow/mfsfr2.py
+++ b/flopy/modflow/mfsfr2.py
@@ -1829,7 +1829,7 @@ class ModflowSfr2(Package):
             fdpth,
             awdth,
             bwdth,
-        ) = [0 if v == self.default_value else v for v in seg_dat]
+        ) = (0 if v == self.default_value else v for v in seg_dat)
 
         f_sfr.write(
             " ".join(fmts[0:4]).format(nseg, icalc, outseg, iupseg) + " "
@@ -1893,9 +1893,9 @@ class ModflowSfr2(Package):
         icalc = self.segment_data[i][j][1]
         seg_dat = np.array(self.segment_data[i])[cols][j]
         fmts = _fmt_string_list(seg_dat)
-        hcond, thickm, elevupdn, width, depth, thts, thti, eps, uhc = [
+        hcond, thickm, elevupdn, width, depth, thts, thti, eps, uhc = (
             0 if v == self.default_value else v for v in seg_dat
-        ]
+        )
 
         if self.isfropt in [0, 4, 5] and icalc <= 0:
             f_sfr.write(
@@ -2439,7 +2439,7 @@ class check:
         # simpler check method using paths from routing graph
         circular_segs = [k for k, v in self.sfr.paths.items() if v is None]
         if len(circular_segs) > 0:
-            txt += "{0} instances where an outlet was not found after {1} consecutive segments!\n".format(
+            txt += "{} instances where an outlet was not found after {} consecutive segments!\n".format(
                 len(circular_segs), self.sfr.nss
             )
             if self.level == 1:

--- a/flopy/modflow/mfswi2.py
+++ b/flopy/modflow/mfswi2.py
@@ -428,7 +428,7 @@ class ModflowSwi2(Package):
         # write SWI2 options
         if self.options != None:
             for o in self.options:
-                f.write(" {}".format(o))
+                f.write(f" {o}")
         f.write("\n")
 
         # write dataset 2a

--- a/flopy/modflow/mfupw.py
+++ b/flopy/modflow/mfupw.py
@@ -296,7 +296,7 @@ class ModflowUpw(Package):
         f_upw.write(f"{self.heading}\n")
         # Item 1: IBCFCB, HDRY, NPLPF
         f_upw.write(
-            "{0:10d}{1:10.3G}{2:10d}{3:10d}{4:s}\n".format(
+            "{:10d}{:10.3G}{:10d}{:10d}{:s}\n".format(
                 self.ipakcb, self.hdry, self.npupw, self.iphdry, self.options
             )
         )

--- a/flopy/modflow/mfuzf1.py
+++ b/flopy/modflow/mfuzf1.py
@@ -762,7 +762,7 @@ class ModflowUzf1(Package):
         if self.iuzfopt > 0:
             comment = " #NUZTOP IUZFOPT IRUNFLG IETFLG ipakcb IUZFCB2 NTRAIL NSETS NUZGAGES"
             f_uzf.write(
-                "{0:10d}{1:10d}{2:10d}{3:10d}{4:10d}{5:10d}{6:10d}{7:10d}{8:10d}{9:15.6E}{10:100s}\n".format(
+                "{:10d}{:10d}{:10d}{:10d}{:10d}{:10d}{:10d}{:10d}{:10d}{:15.6E}{:100s}\n".format(
                     self.nuztop,
                     self.iuzfopt,
                     self.irunflg,
@@ -779,7 +779,7 @@ class ModflowUzf1(Package):
         else:
             comment = " #NUZTOP IUZFOPT IRUNFLG IETFLG ipakcb IUZFCB2 NUZGAGES"
             f_uzf.write(
-                "{0:10d}{1:10d}{2:10d}{3:10d}{4:10d}{5:10d}{6:10d}{7:15.6E}{8:100s}\n".format(
+                "{:10d}{:10d}{:10d}{:10d}{:10d}{:10d}{:10d}{:15.6E}{:100s}\n".format(
                     self.nuztop,
                     self.iuzfopt,
                     self.irunflg,

--- a/flopy/modpath/mp6.py
+++ b/flopy/modpath/mp6.py
@@ -162,7 +162,7 @@ class Modpath6(BaseModel):
             if not os.path.exists(read_dis):
                 # path doesn't exist, probably relative to model_ws
                 read_dis = os.path.join(self.model_ws, dis_file)
-            with open(read_dis, "r") as f:
+            with open(read_dis) as f:
                 line = f.readline()
                 while line[0] == "#":
                     line = f.readline()

--- a/flopy/modpath/mp6sim.py
+++ b/flopy/modpath/mp6sim.py
@@ -277,7 +277,7 @@ class Modpath6Sim(Package):
                     CHeadOption,
                 ) = self.group_placement[i]
                 f_sim.write(
-                    "{0:d} {1:d} {2:d} {3:f} {4:d} {5:d}\n".format(
+                    "{:d} {:d} {:d} {:f} {:d} {:d}\n".format(
                         Grid,
                         GridCellRegionOption,
                         PlacementOption,
@@ -306,7 +306,7 @@ class Modpath6Sim(Package):
                         MaxColumn,
                     ) = self.group_region[i]
                     f_sim.write(
-                        "{0:d} {1:d} {2:d} {3:d} {4:d} {5:d}\n".format(
+                        "{:d} {:d} {:d} {:d} {:d} {:d}\n".format(
                             MinLayer + 1,
                             MinRow + 1,
                             MinColumn + 1,
@@ -344,7 +344,7 @@ class Modpath6Sim(Package):
                         ParticleColumnCount,
                     ) = self.particle_cell_cnt[i]
                     f_sim.write(
-                        "{0:d} {1:d} {2:d} \n".format(
+                        "{:d} {:d} {:d} \n".format(
                             ParticleLayerCount,
                             ParticleRowCount,
                             ParticleColumnCount,
@@ -553,9 +553,9 @@ class StartingLocationsFile(Package):
             groups[["groupname", "count"]].astype(str).values.flatten()
         )
         with open(loc_path, "w") as f:
-            f.write("{}\n".format(self.heading))
-            f.write("{:d}\n".format(self.input_style))
-            f.write("{}\n".format(group_count))
+            f.write(f"{self.heading}\n")
+            f.write(f"{self.input_style:d}\n")
+            f.write(f"{group_count}\n")
 
         groups.to_csv(loc_path, sep=" ", index=False, header=False, mode="a")
 

--- a/flopy/mt3d/mt.py
+++ b/flopy/mt3d/mt.py
@@ -693,16 +693,15 @@ class Mt3dms(BaseModel):
         # write message indicating packages that were successfully loaded
         if mt.verbose:
             print(
-                "\n   The following {0} packages were "
+                "\n   The following {} packages were "
                 "successfully loaded.".format(len(files_successfully_loaded))
             )
             for fname in files_successfully_loaded:
                 print(f"      {os.path.basename(fname)}")
             if len(files_not_loaded) > 0:
                 print(
-                    "   The following {0} packages were not loaded.".format(
-                        len(files_not_loaded)
-                    )
+                    f"   The following {len(files_not_loaded)} packages "
+                    "were not loaded."
                 )
                 for fname in files_not_loaded:
                     print(f"      {os.path.basename(fname)}")
@@ -765,7 +764,7 @@ class Mt3dms(BaseModel):
 
         if not os.path.isfile(fname):
             raise Exception(f"Could not find file: {fname}")
-        with open(fname, "r") as f:
+        with open(fname) as f:
             line = f.readline()
             if line.strip() != firstline:
                 raise Exception(

--- a/flopy/mt3d/mtbtn.py
+++ b/flopy/mt3d/mtbtn.py
@@ -701,7 +701,7 @@ class Mt3dBtn(Package):
 
         # A3
         f_btn.write(
-            "{0:10d}{1:10d}{2:10d}{3:10d}{4:10d}{5:10d}\n".format(
+            "{:10d}{:10d}{:10d}{:10d}{:10d}{:10d}\n".format(
                 self.nlay,
                 self.nrow,
                 self.ncol,
@@ -716,25 +716,25 @@ class Mt3dBtn(Package):
 
         # A5
         if self.parent.adv != None:
-            f_btn.write("{0:2s}".format("T"))
+            f_btn.write("T ")
         else:
-            f_btn.write("{0:2s}".format("F"))
+            f_btn.write("F ")
         if self.parent.dsp != None:
-            f_btn.write("{0:2s}".format("T"))
+            f_btn.write("T ")
         else:
-            f_btn.write("{0:2s}".format("F"))
+            f_btn.write("F ")
         if self.parent.ssm != None:
-            f_btn.write("{0:2s}".format("T"))
+            f_btn.write("T ")
         else:
-            f_btn.write("{0:2s}".format("F"))
+            f_btn.write("F ")
         if self.parent.rct != None:
-            f_btn.write("{0:2s}".format("T"))
+            f_btn.write("T ")
         else:
-            f_btn.write("{0:2s}".format("F"))
+            f_btn.write("F ")
         if self.parent.gcg != None:
-            f_btn.write("{0:2s}".format("T"))
+            f_btn.write("T ")
         else:
-            f_btn.write("{0:2s}".format("F"))
+            f_btn.write("F ")
         f_btn.write("\n")
 
         # A6
@@ -801,7 +801,7 @@ class Mt3dBtn(Package):
             f_btn.write(f"{nobs:10d}{self.nprobs:10d}\n")
             for i in range(nobs):
                 f_btn.write(
-                    "{0:10d}{1:10d}{2:10d}\n".format(
+                    "{:10d}{:10d}{:10d}\n".format(
                         self.obs[i, 0] + 1,
                         self.obs[i, 1] + 1,
                         self.obs[i, 2] + 1,
@@ -823,7 +823,7 @@ class Mt3dBtn(Package):
             s += "\n"
             f_btn.write(s)
             f_btn.write(
-                "{0:10.4G}{1:10d}{2:10.4G}{3:10.4G}\n".format(
+                "{:10.4G}{:10d}{:10.4G}{:10.4G}\n".format(
                     self.dt0[t],
                     self.mxstrn[t],
                     self.ttsmult[t],
@@ -875,12 +875,12 @@ class Mt3dBtn(Package):
             print("   loading COMMENT LINES A1 AND A2...")
         line = f.readline()
         if model.verbose:
-            print("A1: ".format(line.strip()))
+            print(f"A1: {line.strip()}")
 
         # A2
         line = f.readline()
         if model.verbose:
-            print("A2: ".format(line.strip()))
+            print(f"A2: {line.strip()}")
 
         # New keyword options in MT3D-USGS are found here
         line = f.readline()

--- a/flopy/mt3d/mtlkt.py
+++ b/flopy/mt3d/mtlkt.py
@@ -244,7 +244,7 @@ class Mt3dLkt(Package):
 
         # Item 1
         f_lkt.write(
-            "{0:10d}{1:10d}{2:10}{3:10}          ".format(
+            "{:10d}{:10d}{:10}{:10}          ".format(
                 self.nlkinit, self.mxlkbc, self.icbclk, self.ietlak
             )
             + "# NLKINIT, MXLKBC, ICBCLK, IETLAK\n"

--- a/flopy/mt3d/mtsft.py
+++ b/flopy/mt3d/mtsft.py
@@ -302,9 +302,8 @@ class Mt3dSft(Package):
                         val = kwargs.pop(name)
                     else:
                         print(
-                            "SFT: setting {0} for component {1} to zero, kwarg name {2}".format(
-                                base_name, icomp, name
-                            )
+                            f"SFT: setting {base_name} for component {icomp} "
+                            f"to zero, kwarg name {name}"
                         )
                         val = 0.0
                     u2d = Util2d(
@@ -382,7 +381,7 @@ class Mt3dSft(Package):
 
         # Item 1
         f.write(
-            "{0:10d}{1:10d}{2:10d}{3:10d}{4:10d}".format(
+            "{:10d}{:10d}{:10d}{:10d}{:10d}".format(
                 self.nsfinit,
                 self.mxsfbc,
                 self.icbcsf,
@@ -395,7 +394,7 @@ class Mt3dSft(Package):
 
         # Item 2
         f.write(
-            "{0:10d}{1:10.5f}{2:10.5f}{3:10.7f}{4:10d}{5:10.5f}{6:10d}".format(
+            "{:10d}{:10.5f}{:10.5f}{:10.7f}{:10d}{:10.5f}{:10d}".format(
                 self.isfsolv,
                 self.wimp,
                 self.wups,

--- a/flopy/mt3d/mtssm.py
+++ b/flopy/mt3d/mtssm.py
@@ -494,7 +494,7 @@ class Mt3dSsm(Package):
             if self.stress_period_data is not None:
                 self.stress_period_data.write_transient(f_ssm, single_per=kper)
             else:
-                f_ssm.write("{}\n".format(0))
+                f_ssm.write(f"0\n")
 
         f_ssm.close()
         return

--- a/flopy/seawat/swtvdf.py
+++ b/flopy/seawat/swtvdf.py
@@ -269,7 +269,7 @@ class SeawatVdf(Package):
         )
 
         # item 2
-        f_vdf.write("%10.4f%10.4f\n" % (self.densemin, self.densemax))
+        f_vdf.write(f"{self.densemin:10.4f}{self.densemax:10.4f}\n")
 
         # item 3
         if self.nswtcpl > 1 or self.nswtcpl == -1:
@@ -278,11 +278,9 @@ class SeawatVdf(Package):
         # item 4
         if self.mtdnconc >= 0:
             if self.nsrhoeos == 1:
-                f_vdf.write("%10.4f%10.4f\n" % (self.denseref, self.denseslp))
+                f_vdf.write(f"{self.denseref:10.4f}{self.denseslp:10.4f}\n")
             else:
-                f_vdf.write(
-                    "%10.4f%10.4f\n" % (self.denseref, self.denseslp[0])
-                )
+                f_vdf.write(f"{self.denseref:10.4f}{self.denseslp[0]:10.4f}\n")
 
         elif self.mtdnconc == -1:
             f_vdf.write(

--- a/flopy/seawat/swtvsc.py
+++ b/flopy/seawat/swtvsc.py
@@ -245,7 +245,7 @@ class SeawatVsc(Package):
             if self.mutempopt > 0:
                 s = f"{self.mtmutempspec} "
                 for a in tuple(self.amucoeff):
-                    s += "{} ".format(a)
+                    s += f"{a} "
                 f_vsc.write(s + "\n")
 
         # items 4 and 5, transient visc array

--- a/flopy/utils/binaryfile.py
+++ b/flopy/utils/binaryfile.py
@@ -225,7 +225,7 @@ class BinaryHeader(Header):
                     text = ttext[0:16]
                 # pad a short string
                 elif len(ttext) < 16:
-                    text = "{:<16}".format(ttext)
+                    text = f"{ttext:<16}"
                 # the string is just right
                 else:
                     text = ttext
@@ -1317,7 +1317,7 @@ class CellBudgetFile:
         # check and make sure that text is in file
         if text is not None:
             text16 = self._find_text(text)
-            select_indices = np.where((self.recordarray["text"] == text16))
+            select_indices = np.where(self.recordarray["text"] == text16)
             if isinstance(select_indices, tuple):
                 select_indices = select_indices[0]
         else:
@@ -1449,7 +1449,7 @@ class CellBudgetFile:
 
         elif totim is not None:
             if text is None and paknam is None:
-                select_indices = np.where((self.recordarray["totim"] == totim))
+                select_indices = np.where(self.recordarray["totim"] == totim)
             else:
                 if paknam is None and text is not None:
                     select_indices = np.where(
@@ -1477,7 +1477,7 @@ class CellBudgetFile:
 
         # case where only text is entered
         elif text is not None:
-            select_indices = np.where((self.recordarray["text"] == text16))
+            select_indices = np.where(self.recordarray["text"] == text16)
 
         else:
             raise TypeError(
@@ -1906,7 +1906,7 @@ class CellBudgetFile:
         residual = np.zeros((nlay, nrow, ncol), dtype=float)
         if scaled:
             inflow = np.zeros((nlay, nrow, ncol), dtype=float)
-        select_indices = np.where((self.recordarray["totim"] == totim))[0]
+        select_indices = np.where(self.recordarray["totim"] == totim)[0]
 
         for i in select_indices:
             text = self.recordarray[i]["text"].decode()
@@ -2046,7 +2046,7 @@ class HeadUFile(BinaryLayerFile):
         """
 
         if totim >= 0.0:
-            keyindices = np.where((self.recordarray["totim"] == totim))[0]
+            keyindices = np.where(self.recordarray["totim"] == totim)[0]
             if len(keyindices) == 0:
                 msg = f"totim value ({totim}) not found in file..."
                 raise Exception(msg)

--- a/flopy/utils/datafile.py
+++ b/flopy/utils/datafile.py
@@ -422,7 +422,7 @@ class LayerFile:
         """
 
         if totim >= 0.0:
-            keyindices = np.where((self.recordarray["totim"] == totim))[0]
+            keyindices = np.where(self.recordarray["totim"] == totim)[0]
             if len(keyindices) == 0:
                 msg = f"totim value ({totim}) not found in file..."
                 raise Exception(msg)

--- a/flopy/utils/mflistfile.py
+++ b/flopy/utils/mflistfile.py
@@ -306,11 +306,10 @@ class ListBudget:
             and not units == "minutes"
             and not units == "hours"
         ):
-            err = (
+            raise AssertionError(
                 '"units" input variable must be "minutes", "hours", '
-                'or "seconds": {0} was specified'.format(units)
+                f'or "seconds": {units} was specified'
             )
-            raise AssertionError(err)
         try:
             seekpoint = self._seek_to_string("Elapsed run time:")
         except:

--- a/flopy/utils/mfreadnam.py
+++ b/flopy/utils/mfreadnam.py
@@ -217,7 +217,7 @@ def attribs_from_namfile_header(namefile):
     if namefile is None:
         return defaults
     header = []
-    with open(namefile, "r") as f:
+    with open(namefile) as f:
         for line in f:
             if not line.startswith("#"):
                 break
@@ -295,7 +295,7 @@ def get_entries_from_namefile(
         namefile entry that meets a user-specified value.
     """
     entries = []
-    with open(path, "r") as f:
+    with open(path) as f:
         for line in f:
             if line.strip() == "":
                 continue
@@ -357,7 +357,7 @@ def get_input_files(namefile):
     srcdir = os.path.dirname(namefile)
     filelist = []
     fname = os.path.join(srcdir, namefile)
-    with open(fname, "r") as f:
+    with open(fname) as f:
         lines = f.readlines()
 
     for line in lines:
@@ -453,7 +453,7 @@ def get_mf6_nper(tdisfile):
     nper : int
         number of stress periods in the simulation
     """
-    with open(tdisfile, "r") as f:
+    with open(tdisfile) as f:
         lines = f.readlines()
     line = [line for line in lines if "NPER" in line.upper()][0]
     nper = line.strip().split()[1]
@@ -471,7 +471,7 @@ def get_mf6_mshape(disfile):
     mshape : tuple
         tuple with the shape of the MODFLOW 6 model.
     """
-    with open(disfile, "r") as f:
+    with open(disfile) as f:
         lines = f.readlines()
 
     d = {}
@@ -546,7 +546,7 @@ def get_mf6_files(mfnamefile):
     # Go through name files and get files
     for namefile in namefiles:
         fname = os.path.join(srcdir, namefile)
-        with open(fname, "r") as f:
+        with open(fname) as f:
             lines = f.readlines()
         insideblock = False
 
@@ -699,7 +699,7 @@ def get_mf6_ftypes(namefile, ftypekeys):
     ftypes : list
         list of FTYPES that match ftypekeys in namefile
     """
-    with open(namefile, "r") as f:
+    with open(namefile) as f:
         lines = f.readlines()
 
     ftypes = []

--- a/flopy/utils/modpathfile.py
+++ b/flopy/utils/modpathfile.py
@@ -16,7 +16,7 @@ from ..utils.flopy_io import loadtxt
 from ..utils.recarray_utils import ra_slice
 
 
-class _ModpathSeries(object):
+class _ModpathSeries:
     """
     Base class for PathlineFile and TimeseriesFile objects.
 

--- a/flopy/utils/mtlistfile.py
+++ b/flopy/utils/mtlistfile.py
@@ -96,9 +96,7 @@ class MtListBudget:
                         except Exception as e:
                             warnings.warn(
                                 "error parsing GW mass budget "
-                                "starting on line {0}: {1} ".format(
-                                    self.lcount, str(e)
-                                )
+                                f"starting on line {self.lcount}: {e!s}"
                             )
                             break
                     else:
@@ -109,10 +107,8 @@ class MtListBudget:
                             self._parse_sw(f, line)
                         except Exception as e:
                             warnings.warn(
-                                "error parsing SW mass budget"
-                                " starting on line {0}: {1} ".format(
-                                    self.lcount, str(e)
-                                )
+                                "error parsing SW mass budget "
+                                f"starting on line {self.lcount}: {e!s}"
                             )
                             break
                     else:
@@ -474,7 +470,7 @@ class MtListBudget:
 
     def _add_to_sw_data(self, inout, item, cval, fval, comp):
         item += f"_{comp}"
-        if inout.lower() in set(["in", "out"]):
+        if inout.lower() in {"in", "out"}:
             item += f"_{inout}"
         if fval is None:
             lab_val = zip([""], [cval])

--- a/flopy/utils/observationfile.py
+++ b/flopy/utils/observationfile.py
@@ -507,7 +507,7 @@ class CsvFile:
     def __init__(
         self, csvfile, delimiter=",", deletechars="", replace_space=""
     ):
-        with open(csvfile, "r") as self.file:
+        with open(csvfile) as self.file:
             self.delimiter = delimiter
             self.deletechars = deletechars
             self.replace_space = replace_space

--- a/flopy/utils/optionblock.py
+++ b/flopy/utils/optionblock.py
@@ -122,7 +122,7 @@ class OptionBlock:
                                 pass
                             else:
                                 val.append(
-                                    str((object.__getattribute__(self, k)))
+                                    str(object.__getattribute__(self, k))
                                 )
 
                 if "None" in val:

--- a/flopy/utils/swroutputfile.py
+++ b/flopy/utils/swroutputfile.py
@@ -309,10 +309,10 @@ class SwrFile(FlopyBinaryData):
         """
 
         if irec + 1 > self.nrecord:
-            err = "Error: specified irec ({}) ".format(
-                irec
-            ) + "exceeds the total number of records ()".format(self.nrecord)
-            raise Exception(err)
+            raise Exception(
+                f"specified irec ({irec}) exceeds the "
+                f"total number of records ({self.nrecord})"
+            )
 
         gage_record = None
         if self.type == "stage" or self.type == "budget":

--- a/flopy/utils/triangle.py
+++ b/flopy/utils/triangle.py
@@ -730,7 +730,7 @@ class Triangle:
         f = open(fname, "w")
 
         # vertices, write zero to indicate read from node file
-        s = "{} {} {} {}\n".format(0, 0, 0, 0)
+        s = "0 0 0 0\n"
         f.write(s)
 
         # segments

--- a/flopy/utils/util_array.py
+++ b/flopy/utils/util_array.py
@@ -138,11 +138,11 @@ class ArrayFormat:
         else:
             raise Exception(
                 "ArrayFormat._set_defaults() error: "
-                "unsupported dtype: {0}".format(str(self.dtype))
+                f"unsupported dtype: {self.dtype!s}"
             )
 
     def __str__(self):
-        s = "ArrayFormat: npl:{0},format:{1},width:{2},decimal{3}".format(
+        s = "ArrayFormat: npl:{},format:{},width:{},decimal{}".format(
             self.npl, self.format, self.width, self.decimal
         )
         s += f",isfree:{self._isfree},isbinary:{self._isbinary}"
@@ -224,7 +224,7 @@ class ArrayFormat:
             elif self.dtype == np.float32 and width < self.default_float_width:
                 print(
                     "ArrayFormat warning:setting width less "
-                    "than default of {0}".format(self.default_float_width)
+                    f"than default of {self.default_float_width}"
                 )
                 self._width = width
         elif key == "decimal":
@@ -235,13 +235,12 @@ class ArrayFormat:
                 if value < self.default_float_decimal:
                     print(
                         "ArrayFormat warning: setting decimal less than "
-                        "default of {0}".format(self.default_float_decimal)
+                        f"default of {self.default_float_decimal}"
                     )
                 if value < self.decimal:
                     print(
-                        "ArrayFormat warning: setting decimal "
-                        "less than current value of "
-                        "{0}".format(self.default_float_decimal)
+                        "ArrayFormat warning: setting decimal less than "
+                        f"current value of {self.default_float_decimal}"
                     )
                 self._decimal = int(value)
             else:
@@ -379,11 +378,11 @@ class ArrayFormat:
         fd = fd.replace('"', "")
         # strip off '(' and ')'
         fd = fd.strip()[1:-1]
-        if str("FREE") in str(fd.upper()):
+        if "FREE" in fd.upper():
             return "free", None, None, None
-        elif str("BINARY") in str(fd.upper()):
+        elif "BINARY" in fd.upper():
             return "binary", None, None, None
-        if str(".") in str(fd):
+        if "." in fd:
             raw = fd.split(".")
             decimal = int(raw[1])
         else:
@@ -882,7 +881,7 @@ class Util3d(DataInterface):
         else:
             raise Exception(
                 "util_array_3d: value attribute must be list "
-                "or ndarray, not {}".format(type(self.__value))
+                f"or ndarray, not {type(self.__value)}"
             )
         return u2ds
 
@@ -1050,7 +1049,7 @@ class Transient3d(DataInterface):
         if len(shape) != 3:
             raise ValueError(
                 "Transient3d: expected 3 dimensions (nlay, nrow, ncol), found "
-                "shape {0}".format(shape)
+                f"shape {shape}"
             )
         self.shape = shape
         self._dtype = dtype
@@ -1119,13 +1118,13 @@ class Transient3d(DataInterface):
         except Exception as e:
             raise Exception(
                 "Transient3d.__setitem__() error: "
-                "'key'could not be cast to int:{0}".format(str(e))
+                f"'key'could not be cast to int:{e!s}"
             )
         nper = self._model.nper
         if key > self._model.nper or key < 0:
             raise Exception(
                 "Transient3d.__setitem__() error: "
-                "key {0} not in nper range {1}:{2}".format(key, 0, nper)
+                f"key {key} not in nper range 0:{nper}"
             )
 
         self.transient_3ds[key] = self.__get_3d_instance(key, value)
@@ -1185,7 +1184,7 @@ class Transient3d(DataInterface):
                 except Exception as e:
                     raise Exception(
                         "Transient3d error building Util3d instance from "
-                        "value at kper: {}\n{}".format(key, e)
+                        f"value at kper: {key}\n{e!s}"
                     )
                 tran_seq[key] = u3d
             return tran_seq
@@ -1571,13 +1570,13 @@ class Transient2d(DataInterface):
         except Exception as e:
             raise Exception(
                 "Transient2d.__setitem__() error: "
-                "'key'could not be cast to int:{0}".format(str(e))
+                f"'key'could not be cast to int:{e!s}"
             )
         nper = self._model.nper
         if key > self._model.nper or key < 0:
             raise Exception(
                 "Transient2d.__setitem__() error: "
-                "key {0} not in nper range {1}:{2}".format(key, 0, nper)
+                f"key {key} not in nper range 0:{nper}"
             )
 
         self.transient_2ds[key] = self.__get_2d_instance(key, value)
@@ -1634,7 +1633,7 @@ class Transient2d(DataInterface):
                 except Exception as e:
                     raise Exception(
                         "Transient2d error building Util2d instance from "
-                        "value at kper: {}\n{}".format(key, e)
+                        f"value at kper: {key}\n{e!s}"
                     )
                 tran_seq[key] = u2d
             return tran_seq
@@ -2216,11 +2215,11 @@ class Util2d(DataInterface):
         if locat == 0:
             fformat = ""
         if self.dtype == np.int32:
-            cr = "{0:>10.0f}{1:>10.0f}{2:>19s}{3:>10.0f} #{4}\n".format(
+            cr = "{:>10.0f}{:>10.0f}{:>19s}{:>10.0f} #{}\n".format(
                 locat, value, fformat, self.iprn, self._name
             )
         elif self._dtype == np.float32:
-            cr = "{0:>10.0f}{1:>10.5G}{2:>19s}{3:>10.0f} #{4}\n".format(
+            cr = "{:>10.0f}{:>10.5G}{:>19s}{:>10.0f} #{}\n".format(
                 locat, value, fformat, self.iprn, self._name
             )
         else:
@@ -2232,7 +2231,7 @@ class Util2d(DataInterface):
 
     def get_internal_cr(self):
         if self.format.array_free_format:
-            cr = "INTERNAL {0:15} {1:>10s} {2:2.0f} #{3:<30s}\n".format(
+            cr = "INTERNAL {:15} {:>10s} {:2.0f} #{:<30s}\n".format(
                 self.cnstnt_str, self.format.fortran, self.iprn, self._name
             )
             return cr
@@ -2247,7 +2246,7 @@ class Util2d(DataInterface):
             return f"{self.cnstnt:15.6G}"
 
     def get_openclose_cr(self):
-        cr = "OPEN/CLOSE  {0:>30s} {1:15} {2:>10s} {3:2.0f} {4:<30s}\n".format(
+        cr = "OPEN/CLOSE  {:>30s} {:15} {:>10s} {:2.0f} {:<30s}\n".format(
             self.model_file_path,
             self.cnstnt_str,
             self.format.fortran,
@@ -2264,7 +2263,7 @@ class Util2d(DataInterface):
             self.model_file_path, locat, self.format.binary
         )
         if self.format.array_free_format:
-            cr = "EXTERNAL  {0:>30d} {1:15} {2:>10s} {3:2.0f} {4:<30s}\n".format(
+            cr = "EXTERNAL  {:>30d} {:15} {:>10s} {:2.0f} {:<30s}\n".format(
                 locat,
                 self.cnstnt_str,
                 self.format.fortran,
@@ -2291,9 +2290,9 @@ class Util2d(DataInterface):
             and self.locat is None
         ):
             print(
-                "Util2d {0}: locat is None, but model does not "
+                f"Util2d {self._name}: locat is None, but model does not "
                 "support free format and how is internal... "
-                "resetting how = external".format(self._name)
+                "resetting how = external"
             )
             how = "external"
 
@@ -2343,7 +2342,7 @@ class Util2d(DataInterface):
                     if self._model.verbose:
                         print(
                             "Util2d warning: removing existing array "
-                            "file {0}".format(self.model_file_path)
+                            f"file {self.model_file_path}"
                         )
                     try:
                         os.remove(self.python_file_path)
@@ -2358,9 +2357,7 @@ class Util2d(DataInterface):
                 except Exception as e:
                     raise Exception(
                         "Util2d.get_file_array(): error copying "
-                        "{0} to {1}:{2}".format(
-                            self.__value, self.python_file_path, str(e)
-                        )
+                        f"{self.__value} to {self.python_file_path}:{e!s}"
                     )
             if how == "external":
                 return self.get_external_cr()
@@ -2577,8 +2574,8 @@ class Util2d(DataInterface):
         data = np.fromiter(items, dtype=dtype, count=num_items)
         if data.size != num_items:
             raise ValueError(
-                "Util2d.load_txt(): expected array size {0},"
-                " but found size {1}".format(num_items, data.size)
+                f"Util2d.load_txt(): expected array size {num_items}, "
+                f"but found size {data.size}"
             )
         return data.reshape(shape)
 
@@ -2707,8 +2704,8 @@ class Util2d(DataInterface):
             file_in.close()
         if data.size != num_items:
             raise ValueError(
-                "Util2d.load_bin(): expected array size {0},"
-                " but found size {1}".format(num_items, data.size)
+                f"Util2d.load_bin(): expected array size {num_items}, "
+                f"but found size {data.size}"
             )
         return header_data, data.reshape(shape)
 
@@ -2758,7 +2755,7 @@ class Util2d(DataInterface):
                 except:
                     raise Exception(
                         "Util2d error: str not a file and "
-                        "couldn't be cast to int: {0}".format(value)
+                        f"couldn't be cast to int: {value}"
                     )
 
             else:
@@ -2767,7 +2764,7 @@ class Util2d(DataInterface):
                 except:
                     raise Exception(
                         "Util2d error: str not a file and "
-                        "couldn't be cast to float: {0}".format(value)
+                        f"couldn't be cast to float: {value}"
                     )
 
         elif np.isscalar(value):
@@ -2793,8 +2790,8 @@ class Util2d(DataInterface):
                 value = value[0]
             if self.shape != value.shape:
                 raise Exception(
-                    "Util2d:self.shape: {} does not match value.shape: "
-                    "{}".format(self.shape, value.shape)
+                    f"Util2d:self.shape: {self.shape} does not match "
+                    f"value.shape: {value.shape}"
                 )
             if self._dtype != value.dtype:
                 value = value.astype(self._dtype)
@@ -2876,7 +2873,7 @@ class Util2d(DataInterface):
             assert os.path.exists(
                 fname
             ), f"Util2d.load() error: open/close file {fname} not found"
-            if str("binary") not in str(cr_dict["fmtin"].lower()):
+            if "binary" not in cr_dict["fmtin"].lower():
                 f = open(fname, "r")
                 data = Util2d.load_txt(
                     shape=shape, file_in=f, dtype=dtype, fmtin=cr_dict["fmtin"]

--- a/flopy/utils/util_list.py
+++ b/flopy/utils/util_list.py
@@ -382,8 +382,8 @@ class MfList(DataInterface, DataListInterface):
         if d > 0:
             raise Exception(
                 "MfList error: dict integer value for "
-                "kper {0:10d} must be 0 or -1, "
-                "not {1:10d}".format(kper, d)
+                "kper {:10d} must be 0 or -1, "
+                "not {:10d}".format(kper, d)
             )
         if d == 0:
             self.__data[kper] = 0
@@ -394,8 +394,8 @@ class MfList(DataInterface, DataListInterface):
 
     def __cast_recarray(self, kper, d):
         assert d.dtype == self.__dtype, (
-            "MfList error: recarray dtype: {} doesn't match self dtype: "
-            "{}".format(d.dtype, self.dtype)
+            f"MfList error: recarray dtype: {d.dtype} doesn't match "
+            f"self dtype: {self.dtype}"
         )
         self.__data[kper] = d
         self.__vtype[kper] = np.recarray
@@ -404,8 +404,8 @@ class MfList(DataInterface, DataListInterface):
         d = np.atleast_2d(d)
         if d.dtype != self.__dtype:
             assert d.shape[1] == len(self.dtype), (
-                "MfList error: ndarray shape {} doesn't match dtype len: "
-                "{}".format(d.shape, len(self.dtype))
+                f"MfList error: ndarray shape {d.shape} doesn't match "
+                f"dtype len: {len(self.dtype)}"
             )
             # warnings.warn("MfList: ndarray dtype does not match self " +\
             #               "dtype, trying to cast")
@@ -799,7 +799,7 @@ class MfList(DataInterface, DataListInterface):
         if ("k" not in names) or ("i" not in names) or ("j" not in names):
             warnings.warn(
                 "MfList.check_kij(): index fieldnames 'k,i,j' "
-                "not found in self.dtype names: {}".format(names)
+                f"not found in self.dtype names: {names}"
             )
             return
         nr, nc, nl, nper = self._model.get_nrow_ncol_nlay_nper()
@@ -828,11 +828,11 @@ class MfList(DataInterface, DataListInterface):
                 if len(out_idx) > 0:
                     warn_str = (
                         "MfList.check_kij(): warning the following "
-                        "indices are out of bounds in kper {}:\n".format(kper)
+                        f"indices are out of bounds in kper {kper}:\n"
                     )
                     for idx in out_idx:
                         d = data[idx]
-                        warn_str += " {0:9d} {1:9d} {2:9d}\n".format(
+                        warn_str += " {:9d} {:9d} {:9d}\n".format(
                             d["k"] + 1, d["i"] + 1, d["j"] + 1
                         )
                     warnings.warn(warn_str)

--- a/flopy/utils/zonbud.py
+++ b/flopy/utils/zonbud.py
@@ -1454,7 +1454,7 @@ class ZoneBudget:
         zones : np.array
 
         """
-        with open(fname, "r") as f:
+        with open(fname) as f:
             lines = f.readlines()
 
         # Initialize layer
@@ -1466,7 +1466,7 @@ class ZoneBudget:
 
         # First line contains array dimensions
         dimstring = lines.pop(0).strip().split()
-        nlay, nrow, ncol = [int(v) for v in dimstring]
+        nlay, nrow, ncol = (int(v) for v in dimstring)
         zones = np.zeros((nlay, nrow, ncol), dtype=np.int32)
 
         # The number of values to read before placing
@@ -1497,7 +1497,7 @@ class ZoneBudget:
                     iconst = int(rowitems[1])
                 else:
                     fmt = rowitems[1].strip("()")
-                    fmtin, iprn = [int(v) for v in fmt.split("I")]
+                    fmtin, iprn = (int(v) for v in fmt.split("I"))
 
             # ZONE DATA
             else:
@@ -1517,7 +1517,7 @@ class ZoneBudget:
                     if not os.path.isfile(fname):
                         errmsg = f'Could not find external file "{fname}"'
                         raise Exception(errmsg)
-                    with open(fname, "r") as ext_f:
+                    with open(fname) as ext_f:
                         ext_flines = ext_f.readlines()
                     for ext_frow in ext_flines:
                         ext_frowitems = ext_frow.strip().split()
@@ -2462,7 +2462,7 @@ def _get_budget(recarray, zonenamedict, names=None, zones=None, net=False):
     if "totim" in recarray.dtype.names:
         standard_fields.insert(0, "totim")
     select_fields = standard_fields + list(zonenamedict.values())
-    select_records = np.where((recarray["name"] == recarray["name"]))
+    select_records = np.where(recarray["name"] == recarray["name"])
     if zones is not None:
         for idx, z in enumerate(zones):
             if isinstance(z, int):

--- a/flopy/version.py
+++ b/flopy/version.py
@@ -3,4 +3,4 @@
 major = 3
 minor = 3
 micro = 7
-__version__ = "{}.{}.{}".format(major, minor, micro)
+__version__ = f"{major}.{minor}.{micro}"

--- a/scripts/process_benchmarks.py
+++ b/scripts/process_benchmarks.py
@@ -24,7 +24,7 @@ def get_benchmarks(paths):
     num_benchmarks = 0
 
     for path in paths:
-        with open(path, "r") as file:
+        with open(path) as file:
             jsn = json.load(file)
             system = jsn["machine_info"]["system"]
             python = jsn["machine_info"]["python_version"]

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -78,7 +78,7 @@ class Version(NamedTuple):
     def from_file(cls, path: PathLike) -> "Version":
         lines = [
             line.rstrip("\n")
-            for line in open(Path(path).expanduser().absolute(), "r")
+            for line in open(Path(path).expanduser().absolute())
         ]
         vmajor = vminor = vpatch = None
         for line in lines:
@@ -151,13 +151,13 @@ def update_version_py(
 ):
     with open(_version_py_path, "w") as f:
         f.write(
-            f"# {_project_name} version file automatically created using {Path(__file__).name} on {timestamp.strftime('%B %d, %Y %H:%M:%S')}\n"
+            f"# {_project_name} version file automatically created using "
+            f"{Path(__file__).name} on {timestamp:%B %d, %Y %H:%M:%S}\n\n"
         )
-        f.write("\n")
         f.write(f"major = {version.major}\n")
         f.write(f"minor = {version.minor}\n")
         f.write(f"micro = {version.patch}\n")
-        f.write("__version__ = '{}.{}.{}'.format(major, minor, micro)\n")
+        f.write('__version__ = f"{major}.{minor}.{micro}'\n")
     print(f"Updated {_version_py_path} to version {version}")
 
 


### PR DESCRIPTION
This PR is mostly automated with [pyupgrade](https://github.com/asottile/pyupgrade):

    pyupgrade --py38-plus `find . -name "*.py"`

with a few manual checks and edits with these notes:

- Auto-edits that look like `f = open(fpth, "r")` are rejected (for now) to make it clear that the second parameter to `open` is in read-only mode, as the variable `f` persists. These may be revised in `with` statements later.
- Auto-edits that look like `with open(fname, "r") as f:` -> `with open(fname) as f:` are kept, since subsequent lines are (e.g.) `f.readlines()` or `for line in f:` to demonstrate that the file was opened with read mode. However, I don't mind rejecting these edits if folks would rather always see the default `"r"`.
- Most other pyupgrade changes relate to extra (unnecessary) parentheses,  change `%` formatting or other str formatting details. There is usually a good rationale for some of the changes, just ask any questions if relevant.
- Manual edits are to use (e.g.) `"T "` instead of `"{0:2s}".format("T"))`, remove non-functional formats like in flopy/modflow/mfflwob.py, and manually update a few other `.format()` to f-strings where not done automatically.