### PR TITLE
docs(notebooks): fix cell center for Simple MODFLOW 6 Model

### DIFF
--- a/.docs/Notebooks/mf6_simple_model_example.py
+++ b/.docs/Notebooks/mf6_simple_model_example.py
@@ -125,7 +125,7 @@ npf = flopy.mf6.modflow.mfgwfnpf.ModflowGwfnpf(
 # must be entered as a tuple as the first entry.
 # Remember that these must be zero-based indices!
 chd_rec = []
-chd_rec.append(((0, int(N / 4), int(N / 4)), h2))
+chd_rec.append(((0, int(N / 2), int(N / 2)), h2))
 for layer in range(0, Nlay):
     for row_col in range(0, N):
         chd_rec.append(((layer, row_col, 0), h1))


### PR DESCRIPTION
This PR fixes the [Simple MODFLOW 6 Model Example](https://flopy.readthedocs.io/en/3.4.3/Notebooks/mf6_simple_model_example.html), which is based on the [Lake Package Example](https://flopy.readthedocs.io/en/3.4.3/Notebooks/lake_example.html) for mf2005. These models set the "head at the cell in the center in the top layer is fixed to `h2`". The older example is correct, but the MF6 example puts this cell in the middle of the upper left quadrant, and not in the center of the top layer.