### PR TITLE
refactor(dependencies): constrain sphinx-rtd-theme >=1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ doc = [
     "recommonmark",
     "rtds-action",
     "sphinx >=4",
-    "sphinx-rtd-theme",
+    "sphinx-rtd-theme >=1",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Followup to #1898, need to specify recent versions of both sphinx and sphinx-rtd-theme to override RTD's [defaults](https://docs.readthedocs.io/en/stable/build-default-versions.html#external-dependencies)