### PR TITLE
refactor(dependencies): remove python-dateutil

### DIFF
--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -31,7 +31,6 @@ dependencies:
   - virtualenv
 
   # optional
-  - python-dateutil>=2.4.0
   - affine
   - scipy
   - pandas

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ optional = [
     "pymetis ; platform_system != 'Windows'",
     "pyproj",
     "pyshp",
-    "python-dateutil >=2.4.0",
     "pyvista",
     "rasterio",
     "rasterstats",


### PR DESCRIPTION
* `python-dateutil` is already [required by pandas](https://github.com/pandas-dev/pandas/blob/24f7db72a3c93a4d0cfa3763724c01ac65d412c6/pyproject.toml#L35), don't need to list it explicitly
* prevents optional dependency CI testing failures [like this](https://github.com/modflowpy/flopy/actions/runs/7738242585/job/21098676085#step:6:447)