### PR TITLE
fix(OptionBlock): deprecate attribute typo 'auxillary' -> 'auxiliary'

### DIFF
--- a/.docs/Notebooks/nwt_option_blocks_tutorial.py
+++ b/.docs/Notebooks/nwt_option_blocks_tutorial.py
@@ -183,9 +183,9 @@ options
 
 options.noprint = True
 
-# and the user can also add auxillary variables by using `options.auxillary`
+# and the user can also add auxiliary variables by using `options.auxiliary`
 
-options.auxillary = ["aux", "iface"]
+options.auxiliary = ["aux", "iface"]
 
 # ### Now we can create a new wel file using this `OptionBlock`
 #

--- a/autotest/test_uzf.py
+++ b/autotest/test_uzf.py
@@ -658,3 +658,18 @@ def test_uzf_negative_iuzfopt(function_tmpdir):
     assert (
         np.max(extpd) == np.min(extpd) and np.max(extpd) != 0.2
     ), "Read error for iuzfopt less than 0"
+
+
+def test_optionsblock_auxillary_typo():
+    # Incorrect: auxillary
+    #   Correct: auxiliary
+    options = OptionBlock("", ModflowWel, block=True)
+    assert options.auxiliary == []
+    with pytest.deprecated_call():
+        assert options.auxillary == []
+    with pytest.deprecated_call():
+        options.auxillary = ["aux", "iface"]
+    assert options.auxiliary == ["aux", "iface"]
+    options.auxiliary = []
+    with pytest.deprecated_call():
+        assert options.auxillary == []

--- a/flopy/modflow/mfwel.py
+++ b/flopy/modflow/mfwel.py
@@ -222,8 +222,8 @@ class ModflowWel(Package):
                     options.append(f"aux {name} ")
 
         if isinstance(self.options, OptionBlock):
-            if not self.options.auxillary:
-                self.options.auxillary = options
+            if not self.options.auxiliary:
+                self.options.auxiliary = options
         else:
             self.options = options
 
@@ -282,9 +282,9 @@ class ModflowWel(Package):
         if isinstance(self.options, OptionBlock):
             if self.options.noprint:
                 line += "NOPRINT "
-            if self.options.auxillary:
+            if self.options.auxiliary:
                 line += " ".join(
-                    [str(aux).upper() for aux in self.options.auxillary]
+                    [str(aux).upper() for aux in self.options.auxiliary]
                 )
 
         else:

--- a/flopy/pakbase.py
+++ b/flopy/pakbase.py
@@ -1002,15 +1002,15 @@ class Package(PackageInterface):
                         it += 1
                 it += 1
 
-        # add auxillary information to nwt options
+        # add auxiliary information to nwt options
         if nwt_options is not None:
             if options:
                 if options[0] == "noprint":
                     nwt_options.noprint = True
                     if len(options) > 1:
-                        nwt_options.auxillary = options[1:]
+                        nwt_options.auxiliary = options[1:]
                 else:
-                    nwt_options.auxillary = options
+                    nwt_options.auxiliary = options
 
             options = nwt_options
 
@@ -1034,9 +1034,9 @@ class Package(PackageInterface):
                         if options[0] == "noprint":
                             nwt_options.noprint = True
                             if len(options) > 1:
-                                nwt_options.auxillary = options[1:]
+                                nwt_options.auxiliary = options[1:]
                         else:
-                            nwt_options.auxillary = options
+                            nwt_options.auxiliary = options
 
                     options = nwt_options
                 else:

--- a/flopy/utils/optionblock.py
+++ b/flopy/utils/optionblock.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 
 from ..utils import flopy_io
@@ -49,12 +51,21 @@ class OptionBlock:
         self._attr_types = {}
         self.options_line = options_line
         self.package = package
-        self.auxillary = []
+        self.auxiliary = []
         self.noprint = False
         self.block = block
 
         self.__build_attr_types()
         self._set_attributes()
+
+    def __getattr__(self, key):
+        if key == "auxillary":  # catch typo from older version
+            key = "auxiliary"
+            warnings.warn(
+                "the atttribute 'auxillary' is deprecated, use 'auxiliary' instead",
+                category=DeprecationWarning,
+            )
+        return super().__getattribute__(key)
 
     @property
     def single_line_options(self):
@@ -150,6 +161,13 @@ class OptionBlock:
                 is consistant with the attribute data type
 
         """
+        if key == "auxillary":  # catch typo from older version
+            key = "auxiliary"
+            warnings.warn(
+                "the atttribute 'auxillary' is deprecated, use 'auxiliary' instead",
+                category=DeprecationWarning,
+            )
+
         err_msg = "Data type must be compatible with {}"
         if key in ("_context", "_attr_types", "options_line"):
             self.__dict__[key] = value


### PR DESCRIPTION
This attribute is documented [here](https://flopy.readthedocs.io/en/3.6.0/Notebooks/nwt_option_blocks_tutorial.html#Building-an-OptionBlock-from-scratch), but unfortunately is a common typo. The backwards compatible change in this PR shows a DeprecationWarning if the typo attribute name is used (either get or set).