### PR TITLE
test(scripts): don't fail on stderr

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -97,7 +97,7 @@ jobs:
         if: runner.os != 'Windows'
         working-directory: ./autotest
         run: |
-          pytest -v -m="example" -n=auto --durations=0 --keep-failed=.failed
+          pytest -v -m="example" -n=auto -s --durations=0 --keep-failed=.failed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -106,7 +106,7 @@ jobs:
         shell: bash -l {0}
         working-directory: ./autotest
         run: |
-          pytest -v -m="example" -n=auto --durations=0 --keep-failed=.failed
+          pytest -v -m="example" -n=auto -s --durations=0 --keep-failed=.failed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/autotest/test_example_scripts.py
+++ b/autotest/test_example_scripts.py
@@ -1,6 +1,7 @@
 import re
 from functools import reduce
 from os import linesep
+from pprint import pprint
 
 import pytest
 from autotest.conftest import get_project_root_path
@@ -10,7 +11,7 @@ from modflow_devtools.misc import run_py_script
 def get_example_scripts(exclude=None):
     prjroot = get_project_root_path()
 
-    # sort to appease pytest-xdist: all workers must collect identically ordered sets of tests
+    # sort for pytest-xdist: workers must collect tests in the same order
     return sorted(
         reduce(
             lambda a, b: a + b,
@@ -41,15 +42,15 @@ def test_scripts(script):
             pytest.skip(f"script requires optional dependency {pkg!r}")
 
     assert returncode == 0
-
-    allowed_patterns = ["findfont", "warning", "loose", "match_original"]
-
-    assert (
-        not stderr
-        or
-        # trap warnings & non-fatal errors
-        all(
-            (not line or any(p in line.lower() for p in allowed_patterns))
-            for line in stderr.split(linesep)
-        )
-    )
+    pprint(stdout)
+    pprint(stderr)
+    # allowed_patterns = ["findfont", "warning", "loose", "match_original"]
+    # assert (
+    #     not stderr
+    #     or
+    #     # trap warnings & non-fatal errors
+    #     all(
+    #         (not line or any(p in line.lower() for p in allowed_patterns))
+    #         for line in stderr.split(linesep)
+    #     )
+    # )


### PR DESCRIPTION
- prevent [CI failures](https://github.com/modflowpy/flopy/actions/runs/5302617620/jobs/9597672524) on missing fonts, deprecation warnings, etc as long as return code is 0
- show (use `-s` flag) instead of capturing warnings sent to stdout + stderr