### PR TITLE
fix(MFFileMgmt): fix strip_model_relative_path to avoid IndexError

### DIFF
--- a/flopy/mf6/mfpackage.py
+++ b/flopy/mf6/mfpackage.py
@@ -1548,8 +1548,8 @@ class MFPackage(PackageContainer, PackageInterface):
         The parent model, simulation, or package containing this package
     package_type : str
         String defining the package type
-    filename : str
-        Filename of file where this package is stored
+    filename : str or PathLike
+        Name or path of file where this package is stored
     quoted_filename : str
         Filename with quotes around it when there is a space in the name
     pname : str
@@ -1674,7 +1674,7 @@ class MFPackage(PackageContainer, PackageInterface):
                 # filename uses model base name
                 self._filename = f"{self.model_or_sim.name}.{package_type}"
         else:
-            if not isinstance(filename, str):
+            if not isinstance(filename, (str, os.PathLike)):
                 message = (
                     "Invalid fname parameter. Expecting type str. "
                     'Instead type "{}" was '
@@ -1694,7 +1694,9 @@ class MFPackage(PackageContainer, PackageInterface):
                     message,
                     self.model_or_sim.simulation_data.debug,
                 )
-            self._filename = datautil.clean_filename(filename)
+            self._filename = datautil.clean_filename(
+                str(filename).replace("\\", "/")
+            )
         self.path, self.structure = self.model_or_sim.register_package(
             self, not loading_package, pname is None, filename is None
         )


### PR DESCRIPTION
- Fix #1747. `MFSimulation.load()` with absolute or relative paths on Windows could raise `IndexError`, tracing to `MFFileMgmt.strip_model_relative_path`. Avoid this and refactor to use `pathlib`. Test providing namefile by name, by absolute path, and by relative path

- Since Modflow6 supports POSIX paths even on Windows, use forward slash separators in relative path strings returned by `strip_model_relative_path` on all OS &mdash; previously used backslashes on Windows

- Convert back- to forward-slashes in `filename` ctor argument to `MFPackage`. Fixes [an error](https://github.com/modflowpy/flopy/actions/runs/4806458990/jobs/8554004109) introduced in https://github.com/modflowpy/flopy/pull/1759 occurring with a relative `filename` with Windows separators

- Currently FloPy `MFSimulation.write_simulation()` and similar still emit backslashes on Windows, in future these could write posix paths too. Add a test case for this but ignore it for now