### PR TITLE
refactor(recarray_utils): deprecate functions for numpy builtins

### DIFF
--- a/.docs/Notebooks/modpath7_structured_example.py
+++ b/.docs/Notebooks/modpath7_structured_example.py
@@ -30,6 +30,7 @@ from tempfile import TemporaryDirectory
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
+from numpy.lib.recfunctions import repack_fields
 
 # run installed version of flopy or add local path
 try:
@@ -211,7 +212,7 @@ for line in buff:
 # Get locations to extract pathline data
 
 nodew = m.dis.get_node([wel_loc])
-riv_locs = flopy.utils.ra_slice(m.riv.stress_period_data[0], ["k", "i", "j"])
+riv_locs = repack_fields(m.riv.stress_period_data[0][["k", "i", "j"]])
 nodesr = m.dis.get_node(riv_locs.tolist())
 
 # Pathline data

--- a/autotest/test_mp6.py
+++ b/autotest/test_mp6.py
@@ -3,11 +3,11 @@ import shutil
 
 import matplotlib.pyplot as plt
 import numpy as np
-import pandas as pd
 import pytest
 from autotest.conftest import get_example_data_path
 from autotest.test_mp6_cases import Mp6Cases1, Mp6Cases2
-from modflow_devtools.markers import has_pkg, requires_exe, requires_pkg
+from modflow_devtools.markers import requires_exe, requires_pkg
+from numpy.lib.recfunctions import repack_fields
 from pytest_cases import parametrize_with_cases
 
 import flopy
@@ -19,7 +19,6 @@ from flopy.modpath.mp6sim import Modpath6Sim, StartingLocationsFile
 from flopy.plot import PlotMapView
 from flopy.utils import EndpointFile, PathlineFile, TimeseriesFile
 from flopy.utils.flopy_io import loadtxt
-from flopy.utils.recarray_utils import ra_slice
 
 pytestmark = pytest.mark.mf6
 
@@ -171,7 +170,7 @@ def test_get_destination_data(function_tmpdir, mp6_test_path):
 
     # check that all starting locations are included in the pathline data
     # (pathline data slice not just endpoints)
