### PR TITLE
ci: install fonts and clear mpl cache before running notebooks

### DIFF
--- a/.docs/Notebooks/mt3d-usgs_example.py
+++ b/.docs/Notebooks/mt3d-usgs_example.py
@@ -622,6 +622,11 @@ def set_plot_params():
     import matplotlib as mpl
     from matplotlib.font_manager import FontProperties
 
+    mpl.rcParams["font.sans-serif"] = "Arial"
+    mpl.rcParams["font.serif"] = "Times"
+    mpl.rcParams["font.cursive"] = "Zapf Chancery"
+    mpl.rcParams["font.fantasy"] = "Comic Sans MS"
+    mpl.rcParams["font.monospace"] = "Courier New"
     mpl.rcParams["pdf.compression"] = 0
     mpl.rcParams["pdf.fonttype"] = 42
 

--- a/.docs/Notebooks/plot_map_view_example.py
+++ b/.docs/Notebooks/plot_map_view_example.py
@@ -1033,6 +1033,9 @@ with styles.USGSMap():
     inactive = mapview.plot_inactive()
     plt.colorbar(quadmesh, shrink=0.75)
 
+    # change the font type to comic sans
+    styles.set_font_type(family="fantasy", fontname="Comic Sans MS"),
+
     # use styles to add a heading, xlabel, ylabel, and remove tick marks
     styles.heading(
         letter="A.",

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -58,6 +58,13 @@ jobs:
           pip uninstall -y vtk
           pip install --extra-index-url https://wheels.vtk.org trame vtk-osmesa
       
+      - name: Install fonts on Linux
+        if: runner.os == 'Linux'
+        run: |
+          echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
+          sudo apt-get install ttf-mscorefonts-installer fonts-liberation
+          sudo rm -rf ~/.cache/matplotlib
+      
       - name: Install OpenGL on Windows
         if: runner.os == 'Windows'
         shell: pwsh


### PR DESCRIPTION
Prevents missing font errors like `findfont: Generic family 'sans-serif' not found because none of the following families were found: Arial`

Also restore font usages removed from notebooks to avoid these errors in #1790