### PR TITLE
feat: add optional custom print callable

### DIFF
--- a/autotest/test_mbase.py
+++ b/autotest/test_mbase.py
@@ -160,3 +160,32 @@ def test_run_model_exe_rel_path(mf6_model_path, function_tmpdir, use_ext):
         assert success
         assert any(buff)
         assert any(ws.glob("*.lst"))
+
+
+@pytest.mark.mf6
+@requires_exe("mf6")
+@pytest.mark.parametrize("use_paths", [True, False])
+@pytest.mark.parametrize(
+    "exe",
+    [
+        "mf6",
+        Path(which("mf6") or ""),
+        relpath_safe(Path(which("mf6") or "")),
+    ],
+)
+def test_run_model_custom_print(mf6_model_path, function_tmpdir, use_paths, exe):
+    ws = function_tmpdir / "ws"
+    copytree(mf6_model_path, ws)
+
+    success, buff = run_model(
+        exe_name=exe,
+        namefile="mfsim.nam",
+        model_ws=ws if use_paths else str(ws),
+        silent=False,
+        report=True,
+        custom_print=print,
+    )
+
+    assert success
+    assert any(buff)
+    assert any(ws.glob("*.lst"))

--- a/autotest/test_mbase.py
+++ b/autotest/test_mbase.py
@@ -173,7 +173,9 @@ def test_run_model_exe_rel_path(mf6_model_path, function_tmpdir, use_ext):
         relpath_safe(Path(which("mf6") or "")),
     ],
 )
