### PR TITLE
fix(docs): section underline matches section title

### DIFF
--- a/flopy/discretization/grid.py
+++ b/flopy/discretization/grid.py
@@ -128,7 +128,7 @@ class Grid:
         ndarrays for the x, y, and z coordinates
 
     Methods
-    ----------
+    -------
     get_coords(x, y)
         transform point or array of points x, y from model coordinates to
         spatial coordinates

--- a/flopy/discretization/structuredgrid.py
+++ b/flopy/discretization/structuredgrid.py
@@ -140,7 +140,7 @@ class StructuredGrid(Grid):
         y-location points for the edges of the model grid
 
     Methods
-    ----------
+    -------
     get_cell_vertices(i, j)
         returns vertices for a single cell at row, column i, j.
     """

--- a/flopy/discretization/vertexgrid.py
+++ b/flopy/discretization/vertexgrid.py
@@ -61,7 +61,7 @@ class VertexGrid(Grid):
         returns list of cells and their vertices
 
     Methods
-    ----------
+    -------
     get_cell_vertices(cellid)
         returns vertices for a single cell at cellid.
 

--- a/flopy/export/netcdf.py
+++ b/flopy/export/netcdf.py
@@ -976,7 +976,7 @@ class NetCdf:
         Method to initialize a new group within a netcdf file. This group
         can have independent dimensions from the global dimensions
 
-        Parameters:
+        Parameters
         ----------
         name : str
             name of the netcdf group

--- a/flopy/export/utils.py
+++ b/flopy/export/utils.py
@@ -324,10 +324,11 @@ def output_helper(
 
     Returns
     -------
-        None
-    Note:
+    None
+
+    Note
     ----
-        casts down double precision to single precision for netCDF files
+    casts down double precision to single precision for netCDF files
 
     """
     assert isinstance(ml, (BaseModel, ModelInterface))
@@ -867,7 +868,7 @@ def mflist_export(f: Union[str, os.PathLike, NetCdf], mfl, **kwargs):
     export helper for MfList instances
 
     Parameters
-    -----------
+    ----------
     f : str or PathLike or NetCdf
         file path or existing export instance type (NetCdf only for now)
     mfl : MfList instance
@@ -1024,7 +1025,7 @@ def transient2d_export(f: Union[str, os.PathLike], t2d, fmt=None, **kwargs):
     export helper for Transient2d instances
 
     Parameters
-    -----------
+    ----------
     f : str or PathLike
         filename or existing export instance type (NetCdf only for now)
     t2d : Transient2d instance
@@ -1184,7 +1185,7 @@ def array3d_export(f: Union[str, os.PathLike], u3d, fmt=None, **kwargs):
     export helper for Transient2d instances
 
     Parameters
-    -----------
+    ----------
     f : str or PathLike
         filename or existing export instance type (NetCdf only for now)
     u3d : Util3d instance

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -1678,7 +1678,7 @@ class BaseModel(ModelInterface):
                 MfList dictionary key. (default is None)
 
         Returns
-        ----------
+        -------
         axes : list
             Empty list is returned if filename_base is not None. Otherwise
             a list of matplotlib.pyplot.axis are returned.

--- a/flopy/mf6/coordinates/modeldimensions.py
+++ b/flopy/mf6/coordinates/modeldimensions.py
@@ -28,7 +28,7 @@ class DataDimensions:
         (optional)
 
     Methods
-    ----------
+    -------
     get_model_grid : ()
         returns a model grid based on the current simulation data
 
@@ -151,7 +151,7 @@ class PackageDimensions:
         Tuple representing the path to this package
 
     Methods
-    ----------
+    -------
     get_aux_variables : (model_num=0)
         returns the package's aux variables
     boundnames : (model_num=0)
@@ -322,7 +322,7 @@ class ModelDimensions:
         object containing simulation time information
 
     Methods
-    ----------
+    -------
     get_model_grid : ()
         returns a model grid based on the current simulation data
 

--- a/flopy/mf6/coordinates/modelgrid.py
+++ b/flopy/mf6/coordinates/modelgrid.py
@@ -20,7 +20,7 @@ class ModelCell:
         id of model cell
 
     Methods
-    ----------
+    -------
 
     See Also
     --------
@@ -50,7 +50,7 @@ class UnstructuredModelCell(ModelCell):
         name of the model
 
     Methods
-    ----------
+    -------
     get_cellid : ()
         returns the cellid
     get_top : ()
@@ -341,7 +341,7 @@ class ModelGrid:
         DiscretizationType.DISU)
 
     Methods
-    ----------
+    -------
     grid_type : ()
         returns the grid type
     grid_type_consistent : ()
@@ -789,7 +789,7 @@ class UnstructuredModelGrid(ModelGrid):
         contains all simulation related data
 
     Methods
