### PR TITLE
hotfix(numpy 2.0 deprecation)

### DIFF
--- a/flopy/mf6/utils/model_splitter.py
+++ b/flopy/mf6/utils/model_splitter.py
@@ -427,7 +427,7 @@ class Mf6Splitter(object):
                     mnums1 = membership[nodes1]
                     mnums2 = membership[nodes2]
                     ev = np.equal(mnums1, mnums2)
-                    if np.alltrue(ev):
+                    if np.all(ev):
                         continue
                     idx = np.where(~ev)[0]
                     mnum_to = mnums1[idx]

--- a/flopy/plot/map.py
+++ b/flopy/plot/map.py
@@ -284,7 +284,7 @@ class PlotMapView:
                     for ix, nodes in enumerate(triangles):
                         neighbors = self.mg.neighbors(nodes[i], as_nodes=True)
                         isin = np.isin(nodes[i + 1 :], neighbors)
-                        if not np.alltrue(isin):
+                        if not np.all(isin):
                             mask[ix] = True
 
             if ismasked is not None:


### PR DESCRIPTION
simple fix for soon-to-be deprecated `np.alltrue`. See Issue #2086 - this sorts it out