### PR TITLE
docs(notebooks): fix headers so TOCs render properly

### DIFF
--- a/.docs/Notebooks/groundwater2023_watershed_example.py
+++ b/.docs/Notebooks/groundwater2023_watershed_example.py
@@ -133,9 +133,9 @@ for idx, sg in enumerate(sgs):
     ax.plot(sa[:, 0], sa[:, 1], color=riv_colors[idx], lw=0.75, marker="o")
 # -
 
-# # Structured Grids
+# ## Structured Grids
 #
-# ## Structured grid with constant row and column spacing
+# ### Structured grid with constant row and column spacing
 
 # +
 dx = dy = 1666.66666667
@@ -193,7 +193,7 @@ for sg in sgs:
     ax.plot(sa[:, 0], sa[:, 1], "b-")
 # -
 
-# ## Structured grid with variable row and column spacing
+# ### Structured grid with variable row and column spacing
 
 # +
 dx = dy = 5000
@@ -277,7 +277,7 @@ for sg in sgs:
     ax.plot(sa[:, 0], sa[:, 1], "b-", alpha=0.2)
 # -
 
-# ## Local grid refinement grid
+# ### Local grid refinement grid
 
 # +
 from flopy.utils.lgrutil import Lgr
@@ -414,7 +414,7 @@ for sg in sgs:
     ax.plot(sa[:, 0], sa[:, 1], "b-")
 # -
 
-# # Unstructured grids
+# ## Unstructured grids
 
 # create a polygon of the common refinement area for the quadtree grid
 lgr_poly = [
@@ -427,7 +427,7 @@ lgr_poly = [
     ]
 ]
 
-# ## Quadtree grid
+# ### Quadtree grid
 
 # +
 sim = flopy.mf6.MFSimulation()
@@ -498,7 +498,7 @@ for sg in sgs:
     ax.plot(sa[:, 0], sa[:, 1], "b-")
 # -
 
-# ## Triangular grid
+# ### Triangular grid
 
 nodes = []
 for sg in sgs:
@@ -585,7 +585,7 @@ if True:
         ax.plot(sa[:, 0], sa[:, 1], "b-")
 # -
 
-# ## Voronoi Grid from the Triangle object
+# ### Voronoi Grid from the Triangle object
 
 # create vor object and VertexGrid from the triangle object tri
 vor = VoronoiGrid(tri)
@@ -637,13 +637,13 @@ for sg in sgs:
 cg = pmv.contour_array(top_vg, levels=levels, linewidths=0.3, colors="0.75")
 # -
 
-# # Plot all six grids
+# ## Plot all six grids
 #
-# ## Create a polyline for Local Grid Refinement area
+# ### Create a polyline for Local Grid Refinement area
 
 lgr_poly_array = np.array(lgr_poly).squeeze()
 
-# ## Plot the grids
+# ### Plot the grids
 
 # + tags=["nbsphinx-thumbnail"]
 # Make a plot of the six grids
@@ -818,7 +818,7 @@ with styles.USGSMap():
     )
 # -
 
-# ## Plot the river intersection for the six grids
+# ### Plot the river intersection for the six grids
 
 # +
 figwidth = 17.15 / 2.54

--- a/.docs/Notebooks/mf6_parallel_model_splitting_example.py
+++ b/.docs/Notebooks/mf6_parallel_model_splitting_example.py
@@ -41,7 +41,7 @@ from tempfile import TemporaryDirectory
 sys.path.append("../common")
 from notebook_utils import string2geom, geometries
 
-# # Example 1: splitting a simple structured grid model
+# ## Example 1: splitting a simple structured grid model
 # 
 # This example shows the basics of using the `Mf6Splitter()` class and applies the method to the Freyberg (1988) model.
 
@@ -81,7 +81,7 @@ pmv.plot_grid()
 pmv.plot_ibound()
 plt.colorbar(pc);
 
