### PR TITLE
test(mp7): refactor cases, check warning for duplicate mp7sim pkgs

### DIFF
--- a/autotest/test_export.py
+++ b/autotest/test_export.py
@@ -1378,7 +1378,8 @@ def test_vtk_unstructured(function_tmpdir, example_data_path):
 def test_vtk_to_pyvista(function_tmpdir, example_data_path):
     from autotest.test_mp7_cases import Mp7Cases
 
-    case_mf6 = Mp7Cases.mf6(function_tmpdir)
+    case_mf6 = Mp7Cases.mp7_mf6(function_tmpdir)
+    case_mf6.write_input()
     success, buff = case_mf6.run_model()
     assert success, f"MP7 model ({case_mf6.name}) failed"
 

--- a/autotest/test_mp7_cases.py
+++ b/autotest/test_mp7_cases.py
@@ -108,9 +108,9 @@ class Mp7Cases:
             sim,
             pname="ims",
             complexity="SIMPLE",
-            inner_hclose=1e-6,
             rcloserecord=1e-3,
-            outer_hclose=1e-6,
+            inner_dvclose=1e-6,
+            outer_dvclose=1e-6,
             outer_maximum=50,
             inner_maximum=100,
         )
@@ -171,16 +171,21 @@ class Mp7Cases:
             budget_filerecord=budget_record,
         )
 
-        # Write the datasets
-        sim.write_simulation()
+        return sim
 
-        # Run the simulation
+    @staticmethod
+    def mp7_mf6(function_tmpdir):
+        sim = Mp7Cases.mf6(function_tmpdir)
+        sim.write_simulation()
         success, buff = sim.run_simulation()
         assert success, "mf6 model did not run"
 
         # create modpath files
         mp = Modpath7(
-            modelname=f"{nm}_mp", flowmodel=gwf, exe_name="mp7", model_ws=ws
+            modelname=f"{sim.name}_mp",
+            flowmodel=sim.get_model(sim.name),
+            exe_name="mp7",
+            model_ws=sim.sim_path,
         )
         defaultiface6 = {"RCH": 6, "EVT": 6}
         mpbas = Modpath7Bas(mp, porosity=0.1, defaultiface=defaultiface6)
@@ -200,13 +205,6 @@ class Mp7Cases:
             zones=Mp7Cases.zones,
             particlegroups=Mp7Cases.particlegroups,
         )
-
-        # write modpath datasets
-        mp.write_input()
-
-        # run modpath
-        success, buff = mp.run_model()
-        assert success, f"mp7 model ({mp.name}) did not run"
 
         return mp
 
@@ -273,14 +271,21 @@ class Mp7Cases:
         )
         ModflowPcg(m, hclose=1e-6, rclose=1e-3, iter1=100, mxiter=50)
 
-        m.write_input()
+        return m
 
+    @staticmethod
+    def mp7_mf2005(function_tmpdir):
+        m = Mp7Cases.mf2005(function_tmpdir)
+        m.write_input()
         success, buff = m.run_model()
         assert success, "mf2005 model did not run"
 
         # create modpath files
         mp = Modpath7(
-            modelname=f"{nm}_mp", flowmodel=m, exe_name="mp7", model_ws=ws
+            modelname=f"{m.name}_mp",
+            flowmodel=m,
+            exe_name="mp7",
+            model_ws=m.model_ws,
         )
         defaultiface = {"RECHARGE": 6, "ET": 6}
         mpbas = Modpath7Bas(mp, porosity=0.1, defaultiface=defaultiface)
@@ -301,12 +306,10 @@ class Mp7Cases:
             particlegroups=Mp7Cases.particlegroups,
         )
 
-        # write modpath datasets
-        mp.write_input()
         return mp
 
-    def case_mf6(self, function_tmpdir):
-        return Mp7Cases.mf6(function_tmpdir)
+    def case_mp7_mf6(self, function_tmpdir):
+        return Mp7Cases.mp7_mf6(function_tmpdir)
 
-    def case_mf2005(self, function_tmpdir):
-        return Mp7Cases.mf2005(function_tmpdir)
+    def case_mp7_mf2005(self, function_tmpdir):
+        return Mp7Cases.mp7_mf2005(function_tmpdir)

