### PR TITLE
bugfix in mfsfr2.py for tabulate flow format

### DIFF
--- a/flopy/modflow/mfsfr2.py
+++ b/flopy/modflow/mfsfr2.py
@@ -990,7 +990,7 @@ class ModflowSfr2(Package):
             if tabfiles and i == 0:
                 for j in range(numtab):
                     segnum, numval, iunit = map(
-                        int, f.readline().strip().split()
+                        int, f.readline().strip().split()[:3]
                     )
                     tabfiles_dict[segnum] = {"numval": numval, "inuit": iunit}
 


### PR DESCRIPTION
parse only the first three entries to avoid error when the rest of the line are not integers