### PR TITLE
ci(mf6.yml): include more mf6 autotests

### DIFF
--- a/.github/workflows/mf6.yml
+++ b/.github/workflows/mf6.yml
@@ -87,7 +87,7 @@ jobs:
     - name: Run tests
       working-directory: modflow6/autotest
       run: |
-        pytest -v --cov=flopy --cov-report=xml --durations=0 -k "test_gw" -n auto
+        pytest -v --cov=flopy --cov-report=xml --durations=0 -n auto -m "not repo and not regression"
 
     - name: Print coverage report before upload
       working-directory: ./modflow6/autotest


### PR DESCRIPTION
* previously only files named `test_gw*.py` were run
* run the full mf6 test set minus (as before) example model / regression tests (`test_z*.py`)
* may catch more mf6 integration issues without much extra time (previously `mf6.yml` took ~15min, now ~20)
* prepares also for differently-named models e.g. prt