### PR TITLE
refactor(expired deprecation): remove warning for third parameter of Grid.intersect

### DIFF
--- a/flopy/discretization/grid.py
+++ b/flopy/discretization/grid.py
@@ -147,8 +147,6 @@ class Grid:
         1D array of x and y coordinates of cell vertices for whole grid
         (single layer) in C-style (row-major) order
         (same as np.ravel())
-    intersect(x, y, local)
-        returns the row and column of the grid that the x, y point is in
 
     See Also
     --------
@@ -984,38 +982,6 @@ class Grid:
             return self.get_local_coords(x, y)
         else:
             return x, y
-
-    def _warn_intersect(self, module, lineno):
-        """
-        Warning for modelgrid intersect() interface change.
-
-        Should be be removed after a couple of releases. Added in 3.3.5
-
-        Updated in 3.3.6 to raise an error and exit if intersect interface
-        is called incorrectly.
-
-        Should be removed in flopy 3.3.7
-
-        Parameters
-        ----------
-        module : str
-            module name path
-        lineno : int
-            line number where warning is called from
-
-        Returns
-        -------
-            None
-        """
-        module = os.path.split(module)[-1]
-        warning = (
-            "The interface 'intersect(self, x, y, local=False, "
-            "forgive=False)' has been deprecated. Use the "
-            "intersect(self, x, y, z=None, local=False, "
-            "forgive=False) interface instead."
-        )
-
-        raise UserWarning(warning)
 
     def set_coord_info(
         self,

--- a/flopy/discretization/structuredgrid.py
+++ b/flopy/discretization/structuredgrid.py
@@ -1,5 +1,4 @@
 import copy
-import inspect
 import os.path
 from typing import Union
 
@@ -875,11 +874,6 @@ class StructuredGrid(Grid):
             The column number
 
         """
-        if isinstance(z, bool):
-            # trigger interface change warning
-            frame_info = inspect.getframeinfo(inspect.currentframe())
-            self._warn_intersect(frame_info.filename, frame_info.lineno)
-
         # transform x and y to local coordinates
         x, y = super().intersect(x, y, local, forgive)
 

--- a/flopy/discretization/unstructuredgrid.py
+++ b/flopy/discretization/unstructuredgrid.py
@@ -1,5 +1,4 @@
 import copy
-import inspect
 import os
 from typing import Union
 
@@ -581,10 +580,6 @@ class UnstructuredGrid(Grid):
             The CELL2D number
 
         """
-        if isinstance(z, bool):
-            frame_info = inspect.getframeinfo(inspect.currentframe())
-            self._warn_intersect(frame_info.filename, frame_info.lineno)
-
         if local:
             # transform x and y to real-world coordinates
             x, y = super().get_coords(x, y)

--- a/flopy/discretization/vertexgrid.py
+++ b/flopy/discretization/vertexgrid.py
@@ -1,5 +1,4 @@
 import copy
-import inspect
 import os
 
 import numpy as np
@@ -321,10 +320,6 @@ class VertexGrid(Grid):
             The CELL2D number
 
         """
-        if isinstance(z, bool):
-            frame_info = inspect.getframeinfo(inspect.currentframe())
-            self._warn_intersect(frame_info.filename, frame_info.lineno)
-
         if local:
             # transform x and y to real-world coordinates
             x, y = super().get_coords(x, y)


### PR DESCRIPTION
This warning was introduced with #1326 for FloPy 3.3.5, changed to an error with #1489 for FloPy 3.3.6.

This error was intended to be removed for 3.3.7, so this is overdue.