### PR TITLE
refactor(datafiles): use 0-based kstp/kper indexing

### DIFF
--- a/flopy/utils/binaryfile.py
+++ b/flopy/utils/binaryfile.py
@@ -1514,9 +1514,6 @@ class CellBudgetFile:
         list of (kstp, kper) tuples
             List of unique combinations of stress period &
             time step indices (0-based) in the binary file
-
-        .. deprecated:: 3.5
-            Use kstpkper property instead
         """
         return self.kstpkper
 

--- a/flopy/utils/binaryfile.py
+++ b/flopy/utils/binaryfile.py
@@ -829,7 +829,7 @@ class HeadUFile(BinaryLayerFile):
     >>> import flopy.utils.binaryfile as bf
     >>> hdobj = bf.HeadUFile('model.hds')
     >>> hdobj.list_records()
-    >>> usgheads = hdobj.get_data(kstpkper=(1, 50))
+    >>> usgheads = hdobj.get_data(kstpkper=(0, 49))
 
     """
 

--- a/flopy/utils/datafile.py
+++ b/flopy/utils/datafile.py
@@ -477,7 +477,8 @@ class LayerFile:
 
     def get_kstpkper(self):
         """
-        Get stress period and time step tuples.
+        Get a list of unique tuples (stress period, time step) in the file.
+        Indices are 0-based, use `kstpkper` attribute for 1-based.
 
         Returns
         -------
@@ -485,7 +486,7 @@ class LayerFile:
             List of unique combinations of stress period &
             time step indices (0-based) in the binary file
         """
-        return self.kstpkper
+        return [(kstp - 1, kper - 1) for kstp, kper in self.kstpkper]
 
     def get_data(self, kstpkper=None, idx=None, totim=None, mflay=None):
         """

--- a/flopy/utils/datafile.py
+++ b/flopy/utils/datafile.py
@@ -149,9 +149,8 @@ class Header:
 
 class LayerFile:
     """
-    The LayerFile class is the abstract base class from which specific derived
-    classes are formed.  LayerFile This class should not be instantiated
-    directly.
+    Base class for layered output files.
+    Do not instantiate directly.
 
     """
 
@@ -478,7 +477,7 @@ class LayerFile:
     def get_kstpkper(self):
         """
         Get a list of unique tuples (stress period, time step) in the file.
-        Indices are 0-based, use `kstpkper` attribute for 1-based.
+        Indices are 0-based, use the `kstpkper` attribute for 1-based.
 
         Returns
         -------
@@ -495,10 +494,9 @@ class LayerFile:
         Parameters
         ----------
         idx : int
-            The zero-based record number.  The first record is record 0.
+            The zero-based record number. The first record is record 0.
         kstpkper : tuple of ints
-            A tuple containing the time step and stress period (kstp, kper).
-            These are zero-based kstp and kper values.
+            A tuple (kstep, kper) of zero-based time step and stress period.
         totim : float
             The simulation time.
         mflay : integer
@@ -511,14 +509,9 @@ class LayerFile:
             Array has size (nlay, nrow, ncol) if mflay is None or it has size
             (nrow, ncol) if mlay is specified.
 
-        See Also
-        --------
-
         Notes
         -----
-        if both kstpkper and totim are None, will return the last entry
-        Examples
-        --------
+        If both kstpkper and totim are None, the last entry will be returned.
 
         """
         # One-based kstp and kper for pulling out of recarray

--- a/flopy/utils/datafile.py
+++ b/flopy/utils/datafile.py
@@ -477,19 +477,18 @@ class LayerFile:
 
     def get_kstpkper(self):
         """
-        Get a list of unique stress periods and time steps in the file
+        Get stress period and time step tuples.
 
         Returns
-        ----------
-        out : list of (kstp, kper) tuples
-            List of unique kstp, kper combinations in binary file.  kstp and
-            kper values are presently zero-based.
+        -------
+        list of (kstp, kper) tuples
+            List of unique combinations of stress period &
+            time step indices (0-based) in the binary file
 
+        .. deprecated:: 3.5
+            Use kstpkper property instead
         """
-        kstpkper = []
-        for kstp, kper in self.kstpkper:
-            kstpkper.append((kstp - 1, kper - 1))
-        return kstpkper
+        return self.kstpkper
 
     def get_data(self, kstpkper=None, idx=None, totim=None, mflay=None):
         """

