### PR TITLE
refactor(dependencies): pin numpy<2 until other reqs support it

### DIFF
--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -6,7 +6,7 @@ dependencies:
 
   # required
   - python>=3.8
-  - numpy>=1.15.0
+  - numpy>=1.15.0,<2.0.0
   - matplotlib>=1.4.0
 
   # lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "numpy >=1.15.0",
+    "numpy >=1.15.0,<2.0.0",
     "matplotlib >=1.4.0",
     "pandas >=2.0.0"
 ]


### PR DESCRIPTION
* as recommended in https://github.com/numpy/numpy/issues/24300
* once required (pandas, matplotlib) and optional (e.g. scipy) dependencies support v2, a new flopy release can be made 
* #2089 originally proposed CI testing against numpy nightly build but this is not feasible until other deps support v2