### PR TITLE
fix(Modpath6Sim): move import_optional_dependency("pandas") to method

### DIFF
--- a/autotest/test_export.py
+++ b/autotest/test_export.py
@@ -822,7 +822,7 @@ def test_polygon_from_ij(function_tmpdir):
 
 
 @flaky
-@requires_pkg("netCDF4", "pyproj")
+@requires_pkg("netCDF4", "pyproj", "shapely")
 def test_polygon_from_ij_with_epsg(function_tmpdir):
     ws = function_tmpdir
     m = Modflow("toy_model", model_ws=ws)
@@ -1812,7 +1812,7 @@ def test_vtk_export_disu2_grid(function_tmpdir, example_data_path):
 
 @pytest.mark.mf6
 @requires_exe("mf6", "gridgen")
-@requires_pkg("vtk", "shapefile")
+@requires_pkg("vtk", "shapefile", "shapely")
 def test_vtk_export_disu_model(function_tmpdir):
     from vtkmodules.util.numpy_support import vtk_to_numpy
 

--- a/autotest/test_geospatial_util.py
+++ b/autotest/test_geospatial_util.py
@@ -153,7 +153,7 @@ def test_import_geospatial_utils():
     )
 
 
-@requires_pkg("shapefile")
+@requires_pkg("shapefile", "shapely")
 def test_geospatial_collection_load_shpfile(example_data_path):
     # with Path
     shp = example_data_path / "freyberg" / "gis" / "bedrock_outcrop_hole.shp"

--- a/autotest/test_geospatial_util.py
+++ b/autotest/test_geospatial_util.py
@@ -153,6 +153,7 @@ def test_import_geospatial_utils():
     )
 
 
+@requires_pkg("shapefile")
 def test_geospatial_collection_load_shpfile(example_data_path):
     # with Path
     shp = example_data_path / "freyberg" / "gis" / "bedrock_outcrop_hole.shp"

--- a/autotest/test_gridintersect.py
+++ b/autotest/test_gridintersect.py
@@ -754,6 +754,7 @@ def test_rect_grid_polygon_on_inner_boundary():
     # plt.show()
 
 
