### PR TITLE
refactor(expired deprecation): remaining references to SpatialReference

### DIFF
--- a/autotest/test_export.py
+++ b/autotest/test_export.py
@@ -198,7 +198,7 @@ def test_freyberg_export(function_tmpdir, example_data_path):
         verbose=False,
         load_only=["DIS", "BAS6", "NWT", "OC", "RCH", "WEL", "DRN", "UPW"],
     )
-    # test export without instantiating an sr
+    # test export without instantiating a modelgrid
     m.modelgrid.crs = None
     shape = function_tmpdir / f"{name}_drn_sparse.shp"
     m.drn.stress_period_data.export(shape, sparse=True)
@@ -211,7 +211,7 @@ def test_freyberg_export(function_tmpdir, example_data_path):
     m.modelgrid = StructuredGrid(
         delc=m.dis.delc.array, delr=m.dis.delr.array, crs=3070
     )
-    # test export with an sr, regardless of whether or not wkt was found
+    # test export with a modelgrid, regardless of whether or not wkt was found
     m.drn.stress_period_data.export(shape, sparse=True)
     for suffix in [".dbf", ".prj", ".shp", ".shx"]:
         part = shape.with_suffix(suffix)
@@ -221,16 +221,16 @@ def test_freyberg_export(function_tmpdir, example_data_path):
     m.modelgrid = StructuredGrid(
         delc=m.dis.delc.array, delr=m.dis.delr.array, crs=3070
     )
-    # verify that attributes have same sr as parent
+    # verify that attributes have same modelgrid as parent
     assert m.drn.stress_period_data.mg.crs == m.modelgrid.crs
     assert m.drn.stress_period_data.mg.xoffset == m.modelgrid.xoffset
     assert m.drn.stress_period_data.mg.yoffset == m.modelgrid.yoffset
     assert m.drn.stress_period_data.mg.angrot == m.modelgrid.angrot
 
-    # get wkt text was fetched from spatialreference.org
+    # get wkt text from pyproj
     wkt = m.modelgrid.crs.to_wkt()
 
-    # if wkt text was fetched from spatialreference.org
+    # if wkt text was fetched from pyproj
     if wkt is not None:
         # test default package export
         shape = function_tmpdir / f"{name}_dis.shp"

--- a/autotest/test_modflow.py
+++ b/autotest/test_modflow.py
@@ -560,7 +560,7 @@ def test_namfile_readwrite(function_tmpdir, example_data_path):
         angrot=30,
     )
 
-    # test reading and writing of SR information to namfile
+    # test reading and writing of modelgrid information to namfile
     m.write_input()
     m2 = Modflow.load("junk.nam", model_ws=ws)
 

--- a/docs/flopy_method_dependencies.md
+++ b/docs/flopy_method_dependencies.md
@@ -7,10 +7,10 @@ Additional dependencies to use optional FloPy helper methods are listed below.
 | `.export(*.shp)`                                                                     | **Pyshp** >= 2.0.0                                                       |
 | `.export(*.nc)`                                                                      | **netcdf4** >= 1.1, and **python-dateutil** >= 2.4.0                     |
 | `.export(*.tif)`                                                                     | **rasterio**                                                             |
-| `.export(*.asc)` in `flopy.utils.reference` `SpatialReference` class                 | **scipy.ndimage**                                                        |
-| `.interpolate()` in `flopy.utils.reference` `SpatialReference` class                 | **scipy.interpolate**                                                    |
+| `.export_array(*.asc)` in `flopy.export.utils`                                       | **scipy.ndimage**                                                        |
+| `.resample_to_grid()` in `flopy.utils.rasters`                                       | **scipy.interpolate**                                                    |
 | `.interpolate()` in `flopy.mf6.utils.reference` `StructuredSpatialReference` class   | **scipy.interpolate**                                                    |
