### PR TITLE
fix(gridgen): support arbitrary path-like for shapefiles

### DIFF
--- a/.docs/Notebooks/gridgen_example.py
+++ b/.docs/Notebooks/gridgen_example.py
@@ -25,7 +25,6 @@
 
 # +
 import os
-import shutil
 import sys
 from tempfile import TemporaryDirectory
 

--- a/autotest/test_gridgen.py
+++ b/autotest/test_gridgen.py
@@ -11,6 +11,7 @@ from modflow_devtools.markers import requires_exe, requires_pkg
 from modflow_devtools.misc import has_pkg
 
 import flopy
+from flopy.discretization.unstructuredgrid import UnstructuredGrid
 from flopy.discretization.vertexgrid import VertexGrid
 from flopy.utils.gridgen import Gridgen
 
@@ -26,7 +27,7 @@ def test_ctor_accepts_path_or_string_model_ws(function_tmpdir):
     assert g.model_ws == function_tmpdir
 
 
-def base_grid():
+def get_structured_grid():
     """Get a small version of the first grid in:
     .docs/Notebooks/gridgen_example.py"""
 
@@ -57,64 +58,96 @@ def base_grid():
 
 
 @requires_exe("gridgen")
-def test_add_active_domain(function_tmpdir):
-    bgrid = base_grid()
-    grids = []
+# GRIDGEN seems not to like paths containing "[" or "]", as
+# function_tmpdir does with parametrization, do it manually
+# @pytest.mark.parametrize("grid_type", ["vertex", "unstructured"])
+def test_add_active_domain(function_tmpdir):  # , grid_type):
+    bgrid = get_structured_grid()
 
     # test providing active domain various ways
-    for feature in [
-        [[[(0, 0), (0, 60), (40, 80), (60, 0), (0, 0)]]],
-        function_tmpdir / "ad0.shp",
-        function_tmpdir / "ad0",
-        "ad0.shp",
-        "ad0",
-    ]:
-        gridgen = Gridgen(bgrid, model_ws=function_tmpdir)
-        gridgen.add_active_domain(
-            feature,
-            range(bgrid.nlay),
-        )
-        gridgen.build()
-        grid = VertexGrid(**gridgen.get_gridprops_vertexgrid())
-        grid.plot()
-        grids.append(grid)
-        # plt.show()
+    for grid_type in ["vertex", "unstructured"]:
+        grids = []
+        for feature in [
+            [[[(0, 0), (0, 60), (40, 80), (60, 0), (0, 0)]]],
+            function_tmpdir / "ad0.shp",
+            function_tmpdir / "ad0",
+            "ad0.shp",
+            "ad0",
+        ]:
+            print(
+                "Testing add_active_domain() for",
+                grid_type,
+                "grid with features",
+                feature,
+            )
+            gridgen = Gridgen(bgrid, model_ws=function_tmpdir)
+            gridgen.add_active_domain(
+                feature,
+                range(bgrid.nlay),
+            )
+            gridgen.build()
+            grid = (
+                VertexGrid(**gridgen.get_gridprops_vertexgrid())
+                if grid_type == "vertex"
+                else UnstructuredGrid(
+                    **gridgen.get_gridprops_unstructuredgrid()
+                )
+            )
+            grid.plot()
+            grids.append(grid)
+            # plt.show()
 
-        assert grid.nnodes < bgrid.nnodes
-        assert grid.ncpl != bgrid.ncpl
-        assert all(grid.ncpl == g.ncpl for g in grids)
-        assert all(grid.nnodes == g.nnodes for g in grids)
+            assert grid.nnodes < bgrid.nnodes
+            assert not np.array_equal(grid.ncpl, bgrid.ncpl)
+            assert all(np.array_equal(grid.ncpl, g.ncpl) for g in grids)
+            assert all(grid.nnodes == g.nnodes for g in grids)
 
 
 @requires_exe("gridgen")
-def test_add_refinement_feature(function_tmpdir):
-    bgrid = base_grid()
-    grids = []
+# GRIDGEN seems not to like paths containing "[" or "]", as
+# function_tmpdir does with parametrization, do it manually
+# @pytest.mark.parametrize("grid_type", ["vertex", "unstructured"])
+def test_add_refinement_feature(function_tmpdir):  # , grid_type):
+    bgrid = get_structured_grid()
 
     # test providing refinement feature various ways
