### PR TITLE
fix(MFFileMgmt): remove string_to_file_path

### DIFF
--- a/autotest/test_mf6.py
+++ b/autotest/test_mf6.py
@@ -238,32 +238,6 @@ def get_gwt_model(sim, gwtname, gwtpath, modelshape, sourcerecarray=None):
     return gwt
 
 
-def test_string_to_file_path():
-    import platform
-
-    if platform.system().lower() == "windows":
-        unc_path = r"\\server\path\path"
-        new_path = MFFileMgmt.string_to_file_path(unc_path)
-        assert unc_path == new_path, "UNC path error"
-
-        abs_path = r"C:\Users\some_user\path"
-        new_path = MFFileMgmt.string_to_file_path(abs_path)
-        assert abs_path == new_path, "Absolute path error"
-
-        rel_path = r"..\path\some_path"
-        new_path = MFFileMgmt.string_to_file_path(rel_path)
-        assert rel_path == new_path, "Relative path error"
-
-    else:
-        abs_path = "/mnt/c/some_user/path"
-        new_path = MFFileMgmt.string_to_file_path(abs_path)
-        assert abs_path == new_path, "Absolute path error"
-
-        rel_path = "../path/some_path"
-        new_path = MFFileMgmt.string_to_file_path(rel_path)
-        assert rel_path == new_path, "Relative path error"
-
-
 def test_subdir(function_tmpdir):
     sim = MFSimulation(sim_ws=function_tmpdir)
     assert sim.sim_path == function_tmpdir

--- a/flopy/mf6/mfbase.py
+++ b/flopy/mf6/mfbase.py
@@ -311,29 +311,6 @@ class MFFileMgmt:
         else:
             return f"{file}_{num}"
 
-    @staticmethod
-    def string_to_file_path(fp_string):
-        """Interpret string as a file path.  For internal FloPy use, not
-        intended for end user."""
-        file_delimiters = ["/", "\\"]
-        new_string = fp_string
-        for delimiter in file_delimiters:
-            arr_string = new_string.split(delimiter)
-            if len(arr_string) > 1:
-                if os.path.isabs(fp_string):
-                    if not arr_string[0] and not arr_string[1]:
-                        new_string = f"{delimiter}{delimiter}"
-                    else:
-                        new_string = (
-                            f"{arr_string[0]}{delimiter}{arr_string[1]}"
-                        )
-                else:
-                    new_string = os.path.join(arr_string[0], arr_string[1])
-                if len(arr_string) > 2:
-                    for path_piece in arr_string[2:]:
-                        new_string = os.path.join(new_string, path_piece)
-        return new_string
-
     def set_last_accessed_path(self):
         """Set the last accessed simulation path to the current simulation
         path.  For internal FloPy use, not intended for end user."""

--- a/flopy/mf6/mfmodel.py
+++ b/flopy/mf6/mfmodel.py
@@ -1280,7 +1280,7 @@ class MFModel(PackageContainer, ModelInterface):
         # update path in the file manager
         file_mgr = self.simulation_data.mfpath
         file_mgr.set_last_accessed_model_path()
-        path = file_mgr.string_to_file_path(model_ws)
+        path = model_ws
         file_mgr.model_relative_path[self.name] = path
 
         if (
@@ -1730,9 +1730,7 @@ class MFModel(PackageContainer, ModelInterface):
 
         if set_package_filename:
             # filename uses model base name
-            package._filename = MFFileMgmt.string_to_file_path(
-                f"{self.name}.{package.package_type}"
-            )
+            package._filename = f"{self.name}.{package.package_type}"
             if package._filename in self.package_filename_dict:
                 # auto generate a unique file name and register it
                 file_name = MFFileMgmt.unique_file_name(

--- a/flopy/mf6/mfpackage.py
+++ b/flopy/mf6/mfpackage.py
@@ -1672,9 +1672,7 @@ class MFPackage(PackageContainer, PackageInterface):
                 self._filename = f"{base_name}.{package_type}"
             else:
                 # filename uses model base name
-                self._filename = MFFileMgmt.string_to_file_path(
-                    f"{self.model_or_sim.name}.{package_type}"
-                )
+                self._filename = f"{self.model_or_sim.name}.{package_type}"
         else:
             if not isinstance(filename, str):
                 message = (
@@ -1696,9 +1694,7 @@ class MFPackage(PackageContainer, PackageInterface):
                     message,
                     self.model_or_sim.simulation_data.debug,
                 )
-            self._filename = MFFileMgmt.string_to_file_path(
-                datautil.clean_filename(filename)
-            )
+            self._filename = datautil.clean_filename(filename)
         self.path, self.structure = self.model_or_sim.register_package(
             self, not loading_package, pname is None, filename is None
         )


### PR DESCRIPTION
There is a [bug](https://github.com/python/cpython/issues/103220) in Python's `ntpath.join` (the Windows implementation of `os.path.join`) which adds an extra leading slash to UNC paths. This is causing a [test failure](https://github.com/modflowpy/flopy/actions/runs/4622009709/jobs/8174222128?pr=1757#step:9:3199) for `MFFileMgmt.string_to_file_path`, as far as I can tell only for Python>=3.11.1.

The `string_to_file_path` method seems unnecessary: the [tests](https://github.com/modflowpy/flopy/blob/8d52ecef28bdf5624d78ce0b809620353014e42c/autotest/test_mf6.py#L241) just assert that the arg value equals the return value. This PR removes the method.