### PR TITLE
fix(MFSimulationList): fix comma spacing in error message

### DIFF
--- a/flopy/mf6/utils/mfsimlistfile.py
+++ b/flopy/mf6/utils/mfsimlistfile.py
@@ -83,7 +83,7 @@ class MfSimulationList:
         if units not in UNITS:
             msg = (
                 "units input variable must be "
-                + " ,".join(UNITS)
+                + ", ".join(UNITS)
                 + f": {units} was specified."
             )
             raise ValueError(msg)


### PR DESCRIPTION
* previously error message was e.g. "units input variable must be seconds ,minutes ,hours: abc was specified."