-    for features in [
-        [[[(0, 0), (0, 60), (40, 80), (60, 0), (0, 0)]]],
-        function_tmpdir / "rf0.shp",
-        function_tmpdir / "rf0",
-        "rf0.shp",
-        "rf0",
-    ]:
-        gridgen = Gridgen(bgrid, model_ws=function_tmpdir)
-        gridgen.add_refinement_features(
-            features,
-            "polygon",
-            1,
-            range(bgrid.nlay),
-        )
-        gridgen.build()
-        grid = VertexGrid(**gridgen.get_gridprops_vertexgrid())
-        grid.plot()
-        # plt.show()
+    for grid_type in ["vertex", "unstructured"]:
+        grids = []
+        for features in [
+            [[[(0, 0), (0, 60), (40, 80), (60, 0), (0, 0)]]],
+            function_tmpdir / "rf0.shp",
+            function_tmpdir / "rf0",
+            "rf0.shp",
+            "rf0",
+        ]:
+            print(
+                "Testing add_refinement_feature() for",
+                grid_type,
+                "grid with features",
+                features,
+            )
+            gridgen = Gridgen(bgrid, model_ws=function_tmpdir)
+            gridgen.add_refinement_features(
+                features,
+                "polygon",
+                1,
+                range(bgrid.nlay),
+            )
+            gridgen.build()
+            grid = (
+                VertexGrid(**gridgen.get_gridprops_vertexgrid())
+                if grid_type == "vertex"
+                else UnstructuredGrid(
+                    **gridgen.get_gridprops_unstructuredgrid()
+                )
+            )
+            grid.plot()
+            # plt.show()
 
-        assert grid.nnodes > bgrid.nnodes
-        assert grid.ncpl != bgrid.ncpl
-        assert all(grid.ncpl == g.ncpl for g in grids)
-        assert all(grid.nnodes == g.nnodes for g in grids)
+            assert grid.nnodes > bgrid.nnodes
+            assert not np.array_equal(grid.ncpl, bgrid.ncpl)
+            assert all(np.array_equal(grid.ncpl, g.ncpl) for g in grids)
+            assert all(grid.nnodes == g.nnodes for g in grids)
 
 
 @pytest.mark.slow

--- a/flopy/utils/gridgen.py
+++ b/flopy/utils/gridgen.py
@@ -286,9 +286,7 @@ class Gridgen:
         # Set up a blank _refinement_features list with empty list for
         # each layer
         self._rfdict = {}
-        self._refinement_features = []
-        for k in range(self.nlay):
-            self._refinement_features.append([])
+        self._refinement_features = [[] for _ in range(self.nlay)]
 
         # Set up blank _elev and _elev_extent dictionaries
         self._asciigrid_dict = {}
@@ -403,7 +401,7 @@ class Gridgen:
         # expand shapefile path or create one from polygon feature
         if isinstance(feature, (str, os.PathLike)):
             shapefile_path = self.resolve_shapefile_path(feature)
-        elif isinstance(feature, list):
+        elif isinstance(feature, (list, tuple, np.ndarray)):
             shapefile_path = self.model_ws / f"ad{len(self._addict)}.shp"
             features_to_shapefile(feature, "polygon", shapefile_path)
         else:

--- a/flopy/utils/gridgen.py
+++ b/flopy/utils/gridgen.py
@@ -14,6 +14,7 @@ from ..mfusg.mfusgdisu import MfUsgDisU
 from ..modflow import ModflowDis
 from ..utils import import_optional_dependency
 from .util_array import Util2d  # read1d,
+from ..utils.flopy_io import relpath_safe
 
 # todo
 # creation of line and polygon shapefiles from features (holes!)
@@ -407,7 +408,9 @@ class Gridgen:
         ), f"Shapefile does not exist: {shapefile_path}"
 
         # store shapefile info
-        self._addict[shapefile_path.stem] = shapefile_path
+        self._addict[shapefile_path.stem] = relpath_safe(
+            shapefile_path, self.model_ws
+        )
         for k in layers:
             self._active_domain[k] = shapefile_path.stem
 
@@ -460,7 +463,7 @@ class Gridgen:
 
         # store shapefile info
         self._rfdict[shapefile_path.stem] = [
-            shapefile_path,
+            relpath_safe(shapefile_path, self.model_ws),
             featuretype,
             level,
         ]

--- a/flopy/utils/gridgen.py
+++ b/flopy/utils/gridgen.py
@@ -13,8 +13,8 @@ from ..mf6.modflow import ModflowGwfdis
 from ..mfusg.mfusgdisu import MfUsgDisU
 from ..modflow import ModflowDis
 from ..utils import import_optional_dependency
-from .util_array import Util2d  # read1d,
 from ..utils.flopy_io import relpath_safe
+from .util_array import Util2d  # read1d,
 
 # todo
 # creation of line and polygon shapefiles from features (holes!)


### PR DESCRIPTION
* close #2024 
* follow up to #2022 
* support arbitrary paths as `feature`/`features` params to `add_active_domain()`/`add_refinement_feature()`
* support and test shapefile names with/without ".shp" extension (for backwards-compatibility)
* use `ValueError` instead of `Exception` where appropriate