### PR TITLE
refactor(get-modflow): use Path.replace instead of Path.rename

### DIFF
--- a/flopy/utils/get_modflow.py
+++ b/flopy/utils/get_modflow.py
@@ -577,7 +577,7 @@ def run_main(
         for fpath in extract:
             fpath = Path(fpath)
             bindir_path = bindir / fpath
-            bindir_path.rename(bindir / fpath.name)
+            bindir_path.replace(bindir / fpath.name)
             rmdirs.add(fpath.parent)
         # clean up directories, starting with the longest
         for rmdir in reversed(sorted(rmdirs)):


### PR DESCRIPTION
The behavior of `Path.rename()` is [inconsistent between platforms](https://docs.python.org/3/library/pathlib.html#pathlib.Path.rename): on Windows an error is raised if a file with the new name already exists, while on Linux and macOS the file is silently replaced. This PR updates `get-modflow` to use `Path.replace()` instead of `Path.rename()` when moving binaries from the download directory to bin directory, for consistent behavior.

One case for which this is relevant is installing a full suite of binaries from the `executables` distribution, plus bleeding-edge versions of `mf6`, `mf5to6`, `mf2005`, and `zbud6` from the `modflow6-nightly-build` distribution. An easy way to do this is running `get-modflow` twice, e.g.

```
get-modflow bin
get-modflow bin --repo modflow6-nightly-build
```

Currently this works on macOS and Linux but not on Windows.