### PR TITLE
docs: remove workaround for https://github.com/readthedocs/sphinx_rtd_theme/issues/1452

### DIFF
--- a/.docs/conf.py
+++ b/.docs/conf.py
@@ -144,7 +144,6 @@ extensions = [
     "nbsphinx",
     "nbsphinx_link",
     "recommonmark",
-    "sphinxcontrib.jquery",  # https://github.com/readthedocs/sphinx_rtd_theme/issues/1452
 ]
 
 # Settings for GitHub actions integration


### PR DESCRIPTION
No longer needed. Hoping this fixes broken notebook rendering in `latest` due to `ModuleNotFoundError: No module named 'sphinxcontrib.jquery'` in RTD build