### PR TITLE
docs(rtd): pin nbconvert < 7.14

### DIFF
--- a/autotest/test_notebooks.py
+++ b/autotest/test_notebooks.py
@@ -1,5 +1,4 @@
 import re
-from pathlib import Path
 from pprint import pprint
 
 import pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ doc = [
     "ipython[kernel]",
     "jupytext",
     "myst-parser",
+    "nbconvert <7.14.0",
     "nbsphinx",
     "PyYAML",
     "rtds-action",


### PR DESCRIPTION
* fix nbsphinx build error due to nbconvert https://github.com/jupyter/nbconvert/issues/2092
* removed unused import in `test_notebooks.py`