-| `._parse_units_from_proj4()` in `flopy.utils.reference` `SpatialReference` class     | **pyproj**                                                               |
+| `.get_authority_crs()` in `flopy.utils.crs`                                          | **pyproj** >= 2.2.0                                                      |
 | `.generate_classes()` in `flopy.mf6.utils`                                           | [**modflow-devtools**](https://github.com/MODFLOW-USGS/modflow-devtools) |
 | `GridIntersect()` in `flopy.utils.gridintersect`                                     | **shapely**                                                              |
 | `GridIntersect().plot_polygon()` in `flopy.utils.gridintersect`                      | **shapely** and **descartes**                                            |

--- a/flopy/discretization/grid.py
+++ b/flopy/discretization/grid.py
@@ -1193,14 +1193,6 @@ class Grid:
         else:
             return yul - (np.cos(self.angrot_radians) * yext)
 
-    def _set_sr_coord_info(self, sr):
-        self._xoff = sr.xll
-        self._yoff = sr.yll
-        self._angrot = sr.rotation
-        self._epsg = sr.epsg
-        self._proj4 = sr.proj4_str
-        self._require_cache_updates()
-
     def _require_cache_updates(self):
         for cache_data in self._cache_dict.values():
             cache_data.out_of_date = True

--- a/flopy/export/shapefile_utils.py
+++ b/flopy/export/shapefile_utils.py
@@ -15,6 +15,7 @@ from warnings import warn
 import numpy as np
 
 from ..datbase import DataInterface, DataType
+from ..discretization.grid import Grid
 from ..utils import Util3d, flopy_io, import_optional_dependency
 from ..utils.crs import get_crs
 
@@ -28,7 +29,8 @@ def write_gridlines_shapefile(filename: Union[str, os.PathLike], mg):
     ----------
     filename : str or PathLike
         path of the shapefile to write
-    mg : model grid
+    mg : flopy.discretization.grid.Grid object
+        flopy model grid
 
     Returns
     -------
@@ -36,6 +38,10 @@ def write_gridlines_shapefile(filename: Union[str, os.PathLike], mg):
 
     """
     shapefile = import_optional_dependency("shapefile")
+    if not isinstance(mg, Grid):
+        raise ValueError(
+            f"'mg' must be a flopy Grid subclass instance; found '{type(mg)}'"
+        )
     wr = shapefile.Writer(str(filename), shapeType=shapefile.POLYLINE)
     wr.field("number", "N", 18, 0)
     grid_lines = mg.grid_lines
@@ -68,7 +74,7 @@ def write_grid_shapefile(
     ----------
     path : str or PathLike
         shapefile file path
-    mg : flopy.discretization.Grid object
+    mg : flopy.discretization.grid.Grid object
         flopy model grid
     array_dict : dict
         dictionary of model input arrays
@@ -101,7 +107,11 @@ def write_grid_shapefile(
     w = shapefile.Writer(str(path), shapeType=shapefile.POLYGON)
     w.autoBalance = 1
 
-    if mg.grid_type == "structured":
+    if not isinstance(mg, Grid):
+        raise ValueError(
+            f"'mg' must be a flopy Grid subclass instance; found '{type(mg)}'"
+        )
+    elif mg.grid_type == "structured":
         verts = [
             mg.get_cell_vertices(i, j)
             for i in range(mg.nrow)
@@ -112,7 +122,7 @@ def write_grid_shapefile(
     elif mg.grid_type == "unstructured":
         verts = [mg.get_cell_vertices(cellid) for cellid in range(mg.nnodes)]
     else:
-        raise Exception(f"Grid type {mg.grid_type} not supported.")
+        raise NotImplementedError(f"Grid type {mg.grid_type} not supported.")
 
     # set up the attribute fields and arrays of attributes
     if mg.grid_type == "structured":
@@ -293,8 +303,6 @@ def model_attributes_to_shapefile(
         pak = ml.get_package(pname)
         attrs = dir(pak)
         if pak is not None:
-            if "sr" in attrs:
-                attrs.remove("sr")
             if "start_datetime" in attrs:
                 attrs.remove("start_datetime")
             for attr in attrs:

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -696,19 +696,29 @@ class BaseModel(ModelInterface):
         Parameters
         ----------
         item : str
-            3 character package name (case insensitive) or "sr" to access
-            the SpatialReference instance of the ModflowDis object
+            This can be one of:
+
+                * A 3-character package name (case insensitive) returns package
+                * "tr" to access the time discretization object
+                * "modelgrid" to access the spatial discretization object
+                * "nper" to get the number of stress periods
+                * "start_datetime" to get str describing model start date/time
 
 
         Returns
         -------
-        sr : SpatialReference instance
-        pp : Package object
-            Package object of type :class:`flopy.pakbase.Package`
+        object, int or None
+            Package object of type :class:`flopy.pakbase.Package`,
+            :class:`flopy.utils.reference.TemporalReference`, int or None.
+
+        Raises
+        ------
+        AttributeError
+            When package or object name cannot be resolved.
 
         Note
         ----
-        if self.dis is not None, then the spatial reference instance is updated
+        if self.dis is not None, then the modelgrid instance is updated
         using self.dis.delr, self.dis.delc, and self.dis.lenuni before being
         returned
         """
@@ -1388,17 +1398,6 @@ class BaseModel(ModelInterface):
             self._set_name(value)
         elif key == "model_ws":
             self.change_model_ws(value)
-        elif key == "sr" and value.__class__.__name__ == "SpatialReference":
-            warnings.warn(
-                "SpatialReference has been deprecated.",
-                category=DeprecationWarning,
-            )
-            if self.dis is not None:
-                self.dis.sr = value
-            else:
-                raise Exception(
-                    "cannot set SpatialReference - ModflowDis not found"
-                )
         elif key == "tr":
             assert isinstance(
                 value, discretization.reference.TemporalReference

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -698,18 +698,18 @@ class BaseModel(ModelInterface):
         item : str
             This can be one of:
 
-                * A 3-character package name (case insensitive) returns package
-                * "tr" to access the time discretization object
-                * "modelgrid" to access the spatial discretization object
-                * "nper" to get the number of stress periods
+                * A short package name (case insensitive), e.g., "dis" or "bas6"
+                  returns package object
+                * "tr" to access the time discretization object, if set
                 * "start_datetime" to get str describing model start date/time
+                * Some packages use "nper" or "modelgrid" for corner cases
 
 
         Returns
         -------
-        object, int or None
+        object, str, int or None
             Package object of type :class:`flopy.pakbase.Package`,
-            :class:`flopy.utils.reference.TemporalReference`, int or None.
+            :class:`flopy.utils.reference.TemporalReference`, str, int or None.
 
         Raises
         ------
@@ -732,6 +732,7 @@ class BaseModel(ModelInterface):
                 return None
 
         if item == "nper":
+            # most subclasses have a nper property, but ModflowAg needs this
             if self.dis is not None:
                 return self.dis.nper
             else:
@@ -755,6 +756,7 @@ class BaseModel(ModelInterface):
         if pckg is not None or item in self.mfnam_packages:
             return pckg
         if item == "modelgrid":
+            # most subclasses have a modelgrid property, but not MfUsg
             return
         raise AttributeError(item)
 

--- a/flopy/modflow/mfdis.py
+++ b/flopy/modflow/mfdis.py
@@ -773,62 +773,11 @@ class ModflowDis(Package):
             f = open(filename, "r")
 
         # dataset 0 -- header
-        header = ""
         while True:
             line = f.readline()
             if line[0] != "#":
                 break
-            header += line.strip()
 
-        header = header.replace("#", "")
-        xul, yul = None, None
-        rotation = None
-        proj4_str = None
-        start_datetime = "1/1/1970"
-        dep = False
-        for item in header.split(","):
-            if "xul" in item.lower():
-                try:
-                    xul = float(item.split(":")[1])
-                except:
-                    if model.verbose:
-                        print(f"   could not parse xul in {filename}")
-                dep = True
-            elif "yul" in item.lower():
-                try:
-                    yul = float(item.split(":")[1])
-                except:
-                    if model.verbose:
-                        print(f"   could not parse yul in {filename}")
-                dep = True
-            elif "rotation" in item.lower():
-                try:
-                    rotation = float(item.split(":")[1])
-                except:
-                    if model.verbose:
-                        print(f"   could not parse rotation in {filename}")
-                dep = True
-            elif "proj4_str" in item.lower():
-                try:
-                    proj4_str = ":".join(item.split(":")[1:]).strip()
-                except:
-                    if model.verbose:
-                        print(f"   could not parse proj4_str in {filename}")
-                dep = True
-            elif "start" in item.lower():
-                try:
-                    start_datetime = item.split(":")[1].strip()
-                except:
-                    if model.verbose:
-                        print(f"   could not parse start in {filename}")
-                dep = True
-        if dep:
-            warnings.warn(
-                "SpatialReference information found in DIS header,"
-                "this information is being ignored.  "
-                "SpatialReference info is now stored in the namfile"
-                "header"
-            )
         # dataset 1
         nlay, nrow, ncol, nper, itmuni, lenuni = line.strip().split()[0:6]
         nlay = int(nlay)
@@ -945,11 +894,6 @@ class ModflowDis(Package):
             steady=steady,
             itmuni=itmuni,
             lenuni=lenuni,
-            xul=xul,
-            yul=yul,
-            rotation=rotation,
-            crs=proj4_str,
-            start_datetime=start_datetime,
             unitnumber=unitnumber,
             filenames=filenames,
         )

--- a/flopy/modflow/mfsfr2.py
+++ b/flopy/modflow/mfsfr2.py
@@ -2520,7 +2520,7 @@ class check:
             )
         else:
             txt += (
-                "No DIS package or SpatialReference object; cannot "
+                "No DIS package or modelgrid object; cannot "
                 "check reach proximities."
             )
             self._txt_footer(headertxt, txt, "")

