### PR TITLE
fix(mfmodel): fix budgetkey for transport models

### DIFF
--- a/flopy/mf6/mfmodel.py
+++ b/flopy/mf6/mfmodel.py
@@ -682,10 +682,13 @@ class MFModel(PackageContainer, ModelInterface):
 
     @property
     def output(self):
+        budgetkey = None
+        if self.model_type == "gwt6":
+            budgetkey = "MASS BUDGET FOR ENTIRE MODEL"
         try:
-            return self.oc.output
+            return MF6Output(self.oc, budgetkey=budgetkey)
         except AttributeError:
-            return MF6Output(self)
+            return MF6Output(self, budgetkey=budgetkey)
 
     def export(self, f, **kwargs):
         """Method to export a model to a shapefile or netcdf file

--- a/flopy/mf6/utils/output_util.py
+++ b/flopy/mf6/utils/output_util.py
@@ -23,7 +23,7 @@ class MF6Output:
 
     """
 
-    def __init__(self, obj):
+    def __init__(self, obj, budgetkey=None):
         from ..modflow import ModflowGwfoc, ModflowGwtoc, ModflowUtlobs
 
         # set initial observation definitions
@@ -39,6 +39,11 @@ class MF6Output:
         self._obj = obj
         self._methods = []
         self._sim_ws = obj.simulation_data.mfpath.get_sim_path()
+        self._budgetkey = (
+            "VOLUME BUDGET FOR ENTIRE MODEL"
+            if budgetkey is None
+            else budgetkey
+        )
         self.__budgetcsv = False
 
         if not isinstance(obj, (PackageInterface, ModelInterface)):
@@ -382,7 +387,7 @@ class MF6Output:
         if self._lst is not None:
             try:
                 list_file = os.path.join(self._sim_ws, self._lst)
-                return Mf6ListBudget(list_file)
+                return Mf6ListBudget(list_file, budgetkey=self._budgetkey)
             except (AssertionError, OSError):
                 return None
 


### PR DESCRIPTION
* add `budgetkey` param to `MF6Output` and pass it down to `MF6ListBudget` in `MF6Output.__list()`
* update `MFModel.output` to set `budgetkey` to "MASS..." instead of volume for transport models
* fix #2087 