### PR TITLE
fix(release.yml): don't regenerate pkgs from mf6 main on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,9 +63,6 @@ jobs:
           python -c "import flopy; print(f'FloPy version: {flopy.__version__}')"
           echo "version=${ver#"v"}" >> $GITHUB_OUTPUT
 
-      - name: Update FloPy packages
-        run: python -m flopy.mf6.utils.generate_classes --ref master --no-backup
-
       - name: Lint Python files
         run: python scripts/pull_request_prepare.py
 


### PR DESCRIPTION
* support for mf6 develop and last mf6 release is expected as is, without recreating pkgs