### PR TITLE
ci: update PyPI publishing step/docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,6 +198,10 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write  # mandatory for trusted publishing
+    environment:  # requires a 'release' environment in repo settings
+      name: release
+      url: https://pypi.org/p/flopy
     steps:
 
       - name: Checkout master branch
@@ -232,9 +236,6 @@ jobs:
           path: dist
 
       - name: Publish to PyPI
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: python -m twine upload dist/*
 
   reset:

--- a/docs/make_release.md
+++ b/docs/make_release.md
@@ -68,6 +68,9 @@ If the branch name does not end with `rc`, the workflow will proceed to open a P
 
 Publishing the release triggers jobs to publish the `flopy` package to PyPI and open a PR updating `develop` from `master`. This PR also updates version numbers to the just-released version, and appends "+" to the end of the version string to indicate development status.
 
+##### Trusted publishing
+
+The automated release workflow assumes [trusted publishing](https://docs.pypi.org/trusted-publishers/) has been configured in the PyPI admin interface. A GitHub environment called `release` is also required (however it needs no secrets or environment variables).
 
 ### Manual releases
 


### PR DESCRIPTION
Update the release workflow to use PyPI trusted publishing.