### PR TITLE
fix(gridintersect): gridintersect does not work for rotated vertex grids

### DIFF
--- a/autotest/test_gridintersect.py
+++ b/autotest/test_gridintersect.py
@@ -135,9 +135,7 @@ def test_rect_grid_3d_point_outside():
 
 @requires_pkg("shapely")
 def test_rect_grid_3d_point_inside():
-    botm = np.concatenate([np.ones(4), 0.5 * np.ones(4), np.zeros(4)]).reshape(
-        3, 2, 2
-    )
+    botm = np.concatenate([np.ones(4), 0.5 * np.ones(4), np.zeros(4)]).reshape(3, 2, 2)
     gr = get_rect_grid(top=np.ones(4), botm=botm)
     ix = GridIntersect(gr, method="structured")
     result = ix.intersect(Point(2.0, 2.0, 0.2))
@@ -456,9 +454,7 @@ def test_rect_grid_linestring_in_and_out_of_cell():
 def test_rect_grid_linestring_in_and_out_of_cell2():
     gr = get_rect_grid()
     ix = GridIntersect(gr, method="structured")
-    result = ix.intersect(
-        LineString([(5, 15), (5.0, 9), (15.0, 5.0), (5.0, 1.0)])
-    )
+    result = ix.intersect(LineString([(5, 15), (5.0, 9), (15.0, 5.0), (5.0, 1.0)]))
     assert len(result) == 3
     # assert result.cellids[0] == (1, 0)
     # assert result.cellids[1] == (1, 1)
@@ -755,9 +751,7 @@ def test_rect_grid_polygon_outside():
 def test_rect_grid_polygon_in_2cells():
     gr = get_rect_grid()
     ix = GridIntersect(gr, method="structured")
-    result = ix.intersect(
-        Polygon([(2.5, 5.0), (7.5, 5.0), (7.5, 15.0), (2.5, 15.0)])
-    )
+    result = ix.intersect(Polygon([(2.5, 5.0), (7.5, 5.0), (7.5, 15.0), (2.5, 15.0)]))
     assert len(result) == 2
     assert result.areas.sum() == 50.0
 
@@ -794,9 +788,7 @@ def test_rect_grid_polygon_running_along_boundary():
 def test_rect_grid_polygon_on_inner_boundary():
     gr = get_rect_grid()
     ix = GridIntersect(gr, method="structured")
-    result = ix.intersect(
-        Polygon([(5.0, 10.0), (15.0, 10.0), (15.0, 5.0), (5.0, 5.0)])
-    )
+    result = ix.intersect(Polygon([(5.0, 10.0), (15.0, 10.0), (15.0, 5.0), (5.0, 5.0)]))
     assert len(result) == 2
     assert result.areas.sum() == 50.0
 
@@ -977,9 +969,7 @@ def test_rect_grid_polygon_outside_shapely(rtree):
 def test_rect_grid_polygon_in_2cells_shapely(rtree):
     gr = get_rect_grid()
     ix = GridIntersect(gr, method="vertex", rtree=rtree)
-    result = ix.intersect(
-        Polygon([(2.5, 5.0), (7.5, 5.0), (7.5, 15.0), (2.5, 15.0)])
-    )
+    result = ix.intersect(Polygon([(2.5, 5.0), (7.5, 5.0), (7.5, 15.0), (2.5, 15.0)]))
     assert len(result) == 2
     assert result.areas.sum() == 50.0
 
@@ -1000,9 +990,7 @@ def test_rect_grid_polygon_on_outer_boundary_shapely(rtree):
 def test_rect_grid_polygon_on_inner_boundary_shapely(rtree):
     gr = get_rect_grid()
     ix = GridIntersect(gr, method="vertex", rtree=rtree)
-    result = ix.intersect(
-        Polygon([(5.0, 10.0), (15.0, 10.0), (15.0, 5.0), (5.0, 5.0)])
-    )
+    result = ix.intersect(Polygon([(5.0, 10.0), (15.0, 10.0), (15.0, 5.0), (5.0, 5.0)]))
     assert len(result) == 2
     assert result.areas.sum() == 50.0
 
