### PR TITLE
test(gridgen): mark test requiring shapely and pyshp

### DIFF
--- a/autotest/test_gridgen.py
+++ b/autotest/test_gridgen.py
@@ -855,6 +855,7 @@ def test_gridgen(function_tmpdir):
 
 
 @requires_exe("mf6", "gridgen")
+@requires_pkg("shapely", "shapefile")
 def test_flopy_issue_1492(function_tmpdir):
     """
     Submitted by David Brakenhoff in


### PR DESCRIPTION
* fix [failing optional dependency CI tests](https://github.com/modflowpy/flopy/actions/runs/8966183383)