### PR TITLE
docs(rtd): various cleanup

### DIFF
--- a/.docs/conf.py
+++ b/.docs/conf.py
@@ -105,8 +105,8 @@ if not on_rtd:
         os.system(" ".join(cmd))
 
 # -- Project information -----------------------------------------------------
-project = "FloPy Documentation"
-copyright = f"2022, {__author__}"
+project = "FloPy"
+copyright = f"2024, {__author__}"
 author = __author__
 
 # The version.

--- a/.docs/main.rst
+++ b/.docs/main.rst
@@ -3,9 +3,12 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+FloPy
+=====
+
 .. image:: _images/flopylogo.png
 
-**Documentation for version 3.5.0.dev0**
+**Documentation for version 3.6.0.dev0**
 
 Documentation is generated with Sphinx from the `FloPy repository <https://github.com/modflowpy/flopy>`_.
 
@@ -29,4 +32,3 @@ Indices and tables
 
 * :ref:`genindex`
 * :ref:`modindex`
-* :ref:`search`


### PR DESCRIPTION
* title was previously "Indices and tables &mdash; Flopy Documentation \<version> documentation"
  * rename header in `main.rst` from "Indices and tables" -> "FloPy"
  * rename project from "FloPy Documentation" -> "FloPy" in `conf.py`
  * title will now appear simply as "FloPy &mdash; FloPy \<version> documentation"
* remove the ["Search page"](https://flopy.readthedocs.io/en/latest/search.html) link under "Indices and tables" section in `main.rst` &mdash; leads to an [empty page](https://flopy.readthedocs.io/en/latest/search.html) and there is a search box in the left panel anyway
* update version in `main.rst` to 6.5.0.dev0 (this gets auto-updated whenever docs are built, just updating to stay current with status of `develop` branch)
* update copyright year in `conf.py` from 2022 -> 2024