### PR TITLE
ci(RTD): build only html and htmlzip -- disable PDF to conserve memory

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -25,8 +25,9 @@ build:
 sphinx:
   configuration: .docs/conf.py
 
-# Build docs in additional formats such as PDF and ePub
-formats: all
+# Build only html and htmlzip (skip others, including PDF and EPUB)
+formats:
+  - htmlzip
 
 # Set the Python version and requirements
 python:


### PR DESCRIPTION
The RTD builds have stopped working for a few weeks now, with the error occurring while processing the PDF documents with:
```
...
! TeX capacity exceeded, sorry [main memory size=5000000].
\FV@Space ...ionary {\copy \sphinxvisiblespacebox 
                                                  }{\sphinxafterbreak } {\ke...
l.7888 ...TC: datetime.datetime.now(datetime.UTC).
                                                  
!  ==> Fatal error occurred, no output PDF file produced!
Transcript written on flopy.log.
...
```
This type of fatal error is due to insufficient memory on the worker node. [Troubleshooting docs](https://docs.readthedocs.io/en/stable/guides/build-using-too-many-resources.html#reduce-formats-you-re-building) suggests to reduce the number of output formats.

This PR disables the following output formats.

- PDF. For flopy 3.6.0, this document is 2145 pages in US Letter page size (hopefully never printed). Is this document ever read or checked? For example, pages 733 to 753 simply lists numbers 1 to 1000.
- EPUB is an e-book file format. Is this document ever read or checked?

This PR keeps the following output formats:

- HTML is always built, and is the primary document most people use.
- Downloadable HTML ("htmlzip"). For flopy 3.6.0, this archive is 47 MB, which is expected. It is plausible this version of docs may need to be downloaded for "offline use" or for archiving, so I feel it is appropriate to keep this format option.