@@ -1085,9 +1073,7 @@ def test_tri_grid_polygon_in_2cells(rtree):
     if gr == -1:
         return
     ix = GridIntersect(gr, rtree=rtree)
-    result = ix.intersect(
-        Polygon([(2.5, 5.0), (5.0, 5.0), (5.0, 15.0), (2.5, 15.0)])
-    )
+    result = ix.intersect(Polygon([(2.5, 5.0), (5.0, 5.0), (5.0, 15.0), (2.5, 15.0)]))
     assert len(result) == 2
     assert result.areas.sum() == 25.0
 
@@ -1112,9 +1098,7 @@ def test_tri_grid_polygon_on_inner_boundary(rtree):
     if gr == -1:
         return
     ix = GridIntersect(gr, rtree=rtree)
-    result = ix.intersect(
-        Polygon([(5.0, 10.0), (15.0, 10.0), (15.0, 5.0), (5.0, 5.0)])
-    )
+    result = ix.intersect(Polygon([(5.0, 10.0), (15.0, 10.0), (15.0, 5.0), (5.0, 5.0)]))
     assert len(result) == 4
     assert result.areas.sum() == 50.0
 
@@ -1241,6 +1225,10 @@ def test_point_offset_rot_structured_grid_shapely(rtree):
     ix = GridIntersect(sgr, method="vertex", rtree=rtree)
     result = ix.intersect(p)
     assert len(result) == 1
+    # check empty result when using local model coords
+    ix = GridIntersect(sgr, method="vertex", rtree=rtree, local=True)
+    result = ix.intersect(p)
+    assert len(result) == 0
 
 
 @requires_pkg("shapely")
@@ -1257,6 +1245,47 @@ def test_linestring_offset_rot_structured_grid_shapely(rtree):
 @rtree_toggle
 def test_polygon_offset_rot_structured_grid_shapely(rtree):
     sgr = get_rect_grid(angrot=45.0, xyoffset=10.0)
