### PR TITLE
chore(pandas): use sep instead of deprecated delim_whitespace

### DIFF
--- a/flopy/utils/flopy_io.py
+++ b/flopy/utils/flopy_io.py
@@ -355,7 +355,7 @@ def loadtxt(
 
     if use_pandas:
         if delimiter.isspace():
-            kwargs["delim_whitespace"] = True
+            kwargs["sep"] = "\\s+"
         if isinstance(dtype, np.dtype) and "names" not in kwargs:
             kwargs["names"] = dtype.names
 

--- a/flopy/utils/sfroutputfile.py
+++ b/flopy/utils/sfroutputfile.py
@@ -165,7 +165,7 @@ class SfrFile:
         """
         kwargs = {
             "filepath_or_buffer": self.filename,
-            "delim_whitespace": True,
+            "sep": "\\s+",
             "header": None,
             "names": self.names,
             "skiprows": self.sr,


### PR DESCRIPTION
The `delim_whitespace` parameter on `read_table()` and `read_csv()` is [deprecated](https://pandas.pydata.org/docs/whatsnew/v2.2.0.html#other-deprecations), use `sep="\\s+"` instead