--- a/flopy/modpath/mp7sim.py
+++ b/flopy/modpath/mp7sim.py
@@ -108,129 +108,129 @@ class Modpath7Sim(Package):
     """
     MODPATH Simulation File Package Class.
 
-        Parameters
-        ----------
-        model : model object
-            The model object (of type :class:`flopy.modpath.Modpath7`) to
-            which this package will be added.
-        mpnamefilename : str
-            Filename of the MODPATH 7 name file. If mpnamefilename is not
-            defined it will be generated from the model name
-            (default is None).
-        listingfilename : str
-            Filename of the MODPATH 7 listing file. If listingfilename is not
-            defined it will be generated from the model name
-            (default is None).
-        endpointfilename : str
-            Filename of the MODPATH 7 endpoint file. If endpointfilename is
-            not defined it will be generated from the model name
-            (default is None).
-        pathlinefilename : str
-            Filename of the MODPATH 7 pathline file. If pathlinefilename is
-            not defined it will be generated from the model name
-            (default is None).
-        timeseriesfilename : str
-            Filename of the MODPATH 7 timeseries file. If timeseriesfilename
-            is not defined it will be generated from the model name
-            (default is None).
-        tracefilename : str
-            Filename of the MODPATH 7 tracefile file. If tracefilename is not
-            defined it will be generated from the model name
-            (default is None).
-        simulationtype : str
-            MODPATH 7 simulation type. Valid simulation types are 'endpoint',
-            'pathline', 'timeseries', or 'combined' (default is 'pathline').
-        trackingdirection : str
-            MODPATH 7 tracking direction. Valid tracking directions are
-            'forward' or 'backward' (default os 'forward').
-        weaksinkoption : str
-            MODPATH 7 weak sink option. Valid weak sink options are
-            'pass_through' or 'stop_at' (default value is 'stop_at').
-        weaksourceoption : str
-            MODPATH 7 weak source option. Valid weak source options are
-            'pass_through' or 'stop_at' (default value is 'stop_at').
-        budgetoutputoption : str
-            MODPATH 7 budget output option. Valid budget output options are
-            'no' - individual cell water balance errors are not computed
-            and budget record headers are not printed, 'summary' - a summary
-            of individual cell water balance errors for each time step is
-            printed in the listing file without record headers, or
-            'record_summary' -  a summary of individual cell water balance
-            errors for each time step is printed in the listing file with
-            record headers (default is 'summary').
-        traceparticledata : list or tuple
-            List or tuple with two ints that define the particle group and
-            particle id (zero-based) of the specified particle that is
-            followed in detail. If traceparticledata is None, trace mode is
-            off (default is None).
-        budgetcellnumbers : int, list of ints, tuple of ints, or np.ndarray
-            Cell numbers (zero-based) for which detailed water budgets are
-            computed. If budgetcellnumbers is None, detailed water budgets are
-            not calculated (default is None).
-        referencetime : float, list, or tuple
-            Specified reference time if a float or a list/tuple with a single
-            float value is provided (reference time option 1). Otherwise a
-            list or tuple with a zero-based stress period (int) and time
-            step (int) and a float defining the relative time position in the
-            time step is provided (reference time option 2). If referencetime
-            is None, reference time is set to 0 (default is None).
-        stoptimeoption : str
-            String indicating how a particle tracking simulation is
-            terminated based on time. If stop time option is 'total', particles
-            will be stopped at the end of the final time step if 'forward'
-            tracking is simulated or at the beginning of the first time step
-            if backward tracking. If stop time option is 'extend', initial or
-            final steady-state time steps will be extended and all particles
-            will be tracked until they reach a termination location. If stop
-            time option is 'specified', particles will be tracked until they
-            reach a termination location or the specified stop time is reached
-            (default is 'extend').
-        stoptime : float
-            User-specified value of tracking time at which to stop a particle
-            tracking simulation. Stop time is only used if the stop time option
-            is 'specified'. If stoptime is None and the stop time option is
-            'specified' particles will be terminated at the end of the last
-            time step if 'forward' tracking or the beginning of the first time
-            step if 'backward' tracking (default is None).
-        timepointdata : list or tuple
-            List or tuple with 2 items that is only used if simulationtype is
-            'timeseries' or 'combined'. If the second item is a float then the
-            timepoint data corresponds to time point option 1 and the first
-            entry is the number of time points (timepointcount) and the second
-            entry is the time point interval. If the second item is a list,
-            tuple, or np.ndarray then the timepoint data corresponds to time
-            point option 2 and the number of time points entries
-            (timepointcount) in the second item and the second item is an
-            list, tuple, or array of user-defined time points. If Timepointdata
-            is None, time point option 1 is specified and the total simulation
-            time is split into 100 intervals (default is None).
-        zonedataoption : str
-            If zonedataoption is 'off', zone array data are not read and a zone
-            value of 1 is applied to all cells. If zonedataoption is 'on',
-            zone array data are read (default is 'off').
-        stopzone : int
-            A zero-based specified integer zone value that indicates an
-            automatic stopping location for particles and is only used if
-            zonedataoption is 'on'. A value of -1 indicates no automatic stop
-            zone is used.  Stopzone values less than -1 are not allowed. If
-            stopzone is None, stopzone is set to -1 (default is None).
-        zones : float or array of floats (nlay, nrow, ncol)
-            Array of zero-based positive integer zones that are only used if
-            zonedataoption is 'on' (default is 0).
-        retardationfactoroption : str
-            If retardationfactoroption is 'off', retardation array data are not
-            read and a retardation factor of 1 is applied to all cells. If
-            retardationfactoroption is 'on', retardation factor array data are
-            read (default is 'off').
-        retardation : float or array of floats (nlay, nrow, ncol)
-            Array of retardation factors that are only used if
-            retardationfactoroption is 'on' (default is 1).
-        particlegroups : ParticleGroup or list of ParticleGroups
-            ParticleGroup or list of ParticlesGroups that contain data for
-            individual particle groups. If None is specified, a
-            particle in the center of node 0 will be created (default is None).
-        extension : string
-            Filename extension (default is 'mpsim')
+    Parameters
+    ----------
+    model : model object
+        The model object (of type :class:`flopy.modpath.Modpath7`) to
+        which this package will be added.
+    mpnamefilename : str
+        Filename of the MODPATH 7 name file. If mpnamefilename is not
+        defined it will be generated from the model name
+        (default is None).
+    listingfilename : str
+        Filename of the MODPATH 7 listing file. If listingfilename is not
+        defined it will be generated from the model name
+        (default is None).
+    endpointfilename : str
+        Filename of the MODPATH 7 endpoint file. If endpointfilename is
+        not defined it will be generated from the model name
+        (default is None).
+    pathlinefilename : str
+        Filename of the MODPATH 7 pathline file. If pathlinefilename is
+        not defined it will be generated from the model name
+        (default is None).
+    timeseriesfilename : str
+        Filename of the MODPATH 7 timeseries file. If timeseriesfilename
+        is not defined it will be generated from the model name
+        (default is None).
+    tracefilename : str
+        Filename of the MODPATH 7 tracefile file. If tracefilename is not
+        defined it will be generated from the model name
+        (default is None).
+    simulationtype : str
+        MODPATH 7 simulation type. Valid simulation types are 'endpoint',
+        'pathline', 'timeseries', or 'combined' (default is 'pathline').
+    trackingdirection : str
+        MODPATH 7 tracking direction. Valid tracking directions are
+        'forward' or 'backward' (default os 'forward').
+    weaksinkoption : str
+        MODPATH 7 weak sink option. Valid weak sink options are
+        'pass_through' or 'stop_at' (default value is 'stop_at').
+    weaksourceoption : str
+        MODPATH 7 weak source option. Valid weak source options are
+        'pass_through' or 'stop_at' (default value is 'stop_at').
+    budgetoutputoption : str
+        MODPATH 7 budget output option. Valid budget output options are
+        'no' - individual cell water balance errors are not computed
+        and budget record headers are not printed, 'summary' - a summary
+        of individual cell water balance errors for each time step is
+        printed in the listing file without record headers, or
+        'record_summary' -  a summary of individual cell water balance
+        errors for each time step is printed in the listing file with
+        record headers (default is 'summary').
+    traceparticledata : list or tuple
+        List or tuple with two ints that define the particle group and
+        particle id (zero-based) of the specified particle that is
+        followed in detail. If traceparticledata is None, trace mode is
+        off (default is None).
+    budgetcellnumbers : int, list of ints, tuple of ints, or np.ndarray
+        Cell numbers (zero-based) for which detailed water budgets are
+        computed. If budgetcellnumbers is None, detailed water budgets are
+        not calculated (default is None).
+    referencetime : float, list, or tuple
+        Specified reference time if a float or a list/tuple with a single
+        float value is provided (reference time option 1). Otherwise a
+        list or tuple with a zero-based stress period (int) and time
+        step (int) and a float defining the relative time position in the
+        time step is provided (reference time option 2). If referencetime
+        is None, reference time is set to 0 (default is None).
+    stoptimeoption : str
+        String indicating how a particle tracking simulation is
+        terminated based on time. If stop time option is 'total', particles
+        will be stopped at the end of the final time step if 'forward'
+        tracking is simulated or at the beginning of the first time step
+        if backward tracking. If stop time option is 'extend', initial or
+        final steady-state time steps will be extended and all particles
+        will be tracked until they reach a termination location. If stop
+        time option is 'specified', particles will be tracked until they
+        reach a termination location or the specified stop time is reached
+        (default is 'extend').
+    stoptime : float
+        User-specified value of tracking time at which to stop a particle
+        tracking simulation. Stop time is only used if the stop time option
+        is 'specified'. If stoptime is None and the stop time option is
+        'specified' particles will be terminated at the end of the last
+        time step if 'forward' tracking or the beginning of the first time
+        step if 'backward' tracking (default is None).
+    timepointdata : list or tuple
+        List or tuple with 2 items that is only used if simulationtype is
+        'timeseries' or 'combined'. If the second item is a float then the
+        timepoint data corresponds to time point option 1 and the first
+        entry is the number of time points (timepointcount) and the second
+        entry is the time point interval. If the second item is a list,
+        tuple, or np.ndarray then the timepoint data corresponds to time
+        point option 2 and the number of time points entries
+        (timepointcount) in the second item and the second item is an
+        list, tuple, or array of user-defined time points. If Timepointdata
+        is None, time point option 1 is specified and the total simulation
+        time is split into 100 intervals (default is None).
+    zonedataoption : str
+        If zonedataoption is 'off', zone array data are not read and a zone
+        value of 1 is applied to all cells. If zonedataoption is 'on',
+        zone array data are read (default is 'off').
+    stopzone : int
+        A zero-based specified integer zone value that indicates an
+        automatic stopping location for particles and is only used if
+        zonedataoption is 'on'. A value of -1 indicates no automatic stop
+        zone is used.  Stopzone values less than -1 are not allowed. If
+        stopzone is None, stopzone is set to -1 (default is None).
+    zones : float or array of floats (nlay, nrow, ncol)
+        Array of zero-based positive integer zones that are only used if
+        zonedataoption is 'on' (default is 0).
+    retardationfactoroption : str
+        If retardationfactoroption is 'off', retardation array data are not
+        read and a retardation factor of 1 is applied to all cells. If
+        retardationfactoroption is 'on', retardation factor array data are
+        read (default is 'off').
+    retardation : float or array of floats (nlay, nrow, ncol)
+        Array of retardation factors that are only used if
+        retardationfactoroption is 'on' (default is 1).
+    particlegroups : ParticleGroup or list of ParticleGroups
+        ParticleGroup or list of ParticlesGroups that contain data for
+        individual particle groups. If None is specified, a
+        particle in the center of node 0 will be created (default is None).
+    extension : string
+        Filename extension (default is 'mpsim')
 
     Examples
     --------


### PR DESCRIPTION
- add a test for #1817
- refactor mp7 test cases (separate functions for creating gwf and mp7 models/sims)
- update mp7 test cases to use `inner/outer_dvclose` instead of deprecated `hclose`
- make docstring indentation consistent in `mp7sim.py`