### PR TITLE
ci(mf6.yml): use GITHUB_TOKEN to bypass rate limit when installing exes

### DIFF
--- a/.github/workflows/mf6.yml
+++ b/.github/workflows/mf6.yml
@@ -79,6 +79,8 @@ jobs:
 
     - name: Get executables
       working-directory: modflow6/autotest
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
         pytest -v --durations=0 get_exes.py
 


### PR DESCRIPTION
Avoid [errors like this](https://github.com/modflowpy/flopy/actions/runs/4265346307/jobs/7424562227#step:12:620). We already do this in `MODFLOW-USGS/modflow6`, just hadn't updated CI here to do so yet.