### PR TITLE
fix(tutorial, verbosity setter): fixed tutorial model name and verbosity setter (#2182)

### DIFF
--- a/.docs/Notebooks/mf6_data_tutorial01.py
+++ b/.docs/Notebooks/mf6_data_tutorial01.py
@@ -47,7 +47,7 @@ import flopy
 
 temp_dir = TemporaryDirectory()
 workspace = temp_dir.name
-name = "tutorial01_mf6_data"
+name = "tutorial01"
 
 # set up simulation and basic packages
 sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=workspace)
@@ -56,7 +56,8 @@ flopy.mf6.ModflowTdis(
 )
 flopy.mf6.ModflowIms(sim)
 gwf = flopy.mf6.ModflowGwf(sim, modelname=name, save_flows=True)
-flopy.mf6.ModflowGwfdis(gwf, nlay=3, nrow=4, ncol=5)
+botm = [30.0, 20.0, 10.0]
+flopy.mf6.ModflowGwfdis(gwf, nlay=3, nrow=4, ncol=5, top=50.0, botm=botm)
 flopy.mf6.ModflowGwfic(gwf)
 flopy.mf6.ModflowGwfnpf(gwf, save_specific_discharge=True)
 flopy.mf6.ModflowGwfchd(

--- a/flopy/mf6/mfsimbase.py
+++ b/flopy/mf6/mfsimbase.py
@@ -254,7 +254,7 @@ class MFSimulationData:
         self.verify_data = True
         self.debug = False
         self.verbose = True
-        self.verbosity_level = VerbosityLevel.normal
+        self._verbosity_level = VerbosityLevel.normal
         self.max_columns_user_set = False
         self.max_columns_auto_set = False
         self.use_pandas = True
@@ -274,6 +274,17 @@ class MFSimulationData:
         # --- temporary variables ---
         # other external files referenced
         self.referenced_files = {}
+
+    @property
+    def verbosity_level(self):
+        return self._verbosity_level
+
+    @verbosity_level.setter
+    def verbosity_level(self, val):
+        if isinstance(val, VerbosityLevel):
+            self._verbosity_level = val
+        elif isinstance(val, int):
+            self._verbosity_level = VerbosityLevel(val)
 
     @property
     def lazy_io(self):


### PR DESCRIPTION
Tutorial01's name was too long for MODFLOW.  Additionally, it did not define a top and botm.

Added a verbosity setter that automatically converts numerical verbosity values to the verbosity enumeration value, so that interval values are kept consistent.