### PR TITLE
fix(MFFileAccessArray): read_text_data_from_file modified for non-layered

### DIFF
--- a/flopy/mf6/data/mfdatastorage.py
+++ b/flopy/mf6/data/mfdatastorage.py
@@ -2012,6 +2012,7 @@ class DataStorage:
                     self._data_type,
                     self.get_data_dimensions(layer),
                     layer,
+                    self.layered,
                     read_file,
                 )[0]
             if apply_mult and self.layer_storage[layer].factor is not None:
@@ -2470,6 +2471,7 @@ class DataStorage:
                             np_data_type,
                             self.get_data_dimensions(layer),
                             layer,
+                            self.layered,
                             read_file,
                         )[0]
                         * mult

--- a/flopy/mf6/data/mffileaccess.py
+++ b/flopy/mf6/data/mffileaccess.py
@@ -584,8 +584,8 @@ class MFFileAccessArray(MFFileAccess):
         # determine line size
         line_size = None
         if layered:
-            # if the array is layered (meaning a control record for)
-            # each layer, then limit line size to number of columns
+            # if the array is layered (meaning a control record for
+            # each layer), then limit line size to number of columns
             if isinstance(data_dim, list):
                 line_size = data_dim[-1]
         # load variable data from file

--- a/flopy/mf6/data/mffileaccess.py
+++ b/flopy/mf6/data/mffileaccess.py
@@ -577,14 +577,17 @@ class MFFileAccessArray(MFFileAccess):
         data_type,
         data_dim,
         layer,
+        layered,
         fname=None,
         fd=None,
-        data_item=None,
     ):
         # determine line size
         line_size = None
-        if isinstance(data_dim, list):
-            line_size = data_dim[-1]
+        if layered:
+            # if the array is layered (meaning a control record for)
+            # each layer, then limit line size to number of columns
+            if isinstance(data_dim, list):
+                line_size = data_dim[-1]
         # load variable data from file
         current_size = 0
         if layer is None:
@@ -894,6 +897,7 @@ class MFFileAccessArray(MFFileAccess):
                     data_type,
                     storage.get_data_dimensions(layer),
                     layer,
+                    storage.layered,
                     fd=file_handle,
                 )
             except Exception as ex:


### PR DESCRIPTION
[Recent flopy changes](https://github.com/scottrp/flopy/commit/56b175defff2178ef0dc7d14e427f80b5fd0895c) broke reading of non-layered input, as mentioned [here](https://github.com/modflowpy/flopy/issues/2053).

This PR fixes the situation where non-layered input is read from a griddata block and all of the values are provided on one line.  This is the case for reading idomain for a [testmodel](https://github.com/MODFLOW-USGS/modflow6-testmodels/tree/master/mf6/test019_VilhelmsenLGR_nr) from [this file](https://github.com/MODFLOW-USGS/modflow6-testmodels/blob/master/mf6/test019_VilhelmsenLGR_nr/TM9_parent_GN.dis.idomain.dat).