### PR TITLE
fix(modelgrid): retain crs data from classic nam files

### DIFF
--- a/autotest/test_mfreadnam.py
+++ b/autotest/test_mfreadnam.py
@@ -1,7 +1,10 @@
 import pytest
 from autotest.conftest import get_example_data_path
 
-from flopy.utils.mfreadnam import get_entries_from_namefile
+from flopy.utils.mfreadnam import (
+    attribs_from_namfile_header,
+    get_entries_from_namefile,
+)
 
 _example_data_path = get_example_data_path()
 
@@ -39,3 +42,68 @@ def test_get_entries_from_namefile_mf2005(path):
     entry = entries[0]
     assert path.parent.name in entry[0]
     assert entry[1] == package
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        pytest.param(
+            None,
+            {
+                "crs": None,
+                "rotation": 0.0,
+                "xll": None,
+                "xul": None,
+                "yll": None,
+                "yul": None,
+            },
+            id="None",
+        ),
+        pytest.param(
+            _example_data_path / "freyberg" / "freyberg.nam",
+            {
+                "crs": None,
+                "rotation": 0.0,
+                "xll": None,
+                "xul": None,
+                "yll": None,
+                "yul": None,
+            },
+            id="freyberg",
+        ),
+        pytest.param(
+            _example_data_path
+            / "freyberg_multilayer_transient"
+            / "freyberg.nam",
+            {
+                "crs": "+proj=utm +zone=14 +ellps=WGS84 +datum=WGS84 +units=m +no_defs",
+                "rotation": 15.0,
+                "start_datetime": "1/1/2015",
+                "xll": None,
+                "xul": 619653.0,
+                "yll": None,
+                "yul": 3353277.0,
+            },
+            id="freyberg_multilayer_transient",
+        ),
+        pytest.param(
+            _example_data_path
+            / "mt3d_test"
+            / "mfnwt_mt3dusgs"
+            / "sft_crnkNic"
+            / "CrnkNic.nam",
+            {
+                "crs": "EPSG:26916",
+                "rotation": 0.0,
+                "start_datetime": "1-1-1970",
+                "xll": None,
+                "xul": 0.0,
+                "yll": None,
+                "yul": 15.0,
+            },
+            id="CrnkNic",
+        ),
+    ],
+)
+def test_attribs_from_namfile_header(path, expected):
+    assert attribs_from_namfile_header(path) == expected

--- a/autotest/test_modflow.py
+++ b/autotest/test_modflow.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 from autotest.conftest import get_example_data_path
+from modflow_devtools.misc import has_pkg
 from modflow_devtools.markers import excludes_platform, requires_exe
 
 from flopy.discretization import StructuredGrid
@@ -28,6 +29,8 @@ from flopy.modflow import (
 from flopy.mt3d import Mt3dBtn, Mt3dms
 from flopy.seawat import Seawat
 from flopy.utils import Util2d
+
+_example_data_path = get_example_data_path()
 
 
 @pytest.fixture
@@ -74,6 +77,64 @@ def test_modflow_load(namfile, example_data_path):
     assert isinstance(model, Modflow)
     assert not model.load_fail
     assert model.model_ws == str(mpath)
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        pytest.param(
+            _example_data_path / "freyberg" / "freyberg.nam",
+            {
+                "crs": None,
+                "epsg": None,
+                "angrot": 0.0,
+                "xoffset": 0.0,
+                "yoffset": 0.0,
+            },
+            id="freyberg",
+        ),
+        pytest.param(
+            _example_data_path
+            / "freyberg_multilayer_transient"
+            / "freyberg.nam",
+            {
+                "proj4": "+proj=utm +zone=14 +ellps=WGS84 +datum=WGS84 +units=m +no_defs",
+                "angrot": 15.0,
+                "xoffset": 622241.1904510253,
+                "yoffset": 3343617.741737109,
+            },
+            id="freyberg_multilayer_transient",
+        ),
+        pytest.param(
+            _example_data_path
+            / "mt3d_test"
+            / "mfnwt_mt3dusgs"
+            / "sft_crnkNic"
+            / "CrnkNic.nam",
+            {
+                "epsg": 26916,
+                "angrot": 0.0,
+                "xoffset": 0.0,
+                "yoffset": 0.0,
+            },
+            id="CrnkNic",
+        ),
+    ],
+)
+def test_modflow_load_modelgrid(path, expected):
+    """Check modelgrid metadata from NAM file."""
+    model = Modflow.load(path.name, model_ws=path.parent, load_only=[])
+    modelgrid = model.modelgrid
+    for key, expected_value in expected.items():
+        if key == "proj4" and has_pkg("pyproj"):
+            # skip since pyproj will usually restructure proj4 attribute
+            # otherwise continue test without pyproj, as it should be preserved
+            continue
+        modelgrid_value = getattr(modelgrid, key)
+        if isinstance(modelgrid_value, float):
+            assert modelgrid_value == pytest.approx(expected_value), key
+        else:
+            assert modelgrid_value == expected_value, key
 
 
 def test_modflow_load_when_nam_dne():
