### PR TITLE
chore: add virtualenv as test dependency

### DIFF
--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -29,7 +29,7 @@ dependencies:
   - pytest-dotenv
   - pytest-virtualenv
   - pytest-xdist
-
+  - virtualenv
 
   # optional
   - python-dateutil>=2.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ test = [
     "pytest-dotenv",
     "pytest-virtualenv",
     "pytest-xdist",
+    "virtualenv"
 ]
 optional = [
     "affine",


### PR DESCRIPTION
The [`pytest-virtualenv`](https://pypi.org/project/pytest-virtualenv/) plugin can evidently fail to install `virtualenv` where needed (reported with Mamba on Mac). List `virtualenv` separately as a testing dependency