--- a/flopy/mt3d/mt.py
+++ b/flopy/mt3d/mt.py
@@ -333,12 +333,6 @@ class Mt3dms(BaseModel):
         return None
 
     @property
-    def sr(self):
-        if self.mf is not None:
-            return self.mf.sr
-        return None
-
-    @property
     def nlay(self):
         if self.btn:
             return self.btn.nlay

--- a/flopy/pakbase.py
+++ b/flopy/pakbase.py
@@ -655,8 +655,6 @@ class Package(PackageInterface):
         # return [data_object, data_object, ...]
         dl = []
         attrs = dir(self)
-        if "sr" in attrs:
-            attrs.remove("sr")
         if "start_datetime" in attrs:
             attrs.remove("start_datetime")
         for attr in attrs:

--- a/flopy/plot/plotutil.py
+++ b/flopy/plot/plotutil.py
@@ -1060,7 +1060,7 @@ class PlotUtilities:
         ----------
         plotarray : np.array object
         model: fp.modflow.Modflow object
-            optional if spatial reference is provided
+            optional if modelgrid is provided
         modelgrid: fp.discretization.Grid object
             object that defines the spatial orientation of a modflow
             grid within flopy. Optional if model object is provided

--- a/flopy/utils/binaryfile.py
+++ b/flopy/utils/binaryfile.py
@@ -1026,26 +1026,6 @@ class CellBudgetFile:
             self.modelgrid = self.dis.parent.modelgrid
         if "tdis" in kwargs.keys():
             self.tdis = kwargs.pop("tdis")
