### PR TITLE
feat(get-modflow): allow specifying repo owner

### DIFF
--- a/docs/get_modflow.md
+++ b/docs/get_modflow.md
@@ -73,7 +73,7 @@ Other auto-select options are only available if the current user can write files
 
 ## Selecting a distribution
 
-By default the distribution from the [executables repository](https://github.com/MODFLOW-USGS/executables) is installed. This includes the MODFLOW 6 binary `mf6` and over 20 other related programs. The utility can also install from the main [MODFLOW 6 repo](https://github.com/MODFLOW-USGS/modflow6) or the [nightly build](https://github.com/MODFLOW-USGS/modflow6-nightly-build) distributions, which contain only:
+By default the distribution from the [`MODFLOW-USGS/executables` repository](https://github.com/MODFLOW-USGS/executables) is installed. This includes the MODFLOW 6 binary `mf6` and over 20 other related programs. The utility can also install from the main [MODFLOW 6 repo](https://github.com/MODFLOW-USGS/modflow6) or the [nightly build](https://github.com/MODFLOW-USGS/modflow6-nightly-build) distributions, which contain only:
 
 - `mf6`
 - `mf5to6`
@@ -85,3 +85,5 @@ To select a distribution, specify a repository name with the `--repo` command li
 - `executables` (default)
 - `modflow6`
 - `modflow6-nightly-build`
+
+The repository owner can also be configured with the `--owner` option. This can be useful for installing from unreleased MODFLOW 6 feature branches still in development &mdash; the only compatibility requirement is that release assets be named identically to those on the official repositories.


### PR DESCRIPTION
* support `--owner` cli option and corresponding `run_main()` (and other fn) params
* document owner option in `get_modflow.md`
* expand tests

This allows installing from releases posted on e.g. personal forks of modflow6. For instance, after this PR, to install the PRT [development build](https://github.com/aprovost-usgs/modflow6/releases/tag/20230808):

```
get-modflow : --owner aprovost-usgs --repo modflow6
```