### PR TITLE
feat(dis2d): limited support for a 2D structured grid (for overland flow)

### DIFF
--- a/flopy/mf6/coordinates/modeldimensions.py
+++ b/flopy/mf6/coordinates/modeldimensions.py
@@ -405,6 +405,10 @@ class ModelDimensions:
             self._model_grid = ModelGrid(
                 self.model_name, self.simulation_data, DiscretizationType.DISL
             )
+        elif grid_type == DiscretizationType.DIS2D:
+            self._model_grid = ModelGrid(
+                self.model_name, self.simulation_data, DiscretizationType.DIS2D
+            )
         else:
             self._model_grid = ModelGrid(
                 self.model_name,

--- a/flopy/mf6/utils/mfenums.py
+++ b/flopy/mf6/utils/mfenums.py
@@ -11,3 +11,4 @@ class DiscretizationType(Enum):
     DISV = 2
     DISU = 3
     DISL = 4
+    DIS2D = 5


### PR DESCRIPTION
* This first PR doesn't really do anything, except define model shapes and cellids for dis2d
* A DIS2D grid does no have layers or a top array, and botm and idomain have shape (nrow, ncol)
* Also considering DISV2D (no layers)
* Also considering renaming of DISL to DISV1D for 1D line network described by vertices
* No testing yet
* A modelgrid for this discretization type has not been addressed yet
* Unclear what type of plotting and export to support