### PR TITLE
refactor(.gitattributes): exclude examples/data from linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,3 +16,6 @@
 # Do not modify the model data in various directories
 examples/data/** binary
 .docs/groundwater_paper/uspb/** binary
+
+# Exclude example data folder
+examples/data/** linguist-documentation


### PR DESCRIPTION
* `.bas` (and other?) model input files might be interpreted as visual basic by [linguist](https://github.com/github-linguist/linguist/tree/master)?
* mark `examples/data` as docs to exclude from linguist processing
* hopefully repo metadata will be corrected to (mostly) python