### PR TITLE
fix(keystring): flopy key record no longer needs to be named after keystring (#1616)

### DIFF
--- a/flopy/mf6/data/mfdatalist.py
+++ b/flopy/mf6/data/mfdatalist.py
@@ -14,7 +14,7 @@ from ..utils.mfenums import DiscretizationType
 from .mfdatastorage import DataStorage, DataStorageType, DataStructureType
 from .mfdatautil import to_string
 from .mffileaccess import MFFileAccessList
-from .mfstructure import DatumType
+from .mfstructure import DatumType, MFDataStructure
 
 
 class MFList(mfdata.MFMultiDimVar, DataListInterface):
@@ -1104,9 +1104,64 @@ class MFList(mfdata.MFMultiDimVar, DataListInterface):
                                 # everything else is part of the keystring data
                                 data_key = data_val.lower()
                                 if data_key not in data_item.keystring_dict:
-                                    keystr_struct = data_item.keystring_dict[
-                                        f"{data_key}record"
-                                    ]
+                                    key_record = f"{data_key}record"
+                                    if key_record in data_item.keystring_dict:
+                                        keystr_struct = (
+                                            data_item.keystring_dict[
+                                                key_record
+                                            ]
+                                        )
+                                    else:
+                                        # look for data key in child records
+                                        found = False
+                                        for (
+                                            record
+                                        ) in data_item.keystring_dict.values():
+                                            if (
+                                                isinstance(
+                                                    record, MFDataStructure
+                                                )
+                                                and len(
+                                                    record.data_item_structures
+                                                )
+                                                > 0
+                                                and record.data_item_structures[
+                                                    0
+                                                ].name
+                                                == data_key
+                                            ):
+                                                keystr_struct = record
+                                                found = True
+                                                break
+                                        if not found:
+                                            message = (
+                                                "An error occurred "
+                                                "while attempting to resolve "
+                                                f"key {data_key}. This "
+                                                "error occurred while "
+                                                "processing "
+                                                f'"{data_item.name}" line '
+                                                f"{self._crnt_line_num} data "
+                                                f"(data path: {self._path})"
+                                            )
+                                            (
+                                                type_,
+                                                value_,
+                                                traceback_,
+                                            ) = sys.exc_info()
+                                            raise MFDataException(
+                                                self.structure.get_model(),
+                                                self.structure.get_package(),
+                                                self._path,
+                                                "resolving key",
+                                                self.structure.name,
+                                                inspect.stack()[0][3],
+                                                type_,
+                                                value_,
+                                                traceback_,
+                                                message,
+                                                self._simulation_data.debug,
+                                            )
                                 else:
                                     keystr_struct = data_item.keystring_dict[
                                         data_key

--- a/flopy/mf6/data/mffileaccess.py
+++ b/flopy/mf6/data/mffileaccess.py
@@ -1686,23 +1686,51 @@ class MFFileAccessList(MFFileAccess):
                                                 name_data
                                                 not in data_item.keystring_dict
                                             ):
+                                                # look for data key in child records
+                                                found = False
+                                                for (
+                                                    key,
+                                                    record,
+                                                ) in (
+                                                    data_item.keystring_dict.items()
+                                                ):
+                                                    if (
+                                                        isinstance(
+                                                            record,
+                                                            MFDataStructure,
+                                                        )
+                                                        and len(
+                                                            record.data_item_structures
+                                                        )
+                                                        > 0
+                                                        and record.data_item_structures[
+                                                            0
+                                                        ].name
+                                                        == data.lower()
+                                                    ):
+                                                        name_data = key
+                                                        found = True
+                                                        break
                                                 # data does not match any
                                                 # expected keywords
-                                                if (
-                                                    self._simulation_data.verbosity_level.value
-                                                    >= VerbosityLevel.normal.value
-                                                ):
-                                                    print(
-                                                        "WARNING: Failed to "
-                                                        "process line {}.  "
-                                                        "Line does not match"
-                                                        " expected keystring"
-                                                        " {}".format(
-                                                            " ".join(arr_line),
-                                                            data_item.name,
+                                                if not found:
+                                                    if (
+                                                        self._simulation_data.verbosity_level.value
+                                                        >= VerbosityLevel.normal.value
+                                                    ):
+                                                        print(
+                                                            "WARNING: Failed to "
+                                                            "process line {}.  "
+                                                            "Line does not match"
+                                                            " expected keystring"
+                                                            " {}".format(
+                                                                " ".join(
+                                                                    arr_line
+                                                                ),
+                                                                data_item.name,
+                                                            )
                                                         )
-                                                    )
-                                                break
+                                                    break
                                         data_item_ks = (
                                             data_item.keystring_dict[name_data]
                                         )


### PR DESCRIPTION
When a keystring contains a record flopy assumed that the key record name would be <keystring>record.  Since it is very easy for someone to not follow this naming convention in the dfn file, flopy no longer requires it.