### PR TITLE
ci(release): fix publish to PyPi step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,4 +236,4 @@ jobs:
           path: dist
 
       - name: Publish to PyPI
-        run: python -m twine upload dist/*
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Trusted publishing [requires using action `pypi/gh-action-pypi-publish`](https://docs.pypi.org/trusted-publishers/using-a-publisher/#the-easy-way). This is a temporary fix in case another release is made before flopy can adopt [the reusable Python release workflow](https://github.com/MODFLOW-USGS/modflow-devtools/pull/85) forthcoming from devtools.