### PR TITLE
ci: update post-release versioning conventions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,12 +98,6 @@ jobs:
 
       - name: Update changelog
         run: |
-          # move changelog
-          sudo cp ${{ steps.cliff.outputs.changelog }} CHANGELOG.md
-          
-          # show changelog
-          cat CHANGELOG.md
-          
           # substitute full group names
           sed -i 's/#### Ci/#### Continuous integration/' CHANGELOG.md
           sed -i 's/#### Feat/#### New features/' CHANGELOG.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -283,11 +283,9 @@ jobs:
           reset_branch="post-release-${{ steps.latest_tag.outputs.tag }}-reset"
           git switch -c $reset_branch
           
-          # increment patch version
-          major_version=$(echo "${{ steps.latest_tag.outputs.tag }}" | cut -d. -f1)
-          minor_version=$(echo "${{ steps.latest_tag.outputs.tag }}" | cut -d. -f2)
-          patch_version=$(echo "${{ steps.latest_tag.outputs.tag }}" | cut -d. -f3)
-          version="$major_version.$minor_version.$((patch_version + 1))"
+          # update version string (append '+' to indicate development status)
+          version=$(cat version.txt)
+          version="$version+"
           python scripts/update_version.py -v "$version"
           
           # lint Python files
@@ -298,13 +296,13 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
-          git commit -m "ci(release): update to development version $version"
+          git commit -m "ci(release): update to version $version"
           git push -u origin $reset_branch
           
           # create PR into develop
           body='
           # Reinitialize for development
           
-          Updates the `develop` branch from `master` following a successful release. Increments the patch version number.
+          Updates the `develop` branch from `master` following a successful release.
           '
           gh pr create -B "develop" -H "$reset_branch" --title "Reinitialize develop branch" --draft --body "$body"

--- a/docs/make_release.md
+++ b/docs/make_release.md
@@ -66,7 +66,7 @@ If the branch name does not end with `rc`, the workflow will proceed to open a P
 
 **Note:** the PR should be merged, not squashed. Squashing removes the commit history from the `master` branch and causes `develop` and `master` to diverge, which can cause future PRs updating `master` to replay commits from previous releases.
 
-Publishing the release triggers jobs to publish the `flopy` package to PyPI and open a PR updating `develop` from `master`. This PR also updates version strings, incrementing the patch version number.
+Publishing the release triggers jobs to publish the `flopy` package to PyPI and open a PR updating `develop` from `master`. This PR also updates version numbers to the just-released version, and appends "+" to the end of the version string to indicate development status.
 
 
 ### Manual releases


### PR DESCRIPTION
Update the release workflow to append "+" to the version string merged back to `develop` from `master`, to indicate preliminary/development status. This is as opposed to incrementing one of the version numbers, which is not a great solution as it can't always be predicted if the next release will be major, minor, or patch.

Also a minor fix to changelog generation