### PR TITLE
bugfixes and updates for model spiliting integration

### DIFF
--- a/flopy/discretization/unstructuredgrid.py
+++ b/flopy/discretization/unstructuredgrid.py
@@ -177,8 +177,6 @@ class UnstructuredGrid(Grid):
         self._iac = iac
         self._ja = ja
 
-        return
-
     def set_ncpl(self, ncpl):
         if isinstance(ncpl, int):
             ncpl = np.array([ncpl], dtype=int)
@@ -189,7 +187,6 @@ class UnstructuredGrid(Grid):
         assert ncpl.ndim == 1, "ncpl must be 1d"
         self._ncpl = ncpl
         self._require_cache_updates()
-        return
 
     @property
     def is_valid(self):

--- a/flopy/mf6/mfmodel.py
+++ b/flopy/mf6/mfmodel.py
@@ -456,8 +456,8 @@ class MFModel(PackageContainer, ModelInterface):
                 xoff=self._modelgrid.xoffset,
                 yoff=self._modelgrid.yoffset,
                 angrot=self._modelgrid.angrot,
-                iac=dis.iac,
-                ja=dis.ja,
+                iac=dis.iac.array,
+                ja=dis.ja.array,
             )
         elif self.get_grid_type() == DiscretizationType.DISL:
             dis = self.get_package("disl")

--- a/flopy/mf6/modflow/mfgwfgwf.py
+++ b/flopy/mf6/modflow/mfgwfgwf.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on December 15, 2022 12:49:36 UTC
+# FILE created on May 17, 2023 17:50:52 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -464,7 +464,7 @@ class ModflowGwfgwf(mfpackage.MFPackage):
         self,
         simulation,
         loading_package=False,
-        exgtype=None,
+        exgtype="GWF6-GWF6",
         exgmnamea=None,
         exgmnameb=None,
         auxiliary=None,

--- a/flopy/mf6/modflow/mfgwfgwt.py
+++ b/flopy/mf6/modflow/mfgwfgwt.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on December 15, 2022 12:49:36 UTC
+# FILE created on May 17, 2023 17:50:52 UTC
 from .. import mfpackage
 
 
@@ -47,7 +47,7 @@ class ModflowGwfgwt(mfpackage.MFPackage):
         self,
         simulation,
         loading_package=False,
-        exgtype=None,
+        exgtype="GWF6-GWT6",
         exgmnamea=None,
         exgmnameb=None,
         filename=None,

--- a/flopy/mf6/modflow/mfgwtgwt.py
+++ b/flopy/mf6/modflow/mfgwtgwt.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on December 15, 2022 12:49:36 UTC
+# FILE created on May 17, 2023 17:50:52 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -424,7 +424,7 @@ class ModflowGwtgwt(mfpackage.MFPackage):
         self,
         simulation,
         loading_package=False,
-        exgtype=None,
+        exgtype="GWT6-GWT6",
         exgmnamea=None,
         exgmnameb=None,
         gwfmodelname1=None,

--- a/flopy/mf6/utils/createpackages.py
+++ b/flopy/mf6/utils/createpackages.py
@@ -562,6 +562,10 @@ def create_packages():
             doc_string = mfdatautil.MFDocString(ds)
 
         if package[0].dfn_type == mfstructure.DfnType.exch_file:
+            exgtype = (
+                f'"{package_abbr[0:3].upper()}6-{package_abbr[3:].upper()}6"'
+            )
+
             add_var(
                 init_vars,
                 None,
@@ -569,7 +573,7 @@ def create_packages():
                 package_properties,
                 doc_string,
                 data_structure_dict,
-                None,
+                exgtype,
                 "exgtype",
                 "exgtype",
                 build_doc_string(

--- a/flopy/modflow/mf.py
+++ b/flopy/modflow/mf.py
@@ -296,8 +296,8 @@ class Modflow(BaseModel):
                 xoff=self._modelgrid.xoffset,
                 yoff=self._modelgrid.yoffset,
                 angrot=self._modelgrid.angrot,
-                iac=self.disu.iac,
-                ja=self.disu.ja,
+                iac=self.disu.iac.array,
+                ja=self.disu.ja.array,
             )
             print(
                 "WARNING: Model grid functionality limited for unstructured "

--- a/flopy/plot/plotutil.py
+++ b/flopy/plot/plotutil.py
@@ -1807,17 +1807,18 @@ class UnstructuredPlotUtilities:
         return vdict
 
     @staticmethod
-    def irregular_shape_patch(xverts, yverts):
+    def irregular_shape_patch(xverts, yverts=None):
         """
-        Patch for vertex cross section plotting when
-        we have an irregular shape type throughout the
-        model grid or multiple shape types.
+        Patch for vertex cross-section plotting when we have an irregular
+        shape type throughout the model grid or multiple shape types. This
+        method is also used by the model splitter as a helper function
+        for remapping the cell2d array.
 
         Parameters
         ----------
         xverts : list
             xvertices
-        yverts : list
+        yverts : list or None
             yvertices
 
         Returns
@@ -1831,9 +1832,10 @@ class UnstructuredPlotUtilities:
             if len(xv) > max_verts:
                 max_verts = len(xv)
 
-        for yv in yverts:
-            if len(yv) > max_verts:
-                max_verts = len(yv)
+        if yverts is not None:
+            for yv in yverts:
+                if len(yv) > max_verts:
+                    max_verts = len(yv)
 
         adj_xverts = []
         for xv in xverts:
@@ -1844,19 +1846,26 @@ class UnstructuredPlotUtilities:
             else:
                 adj_xverts.append(xv)
 
-        adj_yverts = []
-        for yv in yverts:
-            if len(yv) < max_verts:
-                yv = list(yv)
-                n = max_verts - len(yv)
-                adj_yverts.append(yv + [yv[-1]] * n)
-            else:
-                adj_yverts.append(yv)
+        if yverts is not None:
+            adj_yverts = []
+            for yv in yverts:
+                if len(yv) < max_verts:
+                    yv = list(yv)
+                    n = max_verts - len(yv)
+                    adj_yverts.append(yv + [yv[-1]] * n)
+                else:
+                    adj_yverts.append(yv)
 
-        xverts = np.array(adj_xverts)
-        yverts = np.array(adj_yverts)
+            xverts = np.array(adj_xverts)
+            yverts = np.array(adj_yverts)
 
-        return xverts, yverts
+            return xverts, yverts
+
+        txverts = np.array(adj_xverts)
+        xverts = np.zeros((txverts.shape[0], txverts.shape[1] + 1), dtype=int)
+        xverts[:, 0:-1] = txverts
+        xverts[:, -1] = xverts[:, 0]
+        return xverts
 
     @staticmethod
     def arctan2(verts, reverse=False):


### PR DESCRIPTION
* update: createpackages.py to automatically define `exgtype` parameter in `__init__` for exchange packages
* removed unneeded `return` statements from` UnstructuredGrid` class
* updated: mfmodel.py and mf.py `UnstructuredGrid` creation routine to send `iac` and `ja` as arrays instead of MFArray objects
* updated: `irregular_shape_patch()` in `UnstructuredPlotUtilities`. Update assists with formatting cell2d `iverts` for model splitting and remapping.