### PR TITLE
fix(shapefile_utils): check attr.array for None in model_attributes_to_shapefile

### DIFF
--- a/autotest/test_shapefile_utils.py
+++ b/autotest/test_shapefile_utils.py
@@ -1,13 +1,55 @@
-"""Test functions in flopy/export/shapefile_utils.py
 """
+Test functions in flopy/export/shapefile_utils.py
+"""
+
 import numpy as np
 from modflow_devtools.markers import requires_pkg
 
+import flopy
 from flopy.discretization import StructuredGrid, UnstructuredGrid, VertexGrid
-from flopy.export.shapefile_utils import shp2recarray
+from flopy.export.shapefile_utils import (
+    model_attributes_to_shapefile,
+    shp2recarray,
+)
 from flopy.utils.crs import get_shapefile_crs
 
+from .test_export import disu_sim
 from .test_grid import minimal_unstructured_grid_info, minimal_vertex_grid_info
+
+
+def test_model_attributes_to_shapefile(example_data_path, function_tmpdir):
+    # freyberg mf2005 model
+    name = "freyberg"
+    namfile = f"{name}.nam"
+    ws = example_data_path / name
+    m = flopy.modflow.Modflow.load(
+        namfile, model_ws=ws, check=False, verbose=False
+    )
+    shpfile_path = function_tmpdir / f"{name}.shp"
+    pakg_names = ["DIS", "BAS6", "LPF", "WEL", "RIV", "RCH", "OC", "PCG"]
+    model_attributes_to_shapefile(shpfile_path, m, pakg_names)
+    assert shpfile_path.exists()
+
+    # freyberg mf6 model
+    name = "mf6-freyberg"
+    sim = flopy.mf6.MFSimulation.load(
+        sim_name=name, sim_ws=example_data_path / name
+    )
+    m = sim.get_model()
+    shpfile_path = function_tmpdir / f"{name}.shp"
+    pakg_names = ["dis", "bas6", "npf", "wel", "riv", "rch", "oc", "pcg"]
+    model_attributes_to_shapefile(shpfile_path, m, pakg_names)
+    assert shpfile_path.exists()
+
+    # model with a DISU grid with no angldegx arrays
+    # (https://github.com/modflowpy/flopy/issues/1775)
+    name = "mf6-disu"
+    sim = disu_sim(name, function_tmpdir, missing_arrays=True)
+    m = sim.get_model(name)
+    shpfile_path = function_tmpdir / f"{name}.shp"
+    pakg_names = ["dis"]
+    model_attributes_to_shapefile(shpfile_path, m, pakg_names)
+    assert shpfile_path.exists()
 
 
 @requires_pkg("pyproj")

--- a/flopy/export/shapefile_utils.py
+++ b/flopy/export/shapefile_utils.py
@@ -302,18 +302,19 @@ def model_attributes_to_shapefile(
                     or a.name == "thickness"
                 ):
                     continue
-                if (
-                    a.data_type == DataType.array2d
-                    and a.array.shape == horz_shape
-                ):
+                if a.data_type == DataType.array2d:
+                    if a.array is None or a.array.shape != horz_shape:
+                        warn(
+                            "Failed to get data for "
+                            f"{a.name} array, {pak.name[0]} package"
+                        )
+                        continue
                     name = shape_attr_name(a.name, keep_layer=True)
                     # name = a.name.lower()
                     array_dict[name] = a.array
                 elif a.data_type == DataType.array3d:
                     # Not sure how best to check if an object has array data
-                    try:
-                        assert a.array is not None
-                    except:
+                    if a.array is None:
                         warn(
                             "Failed to get data for "
                             f"{a.name} array, {pak.name[0]} package"
@@ -321,7 +322,6 @@ def model_attributes_to_shapefile(
                         continue
                     if isinstance(a.name, list) and a.name[0] == "thickness":
                         continue
-
                     if a.array.shape == horz_shape:
                         if hasattr(a, "shape"):
                             if a.shape[1] is None:  # usg unstructured Util3d


### PR DESCRIPTION
- fix https://github.com/modflowpy/flopy/issues/1775
- if array data (e.g. `angldegx`) is missing, a warning is shown but export proceeds
- add some test cases for above, factor out a function to create a sim with a GWF model on a DISU grid
- update `test_export.py::test_freyberg_export` to check shapefiles exported for each level (model/pkg/obj) exist
- update `test_export.py::test_export_output` to write netCDF files to tempdir instead of cwd