### PR TITLE
fix(usgcln) add explicit second dimension to util2d.load calls

### DIFF
--- a/flopy/mfusg/mfusgcln.py
+++ b/flopy/mfusg/mfusgcln.py
@@ -625,13 +625,13 @@ class MfUsgCln(Package):
         if model.verbose:
             print("   Reading ibound...")
         ibound = Util2d.load(
-            f, model, (nclnnds,1), np.int32, "ibound", ext_unit_dict
+            f, model, (nclnnds, 1), np.int32, "ibound", ext_unit_dict
         )
 
         if model.verbose:
             print("   Reading strt...")
         strt = Util2d.load(
-            f, model, (nclnnds,1), np.float32, "strt", ext_unit_dict
+            f, model, (nclnnds, 1), np.float32, "strt", ext_unit_dict
         )
 
         if hasattr(f, "read"):
@@ -788,7 +788,7 @@ class MfUsgCln(Package):
             if model.verbose:
                 print("   Reading nndcln...")
             nndcln = Util2d.load(
-                f_obj, model, (ncln,1), np.int32, "nndcln", ext_unit_dict
+                f_obj, model, (ncln, 1), np.int32, "nndcln", ext_unit_dict
             )
             nclnnds = nndcln.array.sum()
             if iclnnds > 0:
@@ -814,13 +814,13 @@ class MfUsgCln(Package):
                 print("   Reading iac_cln...")
             nclnnds = abs(iclnnds)
             iac_cln = Util2d.load(
-                f_obj, model, (nclnnds,1), np.int32, "iac_cln", ext_unit_dict
+                f_obj, model, (nclnnds, 1), np.int32, "iac_cln", ext_unit_dict
             )
 
             if model.verbose:
                 print("   Reading ja_cln...")
             ja_cln = Util2d.load(
-                f_obj, model, (nja_cln,1), np.int32, "ja_cln", ext_unit_dict
+                f_obj, model, (nja_cln, 1), np.int32, "ja_cln", ext_unit_dict
             )
         else:
             raise Exception("mfcln: negative number of CLN segments")

--- a/flopy/mfusg/mfusgcln.py
+++ b/flopy/mfusg/mfusgcln.py
@@ -625,13 +625,13 @@ class MfUsgCln(Package):
         if model.verbose:
             print("   Reading ibound...")
         ibound = Util2d.load(
-            f, model, (nclnnds,), np.int32, "ibound", ext_unit_dict
+            f, model, (nclnnds,1), np.int32, "ibound", ext_unit_dict
         )
 
         if model.verbose:
             print("   Reading strt...")
         strt = Util2d.load(
-            f, model, (nclnnds,), np.float32, "strt", ext_unit_dict
+            f, model, (nclnnds,1), np.float32, "strt", ext_unit_dict
         )
 
         if hasattr(f, "read"):
@@ -788,7 +788,7 @@ class MfUsgCln(Package):
             if model.verbose:
                 print("   Reading nndcln...")
             nndcln = Util2d.load(
-                f_obj, model, (ncln,), np.int32, "nndcln", ext_unit_dict
+                f_obj, model, (ncln,1), np.int32, "nndcln", ext_unit_dict
             )
             nclnnds = nndcln.array.sum()
             if iclnnds > 0:
@@ -814,13 +814,13 @@ class MfUsgCln(Package):
                 print("   Reading iac_cln...")
             nclnnds = abs(iclnnds)
             iac_cln = Util2d.load(
-                f_obj, model, (nclnnds,), np.int32, "iac_cln", ext_unit_dict
+                f_obj, model, (nclnnds,1), np.int32, "iac_cln", ext_unit_dict
             )
 
             if model.verbose:
                 print("   Reading ja_cln...")
             ja_cln = Util2d.load(
-                f_obj, model, (nja_cln,), np.int32, "ja_cln", ext_unit_dict
+                f_obj, model, (nja_cln,1), np.int32, "ja_cln", ext_unit_dict
             )
         else:
             raise Exception("mfcln: negative number of CLN segments")


### PR DESCRIPTION
Util2d.load expects two dimensions. MfusgCln was previously specifying only the first for 1d arrays, but util2d requires both.