### PR TITLE
Fix problem with get_structured_faceflows

### DIFF
--- a/flopy/mf6/utils/postprocessing.py
+++ b/flopy/mf6/utils/postprocessing.py
@@ -126,7 +126,7 @@ def get_structured_faceflows(
             else:
                 # handle 2D layers/rows case
                 return 1 if ncol == 1 else 0
-        elif d == nrow * ncol:
+        elif d % (nrow * ncol) == 0:
             return 2
         else:
             return 1


### PR DESCRIPTION
This branch fixes a bug in get_structured_faceflows (introduced in PR #1968) that caused flf to become 0 for cells for which the cell below has idomain -1. Also includes a new test for it in test_postprocessing.py