### PR TITLE
feat(get-modflow): support ARM mac nightly build

### DIFF
--- a/autotest/test_get_modflow.py
+++ b/autotest/test_get_modflow.py
@@ -126,6 +126,8 @@ def test_get_release(repo):
         assert {a.rpartition("_")[2] for a in actual_assets} >= {
             a for a in expected_assets if not a.startswith("win")
         }
+    elif repo == "modflow6-nightly-build":
+        expected_assets.append("macarm.zip")
     else:
         for ostag in expected_ostags:
             assert any(


### PR DESCRIPTION
* restore/refactor https://github.com/modflowpy/flopy/commit/4c5e2ee3ec6699f61acb04a5e7bd35407b16f9ff, support for the [ARM mac distribution now on the nightly build](https://github.com/MODFLOW-USGS/modflow6-nightly-build/releases/tag/20240223)
* this change is "opt-in" &mdash; default behavior for users on all platforms remains the same, ARM mac users will get intel binaries if no `--ostag` provided
* ARM mac users can request a native binary from the nightly build with e.g.

```
get-modflow : --repo modflow6-nightly-build --ostag macarm
```