### PR TITLE
fix(test_sfr): update test to be more robust with Matplotlib versions

### DIFF
--- a/autotest/test_sfr.py
+++ b/autotest/test_sfr.py
@@ -797,12 +797,8 @@ def test_sfr_plot(mf2005_model_path):
         check=False,
     )
     sfr = m.get_package("SFR")
-    tv = sfr.plot(
-        key="strtop",
-    )
-    assert issubclass(
-        type(tv[0]), matplotlib.axes.SubplotBase
-    ), "could not plot strtop"
+    tv = sfr.plot(key="strtop")
+    assert isinstance(tv[0], matplotlib.axes.SubplotBase)
 
 
 def get_test_matrix():


### PR DESCRIPTION
This fixes CI tests failure that previously worked <24 hrs due to a new release of matplotlib.

Generally, `isinstance()` is more tolerable, and works here for different versions of matplotlib.