### PR TITLE
test: show test package extras in pytest report header

### DIFF
--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -144,21 +144,24 @@ def pytest_report_header(config):
         except metadata.PackageNotFoundError:
             items.append(f"{name} (not found)")
     lines.append("required packages: " + ", ".join(items))
-    installed = []
-    not_found = []
-    for name in extra["optional"]:
-        if name in processed:
-            continue
-        processed.add(name)
-        try:
-            version = metadata.version(name)
-            installed.append(f"{name}-{version}")
-        except metadata.PackageNotFoundError:
-            not_found.append(name)
-    if installed:
-        lines.append("optional packages: " + ", ".join(installed))
-    if not_found:
-        lines.append("optional packages not found: " + ", ".join(not_found))
+    for optional in ["optional", "test"]:
+        installed = []
+        not_found = []
+        for name in extra[optional]:
+            if name in processed:
+                continue
+            processed.add(name)
+            try:
+                version = metadata.version(name)
+                installed.append(f"{name}-{version}")
+            except metadata.PackageNotFoundError:
+                not_found.append(name)
+        if installed:
+            lines.append(f"{optional} packages: {', '.join(installed)}")
+        if not_found:
+            lines.append(
+                f"{optional} packages not found: {', '.join(not_found)}"
+            )
     return "\n".join(lines)
 
 


### PR DESCRIPTION
This minor enhancement will expand the pytest header to show which packages and versions from the "test" extra are installed. It should help in situations like #2180

---

New header would look something like this:
```
============================= test session starts ==============================
platform linux -- Python 3.8.18, pytest-8.2.0, pluggy-1.5.0 -- /opt/hostedtoolcache/Python/3.8.18/x64/bin/python
cachedir: .pytest_cache
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
required packages: numpy-1.24.4, matplotlib-3.7.5, pandas-2.0.3
optional packages: affine-2.4.0, descartes-1.1.0, fiona-1.9.6, geojson-3.1.0, geopandas-0.13.2, imageio-2.34.1, netcdf4-1.6.5, pymetis-2023.1.1, pyproj-3.5.0, pyshp-2.3.1, pyvista-0.43.7, rasterio-1.3.10, rasterstats-0.19.0, scipy-1.10.1, shapely-2.0.4, vtk-9.3.0, xmipy-1.4.0
test packages: flopy-3.7.0.dev0, coverage-7.5.1, flaky-3.8.1, filelock-3.14.0, jupyter-1.0.0, jupytext-1.2, modflow-devtools-1.4.0, pytest-8.2.0, pytest-benchmark-4.0.0, pytest-cov-5.0.0, pytest-dotenv-0.5.2, pytest-xdist-3.6.1, pyzmq-26.0.3, syrupy-4.6.1, virtualenv-20.26.1
rootdir: /home/runner/work/flopy/flopy/autotest
configfile: pytest.ini
plugins: anyio-4.3.0, syrupy-4.6.1, flaky-3.8.1, benchmark-4.0.0, dotenv-0.5.2, cov-5.0.0, xdist-3.6.1
created: 2/2 workers
2 workers [1342 items]
```
note that there is a bit of overlap between "test packages" and "plugins", e.g. "pytest-xdist-3.6.1" and "xdist-3.6.1". However, I'm not sure if packages and pytest plugins can be easily distinguished to reduce the repetition.