### PR TITLE
fix(float32, empty stress period): #1779 and #1793

### DIFF
--- a/flopy/mf6/data/mfdata.py
+++ b/flopy/mf6/data/mfdata.py
@@ -78,6 +78,7 @@ class MFTransient:
     def __init__(self, *args, **kwargs):
         self._current_key = None
         self._data_storage = None
+        self.empty_keys = {}
 
     def add_transient_key(self, transient_key):
         if isinstance(transient_key, int):

--- a/flopy/mf6/data/mfdataarray.py
+++ b/flopy/mf6/data/mfdataarray.py
@@ -1607,7 +1607,9 @@ class MFTransientArray(MFArray, MFTransient):
         dimensions=None,
         block=None,
     ):
-        super().__init__(
+        MFTransient.__init__(self)
+        MFArray.__init__(
+            self,
             sim_data=sim_data,
             model_or_sim=model_or_sim,
             structure=structure,

--- a/flopy/mf6/data/mfdatalist.py
+++ b/flopy/mf6/data/mfdatalist.py
@@ -1475,7 +1475,9 @@ class MFTransientList(MFList, mfdata.MFTransient, DataListInterface):
         package=None,
         block=None,
     ):
-        super().__init__(
+        mfdata.MFTransient.__init__(self)
+        MFList.__init__(
+            self,
             sim_data=sim_data,
             model_or_sim=model_or_sim,
             structure=structure,
@@ -1488,7 +1490,6 @@ class MFTransientList(MFList, mfdata.MFTransient, DataListInterface):
         )
         self._transient_setup(self._data_storage)
         self.repeating = True
-        self.empty_keys = {}
 
     @property
     def data_type(self):

--- a/flopy/mf6/data/mfdatascalar.py
+++ b/flopy/mf6/data/mfdatascalar.py
@@ -723,7 +723,9 @@ class MFScalarTransient(MFScalar, mfdata.MFTransient):
         path=None,
         dimensions=None,
     ):
-        super().__init__(
+        mfdata.MFTransient.__init__(self)
+        MFScalar.__init__(
+            self,
             sim_data=sim_data,
             model_or_sim=model_or_sim,
             structure=structure,

--- a/flopy/mf6/data/mfdatastorage.py
+++ b/flopy/mf6/data/mfdatastorage.py
@@ -1632,6 +1632,10 @@ class DataStorage:
                         not isinstance(data_val, int)
                         or self._recarray_type_list[index][1] != float
                     )
+                    and (
+                        self._recarray_type_list[index][1] != float
+                        or not isinstance(data_val, np.floating)
+                    )
                 ):
                     # for inconsistent types use generic object type
                     self._recarray_type_list[index] = (

--- a/flopy/mf6/mfpackage.py
+++ b/flopy/mf6/mfpackage.py
@@ -1256,8 +1256,10 @@ class MFBlock:
                 key_dict[key] = True
         for key in key_dict.keys():
             has_data = repeating_dataset.has_data(key)
-            empty_key = key in repeating_dataset.empty_keys and \
-                repeating_dataset.empty_keys[key]
+            empty_key = (
+                key in repeating_dataset.empty_keys
+                and repeating_dataset.empty_keys[key]
+            )
             if not self.header_exists(key) and (has_data or empty_key):
                 self._build_repeating_header([key])
 
@@ -1887,8 +1889,11 @@ class MFPackage(PackageContainer, PackageInterface):
     def _get_aux_data(self, aux_names):
         if hasattr(self, "stress_period_data"):
             spd = self.stress_period_data.get_data()
-            if 0 in spd and spd[0] is not None and \
-                    aux_names[0][1] in spd[0].dtype.names:
+            if (
+                0 in spd
+                and spd[0] is not None
+                and aux_names[0][1] in spd[0].dtype.names
+            ):
                 return spd
         if hasattr(self, "packagedata"):
             pd = self.packagedata.get_data()
@@ -1896,8 +1901,11 @@ class MFPackage(PackageContainer, PackageInterface):
                 return pd
         if hasattr(self, "perioddata"):
             spd = self.perioddata.get_data()
-            if 0 in spd and spd[0] is not None and \
-                    aux_names[0][1] in spd[0].dtype.names:
+            if (
+                0 in spd
+                and spd[0] is not None
+                and aux_names[0][1] in spd[0].dtype.names
+            ):
                 return spd
         if hasattr(self, "aux"):
             return self.aux.get_data()

--- a/flopy/mf6/mfpackage.py
+++ b/flopy/mf6/mfpackage.py
@@ -1246,10 +1246,20 @@ class MFBlock:
             self._write_block(fd, self.block_headers[0], ext_file_action)
 
     def _add_missing_block_headers(self, repeating_dataset):
-        for key in repeating_dataset.get_active_key_list():
+        key_data_list = repeating_dataset.get_active_key_list()
+        # assemble a dictionary of data keys and empty keys
+        key_dict = {}
+        for key in key_data_list:
+            key_dict[key[0]] = True
+        for key, value in repeating_dataset.empty_keys.items():
+            if value:
+                key_dict[key] = True
+        for key in key_dict.keys():
             has_data = repeating_dataset.has_data(key)
-            if not self.header_exists(key[0]) and has_data:
-                self._build_repeating_header([key[0]])
+            empty_key = key in repeating_dataset.empty_keys and \
+                repeating_dataset.empty_keys[key]
+            if not self.header_exists(key) and (has_data or empty_key):
+                self._build_repeating_header([key])
 
     def header_exists(self, key, data_path=None):
         if not isinstance(key, list):
@@ -1877,7 +1887,8 @@ class MFPackage(PackageContainer, PackageInterface):
     def _get_aux_data(self, aux_names):
         if hasattr(self, "stress_period_data"):
             spd = self.stress_period_data.get_data()
-            if 0 in spd and aux_names[0][1] in spd[0].dtype.names:
+            if 0 in spd and spd[0] is not None and \
+                    aux_names[0][1] in spd[0].dtype.names:
                 return spd
         if hasattr(self, "packagedata"):
             pd = self.packagedata.get_data()
@@ -1885,7 +1896,8 @@ class MFPackage(PackageContainer, PackageInterface):
                 return pd
         if hasattr(self, "perioddata"):
             spd = self.perioddata.get_data()
-            if 0 in spd and aux_names[0][1] in spd[0].dtype.names:
+            if 0 in spd and spd[0] is not None and \
+                    aux_names[0][1] in spd[0].dtype.names:
                 return spd
         if hasattr(self, "aux"):
             return self.aux.get_data()


### PR DESCRIPTION
Fixed issue where flopy only recognized float64 data and not float32 data.

Fixed issue where block headers were not getting created for empty data blocks.