### PR TITLE
fix(ParticleData): support partlocs as ndarray or list of lists

### DIFF
--- a/autotest/test_particledata.py
+++ b/autotest/test_particledata.py
@@ -1,0 +1,51 @@
+import numpy as np
+
+from flopy.modpath import ParticleData
+
+structured_plocs = [(1, 1, 1), (1, 1, 2)]
+structured_dtype = np.dtype(
+    [
+        ("k", "<i4"),
+        ("i", "<i4"),
+        ("j", "<i4"),
+        ("localx", "<f4"),
+        ("localy", "<f4"),
+        ("localz", "<f4"),
+        ("timeoffset", "<f4"),
+        ("drape", "<i4"),
+    ]
+)
+structured_array = np.core.records.fromrecords(
+    [
+        (1, 1, 1, 0.5, 0.5, 0.5, 0.0, 0),
+        (1, 1, 2, 0.5, 0.5, 0.5, 0.0, 0),
+    ],
+    dtype=structured_dtype,
+)
+
+
+def test_particledata_structured_partlocs_as_list_of_tuples():
+    locs = structured_plocs
+    data = ParticleData(partlocs=locs, structured=True)
+
+    assert data.particlecount == 2
+    assert data.dtype == structured_dtype
+    assert np.array_equal(data.particledata, structured_array)
+
+
+def test_particledata_structured_partlocs_as_ndarray():
+    locs = np.array(structured_plocs)
+    data = ParticleData(partlocs=locs, structured=True)
+
+    assert data.particlecount == 2
+    assert data.dtype == structured_dtype
+    assert np.array_equal(data.particledata, structured_array)
+
+
+def test_particledata_structured_partlocs_as_list_of_lists():
+    locs = [list(p) for p in structured_plocs]
+    data = ParticleData(partlocs=locs, structured=True)
+
+    assert data.particlecount == 2
+    assert data.dtype == structured_dtype
+    assert np.array_equal(data.particledata, structured_array)

--- a/flopy/modpath/mp7particledata.py
+++ b/flopy/modpath/mp7particledata.py
@@ -6,6 +6,7 @@ mp7particledata module. Contains the ParticleData, CellDataType,
 """
 
 import numpy as np
+from numpy.lib.recfunctions import unstructured_to_structured
 
 from ..utils.recarray_utils import create_empty_recarray
 
@@ -125,7 +126,7 @@ class ParticleData:
                     alllen3 = all(len(el) == 3 for el in partlocs)
                     if not alllen3:
                         raise ValueError(
-                            "{}: all partlocs entries  must have 3 items for "
+                            "{}: all partlocs entries must have 3 items for "
                             "structured particle data".format(self.name)
                         )
                 else:
@@ -164,14 +165,16 @@ class ParticleData:
 
             # convert partlocs composed of a lists/tuples of lists/tuples
             # to a numpy array
-            partlocs = np.array(partlocs, dtype=dtype)
+            partlocs = unstructured_to_structured(
+                np.array(partlocs), dtype=dtype
+            )
         elif isinstance(partlocs, np.ndarray):
             dtypein = partlocs.dtype
             if dtypein != dtype:
-                partlocs = np.array(partlocs, dtype=dtype)
+                partlocs = unstructured_to_structured(partlocs, dtype=dtype)
         else:
             raise ValueError(
-                f"{self.name}: partlocs must be a list or tuple with lists or tuples"
+                f"{self.name}: partlocs must be a list or tuple with lists or tuples, or an ndarray"
             )
 
         # localx


### PR DESCRIPTION
Addresses #1628, uses `from numpy.lib.recfunctions import unstructured_to_structured` as suggested and adds a few test cases