+    p = Polygon(
+        [
+            (5, 10.0 + np.sqrt(200.0)),
+            (15, 10.0 + np.sqrt(200.0)),
+            (15, 10.0 + 1.5 * np.sqrt(200.0)),
+            (5, 10.0 + 1.5 * np.sqrt(200.0)),
+        ]
+    )
+    ix = GridIntersect(sgr, method="vertex", rtree=rtree)
+    result = ix.intersect(p)
+    assert len(result) == 3
+
+
+@requires_pkg("shapely")
+@rtree_toggle
+def test_point_offset_rot_vertex_grid_shapely(rtree):
+    sgr = get_rect_vertex_grid(angrot=45.0, xyoffset=10.0)
+    p = Point(10.0, 10 + np.sqrt(200.0))
+    ix = GridIntersect(sgr, method="vertex", rtree=rtree)
+    result = ix.intersect(p)
+    assert len(result) == 1
+    # check empty result when using local model coords
+    ix = GridIntersect(sgr, method="vertex", rtree=rtree, local=True)
+    result = ix.intersect(p)
+    assert len(result) == 0
+
+
+@requires_pkg("shapely")
+@rtree_toggle
+def test_linestring_offset_rot_vertex_grid_shapely(rtree):
+    sgr = get_rect_vertex_grid(angrot=45.0, xyoffset=10.0)
+    ls = LineString([(5, 10.0 + np.sqrt(200.0)), (15, 10.0 + np.sqrt(200.0))])
+    ix = GridIntersect(sgr, method="vertex", rtree=rtree)
+    result = ix.intersect(ls)
+    assert len(result) == 2
+
+
+@requires_pkg("shapely")
+@rtree_toggle
+def test_polygon_offset_rot_vertex_grid_shapely(rtree):
+    sgr = get_rect_vertex_grid(angrot=45.0, xyoffset=10.0)
     p = Polygon(
         [
             (5, 10.0 + np.sqrt(200.0)),
@@ -1318,9 +1347,7 @@ def test_rasters(example_data_path):
     if (np.max(data) - 2608.557) > 1e-4:
         raise AssertionError
 
-    data = rio.resample_to_grid(
-        ml.modelgrid, band=rio.bands[0], method="nearest"
-    )
+    data = rio.resample_to_grid(ml.modelgrid, band=rio.bands[0], method="nearest")
     if data.size != 5913:
         raise AssertionError
     if abs(np.min(data) - 1942.1735) > 1e-4:
@@ -1369,12 +1396,8 @@ def test_raster_sampling_methods(example_data_path):
     }
 
     for method, value in methods.items():
-        data = rio.resample_to_grid(
-            ml.modelgrid, band=rio.bands[0], method=method
-        )
+        data = rio.resample_to_grid(ml.modelgrid, band=rio.bands[0], method=method)
 
         print(data[30, 37])
         if np.abs(data[30, 37] - value) > 1e-05:
-            raise AssertionError(
-                f"{method} resampling returning incorrect values"
-            )
+            raise AssertionError(f"{method} resampling returning incorrect values")

--- a/autotest/test_gridintersect.py
+++ b/autotest/test_gridintersect.py
@@ -1189,6 +1189,10 @@ def test_point_offset_rot_structured_grid():
     ix = GridIntersect(sgr, method="structured")
     result = ix.intersect(p)
     assert len(result) == 1
+    # check empty result when using local model coords
+    ix = GridIntersect(sgr, method="structured", local=True)
+    result = ix.intersect(p)
+    assert len(result) == 0
 
 
 @requires_pkg("shapely")
@@ -1197,8 +1201,11 @@ def test_linestring_offset_rot_structured_grid():
     ls = LineString([(5, 10.0 + np.sqrt(200.0)), (15, 10.0 + np.sqrt(200.0))])
     ix = GridIntersect(sgr, method="structured")
     result = ix.intersect(ls)
-    # NOTE: in shapely 2.0, this returns a Linestring with length 10^-15 in cell (0, 1)
-    assert len(result) == 2 or len(result) == 3
+    assert len(result) == 2
+    # check empty result when using local model coords
+    ix = GridIntersect(sgr, method="structured", local=True)
+    result = ix.intersect(ls)
+    assert len(result) == 0
 
 
 @requires_pkg("shapely")
@@ -1215,6 +1222,10 @@ def test_polygon_offset_rot_structured_grid():
     ix = GridIntersect(sgr, method="structured")
     result = ix.intersect(p)
     assert len(result) == 3
+    # check empty result when using local model coords
+    ix = GridIntersect(sgr, method="structured", local=True)
+    result = ix.intersect(p)
+    assert len(result) == 0
 
 
 @requires_pkg("shapely")
@@ -1239,6 +1250,10 @@ def test_linestring_offset_rot_structured_grid_shapely(rtree):
     ix = GridIntersect(sgr, method="vertex", rtree=rtree)
     result = ix.intersect(ls)
     assert len(result) == 2
+    # check empty result when using local model coords
+    ix = GridIntersect(sgr, method="vertex", rtree=rtree, local=True)
+    result = ix.intersect(ls)
+    assert len(result) == 0
 
 
 @requires_pkg("shapely")
@@ -1256,6 +1271,10 @@ def test_polygon_offset_rot_structured_grid_shapely(rtree):
     ix = GridIntersect(sgr, method="vertex", rtree=rtree)
     result = ix.intersect(p)
     assert len(result) == 3
+    # check empty result when using local model coords
+    ix = GridIntersect(sgr, method="vertex", rtree=rtree, local=True)
+    result = ix.intersect(p)
+    assert len(result) == 0
 
 
 @requires_pkg("shapely")
@@ -1280,6 +1299,10 @@ def test_linestring_offset_rot_vertex_grid_shapely(rtree):
     ix = GridIntersect(sgr, method="vertex", rtree=rtree)
     result = ix.intersect(ls)
     assert len(result) == 2
+    # check empty result when using local model coords
+    ix = GridIntersect(sgr, method="vertex", rtree=rtree, local=True)
+    result = ix.intersect(ls)
+    assert len(result) == 0
 
 
 @requires_pkg("shapely")
@@ -1297,6 +1320,10 @@ def test_polygon_offset_rot_vertex_grid_shapely(rtree):
     ix = GridIntersect(sgr, method="vertex", rtree=rtree)
     result = ix.intersect(p)
     assert len(result) == 3
+    # check empty result when using local model coords
+    ix = GridIntersect(sgr, method="vertex", rtree=rtree, local=True)
+    result = ix.intersect(p)
+    assert len(result) == 0
 
 
 # %% test rasters
@@ -1401,3 +1428,14 @@ def test_raster_sampling_methods(example_data_path):
         print(data[30, 37])
         if np.abs(data[30, 37] - value) > 1e-05:
             raise AssertionError(f"{method} resampling returning incorrect values")
+
+
+if __name__ == "__main__":
+    sgr = get_rect_grid(angrot=45.0, xyoffset=10.0)
+    ls = LineString([(5, 10.0 + np.sqrt(200.0)), (15, 10.0 + np.sqrt(200.0))])
+    ix = GridIntersect(sgr, method="structured")
+    result = ix.intersect(ls)
+    assert len(result) == 2
+    ix = GridIntersect(sgr, method="structured", local=True)
+    result = ix.intersect(ls)
+    assert len(result) == 0

--- a/flopy/discretization/grid.py
+++ b/flopy/discretization/grid.py
@@ -113,26 +113,12 @@ class Grid:
         rotation angle of model grid, as it is rotated around the origin point
     angrot_radians : float
         rotation angle of model grid, in radians
-    xgrid : ndarray
-        returns numpy meshgrid of x edges in reference frame defined by
-        point_type
-    ygrid : ndarray
-        returns numpy meshgrid of y edges in reference frame defined by
-        point_type
-    zgrid : ndarray
-        returns numpy meshgrid of z edges in reference frame defined by
-        point_type
     xcenters : ndarray
         returns x coordinate of cell centers
     ycenters : ndarray
         returns y coordinate of cell centers
     ycenters : ndarray
         returns z coordinate of cell centers
-    xyzgrid : [ndarray, ndarray, ndarray]
-        returns the location of grid edges of all model cells. if the model
-        grid contains spatial reference information, the grid edges are in the
-        coordinate system provided by the spatial reference information.
-        returns a list of three ndarrays for the x, y, and z coordinates
     xyzcellcenters : [ndarray, ndarray, ndarray]
         returns the cell centers of all model cells in the model grid.  if
         the model grid contains spatial reference information, the cell centers
@@ -150,10 +136,6 @@ class Grid:
         returns the model grid lines in a list.  each line is returned as a
         list containing two tuples in the format [(x1,y1), (x2,y2)] where
         x1,y1 and x2,y2 are the endpoints of the line.
-    xyvertices : (point_type) : ndarray
-        1D array of x and y coordinates of cell vertices for whole grid
-        (single layer) in C-style (row-major) order
-        (same as np.ravel())
 
     See Also
     --------

--- a/flopy/utils/gridintersect.py
+++ b/flopy/utils/gridintersect.py
@@ -258,7 +258,10 @@ class GridIntersect:
         shp = gu.shapely
 
         if gu.shapetype in ("Point", "MultiPoint"):
-            if self.method == "structured" and self.mfgrid.grid_type == "structured":
+            if (
+                self.method == "structured"
+                and self.mfgrid.grid_type == "structured"
+            ):
                 rec = self._intersect_point_structured(
                     shp, return_all_intersections=return_all_intersections
                 )
@@ -276,7 +279,10 @@ class GridIntersect:
                         return_all_intersections=return_all_intersections,
                     )
         elif gu.shapetype in ("LineString", "MultiLineString"):
