### PR TITLE
ci: add VTK workarounds for example notebook tests

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -60,6 +60,22 @@ jobs:
           pip install xmipy
           pip install .
 
+      - name: Workaround OpenGL issue on Linux
+        if: runner.os == 'Linux'
+        run: |
+          # referenced from https://github.com/pyvista/pyvista/blob/main/.github/workflows/vtk-pre-test.yml#L53
+          pip uninstall -y vtk
+          pip install --extra-index-url https://wheels.vtk.org trame vtk-osmesa
+      
+      - name: Install OpenGL on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+          $PSDefaultParameterValues['*:ErrorAction']='Stop'
+          powershell .github/install_opengl.ps1
+
       - name: Install Modflow executables
         uses: modflowpy/install-modflow-action@v1
 


### PR DESCRIPTION
The nightly example tests [have been failing](https://github.com/modflowpy/flopy/actions/runs/5130512589) on Linux and Windows due to the same VTK/PyVista issue we initially ran into after #1750. Use the same workarounds introduced for the `rtd.yml` docs build in #1790 (originally referenced from the PyVista repo)

- use `vtk-osmesa` and `trame` on Linux
- install openGL on Windows