### PR TITLE
ci: install mf6 nightly build exes and update flopy pkgs

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -199,8 +199,22 @@ jobs:
           pip install xmipy
           pip install .
 
-      - name: Install Modflow executables
+      - name: Install Modflow-related executables
         uses: modflowpy/install-modflow-action@v1
+
+      - name: Install Modflow dev build executables
+        uses: modflowpy/install-modflow-action@v1
+        with:
+          repo: modflow6-nightly-build
+
+      - name: Update FloPy packages
+        if: runner.os != 'Windows'
+        run: python -c 'import flopy; flopy.mf6.utils.generate_classes(branch="develop", backup=False)'
+
+      - name: Update FloPy packages
+        if: runner.os == 'Windows'
+        shell: bash -l {0}
+        run: python -c 'import flopy; flopy.mf6.utils.generate_classes(branch="develop", backup=False)'
 
       - name: Run tests
         if: runner.os != 'Windows'

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -76,8 +76,22 @@ jobs:
           $PSDefaultParameterValues['*:ErrorAction']='Stop'
           powershell .github/install_opengl.ps1
 
-      - name: Install Modflow executables
+      - name: Install Modflow-related executables
         uses: modflowpy/install-modflow-action@v1
+
+      - name: Install Modflow dev build executables
+        uses: modflowpy/install-modflow-action@v1
+        with:
+          repo: modflow6-nightly-build
+
+      - name: Update FloPy packages
+        if: runner.os != 'Windows'
+        run: python -c 'import flopy; flopy.mf6.utils.generate_classes(branch="develop", backup=False)'
+
+      - name: Update FloPy packages
+        if: runner.os == 'Windows'
+        shell: bash -l {0}
+        run: python -c 'import flopy; flopy.mf6.utils.generate_classes(branch="develop", backup=False)'
 
       - name: Run example tests
         if: runner.os != 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
           python -c "import flopy; print(f'FloPy version: {flopy.__version__}')"
           echo "version=${ver#"v"}" >> $GITHUB_OUTPUT
 
-      - name: Update FloPy plugins
+      - name: Update FloPy packages
         run: python -c 'import flopy; flopy.mf6.utils.generate_classes(branch="master", backup=False)'
 
       - name: Lint Python files


### PR DESCRIPTION
A regression test is broken because an mf6 example model using `develop` branch features was [recently added](https://github.com/MODFLOW-USGS/modflow6-examples/commit/b4a4382050010f9b77bb52ebf8a797c0a9287ceb). Previously flopy used the official release of modflow6 for commit-triggered and nightly CI testing. This PR switches to the development build of mf6 and updates flopy packages so that mf6 and flopy can be developed in sync.

Also correct "plugins" to "packages" in `release.yml`