-        if "sr" in kwargs.keys():
-            from ..discretization import StructuredGrid, UnstructuredGrid
-
-            sr = kwargs.pop("sr")
-            if sr.__class__.__name__ == "SpatialReferenceUnstructured":
-                self.modelgrid = UnstructuredGrid(
-                    vertices=sr.verts,
-                    iverts=sr.iverts,
-                    xcenters=sr.xc,
-                    ycenters=sr.yc,
-                    ncpl=sr.ncpl,
-                )
-            elif sr.__class__.__name__ == "SpatialReference":
-                self.modelgrid = StructuredGrid(
-                    delc=sr.delc,
-                    delr=sr.delr,
-                    xoff=sr.xll,
-                    yoff=sr.yll,
-                    angrot=sr.rotation,
-                )
         if "modelgrid" in kwargs.keys():
             self.modelgrid = kwargs.pop("modelgrid")
         if len(kwargs.keys()) > 0:

--- a/flopy/utils/reference.py
+++ b/flopy/utils/reference.py
@@ -1,9 +1,6 @@
-"""
-Module spatial referencing for flopy model objects
+"""Temporal referencing for flopy model objects."""
 
-"""
 __all__ = ["TemporalReference"]
-# all other classes and methods in this module are deprecated
 
 
 class TemporalReference:


### PR DESCRIPTION
This cleans-up a few remaining references to SpatialReference or related (e.g. "sr"). This extends beyond #1200 and #1892.

Details of changes:

- Some related docstrings improved and expanded
- Remove unused method `_set_sr_coord_info` from `flopy/discretization/grid.py`
- Spatial metadata in `flopy/modflow/mfdis.py` was not actually ignored, but now it actually is ignored and removed, as this should be in classic NAM files

Note that these changes are not related to [`flopy.mf6.utils.reference.SpatialReference`](https://flopy.readthedocs.io/en/3.4.1/source/flopy.mf6.utils.reference.html#flopy.mf6.utils.reference.SpatialReference), which is not deprecated.