### PR TITLE
update(model_splitter.py): 

### DIFF
--- a/.docs/Notebooks/mf6_parallel_model_splitting_example.py
+++ b/.docs/Notebooks/mf6_parallel_model_splitting_example.py
@@ -188,7 +188,7 @@ for pkg in pkgs:
         pak = model.get_package(pkg)
         try:
             rarrays[ix + 1] = pak.stress_period_data.data[0]
-        except TypeError:
+        except (TypeError, AttributeError):
             pass
     recarray = mfsplit.reconstruct_recarray(rarrays)
     if pkg == "riv":

--- a/flopy/mf6/utils/model_splitter.py
+++ b/flopy/mf6/utils/model_splitter.py
@@ -2956,7 +2956,6 @@ class Mf6Splitter(object):
                     continue
 
                 for mkey in mapped_data.keys():
-
                     if mapped_data[mkey]:
                         if item in mapped_data[mkey]:
                             continue


### PR DESCRIPTION
* add check for no boundary condition instances in list based input packages. Do not write package in this case
* update options setting routine to respect previously set options for split models 
* remove maxbound variable from mapped_data for list based input packages. Allows for dynamic maxbound setting by flopy built ins