-# ## Creating an array that defines the new models
+# ### Creating an array that defines the new models
 # 
 # In order to split models, the model domain must be discretized using unique model numbers. Any number of models can be created, however all of the cells within each model must be contiguous.
 # 
@@ -107,7 +107,7 @@ lc = pmv.plot_grid()
 plt.colorbar(pc)
 plt.show()
 
-# ## Splitting the model using `Mf6Splitter()`
+# ### Splitting the model using `Mf6Splitter()`
 # 
 # The `Mf6Splitter()` class accepts one required parameter and one optional parameter. These parameters are:
 #    - `sim`: A flopy.mf6.MFSimulation object
@@ -127,7 +127,7 @@ new_sim.write_simulation()
 success, buff = new_sim.run_simulation(silent=True)
 assert success
 
-# ## Visualize and reassemble model output
+# ### Visualize and reassemble model output
 # 
 # Both models are visualized side by side
 
@@ -166,7 +166,7 @@ cbar_ax = fig.add_axes([0.85, 0.15, 0.05, 0.7])
 cbar = fig.colorbar(pc, cax=cbar_ax, label="Hydraulic heads");
 # -
 
-# ## Array based model output can be assembled into the original model's shape by using the `reconstruct_array()` method
+# ### Array based model output can be assembled into the original model's shape by using the `reconstruct_array()` method
 # 
 # `reconstruct_array` accepts a dictionary of array data. This data is assembled as {model_number: array_from_model}.
 
@@ -174,7 +174,7 @@ array_dict = {1: heads0, 2: heads1}
 
 new_head_array = mfsplit.reconstruct_array(array_dict)
 
-# ## Recarray based model inputs and outputs can also be assembled into the original model's shape by using the `reconstruct_recarray()` method
+# ### Recarray based model inputs and outputs can also be assembled into the original model's shape by using the `reconstruct_recarray()` method
 # 
 # The code below demonstratess how to join the input recarrays for the WEL, RIV, and CHD package and plot them as boundary condition arrays.
 
@@ -211,13 +211,13 @@ plt.colorbar(pc)
 plt.show()
 # -
 
-# # Example 2: a more comprehensive example with the watershed model from Hughes and others 2023
+# ## Example 2: a more comprehensive example with the watershed model from Hughes and others 2023
 # 
 # In this example, a basin model is created and is split into many models.
 # From Hughes, Joseph D., Langevin, Christian D., Paulinski, Scott R., Larsen, Joshua D., and Brakenhoff, David, 2023, FloPy Workflows for Creating Structured and Unstructured MODFLOW Models: Groundwater, https://doi.org/10.1111/gwat.13327
 #
 # 
-# ## Create the model
+# ### Create the model
 # 
 # Load an ASCII raster file
 
@@ -517,7 +517,7 @@ with styles.USGSMap():
         ax.plot(sa[:, 0], sa[:, 1], "b-")
 # -
 
-# ## Split the watershed model
+# ### Split the watershed model
 # 
 # Build a splitting array and split this model into many models for parallel modflow runs
 
@@ -567,7 +567,7 @@ for idx in range(len(row_blocks)-1):
 plt.imshow(mask);
 # -
 
-# ## Now split the model into many models using `Mf6Splitter()`
+# ### Now split the model into many models using `Mf6Splitter()`
 
 mfsplit = Mf6Splitter(sim)
 new_sim = mfsplit.split_model(mask)
@@ -581,7 +581,7 @@ success, buff = new_sim.run_simulation(silent=True)
 assert success
 # -
 
-# ## Reassemble the heads to the original model shape for plotting
+# ### Reassemble the heads to the original model shape for plotting
 # 
 # Create a dictionary of model number : heads and use the `reconstruct_array()` method to get a numpy array that is the original shape of the unsplit model.
 
@@ -634,7 +634,7 @@ with styles.USGSMap():
             ax.plot(sa[:, 0], sa[:, 1], "b-")
 # -
 
