### PR TITLE
fix(mbase): warn if duplicate pkgs or units

### DIFF
--- a/autotest/test_mp7.py
+++ b/autotest/test_mp7.py
@@ -896,8 +896,7 @@ def test_pathline_plotting(function_tmpdir):
 
 
 @requires_exe("mf6", "mp7")
-@pytest.mark.parametrize("verbose", [True, False])
-def test_mp7sim_replacement(function_tmpdir, capfd, verbose):
+def test_mp7sim_replacement(function_tmpdir, capfd):
     mf6sim = Mp7Cases.mf6(function_tmpdir)
     mf6sim.write_simulation()
     mf6sim.run_simulation()
@@ -908,7 +907,6 @@ def test_mp7sim_replacement(function_tmpdir, capfd, verbose):
         flowmodel=mf6sim.get_model(mf6sim.name),
         exe_name="mp7",
         model_ws=mf6sim.sim_path,
-        verbose=verbose,
     )
     defaultiface6 = {"RCH": 6, "EVT": 6}
     mpbas = Modpath7Bas(mp, porosity=0.1, defaultiface=defaultiface6)
@@ -928,27 +926,25 @@ def test_mp7sim_replacement(function_tmpdir, capfd, verbose):
         zones=Mp7Cases.zones,
         particlegroups=Mp7Cases.particlegroups,
     )
-    # add a duplicate mp7sim package
-    mpsim = Modpath7Sim(
-        mp,
-        simulationtype="combined",
-        trackingdirection="forward",
-        weaksinkoption="pass_through",
-        weaksourceoption="pass_through",
-        budgetoutputoption="summary",
-        budgetcellnumbers=[1049, 1259],
-        traceparticledata=[1, 1000],
-        referencetime=[0, 0, 0.0],
-        stoptimeoption="extend",
-        timepointdata=[500, 1000.0],
-        zonedataoption="on",
-        zones=Mp7Cases.zones,
-        particlegroups=Mp7Cases.particlegroups,
-    )
 
-    cap = capfd.readouterr()
-    msg = "Two packages of the same type"
-    assert verbose == (msg in cap.out)
+    # add a duplicate mp7sim package
+    with pytest.warns(UserWarning, match="Two packages of the same type"):
+        mpsim = Modpath7Sim(
+            mp,
+            simulationtype="combined",
+            trackingdirection="forward",
+            weaksinkoption="pass_through",
+            weaksourceoption="pass_through",
+            budgetoutputoption="summary",
+            budgetcellnumbers=[1049, 1259],
+            traceparticledata=[1, 1000],
+            referencetime=[0, 0, 0.0],
+            stoptimeoption="extend",
+            timepointdata=[500, 1000.0],
+            zonedataoption="on",
+            zones=Mp7Cases.zones,
+            particlegroups=Mp7Cases.particlegroups,
+        )
 
     mp.write_input()
     success, buff = mp.run_model()

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -94,7 +94,8 @@ def resolve_exe(
     if exe_path is None:
         if forgive:
             warn(
-                f"The program {exe_name} does not exist or is not executable."
+                f"The program {exe_name} does not exist or is not executable.",
+                category=UserWarning,
             )
             return None
 
@@ -416,7 +417,8 @@ class BaseModel(ModelInterface):
         except:
             warn(
                 f"\n{model_ws} not valid, "
-                f"workspace-folder was changed to {os.getcwd()}\n"
+                f"workspace-folder was changed to {os.getcwd()}\n",
+                category=UserWarning,
             )
             model_ws = os.getcwd()
         self._model_ws = str(model_ws)
@@ -436,7 +438,7 @@ class BaseModel(ModelInterface):
         self._start_datetime = kwargs.pop("start_datetime", "1-1-1970")
 
         if kwargs:
-            warnings.warn(
+            warn(
                 f"unhandled keywords: {kwargs}",
                 category=UserWarning,
             )
@@ -653,20 +655,20 @@ class BaseModel(ModelInterface):
                         pn = p.name[idx]
                     except:
                         pn = p.name
-                    if self.verbose:
-                        print(
-                            f"\nWARNING:\n    unit {u} of package {pn} already in use."
-                        )
+                    warn(
+                        f"Unit {u} of package {pn} already in use.",
+                        category=UserWarning,
+                    )
             self.package_units.append(u)
         for i, pp in enumerate(self.packagelist):
             if pp.allowDuplicates:
                 continue
             elif isinstance(p, type(pp)):
-                if self.verbose:
-                    print(
-                        "\nWARNING:\n    Two packages of the same type, "
-                        f"Replacing existing '{p.name[0]}' package."
-                    )
+                warn(
+                    "Two packages of the same type, "
+                    f"Replacing existing '{p.name[0]}' package.",
+                    category=UserWarning,
+                )
                 self.packagelist[i] = p
                 return
         if self.verbose:


### PR DESCRIPTION
* close #1817
* consistent with MFSimulation verbosity default
* specify category=UserWarning for warnings in mbase.py