### PR TITLE
update(MFSimulationBase): allow simulations to have no attached models

### DIFF
--- a/flopy/mf6/mfmodel.py
+++ b/flopy/mf6/mfmodel.py
@@ -793,6 +793,9 @@ class MFModel(PackageContainer, ModelInterface):
         package_recarray = instance.simulation_data.mfdata[
             (modelname, "nam", "packages", "packages")
         ]
+        if package_recarray.array is None:
+            return instance
+
         for item in package_recarray.get_data():
             if item[0] in priority_packages:
                 packages_ordered.insert(0, (item[0], item[1], item[2]))

--- a/flopy/mf6/mfsimbase.py
+++ b/flopy/mf6/mfsimbase.py
@@ -805,6 +805,9 @@ class MFSimulationBase(PackageContainer):
                 package="nam",
                 message=message,
             )
+        if models is None:
+            return instance
+        
         for item in models:
             # resolve model working folder and name file
             path, name_file = os.path.split(item[1])

--- a/flopy/mf6/mfsimbase.py
+++ b/flopy/mf6/mfsimbase.py
@@ -807,7 +807,7 @@ class MFSimulationBase(PackageContainer):
             )
         if models is None:
             return instance
-        
+
         for item in models:
             # resolve model working folder and name file
             path, name_file = os.path.split(item[1])


### PR DESCRIPTION
Adding this PR because:
* we should be able to define time discretization for a simulation structure prior to adding models and packages
* models are a seperate entity that underly a simulation object
   * IMS and TDIS are the only simulation based packages
   *a simulation object should be able to be written without a model attached to it
   * model objects should be able to be read with no packages attached