### PR TITLE
fix(GridIntersect): combine list of geometries using unary_union

### DIFF
--- a/flopy/utils/gridintersect.py
+++ b/flopy/utils/gridintersect.py
@@ -18,6 +18,10 @@ if shapely is not None:
     if Version(shapely.__version__) < Version("1.8"):
         warnings.warn("GridIntersect requires shapely>=1.8.")
         shapely = None
+    if SHAPELY_GE_20:
+        from shapely import unary_union
+    else:
+        from shapely.ops import unary_union
 else:
     SHAPELY_GE_20 = False
 
@@ -1487,10 +1491,7 @@ class GridIntersect:
                     tempverts.append(vertices[i])
                     ishp = ixshapes[i]
                     if isinstance(ishp, list):
-                        if len(ishp) > 1:
-                            ishp = shapely_geo.MultiLineString(ishp)
-                        else:
-                            ishp = ishp[0]
+                        ishp = unary_union(ishp)
                     tempshapes.append(ishp)
             nodelist = tempnodes
             lengths = templengths


### PR DESCRIPTION
This fix uses [`shapely.unary_union`](https://shapely.readthedocs.io/en/stable/reference/shapely.unary_union.html) (or [`shapely.ops.unary_union`](https://shapely.readthedocs.io/en/1.8.5/manual.html#shapely.ops.unary_union)) to combine a list of 1 or more [Multi]LineString geometries into one geometry.

Ideas on a test for this would be welcome.

Closes #1922