### PR TITLE
feat(exg pkg binary file support)

### DIFF
--- a/.docs/Notebooks/lgr_tutorial01.py
+++ b/.docs/Notebooks/lgr_tutorial01.py
@@ -462,23 +462,11 @@ if include_transport:
     # retrieve the exchange data from the lgr object
     exchangedata = lgr.get_exchange_data(angldegx=True, cdist=True)
     nexg = len(exchangedata)
-
-    # When creating the exchange, which couples the child and parent
-    # models, use the xt3d option, which is an alternative to the
-    # ghost-node correction.  This xt3d option was added as a new
-    # capability for the gwt-gwt and gwf-gwf exchanges in MODFLOW version 6.3.0.
-    exg = flopy.mf6.ModflowGwtgwt(
-        sim,
-        exgtype="GWT6-GWT6",
-        gwfmodelname1=gwfp.name,
-        gwfmodelname2=gwfc.name,
-        # xt3d=True,
-        auxiliary=["angldegx", "cdist"],
-        exgmnamea=pname,
-        exgmnameb=cname,
-        nexg=nexg,
-        exchangedata=exchangedata,
-    )
+    exg_data = {
+        "filename": "exg_data.bin",
+        "data": exchangedata,
+        "binary": True,
+    }
 
     # Set up the parent model and use the lgr.parent object to
     # help provide the necessary information.
@@ -521,6 +509,23 @@ if include_transport:
         sim, linear_acceleration="BICGSTAB", filename="tran.ims"
     )
     sim.register_ims_package(ims_tran, [gwtp.name, gwtc.name])
+
+    # When creating the exchange, which couples the child and parent
+    # models, use the xt3d option, which is an alternative to the
+    # ghost-node correction.  This xt3d option was added as a new
+    # capability for the gwt-gwt and gwf-gwf exchanges in MODFLOW version 6.3.0.
+    exg = flopy.mf6.ModflowGwtgwt(
+        sim,
+        exgtype="GWT6-GWT6",
+        gwfmodelname1=gwfp.name,
+        gwfmodelname2=gwfc.name,
+        # xt3d=True,
+        auxiliary=["angldegx", "cdist"],
+        exgmnamea=pname,
+        exgmnameb=cname,
+        nexg=nexg,
+        exchangedata=exg_data,
+    )
 
     # couple flow and transport models
     gwfgwt_p = flopy.mf6.ModflowGwfgwt(

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -72,8 +72,56 @@ jobs:
           $PSDefaultParameterValues['*:ErrorAction']='Stop'
           powershell .github/install_opengl.ps1
 
-      - name: Install MODFLOW executables
-        uses: modflowpy/install-modflow-action@v1
+      - name: Install Python dependencies
+        run: |
+          pip install --upgrade pip
+          pip install https://github.com/modflowpy/pymake/zipball/master
+          pip install https://github.com/Deltares/xmipy/zipball/develop
+          pip install https://github.com/MODFLOW-USGS/modflowapi/zipball/develop
+          pip install .[test,optional]
+
+      - name: Setup GNU Fortran
+        uses: fortran-lang/setup-fortran@v1
+        with:
+          compiler: gcc
+          version: 13
+
+      - name: Checkout MODFLOW 6
+        uses: actions/checkout@v4
+        with:
+          repository: MODFLOW-USGS/modflow6
+          path: modflow6
+
+      - name: Update flopy MODFLOW 6 classes
+        working-directory: modflow6/autotest
+        run: |
+          python update_flopy.py
+
+      - name: Install meson
+        run: |
+          pip3 install meson ninja
+
+      - name: Setup modflow
+        working-directory: modflow6
+        run: |
+          meson setup builddir --buildtype=debugoptimized --prefix=$(pwd) --libdir=bin
+
+      - name: Build modflow
+        working-directory: modflow6
+        run: |
+          meson compile -C builddir
+
+      - name: Install modflow
+        working-directory: modflow6
+        run: |
+          meson install -C builddir
+
+      - name: Get executables
+        working-directory: modflow6/autotest
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          pytest -v --durations=0 get_exes.py
 
       - name: Run tutorial and example notebooks
         working-directory: autotest

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -72,56 +72,13 @@ jobs:
           $PSDefaultParameterValues['*:ErrorAction']='Stop'
           powershell .github/install_opengl.ps1
 
-      - name: Install Python dependencies
-        run: |
-          pip install --upgrade pip
-          pip install https://github.com/modflowpy/pymake/zipball/master
-          pip install https://github.com/Deltares/xmipy/zipball/develop
-          pip install https://github.com/MODFLOW-USGS/modflowapi/zipball/develop
-          pip install .[test,optional]
+      - name: Install Modflow-related executables
+        uses: modflowpy/install-modflow-action@v1
 
-      - name: Setup GNU Fortran
-        uses: fortran-lang/setup-fortran@v1
+      - name: Install Modflow dev build executables
+        uses: modflowpy/install-modflow-action@v1
         with:
-          compiler: gcc
-          version: 13
-
-      - name: Checkout MODFLOW 6
-        uses: actions/checkout@v4
-        with:
-          repository: MODFLOW-USGS/modflow6
-          path: modflow6
-
-      - name: Update flopy MODFLOW 6 classes
-        working-directory: modflow6/autotest
-        run: |
-          python update_flopy.py
-
-      - name: Install meson
-        run: |
-          pip3 install meson ninja
-
-      - name: Setup modflow
-        working-directory: modflow6
-        run: |
-          meson setup builddir --buildtype=debugoptimized --prefix=$(pwd) --libdir=bin
-
-      - name: Build modflow
-        working-directory: modflow6
-        run: |
-          meson compile -C builddir
-
-      - name: Install modflow
-        working-directory: modflow6
-        run: |
-          meson install -C builddir
-
-      - name: Get executables
-        working-directory: modflow6/autotest
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          pytest -v --durations=0 get_exes.py
+          repo: modflow6-nightly-build
 
       - name: Run tutorial and example notebooks
         working-directory: autotest

--- a/autotest/regression/test_mf6.py
+++ b/autotest/regression/test_mf6.py
@@ -2853,6 +2853,11 @@ def test006_create_tests_2models_gnc(function_tmpdir, example_data_path):
     )
     sim.remove_package(exg_package.package_type)
 
