### PR TITLE
ci: install mf6 development build for CI tests

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -65,6 +65,7 @@ jobs:
         uses: modflowpy/install-modflow-action@v1
 
       - name: Install Modflow dev build executables
+        if: github.ref_name != 'master' && !startsWith(github.ref_name, 'v')
         uses: modflowpy/install-modflow-action@v1
         with:
           repo: modflow6-nightly-build

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -64,6 +64,11 @@ jobs:
       - name: Install Modflow executables
         uses: modflowpy/install-modflow-action@v1
 
+      - name: Install Modflow dev build executables
+        uses: modflowpy/install-modflow-action@v1
+        with:
+          repo: modflow6-nightly-build
+
       - name: Run benchmarks
         if: runner.os != 'Windows'
         working-directory: ./autotest
@@ -88,15 +93,13 @@ jobs:
         if: failure()
         with:
           name: failed-benchmark-${{ matrix.os }}-${{ matrix.python-version }}-${{ github.run_id }}
-          path: |
-            ./autotest/.failed/**
+          path: ./autotest/.failed/**
 
       - name: Upload benchmark result artifact
         uses: actions/upload-artifact@v3
         with:
           name: benchmarks-${{ matrix.os }}-${{ matrix.python-version }}-${{ github.run_id }}
-          path: |
-            ./autotest/.benchmarks/**/*.json
+          path: ./autotest/.benchmarks/**/*.json
 
   post_benchmark:
     needs:

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -129,6 +129,11 @@ jobs:
       - name: Install Modflow executables
         uses: modflowpy/install-modflow-action@v1
       
+      - name: Install Modflow dev build executables
+        uses: modflowpy/install-modflow-action@v1
+        with:
+          repo: modflow6-nightly-build
+      
       - name: Smoke test
         working-directory: autotest
         run: pytest -v -n=auto --smoke --cov=flopy --cov-report=xml --durations=0 --keep-failed=.failed
@@ -212,15 +217,6 @@ jobs:
         uses: modflowpy/install-modflow-action@v1
         with:
           repo: modflow6-nightly-build
-
-      - name: Update FloPy packages
-        if: runner.os != 'Windows'
-        run: python -m flopy.mf6.utils.generate_classes --ref develop --no-backup
-
-      - name: Update FloPy packages
-        if: runner.os == 'Windows'
-        shell: bash -l {0}
-        run: python -m flopy.mf6.utils.generate_classes --ref develop --no-backup
 
       - name: Run tests
         if: runner.os != 'Windows'

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -130,6 +130,7 @@ jobs:
         uses: modflowpy/install-modflow-action@v1
       
       - name: Install Modflow dev build executables
+        if: github.ref_name != 'master' && !startsWith(github.ref_name, 'v')
         uses: modflowpy/install-modflow-action@v1
         with:
           repo: modflow6-nightly-build
@@ -214,6 +215,7 @@ jobs:
         uses: modflowpy/install-modflow-action@v1
 
       - name: Install Modflow dev build executables
+        if: github.ref_name != 'master' && !startsWith(github.ref_name, 'v')
         uses: modflowpy/install-modflow-action@v1
         with:
           repo: modflow6-nightly-build

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -80,6 +80,7 @@ jobs:
         uses: modflowpy/install-modflow-action@v1
 
       - name: Install Modflow dev build executables
+        if: github.ref_name != 'master' && !startsWith(github.ref_name, 'v')
         uses: modflowpy/install-modflow-action@v1
         with:
           repo: modflow6-nightly-build

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -84,20 +84,10 @@ jobs:
         with:
           repo: modflow6-nightly-build
 
-      - name: Update FloPy packages
-        if: runner.os != 'Windows'
-        run: python -m flopy.mf6.utils.generate_classes --ref develop --no-backup
-
-      - name: Update FloPy packages
-        if: runner.os == 'Windows'
-        shell: bash -l {0}
-        run: python -m flopy.mf6.utils.generate_classes --ref develop --no-backup
-
       - name: Run example tests
         if: runner.os != 'Windows'
         working-directory: ./autotest
-        run: |
-          pytest -v -m="example" -n=auto -s --durations=0 --keep-failed=.failed
+        run: pytest -v -m="example" -n=auto -s --durations=0 --keep-failed=.failed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -105,8 +95,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash -l {0}
         working-directory: ./autotest
-        run: |
-          pytest -v -m="example" -n=auto -s --durations=0 --keep-failed=.failed
+        run: pytest -v -m="example" -n=auto -s --durations=0 --keep-failed=.failed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -115,5 +104,4 @@ jobs:
         if: failure()
         with:
           name: failed-example-${{ matrix.os }}-${{ matrix.python-version }}
