### PR TITLE
fix(typos): fixed a variety of typos throughout project

### DIFF
--- a/autotest/regression/test_modflow.py
+++ b/autotest/regression/test_modflow.py
@@ -394,14 +394,14 @@ def test_mf2005_lake(function_tmpdir, namfile, mf2005_test_path):
 
     fn0 = join(ws, Path(namfile).name)
 
-    # write free format files - wont run without resetting to free format - evt external file issue
+    # write free format files - won't run without resetting to free format - evt external file issue
     m.free_format_input = True
 
     # rewrite files
     model_ws2 = join(ws, "external")
     m.change_model_ws(
         model_ws2, reset_external=True
-    )  # l1b2k_bath wont run without this
+    )  # l1b2k_bath won't run without this
     m.write_input()
 
     success, buff = m.run_model()

--- a/autotest/regression/test_swi2.py
+++ b/autotest/regression/test_swi2.py
@@ -39,7 +39,7 @@ def test_mf2005swi2(function_tmpdir, swi_path, namfile):
     model_ws2 = os.path.join(ws, "flopy")
     m.change_model_ws(
         model_ws2, reset_external=True
-    )  # l1b2k_bath wont run without this
+    )  # l1b2k_bath won't run without this
     m.write_input()
 
     success, buff = m.run_model()

--- a/autotest/test_lake_connections.py
+++ b/autotest/test_lake_connections.py
@@ -289,7 +289,7 @@ def test_lake(function_tmpdir, example_data_path):
     lakes.shape = idomain.shape
     gwf.dis.idomain = np.where(lakes > -1, 1, idomain)
 
-    # convert to Newton-Raphson fomulation and update the linear accelerator
+    # convert to Newton-Raphson formulation and update the linear accelerator
     gwf.name_file.newtonoptions = "NEWTON UNDER_RELAXATION"
     sim.ims.linear_acceleration = "BICGSTAB"
 

--- a/autotest/test_model_splitter.py
+++ b/autotest/test_model_splitter.py
@@ -364,7 +364,7 @@ def test_control_records(function_tmpdir):
 
     if spd_ls2["filename"] is None or not spd_ls2["binary"]:
         raise AssertionError(
-            "External binary file input not being preseved for MFList"
+            "External binary file input not being preserved for MFList"
         )
 
 

--- a/autotest/test_modflow.py
+++ b/autotest/test_modflow.py
@@ -1047,7 +1047,7 @@ def test_oc_check():
 
     ModflowDis(m)
     oc.stress_period_data = {(0, 0): ["save head", "save budget"]}
-    chk = oc.check()  # check passsed
+    chk = oc.check()  # check passed
     assert len(chk.summary_array) == 0, len(chk.summary_array)
 
     oc.stress_period_data = {(0, 0): ["save"]}

