### PR TITLE
fix(remove_model): remove_model method fix and tests (#1916)   

### DIFF
--- a/autotest/regression/test_mf6.py
+++ b/autotest/regression/test_mf6.py
@@ -3085,7 +3085,7 @@ def test028_create_tests_sfr(function_tmpdir, example_data_path):
         delc=5000.0,
         top=top,
         botm=botm,
-        #idomain=idomain,
+        idomain=idomain,
         filename=f"{model_name}.dis",
     )
     strt = testutils.read_std_array(os.path.join(pth, "strt.txt"), "float")
@@ -3988,6 +3988,17 @@ def test006_2models_different_dis(function_tmpdir, example_data_path):
     assert gnc_data[0][0] == (0, 2, 1)
     assert gnc_data[0][1] == (0, 0)
     assert gnc_data[0][2] == (0, 1, 1)
+
+    # test remove_model
+    sim2.remove_model(model_name_2)
+    sim2.write_simulation()
+    success, buff = sim2.run_simulation()
+    assert success
+    sim3 = MFSimulation.load(sim_ws=sim.sim_path)
+    assert sim3.get_model(model_name_1) is not None
+    assert sim3.get_model(model_name_2) is None
+    assert len(sim3.name_file.models.get_data()) == 1
+    assert sim3.name_file.exchanges.get_data() is None
 
     sim.delete_output_files()
 

--- a/flopy/mf6/mfsimbase.py
+++ b/flopy/mf6/mfsimbase.py
@@ -2183,11 +2183,36 @@ class MFSimulationBase(PackageContainer):
                 Model name to remove from simulation
 
         """
-        # Remove model
+        # remove model
         del self._models[model_name]
 
-        # TODO: Fully implement this
-        # Update simulation name file
+        # remove from solution group block
+        self._remove_from_all_solution_groups(model_name)
+
+        # remove from models block
+        models_recarray = self.name_file.models.get_data()
+        if models_recarray is not None:
+            new_records = []
+            for record in models_recarray:
+                if len(record) <= 2 or record[2] != model_name:
+                    new_records.append(tuple(record))
+            self.name_file.models.set_data(new_records)
+
+        # remove from exchanges block
+        exch_recarray = self.name_file.exchanges.get_data()
+        if exch_recarray is not None:
+            new_records = []
+            for record in exch_recarray:
+                model_in_record = False
+                if len(record) > 2:
+                    for item in list(record)[2:]:
+                        if item == model_name:
+                            model_in_record = True
+                if not model_in_record:
+                    new_records.append(tuple(record))
+            if len(new_records) == 0:
+                new_records = None
+            self.name_file.exchanges.set_data(new_records)
 
     def is_valid(self):
         """


### PR DESCRIPTION
Method remove_model removes all references to the model from the simulation namefile.  Tests added to autotest.