### PR TITLE
refactor(mf6): remove deprecated features

### DIFF
--- a/flopy/mf6/data/mfdataarray.py
+++ b/flopy/mf6/data/mfdataarray.py
@@ -1815,7 +1815,6 @@ class MFTransientArray(MFArray, MFTransient):
 
     def get_data(self, key=None, apply_mult=True, **kwargs):
         """Returns the data associated with stress period key `key`.
-        If `layer` is None, returns all data for time `key`.
 
         Parameters
         ----------
@@ -1825,14 +1824,6 @@ class MFTransientArray(MFArray, MFTransient):
                 Whether to apply multiplier to data prior to returning it
 
         """
-        if "layer" in kwargs:
-            warnings.warn(
-                "The 'layer' parameter has been deprecated, use 'key' "
-                "instead.",
-                category=DeprecationWarning,
-            )
-            key = kwargs["layer"]
-
         if self._data_storage is not None and len(self._data_storage) > 0:
             if key is None:
                 sim_time = self._data_dimensions.package_dim.model_dim[

--- a/flopy/mf6/mfmodel.py
+++ b/flopy/mf6/mfmodel.py
@@ -1207,7 +1207,7 @@ class MFModel(PackageContainer, ModelInterface):
         for record in solution_group:
             for model_name in record[2:]:
                 if model_name == self.name:
-                    return self.simulation.get_ims_package(record[1])
+                    return self.simulation.get_solution_package(record[1])
         return None
 
     def get_steadystate_list(self):

--- a/flopy/mf6/mfsimbase.py
+++ b/flopy/mf6/mfsimbase.py
@@ -1773,81 +1773,6 @@ class MFSimulationBase(PackageContainer):
             excpt_str = f'file "{filename}" can not be found.'
             raise FlopyException(excpt_str)
 
-    def get_mvr_file(self, filename):
-        """
-        Get a specified mover file.
-
-        Parameters
-        ----------
-            filename : str
-                Name of mover file to get
-
-        Returns
-        --------
-            mover package : MFPackage
-
-        """
-        warnings.warn(
-            "get_mvr_file will be deprecated and will be removed in version "
-            "3.3.6. Use get_file",
-            PendingDeprecationWarning,
-        )
-        if filename in self._other_files:
-            return self._other_files[filename]
-        else:
-            excpt_str = f'MVR file "{filename}" can not be found.'
-            raise FlopyException(excpt_str)
-
-    def get_mvt_file(self, filename):
-        """
-        Get a specified mvt file.
-
-        Parameters
-        ----------
-            filename : str
-                Name of mover transport file to get
-
-        Returns
-        --------
-            mover transport package : MFPackage
-
-        """
-        warnings.warn(
-            "get_mvt_file will be deprecated and will be removed in version "
-            "3.3.6. Use get_file",
-            PendingDeprecationWarning,
-        )
-        if filename in self._other_files:
-            return self._other_files[filename]
-        else:
-            excpt_str = f'MVT file "{filename}" can not be found.'
-            raise FlopyException(excpt_str)
-
-    def get_gnc_file(self, filename):
-        """
-        Get a specified gnc file.
-
-        Parameters
-        ----------
-            filename : str
-                Name of gnc file to get
-
-        Returns
-        --------
-            gnc package : MFPackage
-
-        """
-        warnings.warn(
-            "get_gnc_file will be deprecated and will be removed in version "
-            "3.3.6. Use get_file",
-            PendingDeprecationWarning,
-        )
-        if filename in self._other_files:
-            return self._other_files[filename]
-        else:
-            excpt_str = f'GNC file "{filename}" can not be found.'
-            raise FlopyException(excpt_str)
-
     def remove_exchange_file(self, package):
         """
         Removes the exchange file "package". This is for internal flopy
@@ -2229,15 +2154,6 @@ class MFSimulationBase(PackageContainer):
             )
 
         return self.structure.model_struct_objs[model_type]
-
-    def get_ims_package(self, key):
-        warnings.warn(
-            "get_ims_package() has been deprecated and will be "
-            "removed in version 3.3.7. Use "
-            "get_solution_package() instead.",
-            DeprecationWarning,
-        )
-        return self.get_solution_package(key)
 
     def get_solution_package(self, key):
         """


### PR DESCRIPTION
* layer kwarg in `get_data()` in `mfdataarray.py`, deprecated 3.3.5 (June 2022)
* `get_mvr_file()`, `get_mvt_file()`, `get_gnc_file()` in `mfsimbase.py`, removal overdue since 3.3.6
* `get_ims_package()` in `mfsimbase.py`, removal overdue since 3.4
  *  fix `mfmodel.py` usage to `get_solution_package()`