+    exg_data = {
+        "filename": "exg_data.txt",
+        "data": exgrecarray,
+        "binary": True,
+    }
     exg_package = ModflowGwfgwf(
         sim,
         print_input=True,
@@ -2860,7 +2865,7 @@ def test006_create_tests_2models_gnc(function_tmpdir, example_data_path):
         save_flows=True,
         auxiliary="testaux",
         nexg=36,
-        exchangedata=exgrecarray,
+        exchangedata=exg_data,
         exgtype="gwf6-gwf6",
         exgmnamea=model_name_1,
         exgmnameb=model_name_2,
@@ -4039,6 +4044,11 @@ def test006_2models_different_dis(function_tmpdir, example_data_path):
     exgrecarray = testutils.read_exchangedata(
         os.path.join(pth, "exg.txt"), 3, 2
     )
+    exg_data = {
+        "filename": "exg_data.bin",
+        "data": exgrecarray,
+        "binary": True,
+    }
 
     # build obs dictionary
     gwf_obs = {
@@ -4055,7 +4065,7 @@ def test006_2models_different_dis(function_tmpdir, example_data_path):
         save_flows=True,
         auxiliary="testaux",
         nexg=9,
-        exchangedata=exgrecarray,
+        exchangedata=exg_data,
         exgtype="gwf6-gwf6",
         exgmnamea=model_name_1,
         exgmnameb=model_name_2,

--- a/autotest/regression/test_mf6.py
+++ b/autotest/regression/test_mf6.py
@@ -2886,6 +2886,7 @@ def test006_create_tests_2models_gnc(function_tmpdir, example_data_path):
 
     # change folder to save simulation
     sim.set_sim_path(function_tmpdir)
+    exg_package.exchangedata.set_record(exg_data)
 
     # write simulation to new location
     sim.write_simulation()
@@ -4087,6 +4088,7 @@ def test006_2models_different_dis(function_tmpdir, example_data_path):
 
     # change folder to save simulation
     sim.set_sim_path(function_tmpdir)
+    exg_package.exchangedata.set_record(exg_data)
 
     # write simulation to new location
     sim.write_simulation()

--- a/autotest/regression/test_mf6_pandas.py
+++ b/autotest/regression/test_mf6_pandas.py
@@ -182,13 +182,13 @@ def test_pandas_001(function_tmpdir, example_data_path):
     assert well_data_pd.iloc[0, 1] == 0
     assert well_data_pd.iloc[0, 2] == 4
     assert well_data_pd.iloc[0, 3] == -2000.0
-    assert well_data_pd["layer"][0] == 0
-    assert well_data_pd["row"][0] == 0
-    assert well_data_pd["column"][0] == 4
+    assert well_data_pd["cellid_layer"][0] == 0
+    assert well_data_pd["cellid_row"][0] == 0
+    assert well_data_pd["cellid_column"][0] == 4
     assert well_data_pd["q"][0] == -2000.0
-    assert well_data_pd["layer"][1] == 0
-    assert well_data_pd["row"][1] == 0
-    assert well_data_pd["column"][1] == 7
+    assert well_data_pd["cellid_layer"][1] == 0
+    assert well_data_pd["cellid_row"][1] == 0
+    assert well_data_pd["cellid_column"][1] == 7
     assert well_data_pd["q"][1] == -2.0
 
     well_data_rec = wel_package.stress_period_data.get_data(0)
@@ -284,13 +284,13 @@ def test_pandas_001(function_tmpdir, example_data_path):
     assert well_data_pd_0.iloc[0, 1] == 0
     assert well_data_pd_0.iloc[0, 2] == 4
     assert well_data_pd_0.iloc[0, 3] == -2000.0
-    assert well_data_pd_0["layer"][0] == 0
-    assert well_data_pd_0["row"][0] == 0
-    assert well_data_pd_0["column"][0] == 4
+    assert well_data_pd_0["cellid_layer"][0] == 0
+    assert well_data_pd_0["cellid_row"][0] == 0
+    assert well_data_pd_0["cellid_column"][0] == 4
     assert well_data_pd_0["q"][0] == -2000.0
-    assert well_data_pd_0["layer"][1] == 0
-    assert well_data_pd_0["row"][1] == 0
-    assert well_data_pd_0["column"][1] == 7
+    assert well_data_pd_0["cellid_layer"][1] == 0
+    assert well_data_pd_0["cellid_row"][1] == 0
+    assert well_data_pd_0["cellid_column"][1] == 7
     assert well_data_pd_0["q"][1] == -2.0
     well_data_pd = test_wel.stress_period_data.get_dataframe(1)
     assert isinstance(well_data_pd, pd.DataFrame)
@@ -298,13 +298,13 @@ def test_pandas_001(function_tmpdir, example_data_path):
     assert well_data_pd.iloc[0, 1] == 0
     assert well_data_pd.iloc[0, 2] == 4
     assert well_data_pd.iloc[0, 3] == -1000.0
-    assert well_data_pd["layer"][0] == 0
-    assert well_data_pd["row"][0] == 0
-    assert well_data_pd["column"][0] == 4
+    assert well_data_pd["cellid_layer"][0] == 0
+    assert well_data_pd["cellid_row"][0] == 0
+    assert well_data_pd["cellid_column"][0] == 4
     assert well_data_pd["q"][0] == -1000.0
-    assert well_data_pd["layer"][1] == 0
-    assert well_data_pd["row"][1] == 0
-    assert well_data_pd["column"][1] == 7
+    assert well_data_pd["cellid_layer"][1] == 0
+    assert well_data_pd["cellid_row"][1] == 0
+    assert well_data_pd["cellid_column"][1] == 7
     assert well_data_pd["q"][1] == -20.0
     test_riv = test_mod.get_package("riv")
     riv_data_pd = test_riv.stress_period_data.get_dataframe(0)

--- a/flopy/mf6/coordinates/modeldimensions.py
+++ b/flopy/mf6/coordinates/modeldimensions.py
@@ -102,6 +102,15 @@ class DataDimensions:
             subspace_string
         )
 
+    def get_cellid_size(self, data_item_name):
+        model_num = DatumUtil.cellid_model_num(
+            data_item_name,
+            self.structure.model_data,
+            self.package_dim.model_dim,
+        )
+        model_grid = self.get_model_grid(model_num=model_num)
+        return model_grid.get_num_spatial_coordinates()
+
     def get_model_dim(self, data_item_num, model_num=None):
         if (
             self.package_dim.model_dim is None
@@ -111,9 +120,14 @@ class DataDimensions:
             return self.package_dim.model_dim[0]
         else:
             if model_num is None:
-                model_num = self.structure.data_item_structures[data_item_num][
-                    -1
-                ]
+                # see if the name of the data item indicates which model to use
+                item_name = self.structure.data_item_structures[
+                    data_item_num
+                ].name
+                if item_name[-2] == "m" and DatumUtil.is_int(item_name[-1]):
+                    model_num = int(item_name[-1]) - 1
+                else:
+                    return self.package_dim.model_dim[0]
                 if not (
                     len(self.structure.data_item_structures) > data_item_num
                 ):
@@ -133,8 +147,7 @@ class DataDimensions:
                         f"{len(self.package_dim.model_dim)}."
                     )
 
-            if DatumUtil.is_int(model_num):
-                return self.package_dim.model_dim[int(model_num)]
+            return self.package_dim.model_dim[model_num]
 
 
 class PackageDimensions:

--- a/flopy/mf6/data/mfdataplist.py
+++ b/flopy/mf6/data/mfdataplist.py
@@ -303,36 +303,42 @@ class MFPandasList(mfdata.MFMultiDimVar, DataListInterface):
                     columns = data.columns.tolist()
                     if isinstance(self._mg, StructuredGrid):
                         if (
-                            "layer" in columns
-                            and "row" in columns
-                            and "column" in columns
+                            "cellid_layer" in columns
+                            and "cellid_row" in columns
+                            and "cellid_column" in columns
                         ):
                             data["cellid"] = data[
-                                ["layer", "row", "column"]
+                                ["cellid_layer", "cellid_row", "cellid_column"]
                             ].apply(tuple, axis=1)
                             if not keep_existing:
                                 data = data.drop(
-                                    columns=["layer", "row", "column"]
+                                    columns=[
+                                        "cellid_layer",
+                                        "cellid_row",
+                                        "cellid_column",
+                                    ]
                                 )
                     elif isinstance(self._mg, VertexGrid):
                         cell_2 = None
-                        if "cell" in columns:
-                            cell_2 = "cell"
+                        if "cellid_cell" in columns:
+                            cell_2 = "cellid_cell"
                         elif "ncpl" in columns:
-                            cell_2 = "ncpl"
-                        if cell_2 is not None and "layer" in columns:
-                            data["cellid"] = data[["layer", cell_2]].apply(
-                                tuple, axis=1
-                            )
+                            cell_2 = "cellid_ncpl"
+                        if cell_2 is not None and "cellid_layer" in columns:
+                            data["cellid"] = data[
+                                ["cellid_layer", cell_2]
+                            ].apply(tuple, axis=1)
                             if not keep_existing:
-                                data = data.drop(columns=["layer", cell_2])
+                                data = data.drop(
+                                    columns=["cellid_layer", cell_2]
+                                )
                     elif isinstance(self._mg, UnstructuredGrid):
-                        if "node" in columns:
-                            data["cellid"] = data[["node"]].apply(
+                        if "cellid_node" in columns:
+                            data["cellid"] = data[["cellid_node"]].apply(
                                 tuple, axis=1
                             )
                             if not keep_existing:
-                                data = data.drop(columns=["node"])
+                                data = data.drop(columns=["cellid_node"])
                     else:
                         raise MFDataException(
                             "ERROR: Unrecognized model grid "
@@ -408,14 +414,20 @@ class MFPandasList(mfdata.MFMultiDimVar, DataListInterface):
                         # get the appropriate cellid column headings for the
                         # model's discretization type
                         if isinstance(self._mg, StructuredGrid):
-                            self._append_type_list("layer", i_type, True)
-                            self._append_type_list("row", i_type, True)
-                            self._append_type_list("column", i_type, True)
+                            self._append_type_list(
+                                "cellid_layer", i_type, True
+                            )
+                            self._append_type_list("cellid_row", i_type, True)
+                            self._append_type_list(
+                                "cellid_column", i_type, True
+                            )
                         elif isinstance(self._mg, VertexGrid):
-                            self._append_type_list("layer", i_type, True)
-                            self._append_type_list("cell", i_type, True)
+                            self._append_type_list(
+                                "cellid_layer", i_type, True
+                            )
+                            self._append_type_list("cellid_cell", i_type, True)
                         elif isinstance(self._mg, UnstructuredGrid):
-                            self._append_type_list("node", i_type, True)
+                            self._append_type_list("cellid_node", i_type, True)
                         else:
                             raise MFDataException(
                                 "ERROR: Unrecognized model grid "
@@ -496,42 +508,44 @@ class MFPandasList(mfdata.MFMultiDimVar, DataListInterface):
                 try:
                     pdata.insert(
                         loc=field_idx,
-                        column=self._unique_column_name(pdata, "layer"),
+                        column=self._unique_column_name(pdata, "cellid_layer"),
                         value=pdata.apply(lambda x: x[column_name][0], axis=1),
                     )
                 except (ValueError, TypeError):
                     self._untuple_manually(
                         pdata,
                         field_idx,
-                        self._unique_column_name(pdata, "layer"),
+                        self._unique_column_name(pdata, "cellid_layer"),
                         column_name,
                         0,
                     )
                 try:
                     pdata.insert(
                         loc=field_idx + 1,
-                        column=self._unique_column_name(pdata, "row"),
+                        column=self._unique_column_name(pdata, "cellid_row"),
                         value=pdata.apply(lambda x: x[column_name][1], axis=1),
                     )
                 except (ValueError, TypeError):
                     self._untuple_manually(
                         pdata,
                         field_idx + 1,
-                        self._unique_column_name(pdata, "row"),
+                        self._unique_column_name(pdata, "cellid_row"),
                         column_name,
                         1,
                     )
                 try:
                     pdata.insert(
                         loc=field_idx + 2,
-                        column=self._unique_column_name(pdata, "column"),
+                        column=self._unique_column_name(
+                            pdata, "cellid_column"
+                        ),
                         value=pdata.apply(lambda x: x[column_name][2], axis=1),
                     )
                 except (ValueError, TypeError):
                     self._untuple_manually(
                         pdata,
                         field_idx + 2,
-                        self._unique_column_name(pdata, "column"),
+                        self._unique_column_name(pdata, "cellid_column"),
                         column_name,
                         2,
                     )
@@ -539,48 +553,48 @@ class MFPandasList(mfdata.MFMultiDimVar, DataListInterface):
                 try:
                     pdata.insert(
                         loc=field_idx,
-                        column=self._unique_column_name(pdata, "layer"),
+                        column=self._unique_column_name(pdata, "cellid_layer"),
                         value=pdata.apply(lambda x: x[column_name][0], axis=1),
                     )
                 except (ValueError, TypeError):
                     self._untuple_manually(
                         pdata,
                         field_idx,
-                        self._unique_column_name(pdata, "layer"),
+                        self._unique_column_name(pdata, "cellid_layer"),
                         column_name,
                         0,
                     )
                 try:
                     pdata.insert(
                         loc=field_idx + 1,
-                        column=self._unique_column_name(pdata, "cell"),
+                        column=self._unique_column_name(pdata, "cellid_cell"),
                         value=pdata.apply(lambda x: x[column_name][1], axis=1),
                     )
                 except (ValueError, TypeError):
                     self._untuple_manually(
                         pdata,
                         field_idx + 1,
-                        self._unique_column_name(pdata, "cell"),
+                        self._unique_column_name(pdata, "cellid_cell"),
                         column_name,
                         1,
                     )
             elif isinstance(self._mg, UnstructuredGrid):
-                if column_name == "node":
+                if column_name == "cellid_node":
                     # fixing a problem where node was specified as a tuple
                     # make sure new column is named properly
-                    column_name = "node_2"
-                    pdata = pdata.rename(columns={"node": column_name})
+                    column_name = "cellid_node_2"
+                    pdata = pdata.rename(columns={"cellid_node": column_name})
                 try:
                     pdata.insert(
                         loc=field_idx,
-                        column=self._unique_column_name(pdata, "node"),
+                        column=self._unique_column_name(pdata, "cellid_node"),
                         value=pdata.apply(lambda x: x[column_name][0], axis=1),
                     )
                 except (ValueError, TypeError):
                     self._untuple_manually(
                         pdata,
                         field_idx,
-                        self._unique_column_name(pdata, "node"),
+                        self._unique_column_name(pdata, "cellid_node"),
                         column_name,
                         0,
                     )
@@ -1239,7 +1253,6 @@ class MFPandasList(mfdata.MFMultiDimVar, DataListInterface):
         file_access.write_binary_file(
             self._dataframe_to_recarray(data),
             fd_data_file,
-            self._model_or_sim.modeldiscrit,
         )
         data_storage = self._get_storage_obj()
         data_storage.internal_data = None
@@ -1281,13 +1294,12 @@ class MFPandasList(mfdata.MFMultiDimVar, DataListInterface):
             )
             np_data = file_access.read_binary_data_from_file(
                 file_path,
-                self._model_or_sim.modeldiscrit,
                 build_cellid=False,
             )
             pd_data = pandas.DataFrame(np_data)
             if "col" in pd_data:
                 # keep layer/row/column names consistent
-                pd_data = pd_data.rename(columns={"col": "column"})
+                pd_data = pd_data.rename(columns={"col": "cellid_column"})
             self._decrement_id_fields(pd_data)
         else:
             with open(file_path, "r") as fd_data_file:
@@ -1439,16 +1451,17 @@ class MFPandasList(mfdata.MFMultiDimVar, DataListInterface):
         an item in the expected data structure and the data provided.
         """
         if data_item_struct.numeric_index or data_item_struct.is_cellid:
-            if data_item_struct.name.lower() == "cellid":
+            name = data_item_struct.name.lower()
+            if name.startswith("cellid"):
                 if isinstance(self._mg, StructuredGrid):
-                    id_fields.append("layer")
-                    id_fields.append("row")
-                    id_fields.append("column")
+                    id_fields.append(f"{name}_layer")
+                    id_fields.append(f"{name}_row")
+                    id_fields.append(f"{name}_column")
                 elif isinstance(self._mg, VertexGrid):
-                    id_fields.append("layer")
-                    id_fields.append("cell")
+                    id_fields.append(f"{name}_layer")
+                    id_fields.append(f"{name}_cell")
                 elif isinstance(self._mg, UnstructuredGrid):
-                    id_fields.append("node")
+                    id_fields.append(f"{name}_node")
                 else:
                     raise MFDataException(
                         "ERROR: Unrecognized model grid "

--- a/flopy/mf6/data/mffileaccess.py
+++ b/flopy/mf6/data/mffileaccess.py
@@ -1106,6 +1106,7 @@ class MFFileAccessList(MFFileAccess):
         return np.array(data_list, dtype=header)
 
     def _get_header(self):
+        np_int_type = np.int32
         np_flt_type = np.float64
         header = []
         int_cellid_indexes = {}
@@ -1124,7 +1125,10 @@ class MFFileAccessList(MFFileAccess):
                     ext_cellid_indexes[index] = True
                 ext_index += len(cell_header)
             elif not di_struct.optional:
-                header.append((di_struct.name, np_flt_type))
+                if di_struct.type == DatumType.integer:
+                    header.append((di_struct.name, np_int_type))
+                else:
+                    header.append((di_struct.name, np_flt_type))
                 ext_index += 1
             elif di_struct.name == "aux":
                 aux_var_names = (

--- a/flopy/mf6/data/mffileaccess.py
+++ b/flopy/mf6/data/mffileaccess.py
@@ -1065,11 +1065,14 @@ class MFFileAccessList(MFFileAccess):
                     current_cellid_size += 1
                     rec_len = len(data_record)
                     if rec_len not in cellid_size:
-                        data_item_struct = \
-                            self.structure.data_item_structures[rec_len]
-                        cellid_size[rec_len] = \
+                        data_item_struct = self.structure.data_item_structures[
+                            rec_len
+                        ]
+                        cellid_size[rec_len] = (
                             self._data_dimensions.get_cellid_size(
-                                data_item_struct.name)
+                                data_item_struct.name
+                            )
+                        )
                     if current_cellid_size == cellid_size[rec_len]:
                         data_record += (current_cellid,)
                         current_cellid = ()
@@ -1137,12 +1140,16 @@ class MFFileAccessList(MFFileAccess):
     def _get_cell_header(self, data_item, data_set, index):
         cellid_size = self._data_dimensions.get_cellid_size(data_item.name)
         if cellid_size == 3:
-            return [(f"{data_item.name}_layer", np.int32),
-                    (f"{data_item.name}_row", np.int32),
-                    (f"{data_item.name}_column", np.int32)]
+            return [
+                (f"{data_item.name}_layer", np.int32),
+                (f"{data_item.name}_row", np.int32),
+                (f"{data_item.name}_column", np.int32),
+            ]
         elif cellid_size == 2:
-            return [(f"{data_item.name}_layer", np.int32),
-                    (f"{data_item.name}_cell", np.int32)]
+            return [
+                (f"{data_item.name}_layer", np.int32),
+                (f"{data_item.name}_cell", np.int32),
+            ]
         else:
             return [(f"{data_item.name}_nodes", np.int32)]
 


### PR DESCRIPTION
Support for binary file option with exchange package exchangedata block. In order to support this the column headers for the cellid data (layer, row, column) are renamed in the binary file header to make the unique.  Unique column header names are generated by adding the cellid field name (<cellidm1> or <cellidm2>) as a prefix to the <layer>, <row>, <column>, <node> names.  For example, originally column header for layers was just "layer".  Flopy changes this column header to "cellidm1_layer" for <cellidm1> and "cellidm2_layer" for <cellidm2>. 