### PR TITLE
refactor(expired deprecation): raise AttributeError with to_shapefile

### DIFF
--- a/autotest/test_export.py
+++ b/autotest/test_export.py
@@ -2061,3 +2061,21 @@ def test_vtk_export_disu_model(function_tmpdir):
     strt_vtk = vtk_to_numpy(grid.GetCellData().GetArray("strt"))
     if not np.allclose(gwf.ic.strt.array, strt_vtk):
         raise AssertionError("'strt' array not written in proper node order")
+
+
+def test_to_shapefile_raises_attributeerror():
+    # deprecated 3.2.4, changed to raise AttributeError version 3.8
+    # these attributes and this test may eventually be removed
+    m = flopy.modflow.Modflow()
+    assert isinstance(m, flopy.mbase.BaseModel)
+    with pytest.raises(AttributeError, match="was removed"):
+        m.to_shapefile("nope.shp")
+    dis = flopy.modflow.ModflowDis(m)
+    assert isinstance(dis, flopy.pakbase.Package)
+    with pytest.raises(AttributeError, match="was removed"):
+        dis.to_shapefile("nope.shp")
+    wel = flopy.modflow.ModflowWel(m)
+    spd = wel.stress_period_data
+    assert isinstance(spd, flopy.utils.MfList)
+    with pytest.raises(AttributeError, match="was removed"):
+        spd.to_shapefile("nope.shp", kper=1)

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -1703,34 +1703,10 @@ class BaseModel(ModelInterface):
         )
         return axes
 
-    def to_shapefile(
-        self, filename: Union[str, os.PathLike], package_names=None, **kwargs
-    ):
-        """
-        Wrapper function for writing a shapefile for the model grid.  If
-        package_names is not None, then search through the requested packages
-        looking for arrays that can be added to the shapefile as attributes
-
-        Parameters
-        ----------
-        filename : str or PathLike
-            Path of the shapefile to write
-        package_names : list of package names (e.g. ["dis","lpf"])
-            Packages to export data arrays to shapefile. (default is None)
-
-        Returns
-        -------
-        None
-
-        Examples
-        --------
-        >>> import flopy
-        >>> m = flopy.modflow.Modflow()
-        >>> m.to_shapefile('model.shp', SelPackList)
-
-        """
-        warnings.warn("to_shapefile() is deprecated. use .export()")
-        self.export(filename, package_names=package_names)
+    def to_shapefile(self, *args, **kwargs):
+        """Raises AttributeError, use :meth:`export`."""
+        # deprecated 3.2.4, changed to raise AttributeError version 3.8
+        raise AttributeError(".to_shapefile() was removed; use .export()")
 
 
 def run_model(

--- a/flopy/pakbase.py
+++ b/flopy/pakbase.py
@@ -838,37 +838,10 @@ class Package(PackageInterface):
         axes = PlotUtilities._plot_package_helper(self, **kwargs)
         return axes
 
-    def to_shapefile(self, filename, **kwargs):
-        """
-        Export 2-D, 3-D, and transient 2-D model data to shapefile (polygons).
-        Adds an attribute for each layer in each data array
-
-        Parameters
-        ----------
-        filename : str
-            Shapefile name to write
-
-        Returns
-        ----------
-        None
-
-        See Also
-        --------
-
-        Notes
-        -----
-
-        Examples
-        --------
-        >>> import flopy
-        >>> ml = flopy.modflow.Modflow.load('test.nam')
-        >>> ml.lpf.to_shapefile('test_hk.shp')
-
-        """
-        import warnings
-
-        warnings.warn("to_shapefile() is deprecated. use .export()")
-        self.export(filename)
+    def to_shapefile(self, *args, **kwargs):
+        """Raises AttributeError, use :meth:`export`."""
+        # deprecated 3.2.4, changed to raise AttributeError version 3.8
+        raise AttributeError(".to_shapefile() was removed; use .export()")
 
     def webdoc(self):
         """Open the web documentation."""

--- a/flopy/utils/util_list.py
+++ b/flopy/utils/util_list.py
@@ -998,40 +998,10 @@ class MfList(DataInterface, DataListInterface):
 
         return axes
 
-    def to_shapefile(self, filename, kper=None):
-        """
-        Export stress period boundary condition (MfList) data for a specified
-        stress period
-
-        Parameters
-        ----------
-        filename : str
-            Shapefile name to write
-        kper : int
-            MODFLOW zero-based stress period number to return. (default is None)
-
-        Returns
-        ----------
-        None
-
-        See Also
-        --------
-
-        Notes
-        -----
-
-        Examples
-        --------
-        >>> import flopy
-        >>> ml = flopy.modflow.Modflow.load('test.nam')
-        >>> ml.wel.to_shapefile('test_hk.shp', kper=1)
-        """
-        import warnings
-
-        warnings.warn(
-            "Deprecation warning: to_shapefile() is deprecated. use .export()"
-        )
-        self.export(filename, kper=kper)
+    def to_shapefile(self, *args, **kwargs):
+        """Raises AttributeError, use :meth:`export`."""
+        # deprecated 3.2.4, changed to raise AttributeError version 3.8
+        raise AttributeError(".to_shapefile() was removed; use .export()")
 
     def to_array(self, kper=0, mask=False):
         """


### PR DESCRIPTION
This PR changes deprecated `.to_shapefile()` functions to raise AttributeError with a helpful message.

These are the affected functions:

- [`flopy.utils.util_list.MfList.to_shapefile`](https://flopy.readthedocs.io/en/3.6.0/source/flopy.utils.util_list.html#flopy.utils.util_list.MfList.to_shapefile)
- [`flopy.pakbase.Package.to_shapefile`](https://flopy.readthedocs.io/en/3.6.0/source/flopy.pakbase.html#flopy.pakbase.Package.to_shapefile)
- [`flopy.mbase.BaseModel.to_shapefile`](https://flopy.readthedocs.io/en/3.6.0/source/flopy.mbase.html#flopy.mbase.BaseModel.to_shapefile)

While these functions have been deprecated since 3.2.4 released in 2016 ([changelog](https://flopy.readthedocs.io/en/3.6.0/md/version_changes.html#version-3-2-4)), they were never documented as such. Thus a helpful exception message and cross-referenced docstring is used instead of removing these functions.

---

Xref to #1884 where a similar approach was used.