### PR TITLE
fix(PlotCrossSection): boundary conditions not plotting for DISU

### DIFF
--- a/flopy/plot/crosssection.py
+++ b/flopy/plot/crosssection.py
@@ -877,14 +877,18 @@ class PlotCrossSection:
                 else:
                     idx = mflist["node"]
 
-        if len(self.mg.shape) != 3:
-            plotarray = np.zeros((self._nlay, self._ncpl), dtype=int)
-            plotarray[tuple(idx)] = 1
-        else:
+        if len(self.mg.shape) == 3:
             plotarray = np.zeros(
                 (self.mg.nlay, self.mg.nrow, self.mg.ncol), dtype=int
             )
             plotarray[idx[0], idx[1], idx[2]] = 1
+        elif len(self.mg.shape) == 2:
+            plotarray = np.zeros((self._nlay, self._ncpl), dtype=int)
+            plotarray[tuple(idx)] = 1
+        else:
+            plotarray = np.zeros(self._ncpl, dtype=int)
+            idx = idx.flatten()
+            plotarray[idx] = 1
 
         plotarray = np.ma.masked_equal(plotarray, 0)
         if color is None:


### PR DESCRIPTION
* Update the `plot_bc` method to work properly for fully unstructured grids