--- a/autotest/test_particledata.py
+++ b/autotest/test_particledata.py
@@ -674,7 +674,7 @@ def test_nodeparticledata_to_prp_disv_defaults(
     mp7_rpts.sort()
 
     # convert particle data to prt format, flatten (remove cell ID tuples),
-    # remove irpt as it is not gauranteed to match, and sort
+    # remove irpt as it is not guaranteed to match, and sort
     prt_rpts = flatten(list(pdat.to_prp(grid)))
     prt_rpts = [r[1:] for r in prt_rpts]  #
     prt_rpts.sort()

--- a/autotest/test_specific_discharge.py
+++ b/autotest/test_specific_discharge.py
@@ -319,7 +319,7 @@ def basic_check(Qx_ext, Qy_ext, Qz_ext):
 
 
 def local_balance_check(Qx_ext, Qy_ext, Qz_ext, hdsfile=None, model=None):
-    # calculate water blance at every cell
+    # calculate water balance at every cell
     local_balance = (
         Qx_ext[:, :, :-1]
         - Qx_ext[:, :, 1:]

--- a/flopy/discretization/grid.py
+++ b/flopy/discretization/grid.py
@@ -803,7 +803,7 @@ class Grid:
 
     def cross_section_adjust_indicies(self, k, cbcnt):
         """
-        Method to get adjusted indicies by layer and confining bed
+        Method to get adjusted indices by layer and confining bed
         for PlotCrossSection plotting
 
         Parameters
@@ -826,8 +826,8 @@ class Grid:
         self, plotarray, xcenters, head, elev, projpts
     ):
         """
-        Method to set countour array centers for rare instances where
-        matplotlib contouring is prefered over trimesh plotting
+        Method to set contour array centers for rare instances where
+        matplotlib contouring is preferred over trimesh plotting
 
         Parameters
         ----------

--- a/flopy/discretization/unstructuredgrid.py
+++ b/flopy/discretization/unstructuredgrid.py
@@ -360,7 +360,7 @@ class UnstructuredGrid(Grid):
     @property
     def xyzvertices(self):
         """
-        Method to get model grid verticies
+        Method to get model grid vertices
 
         Returns:
             list of dimension ncpl by nvertices
@@ -442,7 +442,7 @@ class UnstructuredGrid(Grid):
 
     def cross_section_adjust_indicies(self, k, cbcnt):
         """
-        Method to get adjusted indicies by layer and confining bed
+        Method to get adjusted indices by layer and confining bed
         for PlotCrossSection plotting
 
         Parameters
@@ -463,8 +463,8 @@ class UnstructuredGrid(Grid):
         self, plotarray, xcenters, head, elev, projpts
     ):
         """
-        Method to set countour array centers for rare instances where
-        matplotlib contouring is prefered over trimesh plotting
+        Method to set contour array centers for rare instances where
+        matplotlib contouring is preferred over trimesh plotting
 
         Parameters
         ----------

--- a/flopy/export/utils.py
+++ b/flopy/export/utils.py
@@ -596,7 +596,7 @@ def model_export(
         output format flag. 'vtk' will export to vtk
     **kwargs : keyword arguments
         modelgrid: flopy.discretization.Grid
-            user supplied modelgrid object which will supercede the built
+            user supplied modelgrid object which will supersede the built
             in modelgrid object
         crs : pyproj.CRS, int, str, optional if `prjfile` is specified
             Coordinate reference system (CRS) for the model grid
@@ -687,9 +687,9 @@ def package_export(
         package to export
     fmt : str
         output format flag. 'vtk' will export to vtk
-    ** kwargs : keword arguments
+    ** kwargs : keyword arguments
         modelgrid: flopy.discretization.Grid
-            user supplied modelgrid object which will supercede the built
+            user supplied modelgrid object which will supersede the built
             in modelgrid object
         crs : pyproj.CRS, int, str, optional if `prjfile` is specified
             Coordinate reference system (CRS) for the model grid
@@ -873,7 +873,7 @@ def mflist_export(f: Union[str, os.PathLike, NetCdf], mfl, **kwargs):
     mfl : MfList instance
     **kwargs : keyword arguments
         modelgrid : flopy.discretization.Grid
-            model grid instance which will supercede the flopy.model.modelgrid
+            model grid instance which will supersede the flopy.model.modelgrid
         crs : pyproj.CRS, int, str, optional if `prjfile` is specified
             Coordinate reference system (CRS) for the model grid
             (must be projected; geographic CRS are not supported).
@@ -1034,7 +1034,7 @@ def transient2d_export(f: Union[str, os.PathLike], t2d, fmt=None, **kwargs):
         min_valid : minimum valid value
         max_valid : maximum valid value
         modelgrid : flopy.discretization.Grid
-            model grid instance which will supercede the flopy.model.modelgrid
+            model grid instance which will supersede the flopy.model.modelgrid
         if fmt is set to 'vtk', parameters of Vtk initializer
 
     """
@@ -1194,7 +1194,7 @@ def array3d_export(f: Union[str, os.PathLike], u3d, fmt=None, **kwargs):
         min_valid : minimum valid value
         max_valid : maximum valid value
         modelgrid : flopy.discretization.Grid
-            model grid instance which will supercede the flopy.model.modelgrid
+            model grid instance which will supersede the flopy.model.modelgrid
         if fmt is set to 'vtk', parameters of Vtk initializer
 
     """
@@ -1372,7 +1372,7 @@ def array2d_export(
         min_valid : minimum valid value
         max_valid : maximum valid value
         modelgrid : flopy.discretization.Grid
-            model grid instance which will supercede the flopy.model.modelgrid
+            model grid instance which will supersede the flopy.model.modelgrid
         if fmt is set to 'vtk', parameters of Vtk initializer
 
     """
@@ -1525,9 +1525,9 @@ def export_array(
         model grid
     filename : str or PathLike
         Path of output file. Export format is determined by
-        file extention.
+        file extension.
         '.asc'  Arc Ascii grid
-        '.tif'  GeoTIFF (requries rasterio package)
+        '.tif'  GeoTIFF (requires rasterio package)
         '.shp'  Shapefile
     a : 2D numpy.ndarray
         Array to export
@@ -1924,7 +1924,7 @@ def export_array_contours(
     modelgrid : flopy.discretization.Grid object
         model grid object
     filename : str or PathLike
-        Path of output file with '.shp' extention.
+        Path of output file with '.shp' extension.
     a : 2D numpy array
         Array to contour
     fieldname : str

--- a/flopy/export/vtk.py
+++ b/flopy/export/vtk.py
@@ -100,11 +100,11 @@ class Vtk:
     modelgrid : flopy.discretization.Grid object
         any flopy modelgrid object, example. VertexGrid
     vertical_exageration : float
-        floating point value to scale vertical exageration of the vtk points
+        floating point value to scale vertical exaggeration of the vtk points
         default is 1.
     binary : bool
         flag that indicates if Vtk will write a binary or text file. Binary
-        is prefered as paraview has a bug (8/4/2021) where is cannot represent
+        is preferred as paraview has a bug (8/4/2021) where is cannot represent
         NaN values from ASCII (non xml) files. In this case no-data values
         are set to 1e+30.
     xml : bool
@@ -121,7 +121,7 @@ class Vtk:
         boolean flag to interpolate vertex elevations based on shared cell
         elevations. Default is False.
     point_scalars : bool
-        boolen flag to write interpolated data at each point based "shared
+        boolean flag to write interpolated data at each point based "shared
         vertices".
 
     """
@@ -184,7 +184,7 @@ class Vtk:
 
         self.nvpl = nvpl
 
-        # method to accomodate DISU grids, do not use modelgrid.ncpl!
+        # method to accommodate DISU grids, do not use modelgrid.ncpl!
         self.ncpl = len(self.iverts)
         if self.nnodes == len(self.iverts):
             self.nlay = 1
@@ -521,7 +521,7 @@ class Vtk:
             mf6 = False
             hfb_data = pkg.hfb_data
         else:
-            # asssume that there is no transient hfb data for now
+            # assume that there is no transient hfb data for now
             hfb_data = pkg.stress_period_data.array[0]
             mf6 = True
 
@@ -792,7 +792,7 @@ class Vtk:
         if self.__transient_output_data:
             raise AssertionError(
                 "Transient arrays cannot be mixed with transient output, "
-                "Please create a seperate vtk object for transient package "
+                "Please create a separate vtk object for transient package "
                 "data"
             )
 
@@ -1206,7 +1206,7 @@ class Vtk:
         if not self.__transient_output_data and self.__transient_data:
             raise AssertionError(
                 "Head data cannot be mixed with transient package data, "
-                "Please create a seperate vtk object for transient head data"
+                "Please create a separate vtk object for transient head data"
             )
 
         if kstpkper is None:
@@ -1256,7 +1256,7 @@ class Vtk:
         if not self.__transient_output_data and self.__transient_data:
             raise AssertionError(
                 "Binary data cannot be mixed with transient package data, "
-                "Please create a seperate vtk object for transient head data"
+                "Please create a separate vtk object for transient head data"
             )
 
         records = cbc.get_unique_record_names(decode=True)

--- a/flopy/mf6/data/mfdatautil.py
+++ b/flopy/mf6/data/mfdatautil.py
@@ -966,7 +966,7 @@ class ListTemplateGenerator(TemplateGenerator):
                 "Data dimensions can not be determined for  "
                 "{}. Data structure may be jagged or may contain "
                 "a keystring. Data type information is therefore "
-                "dependant on the data and can not be retreived "
+                "dependent on the data and can not be retrieved "
                 "prior to the data being loaded"
                 ".".format(data_storage.data_dimensions.structure.name)
             )

--- a/flopy/mf6/data/mfstructure.py
+++ b/flopy/mf6/data/mfstructure.py
@@ -2070,7 +2070,7 @@ class MFBlockStructure:
 
 class MFInputFileStructure:
     """
-    MODFLOW Input File Stucture class.  Loads file
+    MODFLOW Input File Structure class.  Loads file
     structure information for individual input file
     types.
 

--- a/flopy/mf6/mfmodel.py
+++ b/flopy/mf6/mfmodel.py
@@ -697,7 +697,7 @@ class MFModel(PackageContainer, ModelInterface):
             or dictionary of ....
         **kwargs : keyword arguments
             modelgrid: flopy.discretization.Grid
-                User supplied modelgrid object which will supercede the built
+                User supplied modelgrid object which will supersede the built
                 in modelgrid object
             if fmt is set to 'vtk', parameters of Vtk initializer
 

--- a/flopy/mf6/mfpackage.py
+++ b/flopy/mf6/mfpackage.py
@@ -1591,7 +1591,7 @@ class MFBlock:
             fd.write("\n")
 
     def is_allowed(self):
-        """Determine if block is valid based on the values of dependant
+        """Determine if block is valid based on the values of dependent
         MODFLOW variables."""
         if self.structure.variable_dependant_path:
             # fill in empty part of the path with the current path

--- a/flopy/mf6/utils/binaryfile_utils.py
+++ b/flopy/mf6/utils/binaryfile_utils.py
@@ -177,7 +177,7 @@ class MFOutputRequester:
             return data
 
     def _get_binary_file_object(self, path, bintype, key):
-        # simple method that trys to open the binary file object using Flopy
+        # simple method that tries to open the binary file object using Flopy
         if bintype == "CBC":
             try:
                 return bf.CellBudgetFile(path, precision="double")

--- a/flopy/mf6/utils/createpackages.py
+++ b/flopy/mf6/utils/createpackages.py
@@ -67,7 +67,7 @@ There are three possible types (or combination of them) that can be used for
 "parent package type", MFPackage, MFModel, and MFSimulation. If a package
 supports multiple types of parents (for example, it can be either in the model
 namefile or in a package, like the obs package), include all the types
-supported, seperating each type with a / (MFPackage/MFModel).
+supported, separating each type with a / (MFPackage/MFModel).
 
 To create a new type of model choose a unique three letter model abbreviation
 ("gwf", "gwt", ...). Create a name file dfn with the naming convention

--- a/flopy/mf6/utils/mfobservation.py
+++ b/flopy/mf6/utils/mfobservation.py
@@ -24,7 +24,7 @@ class MFObservation:
     -------
     mfdict: (dict) the sim.simulation_dict.mfdict object for the flopy project
     path: (object) the path object detailing model names and paths
-    key: (tuple, stings) user supplied dictionary key to request observation
+    key: (tuple, strings) user supplied dictionary key to request observation
     utility data
 
     Returns:
@@ -55,7 +55,7 @@ class Observations:
 
     Input:
     ------
-    fi = (sting) name of the observation binary output file
+    fi = (string) name of the observation binary output file
 
     Methods:
     --------
@@ -197,7 +197,7 @@ class Observations:
 
         Parameters
         ----------
-        keys: (string) sting of dictionary/observation keys separated by comma.
+        keys: (string) string of dictionary/observation keys separated by comma.
               (optional)
         idx: (int) time index location (optional)
         totim: (float) simulation time (optional)

--- a/flopy/mf6/utils/model_splitter.py
+++ b/flopy/mf6/utils/model_splitter.py
@@ -2663,7 +2663,7 @@ class Mf6Splitter(object):
 
     def _remap_adv_tag(self, mkey, recarray, item, mapper):
         """
-        Method to remap advanced package ids such as SFR's ifno varaible
+        Method to remap advanced package ids such as SFR's ifno variable
 
         Parameters
         ----------
@@ -3310,5 +3310,5 @@ class Mf6Splitter(object):
 
 # todo: development notes:
 #   Then set up checks for model splitting
-#       (ex. doesnt parallel a fault, doesnt cut through a lake,
+#       (ex. doesn't parallel a fault, doesn't cut through a lake,
 #       active cells in modelgrid...)

--- a/flopy/mf6/utils/output_util.py
+++ b/flopy/mf6/utils/output_util.py
@@ -291,7 +291,7 @@ class MF6Output:
 
     def __budgetcsv(self):
         """
-        Convience method to open and return a budget csv object
+        Convenience method to open and return a budget csv object
 
         Returns
         -------

--- a/flopy/mfusg/mfusgcln.py
+++ b/flopy/mfusg/mfusgcln.py
@@ -5,7 +5,7 @@ Mfusgcln module.
 Contains the MfUsgCln class. Note that the user can
 access the MfUsgCln class as `flopy.mfusg.MfUsgCln`.
 
-Compatible with USG-Transport Version 1.7.0. which can be downloade from
+Compatible with USG-Transport Version 1.7.0. which can be download from
 https://www.gsi-net.com/en/software/free-software/modflow-usg.html
 
 Additional information for this MODFLOW package can be found at the `Online

--- a/flopy/mfusg/mfusgdisu.py
+++ b/flopy/mfusg/mfusgdisu.py
@@ -150,7 +150,7 @@ class MfUsgDisU(Package):
         expanded if CLN or GNC nodes exist in a simulation.
         (default is None.  cl1 and cl2 must be specified, or cl12 must be
         specified)
-    fahl : float or arry of floats
+    fahl : float or array of floats
         Area of the interface Anm between nodes n and m.
         (default is None.  fahl must be specified.)
     perlen : float or array of floats (nper)

--- a/flopy/mfusg/mfusggnc.py
+++ b/flopy/mfusg/mfusggnc.py
@@ -218,7 +218,7 @@ class MfUsgGnc(Package):
 
     @staticmethod
     def get_empty(numgnc=0, numalphaj=1, iflalphan=0):
-        """Returns empty GNC recarray of defualt dtype."""
+        """Returns empty GNC recarray of default dtype."""
         # get an empty recarray that corresponds to dtype
         dtype = MfUsgGnc.get_default_dtype(numalphaj, iflalphan)
         return create_empty_recarray(numgnc, dtype, default_value=-1.0e10)

--- a/flopy/modflow/mfag.py
+++ b/flopy/modflow/mfag.py
@@ -699,7 +699,7 @@ class ModflowAg(Package):
         f : str
             filename
         model : gsflow.modflow.Modflow object
-            model to attach the ag pacakge to
+            model to attach the ag package to
         nper : int
             number of stress periods in model
         ext_unit_dict : dict, optional

--- a/flopy/modflow/mfbas.py
+++ b/flopy/modflow/mfbas.py
@@ -167,7 +167,7 @@ class ModflowBas(Package):
         ----------
         f : str or file handle
             String defining file name or file handle for summary file
-            of check method output. If a sting is passed a file handle
+            of check method output. If a string is passed a file handle
             is created. If f is None, check method does not write
             results to a summary file. (default is None)
         verbose : bool

--- a/flopy/modflow/mfdis.py
+++ b/flopy/modflow/mfdis.py
@@ -665,7 +665,7 @@ class ModflowDis(Package):
         ----------
         f : str or file handle
             String defining file name or file handle for summary file
-            of check method output. If a sting is passed a file handle
+            of check method output. If a string is passed a file handle
             is created. If f is None, check method does not write
             results to a summary file. (default is None)
         verbose : bool

--- a/flopy/modflow/mfoc.py
+++ b/flopy/modflow/mfoc.py
@@ -492,7 +492,7 @@ class ModflowOc(Package):
 
         Returns
         -------
-        iubud : integer ot list of integers
+        iubud : integer or list of integers
             Unit number or list of cell-by-cell budget output unit numbers.
             None is returned if ipakcb is less than one for all packages.
 

--- a/flopy/modflow/mfrch.py
+++ b/flopy/modflow/mfrch.py
@@ -157,7 +157,7 @@ class ModflowRch(Package):
         ----------
         f : str or file handle
             String defining file name or file handle for summary file
-            of check method output. If a sting is passed a file handle
+            of check method output. If a string is passed a file handle
             is created. If f is None, check method does not write
             results to a summary file. (default is None)
         verbose : bool

--- a/flopy/modflow/mfsfr2.py
+++ b/flopy/modflow/mfsfr2.py
@@ -844,7 +844,7 @@ class ModflowSfr2(Package):
                 options.maxval = int(t[2])
                 line = f.readline()
 
-            # set varibles to be passed to class args
+            # set variables to be passed to class args
             transroute = options.transroute
             reachinput = options.reachinput
             tabfiles = isinstance(options.tabfiles, np.ndarray)
@@ -2344,7 +2344,7 @@ class check:
         isnan = np.any(np.isnan(np.array(self.reach_data.tolist())), axis=1)
         nanreaches = self.reach_data[isnan]
         if np.any(isnan):
-            txt += f"Found {len(nanreaches)} reachs with nans:\n"
+            txt += f"Found {len(nanreaches)} reaches with nans:\n"
             if self.level == 1:
                 txt += _print_rec_array(nanreaches, delimiter=" ")
         for per, sd in self.segment_data.items():

--- a/flopy/modpath/mp6sim.py
+++ b/flopy/modpath/mp6sim.py
@@ -171,7 +171,7 @@ class Modpath6Sim(Package):
         ----------
         f : str or file handle
             String defining file name or file handle for summary file
-            of check method output. If a sting is passed a file handle
+            of check method output. If a string is passed a file handle
             is created. If f is None, check method does not write
             results to a summary file. (default is None)
         verbose : bool

--- a/flopy/mt3d/mt.py
+++ b/flopy/mt3d/mt.py
@@ -295,7 +295,7 @@ class Mt3dms(BaseModel):
             else:
                 xoff = self.mf._modelgrid.xoffset
             if xoff is None:
-                # incase mf._modelgrid.xoffset is not set but mf._xul is
+                # in case mf._modelgrid.xoffset is not set but mf._xul is
                 if self.mf._xul is not None:
                     xoff = self._modelgrid._xul_to_xll(self.mf._xul)
                 else:
@@ -307,7 +307,7 @@ class Mt3dms(BaseModel):
             else:
                 yoff = self.mf._modelgrid.yoffset
             if yoff is None:
-                # incase mf._modelgrid.yoffset is not set but mf._yul is
+                # in case mf._modelgrid.yoffset is not set but mf._yul is
                 if self.mf._yul is not None:
                     yoff = self._modelgrid._yul_to_yll(self.mf._yul)
                 else:

--- a/flopy/mt3d/mtbtn.py
+++ b/flopy/mt3d/mtbtn.py
@@ -914,7 +914,7 @@ class Mt3dBtn(Package):
                 if m_arr[i].upper() == "ALTWTSORB":
                     AltWTSorb = True
         elif model.verbose:
-            print("   optional keywords not identifed/loaded")
+            print("   optional keywords not identified/loaded")
 
         # A3
         if model.verbose:

--- a/flopy/pakbase.py
+++ b/flopy/pakbase.py
@@ -296,7 +296,7 @@ class PackageInterface:
         ----------
         f : str or file handle
             String defining file name or file handle for summary file
-            of check method output. If a sting is passed a file handle
+            of check method output. If a string is passed a file handle
             is created. If f is None, check method does not write
             results to a summary file. (default is None)
         verbose : bool
@@ -742,7 +742,7 @@ class Package(PackageInterface):
     @staticmethod
     def _get_sfac_columns():
         """
-        This should be overriden for individual packages that support an
+        This should be overridden for individual packages that support an
         sfac multiplier for individual list columns
 
         """

--- a/flopy/pest/templatewriter.py
+++ b/flopy/pest/templatewriter.py
@@ -87,7 +87,7 @@ class TemplateWriter:
             paktpl.fn_path += ".tpl"
             paktpl.write_file(
                 check=False
-            )  # fot now, turn off checks for template files
+            )  # for now, turn off checks for template files
 
             # Destroy the template version of the package
             paktpl = None

--- a/flopy/plot/crosssection.py
+++ b/flopy/plot/crosssection.py
@@ -1563,7 +1563,7 @@ class PlotCrossSection:
             dictionary defined by node number which contains model
             patch vertices.
         fill_between : bool
-            flag to create polygons that mimick the matplotlib fill between
+            flag to create polygons that mimic the matplotlib fill between
             method. Only used by the plot_fill_between method.
         **kwargs : dictionary
             keyword arguments passed to matplotlib.collections.PatchCollection

--- a/flopy/plot/plotutil.py
+++ b/flopy/plot/plotutil.py
@@ -1326,7 +1326,7 @@ class PlotUtilities:
     @staticmethod
     def _set_layer_range(mflay, maxlay):
         """
-        Re-usable method to check for mflay and set
+        Reusable method to check for mflay and set
         the range of plottable layers
 
         Parameters
@@ -1572,7 +1572,7 @@ class UnstructuredPlotUtilities:
     def line_intersect_grid(ptsin, xgrid, ygrid):
         """
         Uses cross product method to find which cells intersect with the
-        line and then uses the parameterized line equation to caluculate
+        line and then uses the parameterized line equation to calculate
         intersection x, y vertex points. Should be quite fast for large model
         grids!
 

--- a/flopy/plot/styles.py
+++ b/flopy/plot/styles.py
@@ -82,7 +82,7 @@ class styles:
             location of the heading in the y-direction in normalized plot
             dimensions ranging from 0 to 1 (default is 1.01)
         idx : int
-            index for programatically generating the heading letter when letter
+            index for programmatically generating the heading letter when letter
             is None and idx is not None. idx = 0 will generate A
             (default is None)
 

--- a/flopy/utils/binaryfile.py
+++ b/flopy/utils/binaryfile.py
@@ -1086,7 +1086,7 @@ class CellBudgetFile:
 
     def _set_precision(self, precision="single"):
         """
-        Method to set the budget precsion from a CBC file. Enables
+        Method to set the budget precision from a CBC file. Enables
         Auto precision code to work
 
         Parameters

--- a/flopy/utils/crs.py
+++ b/flopy/utils/crs.py
@@ -23,7 +23,7 @@ def get_authority_crs(crs):
     Returns
     -------
     pyproj.CRS instance
-        CRS instance initiallized with the name
+        CRS instance initialized with the name
         and authority code (e.g. "epsg:5070") produced by
         :meth:`pyproj.crs.CRS.to_authority`
 

--- a/flopy/utils/datautil.py
+++ b/flopy/utils/datautil.py
@@ -143,7 +143,7 @@ class PyListUtil:
         compares two lists, returns true if they are identical (with max_error)
     spilt_data_line : (line : string) : list
         splits a string apart (using split) and then cleans up the results
-        dealing with various MODFLOW input file releated delimiters.  returns
+        dealing with various MODFLOW input file related delimiters.  returns
         the delimiter type used.
     clean_numeric : (text : string) : string
         returns a cleaned up version of 'text' with only numeric characters

--- a/flopy/utils/flopy_io.py
+++ b/flopy/utils/flopy_io.py
@@ -225,7 +225,7 @@ def read_fixed_var(line, ncol=1, length=10, ipos=None, free=False):
     ipos : list, int, or numpy array
         user-provided column widths. (default is None)
     free : bool
-        boolean indicating if sting is free format. ncol, length, and
+        boolean indicating if string is free format. ncol, length, and
         ipos are not used if free is True. (default is False)
 
     Returns
@@ -591,7 +591,7 @@ def relpath_safe(
 def scrub_login(s: str) -> str:
     """
     Remove the current login name from the given string,
-    replacing any occurences with "***".
+    replacing any occurrences with "***".
 
     Parameters
     ----------

--- a/flopy/utils/gridintersect.py
+++ b/flopy/utils/gridintersect.py
@@ -150,7 +150,7 @@ class GridIntersect:
         mfgrid : flopy modflowgrid
             MODFLOW grid as implemented in flopy
         method : str, optional
-            Options are either 'vertex' which uses shapely interesection operations
+            Options are either 'vertex' which uses shapely intersection operations
             or 'structured' which uses optimized methods that only work for structured
             grids. The default is None, which determines intersection method based on
             the grid type.

--- a/flopy/utils/observationfile.py
+++ b/flopy/utils/observationfile.py
@@ -44,7 +44,7 @@ class ObsFiles(FlopyBinaryData):
         Returns
         ----------
         out : tuple of int
-            A tupe with the number of records and number of flow items
+            A tuple with the number of records and number of flow items
             in the file. The number of flow items is non-zero only if
             swrtype='flow'.
 

--- a/flopy/utils/optionblock.py
+++ b/flopy/utils/optionblock.py
@@ -155,10 +155,10 @@ class OptionBlock:
         Parameters
         ----------
             key : str
-                string refering to an attribute
+                string referring to an attribute
             value : object
                 a python object (int, str, float, bool) that
-                is consistant with the attribute data type
+                is consistent with the attribute data type
 
         """
         if key == "auxillary":  # catch typo from older version
@@ -241,7 +241,7 @@ class OptionBlock:
         """
         Method to build a type dictionary for type
         enforcements in __setattr__. This uses the package's
-        contex tree to build and enforce attribute
+        context tree to build and enforce attribute
         types for the class
 
         """

--- a/flopy/utils/swroutputfile.py
+++ b/flopy/utils/swroutputfile.py
@@ -136,7 +136,7 @@ class SwrFile(FlopyBinaryData):
         Returns
         ----------
         out : tuple of int
-            A tupe with the number of records and number of flow items
+            A tuple with the number of records and number of flow items
             in the file. The number of flow items is non-zero only if
             swrtype='flow'.
 

--- a/flopy/utils/util_array.py
+++ b/flopy/utils/util_array.py
@@ -488,7 +488,7 @@ class Util3d(DataInterface):
         ext_filename is reset to value.
     bin : bool
         flag to control writing external arrays as binary (optional)
-        (the defaut is False)
+        (the default is False)
 
     Attributes
     ----------
@@ -2391,7 +2391,7 @@ class Util2d(DataInterface):
             record multiplier - this method is used primarily for writing model input files
 
         """
-        # convert array to sting with specified format
+        # convert array to string with specified format
         a_string = self.array2string(
             self.shape, self._array, python_format=self.format.py
         )

--- a/flopy/utils/voronoi.py
+++ b/flopy/utils/voronoi.py
@@ -258,7 +258,7 @@ class VoronoiGrid:
     Parameters
     ----------
     input : flopy.utils.Triangle
-        Constructred and built flopy Triangle object.
+        Constructed and built flopy Triangle object.
     kwargs : dict
         List of additional keyword arguments that will be passed through to
         scipy.spatial.Voronoi.  For circular shaped model grids, the
@@ -368,7 +368,7 @@ class VoronoiGrid:
         ax : matplotlib.pyplot.Axes
             axes to plot the patch collection
         kwargs : dict
-            Additional keyward arguments to pass to the flopy.plot.plot_cvfd
+            Additional keyword arguments to pass to the flopy.plot.plot_cvfd
             function that returns a patch collection from verts and iverts
 
         Returns

--- a/flopy/utils/zonbud.py
+++ b/flopy/utils/zonbud.py
@@ -1380,7 +1380,7 @@ class ZoneBudget:
             elif "totim" in line.lower():
                 otype = 2
             else:
-                raise AssertionError("Cant distinguish output type")
+                raise AssertionError("Can't distinguish output type")
         return otype
 
     @classmethod
@@ -1774,7 +1774,7 @@ class ZoneBudget6:
     model_ws : str
         path to model
     exe_name : str
-        excutable name
+        executable name
     extension : str
         name file extension
     """


### PR DESCRIPTION
This PR was prepared with the help of [codespell](https://github.com/codespell-project/codespell). Typos in .dfn files are not applied here, as they are upstream at https://github.com/MODFLOW-USGS/modflow6/pull/1748. Other changes to mf6 packages have also be held back (as they are normally generate with mf6/utils/createpackages.py).

Typo changes in this PR may be visible in docs, but no other code behavior changes are anticipated.