+@requires_pkg("shapely")
 def test_rect_grid_polygon_multiple_polygons():
     gr = get_rect_grid()
     p = Polygon(

--- a/autotest/test_mbase.py
+++ b/autotest/test_mbase.py
@@ -103,8 +103,8 @@ def test_run_model_when_namefile_not_in_model_ws(
     "exe",
     [
         "mf6",
-        Path(which("mf6")),
-        relpath_safe(Path(which("mf6"))),
+        Path(which("mf6") or ""),
+        relpath_safe(Path(which("mf6") or "")),
     ],
 )
 def test_run_model(mf6_model_path, function_tmpdir, use_paths, exe):

--- a/autotest/test_mf6.py
+++ b/autotest/test_mf6.py
@@ -253,6 +253,7 @@ def to_os_sep(s):
     return s.replace("\\", os.sep).replace("/", os.sep)
 
 
+@requires_exe("mf6")
 def test_load_and_run_sim_when_namefile_uses_filenames(
     function_tmpdir, example_data_path
 ):
@@ -268,6 +269,7 @@ def test_load_and_run_sim_when_namefile_uses_filenames(
     assert success
 
 
+@requires_exe("mf6")
 def test_load_and_run_sim_when_namefile_uses_abs_paths(
     function_tmpdir, example_data_path
 ):
@@ -294,6 +296,7 @@ def test_load_and_run_sim_when_namefile_uses_abs_paths(
     assert success
 
 
+@requires_exe("mf6")
 @pytest.mark.parametrize("sep", ["win", "posix"])
 def test_load_sim_when_namefile_uses_rel_paths(
     function_tmpdir, example_data_path, sep

--- a/autotest/test_mp6.py
+++ b/autotest/test_mp6.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 from autotest.conftest import get_example_data_path
 from autotest.test_mp6_cases import Mp6Cases1, Mp6Cases2
-from modflow_devtools.markers import requires_exe, requires_pkg
+from modflow_devtools.markers import requires_exe, requires_pkg, has_pkg
 from pytest_cases import parametrize_with_cases
 
 import flopy
@@ -110,21 +110,27 @@ def test_mpsim(function_tmpdir, mp6_test_path):
     )
     mp.write_input()
 
-    sim = Modpath6Sim(model=mp)
-    # starting locations file
-    stl = StartingLocationsFile(model=mp)
-    stldata = StartingLocationsFile.get_empty_starting_locations_data(npt=2)
-    stldata["label"] = ["p1", "p2"]
-    stldata[1]["i0"] = 5
-    stldata[1]["j0"] = 6
-    stldata[1]["xloc0"] = 0.1
-    stldata[1]["yloc0"] = 0.2
-    stl.data = stldata
-    mp.write_input()
-    stllines = open(function_tmpdir / "ex6.loc").readlines()
-    assert stllines[3].strip() == "group1"
-    assert int(stllines[4].strip()) == 2
-    assert stllines[6].strip().split()[-1] == "p2"
+    use_pandas_combs = [False]  # test StartingLocationsFile._write_wo_pandas
+    if has_pkg("pandas"):
+        # test StartingLocationsFile._write_particle_data_with_pandas
+        use_pandas_combs.append(True)
+
+    for use_pandas in use_pandas_combs:
+        sim = Modpath6Sim(model=mp)
+        # starting locations file
+        stl = StartingLocationsFile(model=mp, use_pandas=use_pandas)
+        stldata = StartingLocationsFile.get_empty_starting_locations_data(npt=2)
+        stldata["label"] = ["p1", "p2"]
+        stldata[1]["i0"] = 5
+        stldata[1]["j0"] = 6
+        stldata[1]["xloc0"] = 0.1
+        stldata[1]["yloc0"] = 0.2
+        stl.data = stldata
+        mp.write_input()
+        stllines = open(function_tmpdir / "ex6.loc").readlines()
+        assert stllines[3].strip() == "group1"
+        assert int(stllines[4].strip()) == 2
+        assert stllines[6].strip().split()[-1] == "p2"
 
 
 @requires_pkg("pandas", "shapefile")

--- a/autotest/test_mp6.py
+++ b/autotest/test_mp6.py
@@ -133,7 +133,7 @@ def test_mpsim(function_tmpdir, mp6_test_path):
         assert stllines[6].strip().split()[-1] == "p2"
 
 
-@requires_pkg("pandas", "shapefile")
+@requires_pkg("pandas", "shapefile", "shapely")
 def test_get_destination_data(function_tmpdir, mp6_test_path):
     copy_modpath_files(mp6_test_path, function_tmpdir, "EXAMPLE.")
     copy_modpath_files(mp6_test_path, function_tmpdir, "EXAMPLE-3.")

--- a/autotest/test_plot.py
+++ b/autotest/test_plot.py
@@ -30,6 +30,7 @@ from flopy.plot import PlotCrossSection, PlotMapView
 from flopy.utils import CellBudgetFile, EndpointFile, HeadFile, PathlineFile
 
 
+@requires_pkg("shapely")
 def test_map_view():
     m = flopy.modflow.Modflow(rotation=20.0)
     dis = flopy.modflow.ModflowDis(
@@ -602,6 +603,7 @@ def structured_square_grid(side: int = 10, thick: int = 10):
     return StructuredGrid(delr=delr, delc=delc, top=top, botm=botm)
 
 
+@requires_pkg("shapely")
 @pytest.mark.parametrize(
     "line",
     [(), [], (()), [[]], (0, 0), [0, 0], [[0, 0]]],

--- a/autotest/test_sfr.py
+++ b/autotest/test_sfr.py
@@ -373,7 +373,7 @@ def test_const(sfr_data):
     assert True
 
 
-@requires_pkg("pandas", "shapefile")
+@requires_pkg("pandas", "shapefile", "shapely")
 def test_export(function_tmpdir, sfr_data):
     m = Modflow()
     dis = ModflowDis(m, 1, 10, 10, lenuni=2, itmuni=4)

--- a/autotest/test_shapefile_utils.py
+++ b/autotest/test_shapefile_utils.py
@@ -10,7 +10,7 @@ from flopy.utils.crs import get_shapefile_crs
 from .test_grid import minimal_unstructured_grid_info, minimal_vertex_grid_info
 
 
-@requires_pkg("pyproj")
+@requires_pkg("pyproj", "pyshp", "shapely")
 def test_write_grid_shapefile(
     minimal_unstructured_grid_info, minimal_vertex_grid_info, function_tmpdir
 ):

--- a/flopy/modpath/mp6sim.py
+++ b/flopy/modpath/mp6sim.py
@@ -12,12 +12,6 @@ import numpy as np
 from ..pakbase import Package
 from ..utils import Util3d, import_optional_dependency
 
-pd = import_optional_dependency(
-    "pandas",
-    error_message="writing particles is more effcient with pandas",
-    errors="ignore",
-)
-
 
 class Modpath6Sim(Package):
     """
@@ -502,7 +496,7 @@ class StartingLocationsFile(Package):
         data["k0"] += 1
         data["i0"] += 1
         data["j0"] += 1
-        if pd is not None and self.use_pandas and len(data) > 0:
+        if self.use_pandas and len(data) > 0:
             self._write_particle_data_with_pandas(data, float_format)
         else:
             self._write_wo_pandas(data, float_format)
@@ -516,6 +510,10 @@ class StartingLocationsFile(Package):
         :param save_group_mapper bool, if true, save a groupnumber to group name mapper as well.
         :return:
         """
+        pd = import_optional_dependency(
+            "pandas",
+            error_message="specify `use_pandas=False` to use slower methods without pandas",
+        )
         # convert float format string to pandas float format
         float_format = (
             float_format.replace("{", "").replace("}", "").replace(":", "%")

--- a/flopy/modpath/mp6sim.py
+++ b/flopy/modpath/mp6sim.py
@@ -411,8 +411,8 @@ class StartingLocationsFile(Package):
         Input style described in MODPATH6 manual (currently only input style 1 is supported)
     extension : string
         Filename extension (default is 'loc')
-
-    use_pandas: bool, if True and pandas is available use pandas to write the particle locations >2x speed
+    use_pandas: bool, default False
+        If True and pandas is available use pandas to write the particle locations >2x speed
     """
 
     def __init__(
@@ -421,7 +421,7 @@ class StartingLocationsFile(Package):
         inputstyle=1,
         extension="loc",
         verbose=False,
-        use_pandas=True,
+        use_pandas=False,
     ):
         super().__init__(model, extension, "LOC", 33)
 


### PR DESCRIPTION
With a fresh install of FloPy from PyPI without pandas installed, a message is always shown after import:
```bash
$ python -c "import flopy"
Missing optional dependency 'pandas'. writing particles is more effcient with pandas Use pip or conda to install pandas.
```
This PR moves the import of the optional dependency to the `_write_particle_data_with_pandas` method, which raises an error instead with `StartingLocationsFile(model=mp, use_pandas=True)`. Now `import flopy` does not show the message.

Also `test_mpsim` is modified to test with `use_pandas=False` and `use_pandas=True` if pandas is available, which should improve coverage.

Several other miscellaneous edits to tests allow skipping of tests with a subset of optional packages installed, or without `mf6`.