### PR TITLE
feat(generate_classes): add optional owner param

### DIFF
--- a/autotest/test_generate_classes.py
+++ b/autotest/test_generate_classes.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+from pprint import pprint
+
+import pytest
+
+
+@pytest.mark.mf6
+def test_generate_classes_from_dfn(virtualenv, project_root_path):
+    python = virtualenv.python
+    venv = Path(python).parent
+    print(f"Using temp venv at {venv} with python {python}")
+
+    # install flopy/dependencies
+    pprint(virtualenv.run(f"pip install {project_root_path}"))
+    for dependency in ["modflow-devtools"]:
+        pprint(virtualenv.run(f"pip install {dependency}"))
+
+    # get creation time of files
+    mod_files = list(
+        venv.parent.rglob("lib/python3.10/site-packages/flopy/mf6/modflow/*")
+    ) + list(
+        venv.parent.rglob("lib/python3.10/site-packages/flopy/mf6/data/dfn/*")
+    )
+    mod_file_times = [Path(mod_file).stat().st_mtime for mod_file in mod_files]
+    pprint(mod_files)
+
+    # generate classes from develop branch
+    owner = "MODFLOW-USGS"
+    branch = "develop"
+    pprint(
+        virtualenv.run(
+            "python -c 'from flopy.mf6.utils import generate_classes; generate_classes(owner=\""
+            + owner
+            + '", branch="'
+            + branch
+            + "\", backup=False)'"
+        )
+    )
+
+    # make sure files were regenerated
+    modified_files = [
+        mod_files[i]
+        for i, (before, after) in enumerate(
+            zip(
+                mod_file_times,
+                [Path(mod_file).stat().st_mtime for mod_file in mod_files],
+            )
+        )
+        if after > before
+    ]
+    assert any(modified_files)
+    print(f"{len(modified_files)} files were modified:")
+    pprint(modified_files)
+
+    # try with master branch
+    branch = "master"
+    pprint(
+        virtualenv.run(
+            "python -c 'from flopy.mf6.utils import generate_classes; generate_classes(owner=\""
+            + owner
+            + '", branch="'
+            + branch
+            + "\", backup=False)'"
+        )
+    )
+
+    # todo checkout mf6 and test with dfnpath? test with backups?

--- a/autotest/test_generate_classes.py
+++ b/autotest/test_generate_classes.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 from pprint import pprint
 
@@ -16,10 +17,16 @@ def test_generate_classes_from_dfn(virtualenv, project_root_path):
         pprint(virtualenv.run(f"pip install {dependency}"))
 
     # get creation time of files
-    mod_files = list(
-        venv.parent.rglob("lib/python3.10/site-packages/flopy/mf6/modflow/*")
-    ) + list(
-        venv.parent.rglob("lib/python3.10/site-packages/flopy/mf6/data/dfn/*")
+    flopy_path = (
+        venv.parent
+        / "lib"
+        / f"python{sys.version_info.major}.{sys.version_info.minor}"
+        / "site-packages"
+        / "flopy"
+    )
+    assert flopy_path.is_dir()
+    mod_files = list((flopy_path / "mf6" / "modflow").rglob("*")) + list(
+        (flopy_path / "mf6" / "data" / "dfn").rglob("*")
     )
     mod_file_times = [Path(mod_file).stat().st_mtime for mod_file in mod_files]
     pprint(mod_files)

--- a/autotest/test_model_splitter.py
+++ b/autotest/test_model_splitter.py
@@ -1,11 +1,10 @@
 import numpy as np
-
 import pytest
 from autotest.conftest import get_example_data_path
 from modflow_devtools.markers import requires_exe
 
-from flopy.mf6.utils import Mf6Splitter
 from flopy.mf6 import MFSimulation
+from flopy.mf6.utils import Mf6Splitter
 
 
 @requires_exe("mf6")

--- a/autotest/test_mp6.py
+++ b/autotest/test_mp6.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 from autotest.conftest import get_example_data_path
 from autotest.test_mp6_cases import Mp6Cases1, Mp6Cases2
-from modflow_devtools.markers import requires_exe, requires_pkg, has_pkg
+from modflow_devtools.markers import has_pkg, requires_exe, requires_pkg
 from pytest_cases import parametrize_with_cases
 
 import flopy
@@ -119,7 +119,9 @@ def test_mpsim(function_tmpdir, mp6_test_path):
         sim = Modpath6Sim(model=mp)
         # starting locations file
         stl = StartingLocationsFile(model=mp, use_pandas=use_pandas)
-        stldata = StartingLocationsFile.get_empty_starting_locations_data(npt=2)
+        stldata = StartingLocationsFile.get_empty_starting_locations_data(
+            npt=2
+        )
         stldata["label"] = ["p1", "p2"]
         stldata[1]["i0"] = 5
         stldata[1]["j0"] = 6

--- a/autotest/test_notebooks.py
+++ b/autotest/test_notebooks.py
@@ -9,7 +9,8 @@ from modflow_devtools.misc import run_cmd
 def get_notebooks(pattern=None, exclude=None):
     prjroot = get_project_root_path()
     nbpaths = [
-        str(p) for p in (prjroot / ".docs" / "Notebooks").glob("*.py")
+        str(p)
+        for p in (prjroot / ".docs" / "Notebooks").glob("*.py")
         if pattern in p.name
     ]
     return sorted(
@@ -21,7 +22,9 @@ def get_notebooks(pattern=None, exclude=None):
 @pytest.mark.slow
 @pytest.mark.example
 @pytest.mark.parametrize(
-    "notebook", get_notebooks(pattern="tutorial", exclude=["mf6_lgr"]) + get_notebooks(pattern="example")
+    "notebook",
+    get_notebooks(pattern="tutorial", exclude=["mf6_lgr"])
+    + get_notebooks(pattern="example"),
 )
 def test_notebooks(notebook):
     args = ["jupytext", "--from", "py", "--to", "ipynb", "--execute", notebook]

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -27,6 +27,7 @@ dependencies:
   - pytest-cases
   - pytest-cov
   - pytest-dotenv
+  - pytest-virtualenv
   - pytest-xdist
 
 

--- a/flopy/mf6/utils/generate_classes.py
+++ b/flopy/mf6/utils/generate_classes.py
@@ -45,10 +45,9 @@ def list_files(pth, exts=["py"]):
         if ext in exts:
             idx += 1
             print(f"    {idx:5d} - {fn}")
-    return
 
 
-def download_dfn(branch, new_dfn_pth):
+def download_dfn(owner, branch, new_dfn_pth):
     try:
         from modflow_devtools.download import download_and_unzip
     except:
@@ -58,10 +57,9 @@ def download_dfn(branch, new_dfn_pth):
             "pip install modflow-devtools.  Stopping."
         )
         print(msg)
-        return
 
-    mf6url = "https://github.com/MODFLOW-USGS/modflow6/archive/{}.zip"
-    mf6url = mf6url.format(branch)
+    mf6url = "https://github.com/{}/modflow6/archive/{}.zip"
+    mf6url = mf6url.format(owner, branch)
     print(f"  Downloading MODFLOW 6 repository from {mf6url}")
     with tempfile.TemporaryDirectory() as tmpdirname:
         download_and_unzip(mf6url, tmpdirname, verbose=True)
@@ -70,7 +68,6 @@ def download_dfn(branch, new_dfn_pth):
             downloaded_dfn_pth, "doc", "mf6io", "mf6ivar", "dfn"
         )
         shutil.copytree(downloaded_dfn_pth, new_dfn_pth)