-            if self.method == "structured" and self.mfgrid.grid_type == "structured":
+            if (
+                self.method == "structured"
+                and self.mfgrid.grid_type == "structured"
+            ):
                 rec = self._intersect_linestring_structured(
                     shp,
                     keepzerolengths,
@@ -298,7 +304,10 @@ class GridIntersect:
                         return_all_intersections=return_all_intersections,
                     )
         elif gu.shapetype in ("Polygon", "MultiPolygon"):
-            if self.method == "structured" and self.mfgrid.grid_type == "structured":
+            if (
+                self.method == "structured"
+                and self.mfgrid.grid_type == "structured"
+            ):
                 rec = self._intersect_polygon_structured(
                     shp,
                     contains_centroid=contains_centroid,
@@ -429,7 +438,8 @@ class GridIntersect:
             for icell in self.mfgrid._cell2d.icell2d:
                 points = []
                 icverts = [
-                    f"icvert_{i}" for i in range(self.mfgrid._cell2d["ncvert"][icell])
+                    f"icvert_{i}"
+                    for i in range(self.mfgrid._cell2d["ncvert"][icell])
                 ]
                 for iv in self.mfgrid._cell2d[icverts][icell]:
                     if self.local:
@@ -596,7 +606,10 @@ class GridIntersect:
             DeprecationWarning,
         )
         return [
-            igeom for _, igeom in sorted(zip(cellids, geoms), key=lambda pair: pair[0])
+            igeom
+            for _, igeom in sorted(
+                zip(cellids, geoms), key=lambda pair: pair[0]
+            )
         ]
 
     def _intersect_point_shapely(
@@ -650,7 +663,9 @@ class GridIntersect:
             # do intersection
             intersect = shp.intersection(r)
             # parse result per Point
-            collection = parse_shapely_ix_result([], intersect, shptyps=["Point"])
+            collection = parse_shapely_ix_result(
+                [], intersect, shptyps=["Point"]
+            )
             # loop over intersection result and store information
             cell_verts = []
             cell_shps = []
@@ -1017,7 +1032,9 @@ class GridIntersect:
 
                 # masks to obtain overlapping intersection result
                 mask_self = idxs == i  # select not self
-                mask_bnds_empty = shapely.is_empty(isect)  # select boundary ix result
+                mask_bnds_empty = shapely.is_empty(
+                    isect
+                )  # select boundary ix result
                 mask_overlap = np.isin(shapely.get_type_id(isect), [1, 5])
 
                 # calculate difference between self and overlapping result
@@ -1099,9 +1116,9 @@ class GridIntersect:
         # check centroids
         if contains_centroid:
             centroids = shapely.centroid(self.geoms[qcellids])
-            mask_centroid = shapely.contains(ixresult, centroids) | shapely.touches(
+            mask_centroid = shapely.contains(
                 ixresult, centroids
-            )
+            ) | shapely.touches(ixresult, centroids)
             ixresult = ixresult[mask_centroid]
             qcellids = qcellids[mask_centroid]
 
@@ -1290,7 +1307,9 @@ class GridIntersect:
                     tempnodes.append(node)
                     tempshapes.append(ixs)
                 else:
-                    tempshapes[-1] = shapely_geo.MultiPoint([tempshapes[-1], ixs])
+                    tempshapes[-1] = shapely_geo.MultiPoint(
+                        [tempshapes[-1], ixs]
+                    )
 
             ixshapes = tempshapes
             nodelist = tempnodes
@@ -1353,7 +1372,9 @@ class GridIntersect:
                 shp, xoff=-self.mfgrid.xoffset, yoff=-self.mfgrid.yoffset
             )
         if self.mfgrid.angrot != 0.0 and not self.local:
