### PR TITLE
refactor(.gitattributes): Configure github-linguist exclusions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,5 +17,7 @@
 examples/data/** binary
 .docs/groundwater_paper/uspb/** binary
 
-# Exclude example data folder
-examples/data/** linguist-documentation
+# Configure github-linguist exclusions
+*.bas -linguist-detectable
+.docs/** linguist-documentation
+docs/** linguist-documentation


### PR DESCRIPTION
This is a more general fix that supersedes #2017.

Before this PR, one 22 MB file (`.docs/groundwater_paper/uspb/flopy/DG.bas`) was falsely marked as "Visual Basic 6.0" constituting 
74.0% of the total code (by bytes).

The result from `github-linguist` is now 100% Python.