-    return
 
 
 def backup_existing_dfns(flopy_dfn_path):
@@ -81,7 +78,6 @@ def backup_existing_dfns(flopy_dfn_path):
     assert os.path.isdir(
         backup_folder
     ), f"dfn backup files not found: {backup_folder}"
-    return
 
 
 def replace_dfn_files(new_dfn_pth, flopy_dfn_path):
@@ -105,10 +101,11 @@ def delete_mf6_classes():
         if os.path.isfile(os.path.join(pth, entry))
     ]
     delete_files(files, pth, exclude="mfsimulation.py")
-    return
 
 
-def generate_classes(branch="master", dfnpath=None, backup=True):
+def generate_classes(
+    owner="MODFLOW-USGS", branch="master", dfnpath=None, backup=True
+):
     """
     Generate the MODFLOW 6 flopy classes using definition files from the
     MODFLOW 6 GitHub repository or a set of definition files in a folder
@@ -116,6 +113,9 @@ def generate_classes(branch="master", dfnpath=None, backup=True):
 
     Parameters
     ----------
+    owner : str
+        Owner of the MODFLOW 6 repository to use to update the definition
+        files and generate the MODFLOW 6 classes. Default is MODFLOW-USGS.
     branch : str
         Branch name of the MODFLOW 6 repository to use to update the
         definition files and generate the MODFLOW 6 classes. Default is master.
@@ -139,10 +139,12 @@ def generate_classes(branch="master", dfnpath=None, backup=True):
     # download the dfn files and put them in flopy.mf6.data or update using
     # user provided dfnpath
     if dfnpath is None:
-        print(f"  Updating the MODFLOW 6 classes using the branch: {branch}")
+        print(
+            f"  Updating the MODFLOW 6 classes using {owner}/modflow6/{branch}"
+        )
         timestr = time.strftime("%Y%m%d-%H%M%S")
         new_dfn_pth = os.path.join(flopypth, "mf6", "data", f"dfn_{timestr}")
-        download_dfn(branch, new_dfn_pth)
+        download_dfn(owner, branch, new_dfn_pth)
     else:
         print(f"  Updating the MODFLOW 6 classes using {dfnpath}")
         assert os.path.isdir(dfnpath)
@@ -163,5 +165,3 @@ def generate_classes(branch="master", dfnpath=None, backup=True):
     print("  Create mf6 classes using the downloaded definition files.")
     create_packages()
     list_files(os.path.join(flopypth, "mf6", "modflow"))
-
-    return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ test = [
     "pytest-cases",
     "pytest-cov",
     "pytest-dotenv",
+    "pytest-virtualenv",
     "pytest-xdist",
 ]
 optional = [

--- a/scripts/run_notebooks.py
+++ b/scripts/run_notebooks.py
@@ -2,9 +2,7 @@ import os
 import sys
 
 # path to notebooks
-src_pths = (
-    os.path.join("..", ".docs", "Notebooks"),
-)
+src_pths = (os.path.join("..", ".docs", "Notebooks"),)
 
 # parse command line arguments for notebook to create
 nb_files = None


### PR DESCRIPTION
- Add optional `owner` param to `generate_classes()` to update classes from a fork, default is "MODFLOW-USGS"
- Add test using [`pytest-virtualenv`](https://pypi.org/project/pytest-virtualenv/) which allows updating sources in an isolated temporary environment
- Add `pytest-virtualenv` to `pyproject.toml` and `environment.yml`
- Run black and isort on some scripts and autotests