### PR TITLE
fix(keyword data): optional keywords (#1909)

### DIFF
--- a/autotest/test_mf6.py
+++ b/autotest/test_mf6.py
@@ -2186,6 +2186,20 @@ def test_multi_model(function_tmpdir):
         assert rec_array[0][3] == model_names[1]
         assert rec_array[1][1] == "transport.ims"
         assert rec_array[1][2] == model_names[2]
+    # test ssm fileinput
+    gwt2 = sim2.get_model("gwt_model_1")
+    ssm2 = gwt2.get_package("ssm")
+    fileinput = [
+        ("RCH-1", f"gwt_model_1.rch1.spc"),
+        ("RCH-2", f"gwt_model_1.rch2.spc"),
+        ("RCH-3", f"gwt_model_1.rch3.spc", "MIXED"),
+        ("RCH-4", f"gwt_model_1.rch4.spc"),
+    ]
+    ssm2.fileinput = fileinput
+    fi_out = ssm2.fileinput.get_data()
+    assert fi_out[2][1] == "gwt_model_1.rch3.spc"
+    assert fi_out[1][2] is None
+    assert fi_out[2][2] == "MIXED"
 
     # create a new gwt model
     sourcerecarray = [("WEL-1", "AUX", "CONCENTRATION")]

--- a/flopy/mf6/data/mfdatastorage.py
+++ b/flopy/mf6/data/mfdatastorage.py
@@ -2857,6 +2857,7 @@ class DataStorage:
                     if (
                         data_item.type != DatumType.keyword
                         or data_set.block_variable
+                        or data_item.optional
                     ):
                         initial_keyword = False
                         shape_rule = None


### PR DESCRIPTION
Flopy allows some keywords to be excluded from recarrays, like "FILEIN".  This fix makes sure that optional keywords, like "MIXED" are not excluded from recarrays.  Since they are optional their presence adds information to the recarray and they therefore can not be excluded.