### PR TITLE
docs: require sphinx>=4 to fix RTD build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ doc = [
     "PyYAML",
     "recommonmark",
     "rtds-action",
+    "sphinx >=4",
     "sphinx-rtd-theme",
 ]
 


### PR DESCRIPTION
[RTD default versions](https://docs.readthedocs.io/en/stable/build-default-versions.html#external-dependencies) for `sphinx` and `sphinx-rtd-theme` for projects of flopy's age are incompatible. Require at least sphinx 4 to avoid [style attribute errors](https://github.com/readthedocs/sphinx_rtd_theme/issues/1465#issuecomment-1531262630)