@@ -551,12 +612,12 @@ def test_read_usgs_model_reference(function_tmpdir, model_reference_path):
 
 
 def mf2005_model_namfiles():
-    path = get_example_data_path() / "mf2005_test"
+    path = _example_data_path / "mf2005_test"
     return [str(p) for p in path.glob("*.nam")]
 
 
 def parameters_model_namfiles():
-    path = get_example_data_path() / "parameters"
+    path = _example_data_path / "parameters"
     skip = ["twrip.nam", "twrip_upw.nam"]  # TODO: why do these fail?
     return [str(p) for p in path.glob("*.nam") if p.name not in skip]
 
@@ -744,15 +805,15 @@ def test_mflist_add_record():
     np.testing.assert_array_equal(wel.stress_period_data[1], check1)
 
 
-__mf2005_test_path = get_example_data_path() / "mf2005_test"
-__mf2005_namfiles = [
-    Path(__mf2005_test_path) / f
-    for f in __mf2005_test_path.rglob("*")
+_mf2005_test_path = _example_data_path / "mf2005_test"
+_mf2005_namfiles = [
+    Path(_mf2005_test_path) / f
+    for f in _mf2005_test_path.rglob("*")
     if f.suffix == ".nam"
 ]
 
 
-@pytest.mark.parametrize("namfile", __mf2005_namfiles)
+@pytest.mark.parametrize("namfile", _mf2005_namfiles)
 def test_checker_on_load(namfile):
     # load all of the models in the mf2005_test folder
     # model level checks are performed by default on load()
@@ -770,7 +831,7 @@ def test_checker_on_load(namfile):
 
 @pytest.mark.parametrize("str_path", [True, False])
 def test_manual_check(function_tmpdir, str_path):
-    namfile_path = __mf2005_namfiles[0]
+    namfile_path = _mf2005_namfiles[0]
     summary_path = function_tmpdir / "summary"
     model = Modflow.load(namfile_path, model_ws=namfile_path.parent)
     model.change_model_ws(function_tmpdir)

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -410,6 +410,12 @@ class BaseModel(ModelInterface):
         self._crs = kwargs.pop("crs", None)
         self._start_datetime = kwargs.pop("start_datetime", "1-1-1970")
 
+        if kwargs:
+            warnings.warn(
+                f"unhandled keywords: {kwargs}",
+                category=UserWarning,
+            )
+
         # build model discretization objects
         self._modelgrid = Grid(
             crs=self._crs,

--- a/flopy/modflow/mf.py
+++ b/flopy/modflow/mf.py
@@ -278,9 +278,14 @@ class Modflow(BaseModel):
             ibound = self.bas6.ibound.array
         else:
             ibound = None
-
+        # take the first non-None entry
+        crs = (
+            self._modelgrid.crs
+            or self._modelgrid.proj4
+            or self._modelgrid.epsg
+        )
         common_kwargs = {
-            "crs": self._modelgrid.crs or self._modelgrid.epsg,
+            "crs": crs,
             "xoff": self._modelgrid.xoffset,
             "yoff": self._modelgrid.yoffset,
             "angrot": self._modelgrid.angrot,

--- a/flopy/utils/mfreadnam.py
+++ b/flopy/utils/mfreadnam.py
@@ -205,7 +205,17 @@ def parsenamefile(namfilename, packages, verbose=True):
 
 
 def attribs_from_namfile_header(namefile):
-    # check for reference info in the nam file header
+    """Return spatial and temporal reference info from the nam header.
+
+    Parameters
+    ----------
+    namefile : str, PathLike or None
+        Path to NAM file to read.
+
+    Returns
+    -------
+    dict
+    """
     defaults = {
         "xll": None,
         "yll": None,
@@ -255,7 +265,6 @@ def attribs_from_namfile_header(namefile):
             except:
                 print(f"   could not parse rotation in {namefile}")
         elif "proj4_str" in item.lower():
-            # deprecated, use "crs" instead
             try:
                 proj4 = ":".join(item.split(":")[1:]).strip()
                 if proj4.lower() == "none":
@@ -277,6 +286,9 @@ def attribs_from_namfile_header(namefile):
                 defaults["start_datetime"] = start_datetime
             except:
                 print(f"   could not parse start in {namefile}")
+    if "proj4_str" in defaults and defaults["crs"] is None:
+        # handle deprecated keyword, use "crs" instead
+        defaults["crs"] = defaults.pop("proj4_str")
     return defaults
 
 


### PR DESCRIPTION
This fixes a bug from #1737 where loading classic NAM files does not retain any CRS information that may be been stored in the header comment.

- With pyproj installed, the `modelgrid` properties `.proj4` and `.epsg` are generated from the `crs` inputs.
- Without pyproj installed, `.proj4` retains the original string input to crs, and `.epsg` retains a valid integer parsed from the crs input.

This PR adds tests for `flopy.utils.mfreadnam.attribs_from_namfile_header` and checks the same simulations with `Modflow.load` to inspect a few modelgrid properties. This PR was also tested locally without pyproj.