-    ----------
+    -------
     get_unstruct_jagged_array_list : {}
         returns a dictionary of jagged arrays used in the unstructured grid
 

--- a/flopy/mf6/data/mfdataarray.py
+++ b/flopy/mf6/data/mfdataarray.py
@@ -1531,7 +1531,7 @@ class MFArray(MFMultiDimVar):
                 List of unique values to be excluded from the plot.
 
         Returns
-        ----------
+        -------
         out : list
             Empty list is returned if filename_base is not None. Otherwise
             a list of matplotlib.pyplot.axis is returned.
@@ -2100,7 +2100,7 @@ class MFTransientArray(MFArray, MFTransient):
                 extracted. (default is zero).
 
         Returns
-        ----------
+        -------
         axes : list
             Empty list is returned if filename_base is not None. Otherwise
             a list of matplotlib.pyplot.axis is returned.

--- a/flopy/mf6/data/mfdatalist.py
+++ b/flopy/mf6/data/mfdatalist.py
@@ -136,7 +136,7 @@ class MFList(mfdata.MFMultiDimVar, DataListInterface):
             return array with np.nan instead of zero
 
         Returns
-        ----------
+        -------
         out : dict of numpy.ndarrays
             Dictionary of 3-D numpy arrays containing the stress period data
             for a selected stress period. The dictionary keys are the
@@ -1451,7 +1451,7 @@ class MFList(mfdata.MFMultiDimVar, DataListInterface):
                 List of unique values to be excluded from the plot.
 
         Returns
-        ----------
+        -------
         out : list
             Empty list is returned if filename_base is not None. Otherwise
             a list of matplotlib.pyplot.axis is returned.
@@ -2122,7 +2122,7 @@ class MFTransientList(MFList, mfdata.MFTransient, DataListInterface):
                 List of unique values to be excluded from the plot.
 
         Returns
-        ----------
+        -------
         out : list
             Empty list is returned if filename_base is not None. Otherwise
             a list of matplotlib.pyplot.axis is returned.

--- a/flopy/mf6/data/mfdataplist.py
+++ b/flopy/mf6/data/mfdataplist.py
@@ -815,7 +815,7 @@ class MFPandasList(mfdata.MFMultiDimVar, DataListInterface):
             return array with np.nan instead of zero
 
         Returns
-        ----------
+        -------
         out : dict of numpy.ndarrays
             Dictionary of 3-D numpy arrays containing the stress period data
             for a selected stress period. The dictionary keys are the
@@ -1882,7 +1882,7 @@ class MFPandasList(mfdata.MFMultiDimVar, DataListInterface):
                 List of unique values to be excluded from the plot.
 
         Returns
-        ----------
+        -------
         out : list
             Empty list is returned if filename_base is not None. Otherwise
             a list of matplotlib.pyplot.axis is returned.