-    starting_locs = ra_slice(well_epd, ["k0", "i0", "j0"])
+    starting_locs = repack_fields(well_epd[["k0", "i0", "j0"]])
     pathline_locs = np.array(
         np.array(well_pthld)[["k", "i", "j"]].tolist(),
         dtype=starting_locs.dtype,

--- a/flopy/utils/__init__.py
+++ b/flopy/utils/__init__.py
@@ -49,7 +49,7 @@ from .observationfile import HydmodObs, Mf6Obs, SwrObs
 from .optionblock import OptionBlock
 from .postprocessing import get_specific_discharge, get_transmissivities
 from .rasters import Raster
-from .recarray_utils import create_empty_recarray, ra_slice
+from .recarray_utils import create_empty_recarray, ra_slice, recarray
 from .reference import TemporalReference
 from .sfroutputfile import SfrFile
 from .swroutputfile import (

--- a/flopy/utils/modpathfile.py
+++ b/flopy/utils/modpathfile.py
@@ -13,10 +13,9 @@ from pathlib import Path
 from typing import Union
 
 import numpy as np
-from numpy.lib.recfunctions import append_fields, stack_arrays
+from numpy.lib.recfunctions import append_fields, repack_fields, stack_arrays
 
 from ..utils.flopy_io import loadtxt
-from ..utils.recarray_utils import ra_slice
 
 
 class _ModpathSeries:
@@ -1161,7 +1160,7 @@ class EndpointFile:
             else:
                 keys = ["k", "i", "j"]
             try:
-                raslice = ra_slice(ra, keys)
+                raslice = repack_fields(ra[keys])
             except (KeyError, ValueError):
                 raise KeyError(
                     "could not extract "
@@ -1174,7 +1173,7 @@ class EndpointFile:
             else:
                 keys = ["node"]
             try:
-                raslice = ra_slice(ra, keys)
+                raslice = repack_fields(ra[keys])
             except (KeyError, ValueError):
                 msg = f"could not extract '{keys[0]}' key from endpoint data"
                 raise KeyError(msg)

--- a/flopy/utils/recarray_utils.py
+++ b/flopy/utils/recarray_utils.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.lib.recfunctions import repack_fields
 
 
 def create_empty_recarray(length, dtype, default_value=0):
@@ -22,10 +23,11 @@ def create_empty_recarray(length, dtype, default_value=0):
     Examples
     --------
     >>> import numpy as np
-    >>> import flopy
-    >>> dtype = np.dtype([('x', np.float32), ('y', np.float32)])
-    >>> ra = flopy.utils.create_empty_recarray(10, dtype)
-
+    >>> from flopy.utils import create_empty_recarray
+    >>> dt = np.dtype([('x', np.float32), ('y', np.float32)])
+    >>> create_empty_recarray(1, dt)
+    rec.array([(0., 0.)],
+              dtype=[('x', '<f4'), ('y', '<f4')])
     """
     r = np.zeros(length, dtype=dtype)
     msg = "dtype argument must be an instance of np.dtype, not list."
@@ -41,6 +43,9 @@ def ra_slice(ra, cols):
     """
     Create a slice of a recarray
 
+    .. deprecated:: 3.5
+        Use numpy.lib.recfunctions.repack_fields instead
+
     Parameters
     ----------
     ra : np.recarray
@@ -55,19 +60,22 @@ def ra_slice(ra, cols):
 
     Examples
     --------
-    >>> import flopy
-    >>> raslice = flopy.utils.ra_slice(ra, ['x', 'y'])
-
-
+    >>> import numpy as np
+    >>> from flopy.utils import ra_slice
+    >>> a = np.core.records.fromrecords([("a", 1, 1.1), ("b", 2, 2.1)])
+    >>> ra_slice(a, ['f0', 'f1'])
+    rec.array([('a', 1), ('b', 2)],
+              dtype=[('f0', '<U1'), ('f1', '<i4')])
     """
-    raslice = np.column_stack([ra[c] for c in cols])
-    dtype = [(str(d[0]), str(d[1])) for d in ra.dtype.descr if d[0] in cols]
-    return np.array([tuple(r) for r in raslice], dtype=dtype).view(np.recarray)
+    return repack_fields(ra[cols])
 
 
 def recarray(array, dtype):
     """
     Convert a list of lists or tuples to a recarray.
+
+    .. deprecated:: 3.5
+        Use numpy.core.records.fromrecords instead
 
     Parameters
     ----------
@@ -86,10 +94,11 @@ def recarray(array, dtype):
     --------
     >>> import numpy as np
     >>> import flopy
-    >>> dtype = np.dtype([('x', np.float32), ('y', np.float32)])
-    >>> arr = [(1., 2.), (10., 20.), (100., 200.)]
-    >>> ra = flopy.utils.recarray(arr, dtype)
-
+    >>> dt = np.dtype([('x', np.float32), ('y', np.float32)])
+    >>> a = [(1., 2.), (10., 20.), (100., 200.)]
+    >>> flopy.utils.recarray(a, dt)
+    rec.array([(  1.,   2.), ( 10.,  20.), (100., 200.)],
+              dtype=[('x', '<f4'), ('y', '<f4')])
     """
     array = np.atleast_2d(array)
 


### PR DESCRIPTION
- deprecate `ra_slice()`, suggest `numpy.lib.recfunctions.repack_fields()`
- deprecate `recarray()`, suggest `numpy.core.records.fromrecords()`
- add tests demonstrating equivalent usage
- replace occurrences in tests and notebooks
- update docstring examples
  - show output instead of assigning to variable
  - use [doctest](https://docs.python.org/3/library/doctest.html#module-doctest) to verify examples run correctly

Maybe worth doctesting in CI in future?