### PR TITLE
fix(particledata): support 1D numpy array for partlocs

### DIFF
--- a/autotest/test_particledata.py
+++ b/autotest/test_particledata.py
@@ -129,6 +129,46 @@ def test_particledata_unstructured_ctor_with_partlocs_as_ndarray():
     )
 
 
+def test_particledata_unstructured_ctor_with_partlocs_as_list():
+    locs = [0, 1, 2]
+    data = ParticleData(partlocs=locs, structured=False)
+
+    assert data.particlecount == 3
+    assert data.dtype == unstructured_dtype
+    assert isinstance(data.particledata, pd.DataFrame)
+    assert np.array_equal(
+        data.particledata.to_records(index=False),
+        np.core.records.fromrecords(
+            [
+                (0, 0.5, 0.5, 0.5, 0.0, 0),
+                (1, 0.5, 0.5, 0.5, 0.0, 0),
+                (2, 0.5, 0.5, 0.5, 0.0, 0),
+            ],
+            dtype=unstructured_dtype,
+        ),
+    )
+
+
+def test_particledata_unstructured_ctor_with_partlocs_as_ndarray():
+    locs = np.array([0, 1, 2])
+    data = ParticleData(partlocs=locs, structured=False)
+
+    assert data.particlecount == 3
+    assert data.dtype == unstructured_dtype
+    assert isinstance(data.particledata, pd.DataFrame)
+    assert np.array_equal(
+        data.particledata.to_records(index=False),
+        np.core.records.fromrecords(
+            [
+                (0, 0.5, 0.5, 0.5, 0.0, 0),
+                (1, 0.5, 0.5, 0.5, 0.0, 0),
+                (2, 0.5, 0.5, 0.5, 0.0, 0),
+            ],
+            dtype=unstructured_dtype,
+        ),
+    )
+
+
 def test_particledata_structured_ctor_with_partlocs_as_list_of_lists():
     locs = [list(p) for p in [(0, 1, 1), (0, 1, 2)]]
     data = ParticleData(partlocs=locs, structured=True)

--- a/autotest/test_particledata.py
+++ b/autotest/test_particledata.py
@@ -59,6 +59,16 @@ structured_dtype = np.dtype(
         ("drape", "<i4"),
     ]
 )
+unstructured_dtype = np.dtype(
+    [
+        ("node", "<i4"),
+        ("localx", "<f4"),
+        ("localy", "<f4"),
+        ("localz", "<f4"),
+        ("timeoffset", "<f4"),
+        ("drape", "<i4"),
+    ]
+)
 
 
 def test_particledata_structured_ctor_with_partlocs_as_list_of_tuples():
@@ -95,6 +105,26 @@ def test_particledata_structured_ctor_with_partlocs_as_ndarray():
                 (0, 1, 2, 0.5, 0.5, 0.5, 0.0, 0),
             ],
             dtype=structured_dtype,
+        ),
+    )
+
+
+def test_particledata_unstructured_ctor_with_partlocs_as_ndarray():
+    locs = np.array([0, 1, 2])
+    data = ParticleData(partlocs=locs, structured=False)
+
+    assert data.particlecount == 3
+    assert data.dtype == unstructured_dtype
+    assert isinstance(data.particledata, pd.DataFrame)
+    assert np.array_equal(
+        data.particledata.to_records(index=False),
+        np.core.records.fromrecords(
+            [
+                (0, 0.5, 0.5, 0.5, 0.0, 0),
+                (1, 0.5, 0.5, 0.5, 0.0, 0),
+                (2, 0.5, 0.5, 0.5, 0.0, 0),
+            ],
+            dtype=unstructured_dtype,
         ),
     )
 

--- a/flopy/modpath/mp7particledata.py
+++ b/flopy/modpath/mp7particledata.py
@@ -166,12 +166,17 @@ class ParticleData:
                         "one entry".format(self.name)
                     )
 
-            # convert partlocs composed of a lists/tuples of lists/tuples
-            # to a numpy array
+            # convert partlocs to numpy array with proper dtype
+            partlocs = np.array(partlocs)
+            if len(partlocs.shape) == 1:
+                partlocs = partlocs.reshape(len(partlocs), 1)
             partlocs = unstructured_to_structured(
                 np.array(partlocs), dtype=dtype
             )
         elif isinstance(partlocs, np.ndarray):
+            # reshape and convert dtype if needed
+            if len(partlocs.shape) == 1:
+                partlocs = partlocs.reshape(len(partlocs), 1)
             dtypein = partlocs.dtype
             if dtypein != dtype:
                 partlocs = unstructured_to_structured(partlocs, dtype=dtype)


### PR DESCRIPTION
* fix #2072 
* 1D arrays were passed straight to [`numpy.lib.recfunctions.unstructured_to_structured`](https://numpy.org/doc/stable/user/basics.rec.html#numpy.lib.recfunctions.unstructured_to_structured), which when given an array with N dimensions, attempts to return an N-1 dimensional array of structures, so argument needs to be at least 2D