@@ -2604,7 +2604,7 @@ class MFPandasTransientList(
                 List of unique values to be excluded from the plot.
 
         Returns
-        ----------
+        -------
         out : list
             Empty list is returned if filename_base is not None. Otherwise
             a list of matplotlib.pyplot.axis is returned.

--- a/flopy/mf6/data/mfdatascalar.py
+++ b/flopy/mf6/data/mfdatascalar.py
@@ -668,7 +668,8 @@ class MFScalar(mfdata.MFData):
         """
         Helper method to plot scalar objects
 
-        Parameters:
+        Parameters
+        ----------
             scalar : flopy.mf6.data.mfscalar object
             filename_base : str
                 Base file name that will be used to automatically generate file
@@ -976,7 +977,7 @@ class MFScalarTransient(MFScalar, mfdata.MFTransient):
                 extracted. (default is zero).
 
         Returns
-        ----------
+        -------
         axes : list
             Empty list is returned if filename_base is not None. Otherwise
             a list of matplotlib.pyplot.axis is returned.

--- a/flopy/mf6/data/mfdatautil.py
+++ b/flopy/mf6/data/mfdatautil.py
@@ -155,7 +155,7 @@ def list_to_array(sarr, model_grid, kper=0, mask=False):
         return array with np.nan instead of zero
 
     Returns
-    ----------
+    -------
     out : dict of numpy.ndarrays
         Dictionary of 3-D numpy arrays containing the stress period data
         for a selected stress period. The dictionary keys are the

--- a/flopy/mf6/data/mfstructure.py
+++ b/flopy/mf6/data/mfstructure.py
@@ -63,7 +63,7 @@ class Dfn:
     -----
 
     Examples
-    ----
+    --------
     """
 
     def __init__(self):
@@ -179,7 +179,7 @@ class DfnPackage(Dfn):
     -----
 
     Examples
-    ----
+    --------
     """
 
     def __init__(self, package):
@@ -447,7 +447,7 @@ class DfnFile(Dfn):
     -----
 
     Examples
-    ----
+    --------
     """
 
     def __init__(self, file):

--- a/flopy/mf6/mfpackage.py
+++ b/flopy/mf6/mfpackage.py
@@ -3279,7 +3279,7 @@ class MFPackage(PackageContainer, PackageInterface):
                 MfList dictionary key. (default is None)
 
         Returns
-        ----------
+        -------
         axes : list
             Empty list is returned if filename_base is not None. Otherwise
             a list of matplotlib.pyplot.axis are returned.

--- a/flopy/mf6/mfsimbase.py
+++ b/flopy/mf6/mfsimbase.py
@@ -603,7 +603,7 @@ class MFSimulationBase(PackageContainer):
         Override __repr__ to print custom string.
 
         Returns
-        --------
+        -------
             repr string : str
                 string describing object
 
@@ -615,7 +615,7 @@ class MFSimulationBase(PackageContainer):
         Override __str__ to print custom string.
 
         Returns
-        --------
+        -------
             str string : str
                 string describing object
 
@@ -671,7 +671,7 @@ class MFSimulationBase(PackageContainer):
         Return a list of model names associated with this simulation.
 
         Returns
-        --------
+        -------
             list: list of model names
 
         """
@@ -683,7 +683,7 @@ class MFSimulationBase(PackageContainer):
         Return list of exchange files associated with this simulation.
 
         Returns
-        --------
+        -------
             list: list of exchange names
 
         """
@@ -1699,7 +1699,7 @@ class MFSimulationBase(PackageContainer):
                 default is None, i.e. use the builtion print
 
         Returns
-        --------
+        -------
             success : bool
             buff : list of lines of stdout
 
@@ -1786,7 +1786,7 @@ class MFSimulationBase(PackageContainer):
         Return a dictionary of models associated with this simulation.
 
         Returns
-        --------
+        -------
             model dict : dict
                 dictionary of models
 
@@ -1805,7 +1805,7 @@ class MFSimulationBase(PackageContainer):
                 will get the first model.
 
         Returns
-        --------
+        -------
             model : MFModel
 
         """
@@ -1833,7 +1833,7 @@ class MFSimulationBase(PackageContainer):
                 Name of exchange file to get
 
         Returns
-        --------
+        -------
             exchange package : MFPackage
 
         """
@@ -1853,7 +1853,7 @@ class MFSimulationBase(PackageContainer):
                 Name of mover file to get
 
         Returns
-        --------
+        -------
             mover package : MFPackage
 
         """
@@ -2076,7 +2076,7 @@ class MFSimulationBase(PackageContainer):
                 Produce a filename for this package
 
         Returns
-        --------
+        -------
             (path : tuple, package structure : MFPackageStructure)
 
         """
@@ -2213,7 +2213,7 @@ class MFSimulationBase(PackageContainer):
                Solution group of model
 
         Returns
-        --------
+        -------
            model_structure_object : MFModelStructure
         """
 
@@ -2262,7 +2262,7 @@ class MFSimulationBase(PackageContainer):
                 solution package file name
 
         Returns
-        --------
+        -------
             solution_package : MFPackage
 
         """
@@ -2318,7 +2318,7 @@ class MFSimulationBase(PackageContainer):
 
 
         Returns
-        --------
+        -------
             valid : bool
                 Whether this is a valid simulation
 
@@ -2556,7 +2556,7 @@ class MFSimulationBase(PackageContainer):
                     MFList dictionary key. (default is None)
 
         Returns
-        --------
+        -------
              axes: (list)
                 matplotlib.pyplot.axes objects
 

--- a/flopy/mf6/modflow/mfgnc.py
+++ b/flopy/mf6/modflow/mfgnc.py
@@ -229,7 +229,7 @@ class GncPackages(mfpackage.MFChildPackages):
     GncPackages is a container class for the ModflowGnc class.
 
     Methods
-    ----------
+    -------
     initialize
         Initializes a new ModflowGnc package removing any sibling child
         packages attached to the same parent package. See ModflowGnc init

--- a/flopy/mf6/modflow/mfgwemve.py
+++ b/flopy/mf6/modflow/mfgwemve.py
@@ -197,7 +197,7 @@ class GwemvePackages(mfpackage.MFChildPackages):
     GwemvePackages is a container class for the ModflowGwemve class.
 
     Methods
-    ----------
+    -------
     initialize
         Initializes a new ModflowGwemve package removing any sibling child
         packages attached to the same parent package. See ModflowGwemve init

--- a/flopy/mf6/modflow/mfgwfgnc.py
+++ b/flopy/mf6/modflow/mfgwfgnc.py
@@ -229,7 +229,7 @@ class GwfgncPackages(mfpackage.MFChildPackages):
     GwfgncPackages is a container class for the ModflowGwfgnc class.
 
     Methods
-    ----------
+    -------
     initialize
         Initializes a new ModflowGwfgnc package removing any sibling child
         packages attached to the same parent package. See ModflowGwfgnc init

--- a/flopy/mf6/modflow/mfgwfmvr.py
+++ b/flopy/mf6/modflow/mfgwfmvr.py
@@ -406,7 +406,7 @@ class GwfmvrPackages(mfpackage.MFChildPackages):
     GwfmvrPackages is a container class for the ModflowGwfmvr class.
 
     Methods
-    ----------
+    -------
     initialize
         Initializes a new ModflowGwfmvr package removing any sibling child
         packages attached to the same parent package. See ModflowGwfmvr init

--- a/flopy/mf6/modflow/mfgwtmvt.py
+++ b/flopy/mf6/modflow/mfgwtmvt.py
@@ -197,7 +197,7 @@ class GwtmvtPackages(mfpackage.MFChildPackages):
     GwtmvtPackages is a container class for the ModflowGwtmvt class.
 
     Methods
-    ----------
+    -------
     initialize
         Initializes a new ModflowGwtmvt package removing any sibling child
         packages attached to the same parent package. See ModflowGwtmvt init

--- a/flopy/mf6/modflow/mfmvr.py
+++ b/flopy/mf6/modflow/mfmvr.py
@@ -406,7 +406,7 @@ class MvrPackages(mfpackage.MFChildPackages):
     MvrPackages is a container class for the ModflowMvr class.
 
     Methods
-    ----------
+    -------
     initialize
         Initializes a new ModflowMvr package removing any sibling child
         packages attached to the same parent package. See ModflowMvr init

--- a/flopy/mf6/modflow/mfmvt.py
+++ b/flopy/mf6/modflow/mfmvt.py
@@ -197,7 +197,7 @@ class MvtPackages(mfpackage.MFChildPackages):
     MvtPackages is a container class for the ModflowMvt class.
 
     Methods
-    ----------
+    -------
     initialize
         Initializes a new ModflowMvt package removing any sibling child
         packages attached to the same parent package. See ModflowMvt init

--- a/flopy/mf6/modflow/mfutlats.py
+++ b/flopy/mf6/modflow/mfutlats.py
@@ -177,7 +177,7 @@ class UtlatsPackages(mfpackage.MFChildPackages):
     UtlatsPackages is a container class for the ModflowUtlats class.
 
     Methods
-    ----------
+    -------
     initialize
         Initializes a new ModflowUtlats package removing any sibling child
         packages attached to the same parent package. See ModflowUtlats init

--- a/flopy/mf6/modflow/mfutlobs.py
+++ b/flopy/mf6/modflow/mfutlobs.py
@@ -217,7 +217,7 @@ class UtlobsPackages(mfpackage.MFChildPackages):
     UtlobsPackages is a container class for the ModflowUtlobs class.
 
     Methods
-    ----------
+    -------
     initialize
         Initializes a new ModflowUtlobs package removing any sibling child
         packages attached to the same parent package. See ModflowUtlobs init

--- a/flopy/mf6/modflow/mfutltas.py
+++ b/flopy/mf6/modflow/mfutltas.py
@@ -196,7 +196,7 @@ class UtltasPackages(mfpackage.MFChildPackages):
     UtltasPackages is a container class for the ModflowUtltas class.
 
     Methods
-    ----------
+    -------
     initialize
         Initializes a new ModflowUtltas package removing any sibling child
         packages attached to the same parent package. See ModflowUtltas init

--- a/flopy/mf6/modflow/mfutlts.py
+++ b/flopy/mf6/modflow/mfutlts.py
@@ -272,7 +272,7 @@ class UtltsPackages(mfpackage.MFChildPackages):
     UtltsPackages is a container class for the ModflowUtlts class.
 
     Methods
-    ----------
+    -------
     initialize
         Initializes a new ModflowUtlts package removing any sibling child
         packages attached to the same parent package. See ModflowUtlts init

--- a/flopy/mf6/modflow/mfutltvk.py
+++ b/flopy/mf6/modflow/mfutltvk.py
@@ -236,7 +236,7 @@ class UtltvkPackages(mfpackage.MFChildPackages):
     UtltvkPackages is a container class for the ModflowUtltvk class.
 
     Methods
-    ----------
+    -------
     initialize
         Initializes a new ModflowUtltvk package removing any sibling child
         packages attached to the same parent package. See ModflowUtltvk init

--- a/flopy/mf6/modflow/mfutltvs.py
+++ b/flopy/mf6/modflow/mfutltvs.py
@@ -236,7 +236,7 @@ class UtltvsPackages(mfpackage.MFChildPackages):
     UtltvsPackages is a container class for the ModflowUtltvs class.
 
     Methods
-    ----------
+    -------
     initialize
         Initializes a new ModflowUtltvs package removing any sibling child
         packages attached to the same parent package. See ModflowUtltvs init

--- a/flopy/mf6/utils/binaryfile_utils.py
+++ b/flopy/mf6/utils/binaryfile_utils.py
@@ -57,7 +57,7 @@ class MFOutputRequester:
     binary data from the SimulationDict() object on the fly without
     actually storing it in the SimulationDict() object.
 
-    Parameters:
+    Parameters
     ----------
     mfdict: dict
         local instance of the SimulationDict() object
@@ -66,12 +66,12 @@ class MFOutputRequester:
     key: tuple
         user requested data key
 
-    Methods:
+    Methods
     -------
     MFOutputRequester.querybinarydata
         returns: Xarray object
 
-    Examples:
+    Examples
     --------
     >>> data = MFOutputRequester(mfdict, path, key)
     >>> data.querybinarydata

--- a/flopy/mf6/utils/mfobservation.py
+++ b/flopy/mf6/utils/mfobservation.py
@@ -53,15 +53,16 @@ class Observations:
     Simple class to extract and view Observation files for Uzf models
     (possibly all obs/hobs)?
 
-    Input:
-    ------
-    fi = (string) name of the observation binary output file
+    Parameters
+    ----------
+    fi : str
+        name of the observation binary output file
 
-    Methods:
-    --------
+    Methods
+    -------
     get_data(): (np.array) returns array of observation data
         parameters:
-        -----------
+        ----------
         text = (str) specific modflow record name contained in Obs.out file
         idx = (int), (slice(start, stop)) integer or slice of data to be
         returned. corresponds to kstp*kper - 1
@@ -478,7 +479,7 @@ class MFObservationRequester:
         obstype: (string) SINGLE or CONTINUOUS
 
         Returns:
-        --------
+        -------
          sets key: path to self.obs_dataDict
 
         """

--- a/flopy/mfusg/mfusg.py
+++ b/flopy/mfusg/mfusg.py
@@ -307,7 +307,7 @@ class MfUsg(Modflow):
             Option to raise exceptions on package load failure.
 
         Returns
-        ----------
+        -------
         files_successfully_loaded : list of loaded files
         files_not_loaded : list of files that were not loaded
         """

--- a/flopy/mfusg/mfusgwel.py
+++ b/flopy/mfusg/mfusgwel.py
@@ -249,9 +249,10 @@ class MfUsgWel(ModflowWel):
     def _check_for_aux(self, options, cln=False):
         """Check dtype for auxiliary variables, and add to options.
 
-        Parameters:
+        Parameters
         ----------
-            options: (list) package options
+        options: list
+            package options
 
         Returns
         -------
@@ -278,9 +279,10 @@ class MfUsgWel(ModflowWel):
     def write_file(self, f=None):
         """Write the package file.
 
-        Parameters:
+        Parameters
         ----------
-            f: (str) optional file name
+        f : str, optional
+            file name
 
         Returns
         -------

--- a/flopy/modflow/mfwel.py
+++ b/flopy/modflow/mfwel.py
@@ -251,8 +251,10 @@ class ModflowWel(Package):
         """
         Write the package file.
 
-        Parameters:
-            f: (str) optional file name
+        Parameters
+        ----------
+        f : str, optional
+            file name
 
         Returns
         -------

--- a/flopy/pakbase.py
+++ b/flopy/pakbase.py
@@ -812,7 +812,7 @@ class Package(PackageInterface):
                 MfList dictionary key. (default is None)
 
         Returns
-        ----------
+        -------
         axes : list
             Empty list is returned if filename_base is not None. Otherwise
             a list of matplotlib.pyplot.axis are returned.

--- a/flopy/utils/binaryfile.py
+++ b/flopy/utils/binaryfile.py
@@ -554,7 +554,7 @@ class BinaryLayerFile(LayerFile):
             row, and column values must be zero based.
 
         Returns
-        ----------
+        -------
         out : numpy array
             Array has size (ntimes, ncells + 1).  The first column in the
             data array will contain time (totim).
@@ -937,7 +937,7 @@ class HeadUFile(BinaryLayerFile):
             values must be zero based.
 
         Returns
-        ----------
+        -------
         out : numpy array
             Array has size (ntimes, ncells + 1).  The first column in the
             data array will contain time (totim).
@@ -1474,7 +1474,7 @@ class CellBudgetFile:
             Optional boolean used to decode byte strings (default is False).
 
         Returns
-        ----------
+        -------
         names : list of strings
             List of unique text names in the binary file.
 
@@ -1499,7 +1499,7 @@ class CellBudgetFile:
             Optional boolean used to decode byte strings (default is False).
 
         Returns
-        ----------
+        -------
         names : list of strings
             List of unique package names in the binary file.
 
@@ -1520,7 +1520,7 @@ class CellBudgetFile:
         Get a list of unique package names in the file
 
         Returns
-        ----------
+        -------
         out : list of strings
             List of unique package names in the binary file.
 
@@ -1551,7 +1551,7 @@ class CellBudgetFile:
             'RIVER LEAKAGE', 'STORAGE', 'FLOW RIGHT FACE', etc.
 
         Returns
-        ----------
+        -------
         out : tuple
             indices of selected record name in budget file.
 
@@ -1632,7 +1632,7 @@ class CellBudgetFile:
             'COMPACT BUDGET' MODFLOW budget file.  (Default is False.)
 
         Returns
-        ----------
+        -------
         recordlist : list of records
             A list of budget objects.  The structure of the returned object
             depends on the structure of the data in the cbb file.
@@ -1738,7 +1738,7 @@ class CellBudgetFile:
             List of times to from which to get time series.
 
         Returns
-        ----------
+        -------
         out : numpy array
             Array has size (ntimes, ncells + 1).  The first column in the
             data array will contain time (totim).
@@ -1885,7 +1885,7 @@ class CellBudgetFile:
             'COMPACT BUDGET' MODFLOW budget file.  (Default is False.)
 
         Returns
-        ----------
+        -------
         record : a single data record
             The structure of the returned object depends on the structure of
             the data in the cbb file. Compact list data are returned as
@@ -2065,7 +2065,7 @@ class CellBudgetFile:
             Dictionary with node keywords and flows (q) items.
 
         Returns
-        ----------
+        -------
         out : numpy masked array
             List contains unique simulation times (totim) in binary file.
 
@@ -2083,7 +2083,7 @@ class CellBudgetFile:
         Get a list of unique times in the file
 
         Returns
-        ----------
+        -------
         out : list of floats
             List contains unique simulation times (totim) in binary file.
 

--- a/flopy/utils/datafile.py
+++ b/flopy/utils/datafile.py
@@ -252,7 +252,7 @@ class LayerFile:
             Whether to print verbose output
 
         Returns
-        ----------
+        -------
         None
 
         See Also
@@ -341,7 +341,7 @@ class LayerFile:
                 if filename_base is not None. (default is 'png')
 
         Returns
-        ----------
+        -------
         None
 
         See Also
@@ -468,7 +468,7 @@ class LayerFile:
         Get a list of unique times in the file
 
         Returns
-        ----------
+        -------
         out : list of floats
             List contains unique simulation times (totim) in binary file.
 
@@ -505,7 +505,7 @@ class LayerFile:
            all layers will be included. (Default is None.)
 
         Returns
-        ----------
+        -------
         data : numpy array
             Array has size (nlay, nrow, ncol) if mflay is None or it has size
             (nrow, ncol) if mlay is specified.
@@ -556,7 +556,7 @@ class LayerFile:
            nodata value will be assigned np.nan.
 
         Returns
-        ----------
+        -------
         data : numpy array
             Array has size (ntimes, nlay, nrow, ncol) if mflay is None or it
             has size (ntimes, nrow, ncol) if mlay is specified.

--- a/flopy/utils/formattedfile.py
+++ b/flopy/utils/formattedfile.py
@@ -54,7 +54,7 @@ class FormattedHeader(Header):
             the header
 
         Returns
-        ----------
+        -------
         out : numpy array of header information
         also stores the header's format string as self.format_string
 
@@ -257,7 +257,7 @@ class FormattedLayerFile(LayerFile):
             row, and column values must be zero based.
 
         Returns
-        ----------
+        -------
         out : numpy array
             Array has size (ntimes, ncells + 1).  The first column in the
             data array will contain time (totim).

--- a/flopy/utils/geometry.py
+++ b/flopy/utils/geometry.py
@@ -11,7 +11,7 @@ class Shape:
     """
     Parent class for handling geo interfacing, do not instantiate directly
 
-    Parameters:
+    Parameters
     ----------
     type : str
         shapetype string
@@ -233,9 +233,9 @@ class MultiPolygon(Collection):
     Container for housing and describing multipolygon geometries (e.g. to be
         read or written to shapefiles or other geographic data formats)
 
-    Parameters:
+    Parameters
     ----------
-    polygons : list
+    polygons : list, tuple, default ()
         list of flopy.utils.geometry.Polygon objects
     """
 
@@ -261,9 +261,9 @@ class MultiLineString(Collection):
     Container for housing and describing multilinestring geometries (e.g. to be
         read or written to shapefiles or other geographic data formats)
 
-    Parameters:
+    Parameters
     ----------
-    polygons : list
+    linestrings : list, tuple, default ()
         list of flopy.utils.geometry.LineString objects
     """
 
@@ -289,9 +289,9 @@ class MultiPoint(Collection):
     Container for housing and describing multipoint geometries (e.g. to be
         read or written to shapefiles or other geographic data formats)
 
-    Parameters:
+    Parameters
     ----------
-    polygons : list
+    points : list, tuple, default ()
         list of flopy.utils.geometry.Point objects
     """
 

--- a/flopy/utils/mflistfile.py
+++ b/flopy/utils/mflistfile.py
@@ -183,7 +183,7 @@ class ListBudget:
         water budgets.
 
         Returns
-        ----------
+        -------
         out : list of (kstp, kper) tuples
             List of unique kstp, kper combinations in list file.  kstp and
             kper values are zero-based.
@@ -551,7 +551,7 @@ class ListBudget:
             file.
 
         Example
-        --------
+        -------
         >>> objLST = MfListBudget("my_model.lst")
         >>> raryReducedPpg = objLST.get_reduced_pumping()
         >>> dfReducedPpg = pd.DataFrame.from_records(raryReducedPpg)

--- a/flopy/utils/modpathfile.py
+++ b/flopy/utils/modpathfile.py
@@ -585,7 +585,7 @@ class EndpointFile(ModpathFile):
         Get the maximum travel time.
 
         Returns
-        ----------
+        -------
         out : float
             Maximum travel time.
 
@@ -600,7 +600,7 @@ class EndpointFile(ModpathFile):
         ----------
 
         Returns
-        ----------
+        -------
         data : numpy record array
             A numpy recarray with the endpoint particle data
 

--- a/flopy/utils/observationfile.py
+++ b/flopy/utils/observationfile.py
@@ -18,7 +18,7 @@ class ObsFiles(FlopyBinaryData):
         Get a list of unique times in the file
 
         Returns
-        ----------
+        -------
         out : list of floats
             List contains unique simulation times (totim) in binary file.
 
@@ -30,7 +30,7 @@ class ObsFiles(FlopyBinaryData):
         Get the number of times in the file
 
         Returns
-        ----------
+        -------
         out : int
             The number of simulation times (totim) in binary file.
 
@@ -42,7 +42,7 @@ class ObsFiles(FlopyBinaryData):
         Get the number of observations in the file
 
         Returns
-        ----------
+        -------
         out : tuple of int
             A tuple with the number of records and number of flow items
             in the file. The number of flow items is non-zero only if
@@ -56,7 +56,7 @@ class ObsFiles(FlopyBinaryData):
         Get a list of observation names in the file
 
         Returns
-        ----------
+        -------
         out : list of strings
             List of observation names in the binary file. totim is not
             included in the list of observation names.
@@ -82,7 +82,7 @@ class ObsFiles(FlopyBinaryData):
             data for all simulation times are returned. (default is None)
 
         Returns
-        ----------
+        -------
         data : numpy record array
             Array has size (ntimes, nitems). totim is always returned. nitems
             is 2 if idx or obsname is not None or nobs+1.

--- a/flopy/utils/particletrackfile.py
+++ b/flopy/utils/particletrackfile.py
@@ -60,7 +60,7 @@ class ParticleTrackFile(ABC):
         Get the maximum particle ID.
 
         Returns
-        ----------
+        -------
         out : int
             Maximum particle ID.
 
@@ -72,7 +72,7 @@ class ParticleTrackFile(ABC):
         Get the maximum tracking time.
 
         Returns
-        ----------
+        -------
         out : float
             Maximum tracking time.
 
@@ -99,7 +99,7 @@ class ParticleTrackFile(ABC):
             Whether to return only the minimal, canonical fields. Default is False.
 
         Returns
-        ----------
+        -------
         data : np.recarray
             Recarray with dtype ParticleTrackFile.outdtype
 
@@ -136,7 +136,7 @@ class ParticleTrackFile(ABC):
             Whether to return only the minimal, canonical fields. Default is False.
 
         Returns
-        ----------
+        -------
         data : list of numpy record arrays
             List of recarrays with dtype ParticleTrackFile.outdtype
 

--- a/flopy/utils/swroutputfile.py
+++ b/flopy/utils/swroutputfile.py
@@ -109,7 +109,7 @@ class SwrFile(FlopyBinaryData):
         ----------
 
         Returns
-        ----------
+        -------
         data : numpy array
             Array has size (nrecord, 3). None is returned if swrtype is not
             'flow'
@@ -134,7 +134,7 @@ class SwrFile(FlopyBinaryData):
         Get the number of records in the file
 
         Returns
-        ----------
+        -------
         out : tuple of int
             A tuple with the number of records and number of flow items
             in the file. The number of flow items is non-zero only if
@@ -149,7 +149,7 @@ class SwrFile(FlopyBinaryData):
         in the file
 
         Returns
-        ----------
+        -------
         out : list of (kswr, kstp, kper) tuples
             List of unique kswr, kstp, kper combinations in binary file.
             kswr, kstp, and kper values are zero-based.
@@ -162,7 +162,7 @@ class SwrFile(FlopyBinaryData):
         Get the number of times in the file
 
         Returns
-        ----------
+        -------
         out : int
             The number of simulation times (totim) in binary file.
 
@@ -174,7 +174,7 @@ class SwrFile(FlopyBinaryData):
         Get a list of unique times in the file
 
         Returns
-        ----------
+        -------
         out : list of floats
             List contains unique simulation times (totim) in binary file.
 
@@ -186,7 +186,7 @@ class SwrFile(FlopyBinaryData):
         Get a list of unique record names in the file
 
         Returns
-        ----------
+        -------
         out : list of strings
             List of unique text names in the binary file.
 
@@ -210,7 +210,7 @@ class SwrFile(FlopyBinaryData):
             The simulation time. (default is None)
 
         Returns
-        ----------
+        -------
         data : numpy record array
             Array has size (nitems).
 
@@ -288,7 +288,7 @@ class SwrFile(FlopyBinaryData):
             (default is 0)
 
         Returns
-        ----------
+        -------
         out : numpy recarray
             Array has size (ntimes, nitems).  The first column in the
             data array will contain time (totim). nitems is 2 for stage

--- a/flopy/utils/util_array.py
+++ b/flopy/utils/util_array.py
@@ -708,7 +708,7 @@ class Util3d(DataInterface):
                 List of unique values to be excluded from the plot.
 
         Returns
-        ----------
+        -------
         out : list
             Empty list is returned if filename_base is not None. Otherwise
             a list of matplotlib.pyplot.axis is returned.
@@ -1520,7 +1520,7 @@ class Transient2d(DataInterface):
                 extracted. (default is zero).
 
         Returns
-        ----------
+        -------
         out : list
             Empty list is returned if filename_base is not None. Otherwise
             a list of matplotlib.pyplot.axis is returned.
@@ -1974,7 +1974,7 @@ class Util2d(DataInterface):
                 List of unique values to be excluded from the plot.
 
         Returns
-        ----------
+        -------
         out : list
             Empty list is returned if filename_base is not None. Otherwise
             a list of matplotlib.pyplot.axis is returned.

--- a/flopy/utils/util_list.py
+++ b/flopy/utils/util_list.py
@@ -964,7 +964,7 @@ class MfList(DataInterface, DataListInterface):
                 List of unique values to be excluded from the plot.
 
         Returns
-        ----------
+        -------
         out : list
             Empty list is returned if filename_base is not None. Otherwise
             a list of matplotlib.pyplot.axis is returned.
@@ -1015,7 +1015,7 @@ class MfList(DataInterface, DataListInterface):
         mask : boolean
             return array with np.nan instead of zero
         Returns
-        ----------
+        -------
         out : dict of numpy.ndarrays
             Dictionary of 3-D numpy arrays containing the stress period data for
             a selected stress period. The dictionary keys are the MfList dtype

--- a/flopy/utils/utils_def.py
+++ b/flopy/utils/utils_def.py
@@ -152,7 +152,7 @@ def get_util2d_shape_for_layer(model, layer=0):
         layer (base 0) for which Util2d shape is sought.
 
     Returns
-    ---------
+    -------
     (nrow,ncol) : tuple of ints
         util2d shape for the given layer
     """
@@ -186,7 +186,7 @@ def get_unitnumber_from_ext_unit_dict(
         Default is 0, in which case the returned output file is None.
 
     Returns
-    ---------
+    -------
     unitnumber : int
         file unit number for the given modflow package (or None)
     filenames : list
@@ -219,7 +219,7 @@ def type_from_iterable(_iter, index=0, _type=int, default_val=0):
     default_val : default value (0)
 
     Returns
-    ----------
+    -------
     val : value of type _type, or default_val
     """
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,12 @@ extend-include = [
 ]
 
 [tool.ruff.lint]
-select = ["F", "E", "I001"]
+select = [
+    "D409", # pydocstyle - section-underline-matches-section-length
+    "E",    # pycodestyle error
+    "F",    # Pyflakes
+    "I001", # isort - unsorted-imports
+]
 ignore = [
     "E402", # module level import not at top of file
     "E501", # line too long TODO FIXME


### PR DESCRIPTION
This PR fixes the doc section headers to have consistent lengths. It is a cause of many errors while building docs with sphinx.

This was mostly automated with `ruff check --select=D409 --fix` with the rule kept in pyproject.toml for future-proofing.