### PR TITLE
ci: remove branch filters from push trigger

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -1,11 +1,6 @@
 name: FloPy continuous integration
 on:
   push:
-    branches:
-      - master
-      - develop
-      - ci-diagnose*
-      - notebooks
   pull_request:
     branches:
       - master

--- a/.github/workflows/mf6.yml
+++ b/.github/workflows/mf6.yml
@@ -4,11 +4,6 @@ on:
   schedule:
     - cron: '0 8 * * *' # run at 8 AM UTC (12 am PST)
   push:
-    branches:
-      - master
-      - develop
-      - release*
-      - ci-diagnose*
   pull_request:
     branches:
       - master

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -2,12 +2,6 @@ name: FloPy documentation
 
 on:
   push:
-    branches:
-      - master
-      - develop
-      - release*
-      - ci-diagnose*
-      - notebooks*
   pull_request:
     branches:
       - master


### PR DESCRIPTION
Always run commit-triggered workflows (`commit.yml`, `rtd.yml`, `mf6.yml`) on push.

This was suggested recently by @spaulins-usgs. CI testing work on a personal fork before opening a PR avoids consuming the upstream org's actions quota. To do this currently requires adding the branch name to the workflow's `on.push.branches`, then removing it before the PR is merged. This is inconvenient and easily neglected.

It seems safe to assume contributors generally want CI to run on their fork. To exclude a branch, [`branches-ignore`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore) can be used if needed.

Existing branch filters are still kept for PR triggers.