--- a/flopy/utils/datafile.py
+++ b/flopy/utils/datafile.py
@@ -484,9 +484,6 @@ class LayerFile:
         list of (kstp, kper) tuples
             List of unique combinations of stress period &
             time step indices (0-based) in the binary file
-
-        .. deprecated:: 3.5
-            Use kstpkper property instead
         """
         return self.kstpkper
 

--- a/flopy/utils/formattedfile.py
+++ b/flopy/utils/formattedfile.py
@@ -117,7 +117,7 @@ class FormattedLayerFile(LayerFile):
         Build the recordarray and iposarray, which maps the header information
         to the position in the formatted file.
         """
-        self.kstpkper  # 0-based array of time step/stress periods
+        self.kstpkper  # 1-based array of time step/stress periods
         self.recordarray  # array of data headers
         self.iposarray  # array of seek positions for each record
         self.nlay  # Number of model layers
@@ -155,7 +155,6 @@ class FormattedLayerFile(LayerFile):
         self.recordarray = np.array(self.recordarray, self.header.get_dtype())
         self.iposarray = np.array(self.iposarray)
         self.nlay = np.max(self.recordarray["ilay"])
-        return
 
     def _store_record(self, header, ipos):
         """
@@ -167,7 +166,7 @@ class FormattedLayerFile(LayerFile):
         totim = header["totim"]
         if totim > 0 and totim not in self.times:
             self.times.append(totim)
-        kstpkper = (header["kstp"] - 1, header["kper"] - 1)
+        kstpkper = (header["kstp"], header["kper"])
         if kstpkper not in self.kstpkper:
             self.kstpkper.append(kstpkper)
 
@@ -356,7 +355,7 @@ class FormattedHeadFile(FormattedLayerFile):
     >>> import flopy.utils.formattedfile as ff
     >>> hdobj = ff.FormattedHeadFile('model.fhd', precision='single')
     >>> hdobj.list_records()
-    >>> rec = hdobj.get_data(kstpkper=(0, 50))
+    >>> rec = hdobj.get_data(kstpkper=(0, 49))
     >>> rec2 = ddnobj.get_data(totim=100.)
 
     """
@@ -371,7 +370,6 @@ class FormattedHeadFile(FormattedLayerFile):
     ):
         self.text = text
         super().__init__(filename, precision, verbose, kwargs)
-        return
 
     def _get_text_header(self):
         """

--- a/flopy/utils/formattedfile.py
+++ b/flopy/utils/formattedfile.py
@@ -117,7 +117,7 @@ class FormattedLayerFile(LayerFile):
         Build the recordarray and iposarray, which maps the header information
         to the position in the formatted file.
         """
-        self.kstpkper  # array of time step/stress periods with data available
+        self.kstpkper  # 0-based array of time step/stress periods
         self.recordarray  # array of data headers
         self.iposarray  # array of seek positions for each record
         self.nlay  # Number of model layers
@@ -167,7 +167,7 @@ class FormattedLayerFile(LayerFile):
         totim = header["totim"]
         if totim > 0 and totim not in self.times:
             self.times.append(totim)
-        kstpkper = (header["kstp"], header["kper"])
+        kstpkper = (header["kstp"] - 1, header["kper"] - 1)
         if kstpkper not in self.kstpkper:
             self.kstpkper.append(kstpkper)
 
@@ -356,9 +356,8 @@ class FormattedHeadFile(FormattedLayerFile):
     >>> import flopy.utils.formattedfile as ff
     >>> hdobj = ff.FormattedHeadFile('model.fhd', precision='single')
     >>> hdobj.list_records()
-    >>> rec = hdobj.get_data(kstpkper=(1, 50))
+    >>> rec = hdobj.get_data(kstpkper=(0, 50))
     >>> rec2 = ddnobj.get_data(totim=100.)
-
 
     """
 


### PR DESCRIPTION
Prompted by #1338

Plan originally proposed/implemented but abandoned (see discussion below):

* use 0-based indexing for both `kstpkper` attribute and `get_kstpkper()` method
* deprecate `get_kstpkper()` method (redundant)
* applies to
  * `LayerFile` and children
  * `BinaryLayerFile` and children
  * `CellBudgetFile`