-def test_run_model_custom_print(mf6_model_path, function_tmpdir, use_paths, exe):
+def test_run_model_custom_print(
+    mf6_model_path, function_tmpdir, use_paths, exe
+):
     ws = function_tmpdir / "ws"
     copytree(mf6_model_path, ws)
 

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -1784,10 +1784,10 @@ def run_model(
         Additional command line arguments to pass to the executable.
         (Default is None)
     custom_print: callable
-        Optional callbale for printing. It will replace the builtin
-        print function. This is useful for shorter prints or integration
-        into other systems such as GUIs.
-        default is None, i.e. use the builtion print
+        Optional callable for printing. It will replace the builtin print
+        function. This is useful for a shorter print output or integration into
+        other systems such as GUIs.
+        default is None, i.e. use the builtin print
     Returns
     -------
     success : boolean

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -1744,6 +1744,7 @@ def run_model(
     normal_msg="normal termination",
     use_async=False,
     cargs=None,
+    custom_print=None,
 ) -> Tuple[bool, List[str]]:
     """
     Run the model using subprocess.Popen, optionally collecting stdout and printing
@@ -1782,12 +1783,22 @@ def run_model(
     cargs : str or list, optional, default None
         Additional command line arguments to pass to the executable.
         (Default is None)
+    custom_print: callable
+        Optional callbale for printing. It will replace the builtin
+        print function. This is useful for shorter prints or integration
+        into other systems such as GUIs.
+        default is None, i.e. use the builtion print
     Returns
     -------
     success : boolean
     buff : list of lines of stdout (empty if report is False)
 
     """
+    if custom_print is not None:
+        print = custom_print
+    else:
+        print = __builtins__['print']
+
     success = False
     buff = []
 

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -1797,7 +1797,7 @@ def run_model(
     if custom_print is not None:
         print = custom_print
     else:
-        print = __builtins__['print']
+        print = __builtins__["print"]
 
     success = False
     buff = []

--- a/flopy/mf6/mfsimbase.py
+++ b/flopy/mf6/mfsimbase.py
@@ -1631,6 +1631,7 @@ class MFSimulationBase(PackageContainer):
         normal_msg="normal termination",
         use_async=False,
         cargs=None,
+        custom_print=None,
     ):
         """
         Run the simulation.
@@ -1657,6 +1658,11 @@ class MFSimulationBase(PackageContainer):
             cargs : str or list of strings
                 Additional command line arguments to pass to the executable.
                 default is None
+            custom_print: callable
+                Optional callbale for printing. It will replace the builtin
+                print function. This is useful for shorter prints or integration
+                into other systems such as GUIs.
+                default is None, i.e. use the builtion print
 
         Returns
         --------
@@ -1683,6 +1689,7 @@ class MFSimulationBase(PackageContainer):
             normal_msg=normal_msg,
             use_async=use_async,
             cargs=cargs,
+            custom_print=custom_print,
         )
 
     def delete_output_files(self):


### PR DESCRIPTION
## Objective

The printout of a MF6 run can be pretty long, especially if there are many time steps. While it is possible turn off printing altogether, it can be useful to allow the user to customize the printing. This PR suggest to add a callable the will be use during the model instead of the builtin `print` function.

## Example: Print time steps on top of each other

Setting up a model:

```python
import flopy

sim_name = 'AdvGW_tidal' 
sim_ws = 'examples/data/mf6/test005_advgw_tidal'

sim = flopy.mf6.MFSimulation.load(
    sim_name=sim_name,
    exe_name=exe_name,  # not shown here
    sim_ws=sim_ws,
)
```

Defining a custom print callable:

```python
from time import sleep

class CustomPrint:
    """
    Custom print of MF6 output.

    This prints the line containing 'Solving:' in place, i.e. creating
    an up-counting effect for the number of the time step. The last time
    step in each stress period will remain visible and the print of the 
    next stress period will continue on the next line.
    """

    def __init__(self):
        self.one_line_mode = False
        self.last_stress_period = 0
        
    def __call__(self, line):
        if 'executable' in line:
            return
        if 'Solving:' in line:
            stress_period = int(line.split('Stress period:',)[1].split()[0])
            if stress_period > self.last_stress_period:
                self.last_stress_period += 1
                print()
            # don't add a line break to create up-counting number effect
            print(line, end='\r')
            self.one_line_mode = True
            # artificially slow done printing to see the effect
            sleep(0.1)
        else:
            if self.one_line_mode:
                self.one_line_mode = False
                # add line break
                print()
            print(line)
```

Running the model with the custom printing:

```python
sim.run_simulation(custom_print=CustomPrint())
```

Yields this output:

```raw
 MODFLOW 6
                U.S. GEOLOGICAL SURVEY MODULAR HYDROLOGIC MODEL
                        VERSION 6.4.1 Release 12/09/2022

        MODFLOW 6 compiled Feb 12 2023 12:41:20 with GCC version 11.3.0

This software has been approved for release by the U.S. Geological 
Survey (USGS). Although the software has been subjected to rigorous 
review, the USGS reserves the right to update the software as needed 
pursuant to further analysis and review. No warranty, expressed or 
implied, is made by the USGS or the U.S. Government as to the 
functionality of the software and related material nor shall the 
fact of release constitute any such warranty. Furthermore, the 
software is released on condition that neither the USGS nor the U.S. 
Government shall be held liable for any damages resulting from its 
authorized or unauthorized use. Also refer to the USGS Water 
Resources Software User Rights Notice for complete use, copyright, 
and distribution information.


 Run start date and time (yyyy/mm/dd hh:mm:ss): 2024/03/05 18:27:16

 Writing simulation list file: mfsim.lst
 Using Simulation name file: mfsim.nam


    Solving:  Stress period:     1    Time step:     1
    Solving:  Stress period:     2    Time step:   120
    Solving:  Stress period:     3    Time step:   120
    Solving:  Stress period:     4    Time step:   120

 Run end date and time (yyyy/mm/dd hh:mm:ss): 2024/03/05 18:27:17
 Elapsed run time:  0.242 Seconds

 Normal termination of simulation.
```

Over time the output develops like this:

```raw
    Solving:  Stress period:     1    Time step:     1
    Solving:  Stress period:     2    Time step:    63
```

A little bit later:

```raw
    Solving:  Stress period:     1    Time step:     1
    Solving:  Stress period:     2    Time step:   120
    Solving:  Stress period:     3    Time step:     5
```

Of course other print variations are possible.

## Impact

The impact on the code is minimal. Essentially handing through a custom callable and using it instead of `print` will do. No changes in behavior will occur if no callable is supplied.

## Testing

Running `pytest` yields the same result as without the changes.
