### PR TITLE
test: mark tests requiring shapely

### DIFF
--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -35,16 +35,16 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
           cache: 'pip'
           cache-dependency-path: pyproject.toml
 
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
 
-      - name: Install hdf5 (macOS)
-        if: runner.os == 'macOS'
-        run: brew install hdf5
+      # - name: Install hdf5 (macOS)
+      #   if: runner.os == 'macOS'
+      #   run: brew install hdf5
 
       - name: Install flopy and dependencies
         run: pip install ".[test, doc, optional]"

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -42,10 +42,6 @@ jobs:
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
 
-      # - name: Install hdf5 (macOS)
-      #   if: runner.os == 'macOS'
-      #   run: brew install hdf5
-
       - name: Install flopy and dependencies
         run: pip install ".[test, doc, optional]"
       

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -42,6 +42,10 @@ jobs:
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
 
+      - name: Install hdf5 (macOS)
+        if: runner.os == 'macOS'
+        run: brew install hdf5
+
       - name: Install flopy and dependencies
         run: pip install ".[test, doc, optional]"
       

--- a/autotest/test_export.py
+++ b/autotest/test_export.py
@@ -1707,7 +1707,7 @@ def test_vtk_add_model_without_packages_names(function_tmpdir):
 
 
 @pytest.mark.mf6
-@requires_pkg("vtk")
+@requires_pkg("vtk", "shapely")
 def test_vtk_export_disv1_model(function_tmpdir):
     from vtkmodules.util.numpy_support import vtk_to_numpy
     from vtkmodules.vtkIOLegacy import vtkUnstructuredGridReader
@@ -1779,7 +1779,7 @@ def test_vtk_export_disv1_model(function_tmpdir):
 
 
 @pytest.mark.mf6
-@requires_pkg("vtk")
+@requires_pkg("vtk", "shapely")
 def test_vtk_export_disv2_model(function_tmpdir):
     from vtkmodules.util.numpy_support import vtk_to_numpy
     from vtkmodules.vtkIOLegacy import vtkUnstructuredGridReader

--- a/autotest/test_grid.py
+++ b/autotest/test_grid.py
@@ -882,6 +882,7 @@ def test_grid_crs_exceptions():
         sg.set_coord_info(prj=not_a_file)
 
 
+@requires_pkg("shapely")
 def test_tocvfd1():
     vertdict = {}
     vertdict[0] = [(0, 0), (100, 0), (100, 100), (0, 100), (0, 0)]
@@ -890,6 +891,7 @@ def test_tocvfd1():
     assert 6 in iverts[0]
 
 
+@requires_pkg("shapely")
 def test_tocvfd2():
     vertdict = {}
     vertdict[0] = [(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)]
@@ -898,6 +900,7 @@ def test_tocvfd2():
     assert [1, 4, 5, 6, 2, 1] in iverts
 
 
+@requires_pkg("shapely")
 def test_tocvfd3():
     # create the nested grid described in the modflow-usg documentation
 

--- a/autotest/test_gridutil.py
+++ b/autotest/test_gridutil.py
@@ -2,6 +2,7 @@ from itertools import product
 
 import numpy as np
 import pytest
+from modflow_devtools.markers import requires_pkg
 
 from flopy.utils.gridutil import (
     get_disu_kwargs,
@@ -61,6 +62,7 @@ def test_get_lni_infers_layer_count_when_int_ncpl(ncpl, nodes, expected):
         assert ln == expected[i]
 
 
+@requires_pkg("shapely")
 @pytest.mark.parametrize(
     "nlay, nrow, ncol, delr, delc, tp, botm",
     [
@@ -123,6 +125,7 @@ def test_get_disu_kwargs(nlay, nrow, ncol, delr, delc, tp, botm):
     # print(kwargs["nja"])
 
 
+@requires_pkg("shapely")
 @pytest.mark.parametrize(
     "nlay, nrow, ncol, delr, delc, tp, botm",
     [
@@ -160,6 +163,7 @@ def test_get_disv_kwargs(nlay, nrow, ncol, delr, delc, tp, botm):
     # print(kwargs["cell2d"])
 
 
+@requires_pkg("shapely")
 @pytest.mark.parametrize(
     "qx, qy, qz, nlay, nrow, ncol",
     [


### PR DESCRIPTION
Fix [optional dependency CI tests](https://github.com/modflowpy/flopy/actions/runs/8875519001/job/24365119996) by marking tests requiring shapely. Also, it seems netcdf4-python is no longer happy with python3.8 on mac.