### PR TITLE
refactor(get_cell_vertices): raise helpful messages, improve docs, add tests

### DIFF
--- a/autotest/test_grid.py
+++ b/autotest/test_grid.py
@@ -145,6 +145,31 @@ def test_get_vertices():
     assert np.array_equal(a1, a2)
 
 
+def test_get_cell_vertices():
+    m = Modflow()
+    _ = ModflowDis(m, nrow=40, ncol=20, delr=25.0, delc=25.0)
+    mg = m.modelgrid
+    ul = [(0.0, 1000.0), (25.0, 1000.0), (25.0, 975.0), (0.0, 975.0)]
+    assert mg.get_cell_vertices(0) == ul
+    assert mg.get_cell_vertices(0, 0) == ul
+    ll = [(0.0, 25.0), (25.0, 25.0), (25.0, 0.0), (0.0, 0.0)]
+    assert mg.get_cell_vertices(780) == ll
+    assert mg.get_cell_vertices(node=780) == ll
+    assert mg.get_cell_vertices(39, 0) == ll
+    assert mg.get_cell_vertices(j=0, i=39) == ll
+    # test exceptions
+    with pytest.raises(TypeError):
+        mg.get_cell_vertices()
+    with pytest.raises(TypeError):
+        mg.get_cell_vertices(0, 0, 0)
+    with pytest.raises(TypeError):
+        mg.get_cell_vertices(0, 0, node=0)
+    with pytest.raises(TypeError):
+        mg.get_cell_vertices(0, i=0)
+    with pytest.raises(TypeError):
+        mg.get_cell_vertices(nn=0)
+
+
 def test_get_lrc_get_node():
     nlay, nrow, ncol = 3, 4, 5
     nnodes = nlay * nrow * ncol

--- a/flopy/discretization/structuredgrid.py
+++ b/flopy/discretization/structuredgrid.py
@@ -991,30 +991,53 @@ class StructuredGrid(Grid):
 
     def get_cell_vertices(self, *args, **kwargs):
         """
-        Method to get a set of cell vertices for a single cell
-            used in the Shapefile export utilities and plotting code
-        :param node: (int) node number
-        :param i: (int) cell row number
-        :param j: (int) cell column number
+        Get a set of cell vertices for a single cell.
+
+        Parameters
+        ----------
+        node : int, optional
+            Node index, mutually exclusive with i and j
+        i, j : int, optional
+            Row and column index, mutually exclusive with node
+
         Returns
-        ------- list of x,y cell vertices
+        -------
+        list
+            list of tuples with x,y coordinates to cell vertices
+
+        Examples
+        --------
+        >>> import flopy
+        >>> import numpy as np
+        >>> delr, delc = np.array([10.0] * 3), np.array([10.0] * 4)
+        >>> sg = flopy.discretization.StructuredGrid(delr=delr, delc=delc)
+        >>> sg.get_cell_vertices(node=0)
+        [(0.0, 40.0), (10.0, 40.0), (10.0, 30.0), (0.0, 30.0)]
+        >>> sg.get_cell_vertices(3, 0)
+        [(0.0, 10.0), (10.0, 10.0), (10.0, 0.0), (0.0, 0.0)]
         """
-        nn = None
         if kwargs:
-            if "node" in kwargs:
-                nn = kwargs.pop("node")
-            else:
+            if args:
+                raise TypeError(
+                    "mixed positional and keyword arguments not supported"
+                )
+            elif "node" in kwargs:
+                _, i, j = self.get_lrc(kwargs.pop("node"))[0]
+            elif "i" in kwargs and "j" in kwargs:
                 i = kwargs.pop("i")
                 j = kwargs.pop("j")
+            if kwargs:
+                unused = ", ".join(kwargs.keys())
+                raise TypeError(f"unused keyword arguments: {unused}")
+        elif len(args) == 0:
+            raise TypeError("expected one or more arguments")
 
-        if len(args) > 0:
-            if len(args) == 1:
-                nn = args[0]
-            else:
-                i, j = args[0:2]
-
-        if nn is not None:
-            k, i, j = self.get_lrc(nn)[0]
+        if len(args) == 1:
+            _, i, j = self.get_lrc(args[0])[0]
+        elif len(args) == 2:
+            i, j = args
+        elif len(args) > 2:
+            raise TypeError("too many arguments")
 
         self._copy_cache = False
         cell_verts = [


### PR DESCRIPTION
This is a general refactor of `get_cell_vertices()` to raise helpful exception messages, improve the docstrings, and add some missing tests.