-          path: |
-            ./autotest/.failed/**
+          path: ./autotest/.failed/**

--- a/.github/workflows/mf6.yml
+++ b/.github/workflows/mf6.yml
@@ -52,6 +52,7 @@ jobs:
       with:
         repository: MODFLOW-USGS/modflow6
         path: modflow6
+        ref: ${{ (github.ref_name == 'master' || startsWith(github.ref_name, 'v')) && 'master' || 'develop' }}
 
     - name: Update flopy MODFLOW 6 classes
       working-directory: modflow6/autotest

--- a/.github/workflows/optional.yml
+++ b/.github/workflows/optional.yml
@@ -60,6 +60,11 @@ jobs:
       - name: Install Modflow executables
         uses: modflowpy/install-modflow-action@v1
       
+      - name: Install Modflow dev build executables
+        uses: modflowpy/install-modflow-action@v1
+        with:
+          repo: modflow6-nightly-build
+      
       - name: Smoke test (${{ matrix.optdeps }})
         working-directory: autotest
         run: pytest -v -n=auto --smoke --cov=flopy --cov-report=xml --durations=0 --keep-failed=.failed

--- a/.github/workflows/optional.yml
+++ b/.github/workflows/optional.yml
@@ -61,6 +61,7 @@ jobs:
         uses: modflowpy/install-modflow-action@v1
       
       - name: Install Modflow dev build executables
+        if: github.ref_name != 'master' && !startsWith(github.ref_name, 'v')
         uses: modflowpy/install-modflow-action@v1
         with:
           repo: modflow6-nightly-build

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -68,15 +68,6 @@ jobs:
         with:
           repo: modflow6-nightly-build
 
-      - name: Update FloPy packages
-        if: runner.os != 'Windows'
-        run: python -m flopy.mf6.utils.generate_classes --ref develop --no-backup
-
-      - name: Update FloPy packages
-        if: runner.os == 'Windows'
-        shell: bash -l {0}
-        run: python -m flopy.mf6.utils.generate_classes --ref develop --no-backup
-
       - name: Run regression tests
         if: runner.os != 'Windows'
         working-directory: ./autotest
@@ -97,5 +88,4 @@ jobs:
         if: failure()
         with:
           name: failed-regression-${{ matrix.os }}-${{ matrix.python-version }}
-          path: |
-            ./autotest/.failed/**
+          path: ./autotest/.failed/**

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -64,6 +64,7 @@ jobs:
         uses: modflowpy/install-modflow-action@v1
 
       - name: Install Modflow dev build executables
+        if: github.ref_name != 'master' && !startsWith(github.ref_name, 'v')
         uses: modflowpy/install-modflow-action@v1
         with:
           repo: modflow6-nightly-build

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -78,6 +78,7 @@ jobs:
         uses: modflowpy/install-modflow-action@v1
 
       - name: Install Modflow dev build executables
+        if: github.ref_name != 'master' && !startsWith(github.ref_name, 'v')
         uses: modflowpy/install-modflow-action@v1
         with:
           repo: modflow6-nightly-build

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -77,6 +77,11 @@ jobs:
       - name: Install MODFLOW executables
         uses: modflowpy/install-modflow-action@v1
 
+      - name: Install Modflow dev build executables
+        uses: modflowpy/install-modflow-action@v1
+        with:
+          repo: modflow6-nightly-build
+
       - name: Run tutorial and example notebooks
         working-directory: autotest
         run: pytest -v -n auto test_notebooks.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,8 @@ Before you submit your Pull Request (PR) consider the following guidelines:
      git checkout -b my-fix-branch develop
      ```
 
+    **Note**: it's advised not to begin bugfix or feature branch names with the letter "v". This condition is used in Github Actions CI to determine whether a branch is a release candidate. Branches intended for release are tested against the latest official release of MODFLOW 6, while the FloPy `develop` branch tests against the `develop` branch of MODFLOW 6.
+
 4. Create your patch, **including appropriate test cases**. See [DEVELOPER,md](DEVELOPER.md#running-tests) for guidelines for constructing autotests.
 5. Run the [isort import sorter](https://github.com/PyCQA/isort) and [black formatter](https://github.com/psf/black). There is a utility script to do this in the `scripts` directory:
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -360,7 +360,7 @@ By default, `pytest-benchmark` will only print profiling results to `stdout`. If
 
 ## Branching model
 
-This project follows the [git flow](https://nvie.com/posts/a-successful-git-branching-model/): development occurs on the `develop` branch, while `main` is reserved for the state of the latest release. Development PRs are typically squashed to `develop`, to avoid merge commits. At release time, release branches are merged to `main`, and then `main` is merged back into `develop`.
+This project follows the [git flow](https://nvie.com/posts/a-successful-git-branching-model/): development occurs on the `develop` branch, while the mainline is reserved for the state of the latest release. Development PRs are typically squashed to `develop`, to avoid merge commits. At release time, release branches named e.g. `vx.y.z` are merged to main, then main is merged back into `develop`.
 
 ## Deprecation policy
 


### PR DESCRIPTION
* follow up to #1824 
* 1824 switched some CI testing to the mf6 development build, use it for all CI tests
* don't update flopy packages from DFNs before CI testing, test current repo state

The motivation here is that flopy's `develop` branch should test against the mf6 development build so the projects can be developed in sync. The move to update flopy packages in CI was misguided &mdash; we want to test the codebase as it exists in version control.

Master and release branches are still tested against the latest official mf6 release.