### PR TITLE
fix(get-modflow): manage internal "bin" dir structures

### DIFF
--- a/autotest/test_get_modflow.py
+++ b/autotest/test_get_modflow.py
@@ -115,6 +115,7 @@ def test_get_release(repo):
     assets = release["assets"]
 
     expected_assets = ["linux.zip", "mac.zip", "win64.zip"]
+    expected_ostags = [a.replace(".zip", "") for a in expected_assets]
     actual_assets = [asset["name"] for asset in assets]
 
     if repo == "modflow6":
@@ -123,7 +124,10 @@ def test_get_release(repo):
             a for a in expected_assets if not a.startswith("win")
         }
     else:
-        assert set(actual_assets) >= set(expected_assets)
+        for ostag in expected_ostags:
+            assert any(
+                ostag in a for a in actual_assets
+            ), f"dist not found for {ostag}"
 
 
 @pytest.mark.parametrize("bindir", bindir_options.keys())

--- a/autotest/test_get_modflow.py
+++ b/autotest/test_get_modflow.py
@@ -105,10 +105,6 @@ def test_get_releases(repo):
     releases = get_releases(repo)
     assert "latest" in releases
 
-    # test page size option
-    if repo == "modflow6-nightly-build":
-        assert len(releases) == 31  # last 30 releases +1 for "latest"
-
 
 @flaky
 @requires_github


### PR DESCRIPTION
There have been recent changes to modflow6-nightly-build that have changed how get-modflow works.

From Linux:
```
$ get-modflow :python --repo modflow6-nightly-build --release-id 20230622
auto-selecting option ':python' for ':python'
fetched release '20230622' info from MODFLOW-USGS/modflow6-nightly-build
downloading 'https://github.com/MODFLOW-USGS/modflow6-nightly-build/releases/download/20230622/mf6.4.2dev_linux.zip' to '/tmp/tmp84o_afdm/modflow6_nightly-20230622-mf6.4.2dev_linux.zip'

extracting 7 files to '/tmp/py310/bin'
mf6.4.2dev_linux/bin/libmf6.so   mf6.4.2dev_linux/code.json
mf6.4.2dev_linux/bin/mf5to6      mf6.4.2dev_linux/doc/mf6io.pdf
mf6.4.2dev_linux/bin/mf6         mf6.4.2dev_linux/doc/release.pdf
mf6.4.2dev_linux/bin/zbud6
updated flopy metadata file: '/home/mtoews/.local/share/flopy/get_modflow.json'
```
This incorrectly put a subdirectory in bindir:
```
$ tree /tmp/py310/bin/mf6.4.2dev_linux/
/tmp/py310/bin/mf6.4.2dev_linux/
├── bin
│   ├── libmf6.so
│   ├── mf5to6
│   ├── mf6
│   └── zbud6
├── code.json
└── doc
    ├── mf6io.pdf
    └── release.pdf
```

This PR fixes this by selecting files to extract if they are within a "bin" directory. And if none are found, take them all. The `rmtree` is needed to clean up "mf6.4.2dev_linux" and other remaining files (code.json and doc subfolder).

It also avoids extracting "code.json" with other repos.

---

This PR does not fix a related Windows issue:
```
> get-modflow :python --repo modflow6-nightly-build --release-id 20230622
auto-selecting option ':python' for ':python'
fetched release '20230622' info from MODFLOW-USGS/modflow6-nightly-build
Traceback (most recent call last):
  File "C:\Users\mtoews\AppData\Local\miniforge3\envs\pyforge\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Users\mtoews\AppData\Local\miniforge3\envs\pyforge\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "d:\Temp\py310\Scripts\get-modflow.exe\__main__.py", line 7, in <module>
  File "D:\src\flopy\flopy\utils\get_modflow.py", line 723, in cli_main
    run_main(**args, _is_cli=True)
  File "D:\src\flopy\flopy\utils\get_modflow.py", line 406, in run_main
    raise ValueError(
ValueError: could not find ostag 'win64' from release '20230622'; see available assets here:
https://github.com/MODFLOW-USGS/modflow6-nightly-build/releases/tag/20230622
```
Indeed, there are only linux and mac assets for this [recent release tag](https://github.com/MODFLOW-USGS/modflow6-nightly-build/releases/tag/20230622). Should there be win64 too?