-# # Example 3: create an optimized splitting mask for a model
+# ## Example 3: create an optimized splitting mask for a model
 # 
 # In the previous examples, the watershed model splitting mask was defined by the user. `Mf6Splitter` also has a method called `optimize_splitting_mask` that creates a mask based on the number of models the user would like to generate.
 # 
@@ -660,7 +660,7 @@ success, buff = new_sim.run_simulation(silent=True)
 assert success
 # -
 
-# ## Reassemble the heads and plot results
+# ### Reassemble the heads and plot results
 
 model_names = list(new_sim.model_names)
 head_dict = {}

--- a/.docs/Notebooks/mf6_support_example.py
+++ b/.docs/Notebooks/mf6_support_example.py
@@ -469,7 +469,7 @@ rch_package.obs.initialize(
 )
 # -
 
-# # Saving and Running a MF6 Simulation
+# ## Saving and Running a MF6 Simulation
 
 # Saving and running a simulation are done with the MFSimulation class's write_simulation and run_simulation methods.
 
@@ -484,7 +484,7 @@ for line in buff:
     print(line)
 # -
 
-# # Exporting a MF6 Model
+# ## Exporting a MF6 Model
 
 # Exporting a MF6 model to a shapefile or netcdf is the same as exporting a MF2005 model.
 
@@ -500,14 +500,14 @@ model.dis.export(pth / "dis.nc")
 model.dis.botm.export(str(pth / "botm.shp"))  # supports os.PathLike or str
 # -
 
-# # Loading an Existing MF6 Simulation
+# ## Loading an Existing MF6 Simulation
 
 # Loading a simulation can be done with the flopy.mf6.MFSimulation.load static method.
 
 # load the simulation
 loaded_sim = flopy.mf6.MFSimulation.load(sim_name, "mf6", "mf6", sim_path)
 
-# # Retrieving Data and Modifying an Existing MF6 Simulation
+# ## Retrieving Data and Modifying an Existing MF6 Simulation
 
 # Data can be easily retrieved from a simulation.  Data can be retrieved using two methods.  One method is to retrieve the data object from a master simulation dictionary that keeps track of all the data.  The master simulation dictionary is accessed by accessing a simulation's "simulation_data" property and then the "mfdata" property:
 #

--- a/.docs/Notebooks/modpath7_structured_transient_example.py
+++ b/.docs/Notebooks/modpath7_structured_transient_example.py
@@ -283,7 +283,7 @@ add_legend(ax)
 plt.show()
 # -
 
-# # Running the simulation
+# ## Running the simulation
 #
 # Run the MODFLOW 6 flow simulation.
 

--- a/.docs/Notebooks/mt3d-usgs_example.py
+++ b/.docs/Notebooks/mt3d-usgs_example.py
@@ -549,7 +549,7 @@ mt.write_input()
 mt.run_model(silent=True, report=True)
 
 
-# # Compare mt3d-usgs results to an analytical solution
+# ## Compare mt3d-usgs results to an analytical solution
 
 # +
 # Define a function to read SFT output file

--- a/.docs/Notebooks/nwt_option_blocks_tutorial.py
+++ b/.docs/Notebooks/nwt_option_blocks_tutorial.py
@@ -64,7 +64,7 @@ ml.change_model_ws(new_pth=model_ws)
 ml.write_input()
 # -
 
-# ## Let's look at the options attribute of the UZF object
+# ### Let's look at the options attribute of the UZF object
 #
 # The `uzf.options` attribute is an `OptionBlock` object. The representation of this object is the option block that will be written to output, which allows the user to easily check to make sure the block has the options they want.
 
@@ -135,7 +135,7 @@ print(uzf3.options)
 print(uzf3.options.block)
 # -
 
-# ## We can also look at the WEL object 
+# ### We can also look at the WEL object 
 
 wel = ml.get_package("WEL")
 wel.options
@@ -169,7 +169,7 @@ wel2.options
 wel2.options.block
 # -
 
-# # Building an OptionBlock from scratch
+# ## Building an OptionBlock from scratch
 #
 # The user can also build an `OptionBlock` object from scratch to add to a `ModflowSfr2`, `ModflowUzf1`, or `ModflowWel` file.
 #

