### PR TITLE
fix(get-modflow): accommodate mf6 release asset name change

### DIFF
--- a/.docs/Notebooks/array_output_tutorial.py
+++ b/.docs/Notebooks/array_output_tutorial.py
@@ -25,9 +25,9 @@
 # + [markdown] pycharm={"name": "#%% md\n"}
 # load and run the Freyberg model
 
-import os
 
 # + pycharm={"name": "#%%\n"}
+import os
 import sys
 from tempfile import TemporaryDirectory
 

--- a/.docs/Notebooks/plot_cross_section_example.py
+++ b/.docs/Notebooks/plot_cross_section_example.py
@@ -23,9 +23,9 @@
 #
 # ### Mapping is demonstrated for MODFLOW-2005 and MODFLOW-6 models in this notebook
 
-import os
 
 # + pycharm={"name": "#%%\n"}
+import os
 import sys
 from tempfile import TemporaryDirectory
 

--- a/.docs/Notebooks/plot_map_view_example.py
+++ b/.docs/Notebooks/plot_map_view_example.py
@@ -24,9 +24,9 @@
 # ### Mapping is demonstrated for MODFLOW-2005, MODFLOW-USG, and MODFLOW-6 models in this notebook
 #
 
-import os
 
 # +
+import os
 import sys
 from tempfile import TemporaryDirectory
 
@@ -315,8 +315,6 @@ fig.colorbar(sm, shrink=0.75, ax=ax)
 # + [markdown] pycharm={"name": "#%% md\n"}
 # Array contours can be exported directly to a shapefile.
 
-from shapefile import Reader
-
 # + pycharm={"name": "#%%\n"}
 from flopy.export.utils import (  # use export_contourf for filled contours
     export_contours,
@@ -324,6 +322,8 @@ from flopy.export.utils import (  # use export_contourf for filled contours
 
 shp_path = os.path.join(modelpth, "contours.shp")
 export_contours(shp_path, contour_set)
+
+from shapefile import Reader
 
 with Reader(shp_path) as r:
     nshapes = len(r.shapes())

--- a/autotest/test_flopy_module.py
+++ b/autotest/test_flopy_module.py
@@ -1,15 +1,16 @@
 import os
 import re
-from packaging.version import Version
 from pathlib import Path
 
 import numpy as np
+from packaging.version import Version
 
 import flopy
 
 
 def test_import_and_version_string():
     import flopy
+
     # an error is raised if the version string can't be parsed
     Version(flopy.__version__)
 

--- a/flopy/utils/get_modflow.py
+++ b/flopy/utils/get_modflow.py
@@ -396,18 +396,14 @@ def run_main(
     release = get_release(repo, release_id, quiet)
     assets = release.get("assets", [])
 
-    # Windows 64-bit asset in modflow6 repo release has no OS tag
-    if repo == "modflow6" and ostag == "win64":
-        asset = list(sorted(assets, key=lambda a: len(a["name"])))[0]
+    for asset in assets:
+        if ostag in asset["name"]:
+            break
     else:
-        for asset in assets:
-            if ostag in asset["name"]:
-                break
-        else:
-            raise ValueError(
-                f"could not find ostag {ostag!r} from release {release['tag_name']!r}; "
-                f"see available assets here:\n{release['html_url']}"
-            )
+        raise ValueError(
+            f"could not find ostag {ostag!r} from release {release['tag_name']!r}; "
+            f"see available assets here:\n{release['html_url']}"
+        )
     asset_name = asset["name"]
     download_url = asset["browser_download_url"]
     if repo == "modflow6":


### PR DESCRIPTION
The [mf6 windows distribution](https://github.com/MODFLOW-USGS/modflow6/releases/tag/6.4.2) has an OS tag `win64` now so can be handled in the same way as the nightly build and executables dists &mdash; all three now have assets with `linux`, `mac`, and `win64` in the name

Fixes `get-modflow <bindir> --repo modflow6`, which could break if used with the latest release