-            shp = affinity_loc.rotate(shp, -self.mfgrid.angrot, origin=(0.0, 0.0))
+            shp = affinity_loc.rotate(
+                shp, -self.mfgrid.angrot, origin=(0.0, 0.0)
+            )
 
         # clip line to mfgrid bbox
         lineclip = shp.intersection(pl)
@@ -1464,7 +1485,9 @@ class GridIntersect:
                 templengths.append(
                     sum([l for l, i in zip(lengths, nodelist) if i == inode])
                 )
-                tempverts.append([v for v, i in zip(vertices, nodelist) if i == inode])
+                tempverts.append(
+                    [v for v, i in zip(vertices, nodelist) if i == inode]
+                )
                 tempshapes.append(
                     [ix for ix, i in zip(ixshapes, nodelist) if i == inode]
                 )
@@ -1615,7 +1638,9 @@ class GridIntersect:
 
         return nodelist, lengths, vertices, ixshapes
 
-    def _check_adjacent_cells_intersecting_line(self, linestring, i_j, nodelist):
+    def _check_adjacent_cells_intersecting_line(
+        self, linestring, i_j, nodelist
+    ):
         """helper method that follows a line through a structured grid.
 
         Parameters
@@ -1908,12 +1933,16 @@ class GridIntersect:
         ixshapes = []
 
         # transform polygon to local grid coordinates
-        if (self.mfgrid.xoffset != 0.0 or self.mfgrid.yoffset != 0.0) and not self.local:
+        if (
+            self.mfgrid.xoffset != 0.0 or self.mfgrid.yoffset != 0.0
+        ) and not self.local:
             shp = affinity_loc.translate(
                 shp, xoff=-self.mfgrid.xoffset, yoff=-self.mfgrid.yoffset
             )
         if self.mfgrid.angrot != 0.0 and not self.local:
-            shp = affinity_loc.rotate(shp, -self.mfgrid.angrot, origin=(0.0, 0.0))
+            shp = affinity_loc.rotate(
+                shp, -self.mfgrid.angrot, origin=(0.0, 0.0)
+            )
 
         # use the bounds of the polygon to restrict the cell search
         minx, miny, maxx, maxy = shp.bounds
@@ -1961,7 +1990,9 @@ class GridIntersect:
                 # option: min_area_fraction, only store if intersected area
                 # is larger than fraction * cell_area
                 if min_area_fraction:
-                    if intersect.area < (min_area_fraction * cell_polygon.area):
+                    if intersect.area < (
+                        min_area_fraction * cell_polygon.area
+                    ):
                         continue
 
                 nodelist.append((i, j))
@@ -1977,9 +2008,13 @@ class GridIntersect:
                     v_realworld = []
                     if intersect.geom_type.startswith("Multi"):
                         for ipoly in intersect.geoms:
-                            v_realworld += self._transform_geo_interface_polygon(ipoly)
+                            v_realworld += (
+                                self._transform_geo_interface_polygon(ipoly)
+                            )
                     else:
-                        v_realworld += self._transform_geo_interface_polygon(intersect)
+                        v_realworld += self._transform_geo_interface_polygon(
+                            intersect
+                        )
                     intersect_realworld = affinity_loc.rotate(
                         intersect, self.mfgrid.angrot, origin=(0.0, 0.0)
                     )
@@ -2361,7 +2396,10 @@ def _polygon_patch(polygon, **kwargs):
     patch = PathPatch(
         Path.make_compound_path(
             Path(np.asarray(polygon.exterior.coords)[:, :2]),
-            *[Path(np.asarray(ring.coords)[:, :2]) for ring in polygon.interiors],
+            *[
+                Path(np.asarray(ring.coords)[:, :2])
+                for ring in polygon.interiors
+            ],
         ),
         **kwargs,
     )


### PR DESCRIPTION
This PR fixes #2106. 
- Gridintersect now correctly picks up the rotated/offset real-world coordinates for vertex grids.
- Added a `local` kwarg that uses local model coordinates to build intersection grid if set to True.
- Added tests

When looking through the documentation of the Grid objects I came across some entries under Attributes and Methods that do not seem to be used:
- xgrid, ygrid and zgrid are not valid attributes as far as I can tell
- xyzgrid is not an attribute and only available as key in `Grid._cache_dict`
- the method xyvertices also doesn't exist

I removed them now in this PR, but if this is best fixed/improved in a separate PR, let me know. 