### PR TITLE
refactor: use_pandas=False in mf6 sim/pkgs until regressions fixed

### DIFF
--- a/.docs/Notebooks/modpath7_structured_transient_example.py
+++ b/.docs/Notebooks/modpath7_structured_transient_example.py
@@ -238,7 +238,9 @@ dd = [
     [drain[0], drain[1], i + drain[2][0], 322.5, 100000.0, 6]
     for i in range(drain[2][1] - drain[2][0])
 ]
-drn = flopy.mf6.modflow.mfgwfdrn.ModflowGwfdrn(gwf, auxiliary=["IFACE"], stress_period_data={0: dd})
+drn = flopy.mf6.modflow.mfgwfdrn.ModflowGwfdrn(
+    gwf, auxiliary=["IFACE"], stress_period_data={0: dd}
+)
 
 # output control
 headfile = f"{sim_name}.hds"
@@ -410,5 +412,3 @@ try:
     temp_dir.cleanup()
 except:
     pass
-
-

--- a/autotest/regression/test_mf6_pandas.py
+++ b/autotest/regression/test_mf6_pandas.py
@@ -48,7 +48,6 @@ from flopy.mf6 import (
 )
 from flopy.mf6.data.mfdataplist import MFPandasList
 
-
 pytestmark = pytest.mark.mf6
 
 

--- a/autotest/test_mbase.py
+++ b/autotest/test_mbase.py
@@ -10,7 +10,6 @@ from flopy import run_model
 from flopy.mbase import resolve_exe
 from flopy.utils.flopy_io import relpath_safe
 
-
 _system = system()
 
 

--- a/autotest/test_model_splitter.py
+++ b/autotest/test_model_splitter.py
@@ -346,7 +346,7 @@ def test_control_records(function_tmpdir):
 
     spd_ls1 = ml1.wel.stress_period_data.get_record(1)
     spd_ls2 = ml1.wel.stress_period_data.get_record(2)
