### PR TITLE
refactor(triangle): raise if output files not found

### DIFF
--- a/autotest/test_triangle.py
+++ b/autotest/test_triangle.py
@@ -1,0 +1,20 @@
+import shutil
+from os import environ
+from platform import system
+
+import pytest
+from modflow_devtools.markers import requires_exe
+from modflow_devtools.misc import set_env
+
+import flopy
+from flopy.utils.triangle import Triangle
+
+
+@requires_exe("mf6")
+def test_output_files_not_found(function_tmpdir):
+    tri = Triangle(model_ws=function_tmpdir, maximum_area=1.0, angle=30)
+
+    # if expected output files are not found,
+    # Triangle should raise FileNotFoundError
+    with pytest.raises(FileNotFoundError):
+        tri._load_results()

--- a/flopy/utils/triangle.py
+++ b/flopy/utils/triangle.py
@@ -57,7 +57,6 @@ class Triangle:
         self._nodes = nodes
         self.additional_args = additional_args
         self._initialize_vars()
-        return
 
     def add_polygon(self, polygon):
         """
@@ -90,7 +89,6 @@ class Triangle:
         if len(polygon) > 1:
             for hole in polygon[1:]:
                 self.add_hole(hole)
-        return
 
     def add_hole(self, hole):
         """
@@ -107,7 +105,6 @@ class Triangle:
 
         """
         self._holes.append(hole)
-        return
 
     def add_region(self, point, attribute=0, maximum_area=None):
         """
@@ -131,7 +128,6 @@ class Triangle:
 
         """
         self._regions.append([point, attribute, maximum_area])
-        return
 
     def build(self, verbose=False):
         """
@@ -195,8 +191,6 @@ class Triangle:
         self.iverts = []
         for row in self.ele:
             self.iverts.append([row[1], row[2], row[3]])
-
-        return
 
     def plot(
         self,
@@ -320,7 +314,6 @@ class Triangle:
             y1 = self.node["y"][iv1]
             y2 = self.node["y"][iv2]
             ax.plot([x1, x2], [y1, y2], **kwargs)
-        return
 
     def plot_vertices(self, ax=None, **kwargs):
         """
@@ -342,7 +335,6 @@ class Triangle:
         if ax is None:
             ax = plt.gca()
         ax.plot(self.node["x"], self.node["y"], lw=0, **kwargs)
-        return
 
     def label_vertices(self, ax=None, onebased=True, **kwargs):
         """
@@ -374,7 +366,6 @@ class Triangle:
             if onebased:
                 s += 1
             ax.text(x, y, str(s), **kwargs)
-        return
 
     def plot_centroids(self, ax=None, **kwargs):
         """
@@ -397,7 +388,6 @@ class Triangle:
             ax = plt.gca()
         xcyc = self.get_xcyc()
         ax.plot(xcyc[:, 0], xcyc[:, 1], lw=0, **kwargs)
-        return
 
     def label_cells(self, ax=None, onebased=True, **kwargs):
         """
@@ -430,7 +420,6 @@ class Triangle:
             if onebased:
                 s += 1
             ax.text(x, y, str(s), **kwargs)
-        return
 
     def get_xcyc(self):
         """
@@ -600,7 +589,6 @@ class Triangle:
                 os.remove(fname)
                 if os.path.isfile(fname):
                     print(f"Could not remove: {fname}")
-        return
 
     def _initialize_vars(self):
         self.file_prefix = "_triangle"
@@ -613,7 +601,6 @@ class Triangle:
         self.verts = None
         self.iverts = None
         self.edgedict = None
-        return
 
     def _load_results(self):
         # node file
@@ -621,8 +608,7 @@ class Triangle:
         dt = [("ivert", int), ("x", float), ("y", float)]
         fname = os.path.join(self.model_ws, f"{self.file_prefix}.1.{ext}")
         setattr(self, ext, None)
-        if os.path.isfile(fname):
-            f = open(fname, "r")
+        with open(fname, "r") as f:
             line = f.readline()
             f.close()
             ll = line.strip().split()
@@ -644,8 +630,7 @@ class Triangle:
         dt = [("icell", int), ("iv1", int), ("iv2", int), ("iv3", int)]
         fname = os.path.join(self.model_ws, f"{self.file_prefix}.1.{ext}")
         setattr(self, ext, None)
-        if os.path.isfile(fname):
-            f = open(fname, "r")
+        with open(fname, "r") as f:
             line = f.readline()
             f.close()
             ll = line.strip().split()
@@ -664,8 +649,7 @@ class Triangle:
         dt = [("iedge", int), ("endpoint1", int), ("endpoint2", int)]
         fname = os.path.join(self.model_ws, f"{self.file_prefix}.1.{ext}")
         setattr(self, ext, None)
-        if os.path.isfile(fname):
-            f = open(fname, "r")
+        with open(fname, "r") as f:
             line = f.readline()
             f.close()
             ll = line.strip().split()
@@ -687,8 +671,7 @@ class Triangle:
         ]
         fname = os.path.join(self.model_ws, f"{self.file_prefix}.1.{ext}")
         setattr(self, ext, None)
-        if os.path.isfile(fname):
-            f = open(fname, "r")
+        with open(fname, "r") as f:
             line = f.readline()
             f.close()
             ll = line.strip().split()
@@ -698,8 +681,6 @@ class Triangle:
             a = np.loadtxt(fname, skiprows=1, comments="#", dtype=dt)
             assert a.shape[0] == ncells
             setattr(self, ext, a)
-
-        return
 
     def _write_nodefile(self, fname):
         f = open(fname, "w")
@@ -776,7 +757,6 @@ class Triangle:
             f.write(s)
 
         f.close()
-        return
 
     def _create_edge_dict(self):
         """
@@ -789,4 +769,3 @@ class Triangle:
                 edgedict[(iv1, iv2)] = iseg
                 edgedict[(iv2, iv1)] = iseg
         self.edgedict = edgedict
-        return


### PR DESCRIPTION
- previously `Triangle.build()` would continue silently if expected output files not found after invoking exe
- raise `FileNotFoundError` immediately instead
- remove unneeded return statements
- [motivation](https://github.com/modflowpy/flopy/discussions/1948#discussioncomment-7017393)