--- a/.docs/Notebooks/raster_intersection_example.py
+++ b/.docs/Notebooks/raster_intersection_example.py
@@ -335,7 +335,7 @@ plt.colorbar(ax, shrink=0.7);
 
 # __Note: bi-cubic sampling does not work well with triangular meshes and is not recommended for unstructured grids__
 
-# # Sampling points, Cropping, and performing intersections using raster data
+# ## Sampling points, Cropping, and performing intersections using raster data
 #
 # The `Raster` class contains useful methods for sampling single points, cross sections, cropping and performing intersections.
 #
@@ -378,7 +378,7 @@ ax.set_title("Elevation profile")
 df.head()
 # -
 
-# ### Sampling all points within a polygon in the raster
+# ## Sampling all points within a polygon in the raster
 #
 # The user can also sample all points within an arbitrary polygon within the raster using the `sample_polygon()` method.
 #
@@ -415,7 +415,7 @@ s = "Minimum elevation: {:.2f}\nMaximum elevation: {:.2f}\nMean elevation: {:.2f
 print(s.format(dmin, dmax, mean, stdv))
 # -
 
-# ### Cropping and resampling to a modelgrid
+# ## Cropping and resampling to a modelgrid
 #
 # The `crop()` method can accept a `list` or `np.array` of vertices, a shapely `Polygon` object, or a GeoJSON dictionary
 #
@@ -488,7 +488,7 @@ plt.title("Resample time, bi-linear: {:.3f} sec".format(resample_time))
 plt.colorbar(ax, shrink=0.7);
 # -
 
-# ### Here's an example of loading an arbitrary shape that will be used to define a model boundary
+# ## Arbitrary-shaped model boundaries
 #
 # In the example pyshp and shapely are used to get geometry information and then we create a top array and an ibound array using that geometry information
 #

--- a/.docs/Notebooks/sfrpackage_example.py
+++ b/.docs/Notebooks/sfrpackage_example.py
@@ -17,7 +17,7 @@
 #       - name: Andy Leaf
 # ---
 
-# ## SFR package Prudic and others (2004) example
+# # SFR package Prudic and others (2004) example
 # Demonstrates functionality of Flopy SFR module using the example documented by [Prudic and others (2004)](https://doi.org/10.3133/ofr20041042):  
 #
 # #### Problem description:
@@ -258,10 +258,11 @@ im = plt.imshow(sfrQ, interpolation="none")
 plt.colorbar(im, label="Streamflow, in cubic feet per second");
 
 # ## Reading transient SFR formatted output
-# the `SfrFile` class handles this the same way
 #
-# files for the transient version of the above example were already copied to the `data` folder in the third cell above
-# first run the transient model to get the output:
+# The `SfrFile` class handles this the same way
+#
+# Files for the transient version of the above example were already copied to the `data` folder in the third cell above.
+# First run the transient model to get the output:
 # ```
 # >mf2005 test1tr.nam
 # ```

--- a/.docs/Notebooks/zonebudget_example.py
+++ b/.docs/Notebooks/zonebudget_example.py
@@ -230,7 +230,7 @@ df = zb.get_dataframes(
 df.head(6)
 
 
-# ## Plot Budget Components
+# ### Plot Budget Components
 # The following is a function that can be used to better visualize the budget components using matplotlib.
 
 # +
@@ -341,7 +341,7 @@ plt.tight_layout()
 plt.show()
 # -
 
-# # Zonebudget for Modflow 6 (`ZoneBudget6`)
+# ## Zonebudget for Modflow 6 (`ZoneBudget6`)
 #
 # This section shows how to build and run a Zonebudget when working with a MODFLOW 6 model. 
 #


### PR DESCRIPTION
In the ReadTheDocs sidebar, rendering of tables of contents requires a valid hierarchy of headers in each notebook (title must be higher level than subsections), otherwise links to notebook subsections are included in the TOC.