- 
+
     if spd_ls1["filename"] is None or spd_ls1["binary"]:
         raise AssertionError(
             "External ascii files not being preserved for MFList"

--- a/flopy/mf6/data/dfn/gwf-chd.dfn
+++ b/flopy/mf6/data/dfn/gwf-chd.dfn
@@ -1,6 +1,7 @@
 # --------------------- gwf chd options ---------------------
 # flopy multi-package
 # package-type stress-package
+# modflow6 aux-sfac-param head
 
 block options
 name auxiliary
@@ -36,6 +37,7 @@ reader urword
 optional true
 longname print input to listing file
 description REPLACE print_input {'{#1}': 'constant-head'}
+mf6internal iprpak
 
 block options
 name print_flows
@@ -44,6 +46,7 @@ reader urword
 optional true
 longname print CHD flows to listing file
 description REPLACE print_flows {'{#1}': 'constant-head'}
+mf6internal iprflow
 
 block options
 name save_flows
@@ -52,6 +55,7 @@ reader urword
 optional true
 longname save CHD flows to budget file
 description REPLACE save_flows {'{#1}': 'constant-head'}
+mf6internal ipakcb
 
 block options
 name ts_filerecord
@@ -128,6 +132,15 @@ optional false
 longname obs6 input filename
 description REPLACE obs6_filename {'{#1}': 'constant-head'}
 
+# dev options
+block options
+name dev_no_newton
+type keyword
+reader urword
+optional true
+longname turn off Newton for unconfined cells
+description turn off Newton for unconfined cells
+mf6internal inewton
 
 # --------------------- gwf chd dimensions ---------------------
 
@@ -162,6 +175,7 @@ shape (maxbound)
 reader urword
 longname
 description
+mf6internal spd
 
 block period
 name cellid
@@ -195,6 +209,7 @@ optional true
 time_series true
 longname auxiliary variables
 description REPLACE aux {'{#1}': 'constant head'}
+mf6internal auxvar
 
 block period
 name boundname

--- a/flopy/mf6/data/dfn/gwf-drn.dfn
+++ b/flopy/mf6/data/dfn/gwf-drn.dfn
@@ -45,6 +45,7 @@ reader urword
 optional true
 longname print input to listing file
 description REPLACE print_input {'{#1}': 'drain'}
+mf6internal iprpak
 
 block options
 name print_flows
@@ -53,6 +54,7 @@ reader urword
 optional true
 longname print calculated flows to listing file
 description REPLACE print_flows {'{#1}': 'drain'}
+mf6internal iprflow
 
 block options
 name save_flows
@@ -61,6 +63,7 @@ reader urword
 optional true
 longname save CHD flows to budget file
 description REPLACE save_flows {'{#1}': 'drain'}
+mf6internal ipakcb
 
 block options
 name ts_filerecord
@@ -146,6 +149,16 @@ optional true
 longname
 description REPLACE mover {'{#1}': 'Drain'}
 
+# dev options
+block options
+name dev_cubic_scaling
+type keyword
+reader urword
+optional true
+longname cubic-scaling
+description cubic-scaling is used to scale the drain conductance
+mf6internal icubicsfac
+
 # --------------------- gwf drn dimensions ---------------------
 
 block dimensions
@@ -179,6 +192,7 @@ shape (maxbound)
 reader urword
 longname
 description
+mf6internal spd
 
 block period
 name cellid
@@ -223,6 +237,7 @@ optional true
 time_series true
 longname auxiliary variables
 description REPLACE aux {'{#1}': 'drain'}
+mf6internal auxvar
 
 block period
 name boundname

--- a/flopy/mf6/data/dfn/gwf-evt.dfn
+++ b/flopy/mf6/data/dfn/gwf-evt.dfn
@@ -45,6 +45,7 @@ reader urword
 optional true
 longname print input to listing file
 description REPLACE print_input {'{#1}': 'evapotranspiration'}
+mf6internal iprpak
 
 block options
 name print_flows
@@ -53,6 +54,7 @@ reader urword
 optional true
 longname print evapotranspiration rates to listing file
 description REPLACE print_flows {'{#1}': 'evapotranspiration'}
+mf6internal iprflow
 
 block options
 name save_flows
@@ -61,6 +63,7 @@ reader urword
 optional true
 longname save evapotranspiration rates to budget file
 description REPLACE save_flows {'{#1}': 'evapotranspiration'}
+mf6internal ipakcb
 
 block options
 name ts_filerecord
@@ -144,6 +147,7 @@ reader urword
 optional true
 longname specify proportion of evapotranspiration rate at ET surface
 description indicates that the proportion of the evapotranspiration rate at the ET surface will be specified as PETM0 in list input.
+mf6internal surfratespec
 
 # --------------------- gwf evt dimensions ---------------------
 
@@ -185,6 +189,7 @@ shape (maxbound)
 reader urword
 longname
 description
+mf6internal spd
 
 block period
 name cellid
@@ -236,6 +241,7 @@ shape (nseg-1)
 tagged false
 in_record true
 reader urword
+optional true
 time_series true
 longname proportion of ET extinction depth
 description is the proportion of the ET extinction depth at the bottom of a segment (dimensionless). pxdp is an array of size (nseg - 1).  Values in pxdp must be greater than 0.0 and less than 1.0.  pxdp values for a cell must increase monotonically.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.
@@ -247,6 +253,7 @@ shape (nseg-1)
 tagged false
 in_record true
 reader urword
+optional true
 time_series true
 longname proportion of maximum ET rate
 description is the proportion of the maximum ET flux rate at the bottom of a segment (dimensionless). petm is an array of size (nseg - 1).  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.
@@ -274,6 +281,7 @@ optional true
 time_series true
 longname auxiliary variables
 description REPLACE aux {'{#1}': 'evapotranspiration'}
+mf6internal auxvar
 
 block period
 name boundname

--- a/flopy/mf6/data/dfn/gwf-evta.dfn
+++ b/flopy/mf6/data/dfn/gwf-evta.dfn
@@ -1,6 +1,7 @@
 # --------------------- gwf evta options ---------------------
 # flopy multi-package
 # package-type stress-package
+# modflow6 aux-sfac-param rate
 
 block options
 name readasarrays
@@ -46,6 +47,7 @@ reader urword
 optional true
 longname print input to listing file
 description REPLACE print_input {'{#1}': 'evapotranspiration'}
+mf6internal iprpak
 
 block options
 name print_flows
@@ -54,6 +56,7 @@ reader urword
 optional true
 longname print evapotranspiration rates to listing file
 description REPLACE print_flows {'{#1}': 'evapotranspiration'}
+mf6internal iprflow
 
 block options
 name save_flows
@@ -62,6 +65,7 @@ reader urword
 optional true
 longname save CHD flows to budget file
 description REPLACE save_flows {'{#1}': 'evapotranspiration'}
+mf6internal ipakcb
 
 block options
 name tas_filerecord
@@ -178,6 +182,7 @@ name rate
 type double precision
 shape (ncol*nrow; ncpl)
 reader readarray
+time_series true
 longname evapotranspiration surface
 description is the maximum ET flux rate ($LT^{-1}$).
 default_value 1.e-3
@@ -192,9 +197,11 @@ description is the ET extinction depth ($L$).
 default_value 1.0
 
 block period
-name aux(iaux)
+name aux
 type double precision
 shape (ncol*nrow; ncpl)
 reader readarray
+time_series true
 longname auxiliary variable iaux
 description is an array of values for auxiliary variable AUX(IAUX), where iaux is a value from 1 to NAUX, and AUX(IAUX) must be listed as part of the auxiliary variables.  A separate array can be specified for each auxiliary variable.  If an array is not specified for an auxiliary variable, then a value of zero is assigned.  If the value specified here for the auxiliary variable is the same as auxmultname, then the evapotranspiration rate will be multiplied by this array.
+mf6internal auxvar

--- a/flopy/mf6/data/dfn/gwf-ghb.dfn
+++ b/flopy/mf6/data/dfn/gwf-ghb.dfn
@@ -36,6 +36,7 @@ reader urword
 optional true
 longname print input to listing file
 description REPLACE print_input {'{#1}': 'general-head boundary'}
+mf6internal iprpak
 
 block options
 name print_flows
@@ -44,6 +45,7 @@ reader urword
 optional true
 longname print calculated flows to listing file
 description REPLACE print_flows {'{#1}': 'general-head boundary'}
+mf6internal iprflow
 
 block options
 name save_flows
@@ -52,6 +54,7 @@ reader urword
 optional true
 longname save CHD flows to budget file
 description REPLACE save_flows {'{#1}': 'general-head boundary'}
+mf6internal ipakcb
 
 block options
 name ts_filerecord
@@ -170,6 +173,7 @@ shape (maxbound)
 reader urword
 longname
 description
+mf6internal spd
 
 block period
 name cellid
@@ -214,6 +218,7 @@ optional true
 time_series true
 longname auxiliary variables
 description REPLACE aux {'{#1}': 'general-head boundary'}
+mf6internal auxvar
 
 block period
 name boundname

--- a/flopy/mf6/data/dfn/gwf-rch.dfn
+++ b/flopy/mf6/data/dfn/gwf-rch.dfn
@@ -1,6 +1,7 @@
 # --------------------- gwf rch options ---------------------
 # flopy multi-package
 # package-type stress-package
+# modflow6 aux-sfac-param recharge
 
 block options
 name fixed_cell
@@ -45,6 +46,7 @@ reader urword
 optional true
 longname print input to listing file
 description REPLACE print_input {'{#1}': 'recharge'}
+mf6internal iprpak
 
 block options
 name print_flows
@@ -53,6 +55,7 @@ reader urword
 optional true
 longname print recharge rates to listing file
 description REPLACE print_flows {'{#1}': 'recharge'}
+mf6internal iprflow
 
 block options
 name save_flows
@@ -61,6 +64,7 @@ reader urword
 optional true
 longname save recharge to budget file
 description REPLACE save_flows {'{#1}': 'recharge'}
+mf6internal ipakcb
 
 block options
 name ts_filerecord
@@ -170,6 +174,7 @@ shape (maxbound)
 reader urword
 longname
 description
+mf6internal spd
 
 block period
 name cellid
@@ -203,6 +208,7 @@ optional true
 time_series true
 longname auxiliary variables
 description REPLACE aux {'{#1}': 'recharge'}
+mf6internal auxvar
 
 block period
 name boundname

--- a/flopy/mf6/data/dfn/gwf-rcha.dfn
+++ b/flopy/mf6/data/dfn/gwf-rcha.dfn
@@ -1,6 +1,7 @@
 # --------------------- gwf rcha options ---------------------
 # flopy multi-package
 # package-type stress-package
+# modflow6 aux-sfac-param recharge
 
 block options
 name readasarrays
@@ -46,6 +47,7 @@ reader urword
 optional true
 longname print input to listing file
 description REPLACE print_input {'{#1}': 'recharge'}
+mf6internal iprpak
 
 block options
 name print_flows
@@ -54,6 +56,7 @@ reader urword
 optional true
 longname print recharge rates to listing file
 description REPLACE print_flows {'{#1}': 'recharge'}
+mf6internal iprflow
 
 block options
 name save_flows
@@ -62,6 +65,7 @@ reader urword
 optional true
 longname save CHD flows to budget file
 description REPLACE save_flows {'{#1}': 'recharge'}
+mf6internal ipakcb
 
 block options
 name tas_filerecord
@@ -169,6 +173,7 @@ name recharge
 type double precision
 shape (ncol*nrow; ncpl)
 reader readarray
+time_series true
 longname recharge rate
 description is the recharge flux rate ($LT^{-1}$).  This rate is multiplied inside the program by the surface area of the cell to calculate the volumetric recharge rate. The recharge array may be defined by a time-array series (see the "Using Time-Array Series in a Package" section).
 default_value 1.e-3
@@ -178,6 +183,8 @@ name aux
 type double precision
 shape (ncol*nrow; ncpl)
 reader readarray
+time_series true
 optional true
 longname auxiliary variable iaux
 description is an array of values for auxiliary variable aux(iaux), where iaux is a value from 1 to naux, and aux(iaux) must be listed as part of the auxiliary variables.  A separate array can be specified for each auxiliary variable.  If an array is not specified for an auxiliary variable, then a value of zero is assigned.  If the value specified here for the auxiliary variable is the same as auxmultname, then the recharge array will be multiplied by this array.
+mf6internal auxvar

--- a/flopy/mf6/data/dfn/gwf-riv.dfn
+++ b/flopy/mf6/data/dfn/gwf-riv.dfn
@@ -36,6 +36,7 @@ reader urword
 optional true
 longname print input to listing file
 description REPLACE print_input {'{#1}': 'river'}
+mf6internal iprpak
 
 block options
 name print_flows
@@ -44,6 +45,7 @@ reader urword
 optional true
 longname print calculated flows to listing file
 description REPLACE print_flows {'{#1}': 'river'}
+mf6internal iprflow
 
 block options
 name save_flows
@@ -52,6 +54,7 @@ reader urword
 optional true
 longname save CHD flows to budget file
 description REPLACE save_flows {'{#1}': 'river'}
+mf6internal ipakcb
 
 block options
 name ts_filerecord
@@ -170,6 +173,7 @@ shape (maxbound)
 reader urword
 longname
 description
+mf6internal spd
 
 block period
 name cellid
@@ -225,6 +229,7 @@ optional true
 time_series true
 longname auxiliary variables
 description REPLACE aux {'{#1}': 'river'}
+mf6internal auxvar
 
 block period
 name boundname

--- a/flopy/mf6/data/dfn/gwf-wel.dfn
+++ b/flopy/mf6/data/dfn/gwf-wel.dfn
@@ -36,6 +36,7 @@ reader urword
 optional true
 longname print input to listing file
 description REPLACE print_input {'{#1}': 'well'}
+mf6internal iprpak
 
 block options
 name print_flows
@@ -44,6 +45,7 @@ reader urword
 optional true
 longname print calculated flows to listing file
 description REPLACE print_flows {'{#1}': 'well'}
+mf6internal iprflow
 
 block options
 name save_flows
@@ -52,6 +54,7 @@ reader urword
 optional true
 longname save well flows to budget file
 description REPLACE save_flows {'{#1}': 'well'}
+mf6internal ipakcb
 
 block options
 name auto_flow_reduce
@@ -60,6 +63,7 @@ reader urword
 optional true
 longname cell fractional thickness for reduced pumping
 description keyword and real value that defines the fraction of the cell thickness used as an interval for smoothly adjusting negative pumping rates to 0 in cells with head values less than or equal to the bottom of the cell. Negative pumping rates are adjusted to 0 or a smaller negative value when the head in the cell is equal to or less than the calculated interval above the cell bottom. AUTO\_FLOW\_REDUCE is set to 0.1 if the specified value is less than or equal to zero. By default, negative pumping rates are not reduced during a simulation.
+mf6internal flowred
 
 block options
 name afrcsv_filerecord
@@ -70,6 +74,7 @@ tagged true
 optional true
 longname
 description
+mf6internal afrcsv_rec
 
 block options
 name auto_flow_reduce_csv
@@ -81,6 +86,7 @@ tagged true
 optional false
 longname budget keyword
 description keyword to specify that record corresponds to the AUTO\_FLOW\_REDUCE output option in which a new record is written for each well and for each time step in which the user-requested extraction rate is reduced by the program.
+mf6internal afrcsv
 
 block options
 name fileout
@@ -222,6 +228,7 @@ shape (maxbound)
 reader urword
 longname
 description
+mf6internal spd
 
 block period
 name cellid
@@ -255,6 +262,7 @@ optional true
 time_series true
 longname auxiliary variables
 description REPLACE aux {'{#1}': 'well'}
+mf6internal auxvar
 
 block period
 name boundname

--- a/flopy/mf6/mfsimbase.py
+++ b/flopy/mf6/mfsimbase.py
@@ -257,7 +257,7 @@ class MFSimulationData:
         self.verbosity_level = VerbosityLevel.normal
         self.max_columns_user_set = False
         self.max_columns_auto_set = False
-        self.use_pandas = True
+        self.use_pandas = False
 
         self._update_str_format()
 
@@ -458,7 +458,7 @@ class MFSimulationBase(PackageContainer):
         memory_print_option=None,
         write_headers=True,
         lazy_io=False,
-        use_pandas=True,
+        use_pandas=False,
     ):
         super().__init__(MFSimulationData(sim_ws, self), sim_name)
         self.simulation_data.verbosity_level = self._resolve_verbosity_level(
@@ -691,7 +691,7 @@ class MFSimulationBase(PackageContainer):
         verify_data=False,
         write_headers=True,
         lazy_io=False,
-        use_pandas=True,
+        use_pandas=False,
     ):
         """
         Load an existing model. Do not call this method directly.  Should only

--- a/flopy/mf6/modflow/mfgwfchd.py
+++ b/flopy/mf6/modflow/mfgwfchd.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on August 29, 2023 20:06:54 UTC
+# FILE created on October 05, 2023 17:07:18 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -60,6 +60,8 @@ class ModflowGwfchd(mfpackage.MFPackage):
           containing data for the obs package with variable names as keys and
           package data as values. Data just for the observations variable is
           also acceptable. See obs package documentation for more information.
+    dev_no_newton : boolean
+        * dev_no_newton (boolean) turn off Newton for unconfined cells
     maxbound : integer
         * maxbound (integer) integer value specifying the maximum number of
           constant-head cells that will be specified for use during any stress
@@ -148,6 +150,7 @@ class ModflowGwfchd(mfpackage.MFPackage):
             "type keyword",
             "reader urword",
             "optional true",
+            "mf6internal iprpak",
         ],
         [
             "block options",
@@ -155,6 +158,7 @@ class ModflowGwfchd(mfpackage.MFPackage):
             "type keyword",
             "reader urword",
             "optional true",
+            "mf6internal iprflow",
         ],
         [
             "block options",
@@ -162,6 +166,7 @@ class ModflowGwfchd(mfpackage.MFPackage):
             "type keyword",
             "reader urword",
             "optional true",
+            "mf6internal ipakcb",
         ],
         [
             "block options",
@@ -238,6 +243,14 @@ class ModflowGwfchd(mfpackage.MFPackage):
             "optional false",
         ],
         [
+            "block options",
+            "name dev_no_newton",
+            "type keyword",
+            "reader urword",
+            "optional true",
+            "mf6internal inewton",
+        ],
+        [
             "block dimensions",
             "name maxbound",
             "type integer",
@@ -262,6 +275,7 @@ class ModflowGwfchd(mfpackage.MFPackage):
             "type recarray cellid head aux boundname",
             "shape (maxbound)",
             "reader urword",
+            "mf6internal spd",
         ],
         [
             "block period",
@@ -292,6 +306,7 @@ class ModflowGwfchd(mfpackage.MFPackage):
             "reader urword",
             "optional true",
             "time_series true",
+            "mf6internal auxvar",
         ],
         [
             "block period",
@@ -317,6 +332,7 @@ class ModflowGwfchd(mfpackage.MFPackage):
         save_flows=None,
         timeseries=None,
         observations=None,
+        dev_no_newton=None,
         maxbound=None,
         stress_period_data=None,
         filename=None,
@@ -342,6 +358,7 @@ class ModflowGwfchd(mfpackage.MFPackage):
         self._obs_package = self.build_child_package(
             "obs", observations, "continuous", self._obs_filerecord
         )
+        self.dev_no_newton = self.build_mfdata("dev_no_newton", dev_no_newton)
         self.maxbound = self.build_mfdata("maxbound", maxbound)
         self.stress_period_data = self.build_mfdata(
             "stress_period_data", stress_period_data

--- a/flopy/mf6/modflow/mfgwfdrn.py
+++ b/flopy/mf6/modflow/mfgwfdrn.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on August 29, 2023 20:06:54 UTC
+# FILE created on October 05, 2023 17:07:18 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -79,6 +79,9 @@ class ModflowGwfdrn(mfpackage.MFPackage):
           Package can be used with the Water Mover (MVR) Package. When the
           MOVER option is specified, additional memory is allocated within the
           package to store the available, provided, and received water.
+    dev_cubic_scaling : boolean
+        * dev_cubic_scaling (boolean) cubic-scaling is used to scale the drain
+          conductance
     maxbound : integer
         * maxbound (integer) integer value specifying the maximum number of
           drains cells that will be specified for use during any stress period.
@@ -179,6 +182,7 @@ class ModflowGwfdrn(mfpackage.MFPackage):
             "type keyword",
             "reader urword",
             "optional true",
+            "mf6internal iprpak",
         ],
         [
             "block options",
@@ -186,6 +190,7 @@ class ModflowGwfdrn(mfpackage.MFPackage):
             "type keyword",
             "reader urword",
             "optional true",
+            "mf6internal iprflow",
         ],
         [
             "block options",
@@ -193,6 +198,7 @@ class ModflowGwfdrn(mfpackage.MFPackage):
             "type keyword",
             "reader urword",
             "optional true",
+            "mf6internal ipakcb",
         ],
         [
             "block options",
@@ -277,6 +283,14 @@ class ModflowGwfdrn(mfpackage.MFPackage):
             "optional true",
         ],
         [
+            "block options",
+            "name dev_cubic_scaling",
+            "type keyword",
+            "reader urword",
+            "optional true",
+            "mf6internal icubicsfac",
+        ],
+        [
             "block dimensions",
             "name maxbound",
             "type integer",
@@ -301,6 +315,7 @@ class ModflowGwfdrn(mfpackage.MFPackage):
             "type recarray cellid elev cond aux boundname",
             "shape (maxbound)",
             "reader urword",
+            "mf6internal spd",
         ],
         [
             "block period",
@@ -341,6 +356,7 @@ class ModflowGwfdrn(mfpackage.MFPackage):
             "reader urword",
             "optional true",
             "time_series true",
+            "mf6internal auxvar",
         ],
         [
             "block period",
@@ -368,6 +384,7 @@ class ModflowGwfdrn(mfpackage.MFPackage):
         timeseries=None,
         observations=None,
         mover=None,
+        dev_cubic_scaling=None,
         maxbound=None,
         stress_period_data=None,
         filename=None,
@@ -395,6 +412,9 @@ class ModflowGwfdrn(mfpackage.MFPackage):
             "obs", observations, "continuous", self._obs_filerecord
         )
         self.mover = self.build_mfdata("mover", mover)
+        self.dev_cubic_scaling = self.build_mfdata(
+            "dev_cubic_scaling", dev_cubic_scaling
+        )
         self.maxbound = self.build_mfdata("maxbound", maxbound)
         self.stress_period_data = self.build_mfdata(
             "stress_period_data", stress_period_data

--- a/flopy/mf6/modflow/mfgwfevt.py
+++ b/flopy/mf6/modflow/mfgwfevt.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on August 29, 2023 20:06:54 UTC
+# FILE created on October 05, 2023 17:07:18 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -199,6 +199,7 @@ class ModflowGwfevt(mfpackage.MFPackage):
             "type keyword",
             "reader urword",
             "optional true",
+            "mf6internal iprpak",
         ],
         [
             "block options",
@@ -206,6 +207,7 @@ class ModflowGwfevt(mfpackage.MFPackage):
             "type keyword",
             "reader urword",
             "optional true",
+            "mf6internal iprflow",
         ],
         [
             "block options",
@@ -213,6 +215,7 @@ class ModflowGwfevt(mfpackage.MFPackage):
             "type keyword",
             "reader urword",
             "optional true",
+            "mf6internal ipakcb",
         ],
         [
             "block options",
@@ -294,6 +297,7 @@ class ModflowGwfevt(mfpackage.MFPackage):
             "type keyword",
             "reader urword",
             "optional true",
+            "mf6internal surfratespec",
         ],
         [
             "block dimensions",
@@ -328,6 +332,7 @@ class ModflowGwfevt(mfpackage.MFPackage):
             "boundname",
             "shape (maxbound)",
             "reader urword",
+            "mf6internal spd",
         ],
         [
             "block period",
@@ -376,6 +381,7 @@ class ModflowGwfevt(mfpackage.MFPackage):
             "tagged false",
             "in_record true",
             "reader urword",
+            "optional true",
             "time_series true",
         ],
         [
@@ -386,6 +392,7 @@ class ModflowGwfevt(mfpackage.MFPackage):
             "tagged false",
             "in_record true",
             "reader urword",
+            "optional true",
             "time_series true",
         ],
         [
@@ -409,6 +416,7 @@ class ModflowGwfevt(mfpackage.MFPackage):
             "reader urword",
             "optional true",
             "time_series true",
+            "mf6internal auxvar",
         ],
         [
             "block period",

--- a/flopy/mf6/modflow/mfgwfevta.py
+++ b/flopy/mf6/modflow/mfgwfevta.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on August 29, 2023 20:06:54 UTC
+# FILE created on October 05, 2023 17:07:18 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -81,15 +81,14 @@ class ModflowGwfevta(mfpackage.MFPackage):
         * rate (double) is the maximum ET flux rate (:math:`LT^{-1}`).
     depth : [double]
         * depth (double) is the ET extinction depth (:math:`L`).
-    aux(iaux) : [double]
-        * aux(iaux) (double) is an array of values for auxiliary variable
-          AUX(IAUX), where iaux is a value from 1 to NAUX, and AUX(IAUX) must
-          be listed as part of the auxiliary variables. A separate array can be
-          specified for each auxiliary variable. If an array is not specified
-          for an auxiliary variable, then a value of zero is assigned. If the
-          value specified here for the auxiliary variable is the same as
-          auxmultname, then the evapotranspiration rate will be multiplied by
-          this array.
+    aux : [double]
+        * aux (double) is an array of values for auxiliary variable AUX(IAUX),
+          where iaux is a value from 1 to NAUX, and AUX(IAUX) must be listed as
+          part of the auxiliary variables. A separate array can be specified
+          for each auxiliary variable. If an array is not specified for an
+          auxiliary variable, then a value of zero is assigned. If the value
+          specified here for the auxiliary variable is the same as auxmultname,
+          then the evapotranspiration rate will be multiplied by this array.
     filename : String
         File name for this package.
     pname : String
@@ -112,7 +111,7 @@ class ModflowGwfevta(mfpackage.MFPackage):
     surface = ArrayTemplateGenerator(("gwf6", "evta", "period", "surface"))
     rate = ArrayTemplateGenerator(("gwf6", "evta", "period", "rate"))
     depth = ArrayTemplateGenerator(("gwf6", "evta", "period", "depth"))
-    aux = ArrayTemplateGenerator(("gwf6", "evta", "period", "aux(iaux)"))
+    aux = ArrayTemplateGenerator(("gwf6", "evta", "period", "aux"))
     package_abbr = "gwfevta"
     _package_type = "evta"
     dfn_file_name = "gwf-evta.dfn"
@@ -158,6 +157,7 @@ class ModflowGwfevta(mfpackage.MFPackage):
             "type keyword",
             "reader urword",
             "optional true",
+            "mf6internal iprpak",
         ],
         [
             "block options",
@@ -165,6 +165,7 @@ class ModflowGwfevta(mfpackage.MFPackage):
             "type keyword",
             "reader urword",
             "optional true",
+            "mf6internal iprflow",
         ],
         [
             "block options",
@@ -172,6 +173,7 @@ class ModflowGwfevta(mfpackage.MFPackage):
             "type keyword",
             "reader urword",
             "optional true",
+            "mf6internal ipakcb",
         ],
         [
             "block options",
@@ -282,6 +284,7 @@ class ModflowGwfevta(mfpackage.MFPackage):
             "type double precision",
             "shape (ncol*nrow; ncpl)",
             "reader readarray",
+            "time_series true",
             "default_value 1.e-3",
         ],
         [
@@ -294,10 +297,12 @@ class ModflowGwfevta(mfpackage.MFPackage):
         ],
         [
             "block period",
-            "name aux(iaux)",
+            "name aux",
             "type double precision",
             "shape (ncol*nrow; ncpl)",
             "reader readarray",
+            "time_series true",
+            "mf6internal auxvar",
         ],
     ]
 
@@ -347,5 +352,5 @@ class ModflowGwfevta(mfpackage.MFPackage):
         self.surface = self.build_mfdata("surface", surface)
         self.rate = self.build_mfdata("rate", rate)
         self.depth = self.build_mfdata("depth", depth)
-        self.aux = self.build_mfdata("aux(iaux)", aux)
+        self.aux = self.build_mfdata("aux", aux)
         self._init_complete = True

--- a/flopy/mf6/modflow/mfgwfghb.py
+++ b/flopy/mf6/modflow/mfgwfghb.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on August 29, 2023 20:06:54 UTC
+# FILE created on October 05, 2023 17:07:18 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -159,6 +159,7 @@ class ModflowGwfghb(mfpackage.MFPackage):
             "type keyword",
             "reader urword",
             "optional true",
+            "mf6internal iprpak",
         ],
         [
             "block options",
@@ -166,6 +167,7 @@ class ModflowGwfghb(mfpackage.MFPackage):
             "type keyword",
             "reader urword",
             "optional true",
+            "mf6internal iprflow",
         ],
         [
             "block options",
@@ -173,6 +175,7 @@ class ModflowGwfghb(mfpackage.MFPackage):
             "type keyword",
             "reader urword",
             "optional true",
+            "mf6internal ipakcb",
         ],
         [
             "block options",
@@ -281,6 +284,7 @@ class ModflowGwfghb(mfpackage.MFPackage):
             "type recarray cellid bhead cond aux boundname",
             "shape (maxbound)",
             "reader urword",
+            "mf6internal spd",
         ],
         [
             "block period",
@@ -321,6 +325,7 @@ class ModflowGwfghb(mfpackage.MFPackage):
             "reader urword",
             "optional true",
             "time_series true",
+            "mf6internal auxvar",
         ],
         [
             "block period",

--- a/flopy/mf6/modflow/mfgwfrch.py
+++ b/flopy/mf6/modflow/mfgwfrch.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on August 29, 2023 20:06:54 UTC
+# FILE created on October 05, 2023 17:07:18 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -162,6 +162,7 @@ class ModflowGwfrch(mfpackage.MFPackage):
             "type keyword",
             "reader urword",
             "optional true",
+            "mf6internal iprpak",
         ],
         [
             "block options",
@@ -169,6 +170,7 @@ class ModflowGwfrch(mfpackage.MFPackage):
             "type keyword",
             "reader urword",
             "optional true",
+            "mf6internal iprflow",
         ],
         [
             "block options",
@@ -176,6 +178,7 @@ class ModflowGwfrch(mfpackage.MFPackage):
             "type keyword",
             "reader urword",
             "optional true",
+            "mf6internal ipakcb",
         ],
         [
             "block options",
@@ -276,6 +279,7 @@ class ModflowGwfrch(mfpackage.MFPackage):
             "type recarray cellid recharge aux boundname",
             "shape (maxbound)",
             "reader urword",
+            "mf6internal spd",
         ],
         [
             "block period",
@@ -306,6 +310,7 @@ class ModflowGwfrch(mfpackage.MFPackage):
             "reader urword",
             "optional true",
             "time_series true",
+            "mf6internal auxvar",
         ],
         [
             "block period",

--- a/flopy/mf6/modflow/mfgwfrcha.py
+++ b/flopy/mf6/modflow/mfgwfrcha.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on August 29, 2023 20:06:54 UTC
+# FILE created on October 05, 2023 17:07:18 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ArrayTemplateGenerator, ListTemplateGenerator
 
@@ -156,6 +156,7 @@ class ModflowGwfrcha(mfpackage.MFPackage):
             "type keyword",
             "reader urword",
             "optional true",
+            "mf6internal iprpak",
         ],
         [
             "block options",
@@ -163,6 +164,7 @@ class ModflowGwfrcha(mfpackage.MFPackage):
             "type keyword",
             "reader urword",
             "optional true",
+            "mf6internal iprflow",
         ],
         [
             "block options",
@@ -170,6 +172,7 @@ class ModflowGwfrcha(mfpackage.MFPackage):
             "type keyword",
             "reader urword",
             "optional true",
+            "mf6internal ipakcb",
         ],
         [
             "block options",
@@ -272,6 +275,7 @@ class ModflowGwfrcha(mfpackage.MFPackage):
             "type double precision",
             "shape (ncol*nrow; ncpl)",
             "reader readarray",
+            "time_series true",
             "default_value 1.e-3",
         ],
         [
@@ -280,7 +284,9 @@ class ModflowGwfrcha(mfpackage.MFPackage):
             "type double precision",
             "shape (ncol*nrow; ncpl)",
             "reader readarray",
+            "time_series true",
             "optional true",
+            "mf6internal auxvar",
         ],
     ]
 

--- a/flopy/mf6/modflow/mfgwfriv.py
+++ b/flopy/mf6/modflow/mfgwfriv.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on August 29, 2023 20:06:54 UTC
+# FILE created on October 05, 2023 17:07:18 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -160,6 +160,7 @@ class ModflowGwfriv(mfpackage.MFPackage):
             "type keyword",
             "reader urword",
             "optional true",
+            "mf6internal iprpak",
         ],
         [
             "block options",
@@ -167,6 +168,7 @@ class ModflowGwfriv(mfpackage.MFPackage):
             "type keyword",
             "reader urword",
             "optional true",
+            "mf6internal iprflow",
         ],
         [
             "block options",
@@ -174,6 +176,7 @@ class ModflowGwfriv(mfpackage.MFPackage):
             "type keyword",
             "reader urword",
             "optional true",
+            "mf6internal ipakcb",
         ],
         [
             "block options",
@@ -282,6 +285,7 @@ class ModflowGwfriv(mfpackage.MFPackage):
             "type recarray cellid stage cond rbot aux boundname",
             "shape (maxbound)",
             "reader urword",
+            "mf6internal spd",
         ],
         [
             "block period",
@@ -332,6 +336,7 @@ class ModflowGwfriv(mfpackage.MFPackage):
             "reader urword",
             "optional true",
             "time_series true",
+            "mf6internal auxvar",
         ],
         [
             "block period",

--- a/flopy/mf6/modflow/mfgwfwel.py
+++ b/flopy/mf6/modflow/mfgwfwel.py
@@ -1,6 +1,6 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.  THIS FILE MUST BE CREATED BY
 # mf6/utils/createpackages.py
-# FILE created on August 29, 2023 20:06:54 UTC
+# FILE created on October 05, 2023 17:07:18 UTC
 from .. import mfpackage
 from ..data.mfdatautil import ListTemplateGenerator
 
@@ -172,6 +172,7 @@ class ModflowGwfwel(mfpackage.MFPackage):
             "type keyword",
             "reader urword",
             "optional true",
+            "mf6internal iprpak",
         ],
         [
             "block options",
@@ -179,6 +180,7 @@ class ModflowGwfwel(mfpackage.MFPackage):
             "type keyword",
             "reader urword",
             "optional true",
+            "mf6internal iprflow",
         ],
         [
             "block options",
@@ -186,6 +188,7 @@ class ModflowGwfwel(mfpackage.MFPackage):
             "type keyword",
             "reader urword",
             "optional true",
+            "mf6internal ipakcb",
         ],
         [
             "block options",
@@ -193,6 +196,7 @@ class ModflowGwfwel(mfpackage.MFPackage):
             "type double precision",
             "reader urword",
             "optional true",
+            "mf6internal flowred",
         ],
         [
             "block options",
@@ -202,6 +206,7 @@ class ModflowGwfwel(mfpackage.MFPackage):
             "reader urword",
             "tagged true",
             "optional true",
+            "mf6internal afrcsv_rec",
         ],
         [
             "block options",
@@ -212,6 +217,7 @@ class ModflowGwfwel(mfpackage.MFPackage):
             "reader urword",
             "tagged true",
             "optional false",
+            "mf6internal afrcsv",
         ],
         [
             "block options",
@@ -341,6 +347,7 @@ class ModflowGwfwel(mfpackage.MFPackage):
             "type recarray cellid q aux boundname",
             "shape (maxbound)",
             "reader urword",
+            "mf6internal spd",
         ],
         [
             "block period",
@@ -371,6 +378,7 @@ class ModflowGwfwel(mfpackage.MFPackage):
             "reader urword",
             "optional true",
             "time_series true",
+            "mf6internal auxvar",
         ],
         [
             "block period",

--- a/flopy/mf6/modflow/mfsimulation.py
+++ b/flopy/mf6/modflow/mfsimulation.py
@@ -87,7 +87,7 @@ class MFSimulation(mfsimbase.MFSimulationBase):
         sim_ws: Union[str, os.PathLike] = os.curdir,
         verbosity_level=1,
         write_headers=True,
-        use_pandas=True,
+        use_pandas=False,
         lazy_io=False,
         continue_=None,
         nocheck=None,
@@ -131,7 +131,7 @@ class MFSimulation(mfsimbase.MFSimulationBase):
         verify_data=False,
         write_headers=True,
         lazy_io=False,
-        use_pandas=True,
+        use_pandas=False,
     ):
         return mfsimbase.MFSimulationBase.load(
             cls,

--- a/flopy/mf6/utils/createpackages.py
+++ b/flopy/mf6/utils/createpackages.py
@@ -443,7 +443,7 @@ def build_sim_load():
         "sim_ws: Union[str, os.PathLike] = os.curdir,\n             "
         "strict=True, verbosity_level=1, load_only=None,\n             "
         "verify_data=False, write_headers=True,\n             "
-        "lazy_io=False, use_pandas=True):\n        "
+        "lazy_io=False, use_pandas=False):\n        "
         "return mfsimbase.MFSimulationBase.load(cls, sim_name, version, "
         "\n                                               "
         "exe_name, sim_ws, strict,\n"
@@ -1002,7 +1002,7 @@ def create_packages():
             init_vars = build_model_init_vars(options_param_list)
 
             options_param_list.insert(0, "lazy_io=False")
-            options_param_list.insert(0, "use_pandas=True")
+            options_param_list.insert(0, "use_pandas=False")
             options_param_list.insert(0, "write_headers=True")
             options_param_list.insert(0, "verbosity_level=1")
             options_param_list.insert(


### PR DESCRIPTION
* avoid test failures with `use_pandas=True`
  * mf6: `test_gwf_disu.py`, `test_gwf_errors.py::test_disu_errors`
  * flopy: `test_binaryfile.py::test_read_mf6_2sp`
* regenerate mf6 pkg classes from mf6 develop
* run formatter in notebooks/autotests
* supersedes #1978