### PR TITLE
fix(mp6sim): use keyword args for pandas DataFrame.drop

### DIFF
--- a/flopy/modpath/mp6sim.py
+++ b/flopy/modpath/mp6sim.py
@@ -561,7 +561,7 @@ class StartingLocationsFile(Package):
 
         # write particle data
         print("writing loc particle data")
-        data.drop("groupname", 1, inplace=True)
+        data.drop(labels="groupname", axis=1, inplace=True)
         data.to_csv(
             loc_path,
             sep=" ",


### PR DESCRIPTION
[Pandas 2.0](https://pandas.pydata.org/pandas-docs/version/2.0/whatsnew/v2.0.0.html) made [non-keyword arguments illegal for `DataFrame.drop()`](https://github.com/pandas-dev/pandas/pull/41486), update usage in `mp6sim.py`.