### PR TITLE
fix(binaryfile): avoid numpy deprecation warnings

### DIFF
--- a/flopy/utils/binaryfile.py
+++ b/flopy/utils/binaryfile.py
@@ -562,7 +562,7 @@ class BinaryLayerFile(LayerFile):
                 )  # change ilay from header to zero-based
                 if ilay != k:
                     continue
-                ipos = int(self.iposarray[irec])
+                ipos = self.iposarray[irec].item()
 
                 # Calculate offset necessary to reach intended cell
                 self.file.seek(ipos + int(ioffset), 0)
@@ -1031,9 +1031,9 @@ class CellBudgetFile:
                     print(f"{itxt}: {s}")
                 print("file position: ", ipos)
                 if (
-                    int(header["imeth"]) != 5
-                    and int(header["imeth"]) != 6
-                    and int(header["imeth"]) != 7
+                    header["imeth"].item() != 5
+                    and header["imeth"].item() != 6
+                    and header["imeth"].item() != 7
                 ):
                     print("")
 
@@ -1141,7 +1141,7 @@ class CellBudgetFile:
             )
             for name in temp.dtype.names:
                 header2[name] = temp[name]
-            if int(header2["imeth"]) == 6:
+            if header2["imeth"].item() == 6:
                 header2["modelnam"] = binaryread(self.file, str, charlen=16)
                 header2["paknam"] = binaryread(self.file, str, charlen=16)
                 header2["modelnam2"] = binaryread(self.file, str, charlen=16)
@@ -1689,7 +1689,7 @@ class CellBudgetFile:
             idx = np.array([idx])
 
         header = self.recordarray[idx]
-        ipos = int(self.iposarray[idx])
+        ipos = self.iposarray[idx].item()
         self.file.seek(ipos, 0)
         imeth = header["imeth"][0]
 

--- a/flopy/utils/gridutil.py
+++ b/flopy/utils/gridutil.py
@@ -58,7 +58,15 @@ def get_lni(ncpl, nodes) -> List[Tuple[int, int]]:
     return tuples
 
 
-def get_disu_kwargs(nlay, nrow, ncol, delr, delc, tp, botm):
+def get_disu_kwargs(
+    nlay,
+    nrow,
+    ncol,
+    delr: np.ndarray,
+    delc: np.ndarray,
+    tp: np.ndarray,
+    botm: np.ndarray,
+):
     """
     Simple utility for creating args needed to construct
     a disu package
@@ -88,7 +96,7 @@ def get_disu_kwargs(nlay, nrow, ncol, delr, delc, tp, botm):
                 cl12.append(n + 1)
                 hwva.append(n + 1)
                 if k == 0:
-                    top[n] = tp
+                    top[n] = tp.item()
                 else:
                     top[n] = botm[k - 1]
                 bot[n] = botm[k]

--- a/flopy/utils/gridutil.py
+++ b/flopy/utils/gridutil.py
@@ -62,14 +62,30 @@ def get_disu_kwargs(
     nlay,
     nrow,
     ncol,
-    delr: np.ndarray,
-    delc: np.ndarray,
-    tp: np.ndarray,
-    botm: np.ndarray,
+    delr,
+    delc,
+    tp,
+    botm,
 ):
     """
-    Simple utility for creating args needed to construct
-    a disu package
+    Create args needed to construct a DISU package.
+
+    Parameters
+    ----------
+    nlay : int
+        Number of layers
+    nrow : int
+        Number of rows
+    ncol : int
+        Number of columns
+    delr : numpy.ndarray
+        Column spacing along a row
+    delc : numpy.ndarray
+        Row spacing along a column
+    tp : int or numpy.ndarray
+        Top elevation(s) of cells in the model's top layer
+    botm : numpy.ndarray
+        Bottom elevation(s) of all cells in the model
     """
 
     def get_nn(k, i, j):
@@ -96,7 +112,7 @@ def get_disu_kwargs(
                 cl12.append(n + 1)
                 hwva.append(n + 1)
                 if k == 0:
-                    top[n] = tp.item()
+                    top[n] = tp.item() if isinstance(tp, np.ndarray) else tp
                 else:
                     top[n] = botm[k - 1]
                 bot[n] = botm[k]


### PR DESCRIPTION
In the future, [numpy will stop treating arrays with 1 element and dimension >0 as scalars](https://numpy.org/doc/stable/release/1.25.0-notes.html#deprecations). Use `.item()` to access the single element.

This may need to be fixed elsewhere in the codebase, this is the only place I have seen warnings from recently.