### PR TITLE
refactor(exceptions): raise NotImplementedError where appropriate

### DIFF
--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -956,8 +956,8 @@ class BaseModel(ModelInterface):
                     self.output_binflag.pop(i)
                     self.output_packages.pop(i)
         else:
-            msg = " either fname or unit must be passed to remove_output()"
-            raise Exception(msg)
+            msg = "either fname or unit must be passed to remove_output()"
+            raise TypeError(msg)
 
     def get_output(
         self, fname: Optional[Union[str, os.PathLike]] = None, unit=None
@@ -985,8 +985,8 @@ class BaseModel(ModelInterface):
                     return self.output_fnames[i]
             return None
         else:
-            msg = " either fname or unit must be passed to get_output()"
-            raise Exception(msg)
+            msg = "either fname or unit must be passed to get_output()"
+            raise TypeError(msg)
 
     def set_output_attribute(
         self,
@@ -1020,11 +1020,10 @@ class BaseModel(ModelInterface):
                     idx = i
                     break
         else:
-            msg = (
-                " either fname or unit must be passed "
+            raise TypeError(
+                "either fname or unit must be passed "
                 "to set_output_attribute()"
             )
-            raise Exception(msg)
         if attr is not None:
             if idx is not None:
                 for key, value in attr.items:
@@ -1065,8 +1064,8 @@ class BaseModel(ModelInterface):
                     idx = i
                     break
         else:
-            raise Exception(
-                " either fname or unit must be passed "
+            raise TypeError(
+                "either fname or unit must be passed "
                 "to set_output_attribute()"
             )
         v = None
@@ -1147,8 +1146,8 @@ class BaseModel(ModelInterface):
                 if u == unit:
                     plist.append(i)
         else:
-            msg = " either fname or unit must be passed to remove_external()"
-            raise Exception(msg)
+            msg = "either fname or unit must be passed to remove_external()"
+            raise TypeError(msg)
         # remove external file
         j = 0
         for i in plist:
@@ -1476,10 +1475,8 @@ class BaseModel(ModelInterface):
             normal_msg=normal_msg,
         )
 
-    def load_results(self):
-        print("load_results not implemented")
-
-        return None
+    def load_results(self, **kwargs):
+        raise NotImplementedError("load_results not implemented")
 
     def write_input(self, SelPackList=False, check=False):
         """
@@ -1543,18 +1540,14 @@ class BaseModel(ModelInterface):
         Every Package needs its own writenamefile function
 
         """
-        raise Exception(
-            "IMPLEMENTATION ERROR: writenamefile must be overloaded"
-        )
+        raise NotImplementedError("write_name_file must be overloaded")
 
     def set_model_units(self):
         """
         Every model needs its own set_model_units method
 
         """
-        raise Exception(
-            "IMPLEMENTATION ERROR: set_model_units must be overloaded"
-        )
+        raise NotImplementedError("set_model_units must be overloaded")
 
     @property
     def name(self):

--- a/flopy/modflow/mf.py
+++ b/flopy/modflow/mf.py
@@ -35,8 +35,7 @@ class ModflowGlobal(Package):
         return "Global Package class"
 
     def write_file(self):
-        # Not implemented for global class
-        return
+        raise NotImplementedError
 
 
 class ModflowList(Package):
@@ -53,8 +52,7 @@ class ModflowList(Package):
         return "List Package class"
 
     def write_file(self):
-        # Not implemented for list class
-        return
+        raise NotImplementedError
 
 
 class Modflow(BaseModel):

--- a/flopy/modflow/mfmlt.py
+++ b/flopy/modflow/mfmlt.py
@@ -91,16 +91,16 @@ class ModflowMlt(Package):
         """
         Write the package file.
 
-        Returns
-        -------
-        None
+        Raises
+        ------
+        NotImplementedError
 
         Notes
         -----
         Not implemented because parameters are only supported on load
 
         """
-        pass
+        raise NotImplementedError
 
     @classmethod
     def load(cls, f, model, nrow=None, ncol=None, ext_unit_dict=None):

--- a/flopy/modflow/mfpval.py
+++ b/flopy/modflow/mfpval.py
@@ -92,16 +92,16 @@ class ModflowPval(Package):
         """
         Write the package file.
 
-        Returns
-        -------
-        None
+        Raises
+        ------
+        NotImplementedError
 
         Notes
         -----
         Not implemented because parameters are only supported on load
 
         """
-        pass
+        raise NotImplementedError
 
     def __getitem__(self, item):
         """

--- a/flopy/modflow/mfswr1.py
+++ b/flopy/modflow/mfswr1.py
@@ -87,15 +87,12 @@ class ModflowSwr1(Package):
         """
         Write the package file.
 
-        Returns
-        -------
-        None
+        Raises
+        ------
+        NotImplementedError
 
         """
-        print("SWR1 write method not implemented yet")
-        # f = open(self.fn_path, 'w')
-        # f.write('{0}\n'.format(self.heading))
-        # f.close()
+        raise NotImplementedError("SWR1 write method not implemented yet")
 
     @classmethod
     def load(cls, f, model, ext_unit_dict=None):

--- a/flopy/modflow/mfzon.py
+++ b/flopy/modflow/mfzon.py
@@ -95,16 +95,16 @@ class ModflowZon(Package):
         """
         Write the package file.
 
-        Returns
-        -------
-        None
+        Raises
+        ------
+        NotImplementedError
 
         Notes
         -----
         Not implemented because parameters are only supported on load
 
         """
-        return
+        raise NotImplementedError
 
     @classmethod
     def load(cls, f, model, nrow=None, ncol=None, ext_unit_dict=None):

--- a/flopy/modpath/mp6.py
+++ b/flopy/modpath/mp6.py
@@ -21,8 +21,7 @@ class Modpath6List(Package):
         return
 
     def write_file(self):
-        # Not implemented for list class
-        return
+        raise NotImplementedError
 
 
 class Modpath6(BaseModel):

--- a/flopy/modpath/mp7.py
+++ b/flopy/modpath/mp7.py
@@ -34,8 +34,7 @@ class Modpath7List(Package):
         return
 
     def write_file(self):
-        # Not implemented for list class
-        return
+        raise NotImplementedError
 
 
 class Modpath7(BaseModel):

--- a/flopy/mt3d/mt.py
+++ b/flopy/mt3d/mt.py
@@ -36,8 +36,7 @@ class Mt3dList(Package):
         return "List package class"
 
     def write_file(self):
-        # Not implemented for list class
-        return
+        raise NotImplementedError
 
 
 class Mt3dms(BaseModel):

--- a/flopy/pakbase.py
+++ b/flopy/pakbase.py
@@ -861,8 +861,7 @@ class Package(PackageInterface):
         Every Package needs its own write_file function
 
         """
-        print("IMPLEMENTATION ERROR: write_file must be overloaded")
-        return
+        raise NotImplementedError("write_file must be overloaded")
 
     @staticmethod
     def load(

--- a/flopy/seawat/swt.py
+++ b/flopy/seawat/swt.py
@@ -24,8 +24,7 @@ class SeawatList(Package):
         return "List package class"
 
     def write_file(self):
-        # Not implemented for list class
-        return
+        raise NotImplementedError
 
 
 class Seawat(BaseModel):

--- a/flopy/utils/datafile.py
+++ b/flopy/utils/datafile.py
@@ -409,7 +409,7 @@ class LayerFile:
         Build the recordarray and iposarray, which maps the header information
         to the position in the formatted file.
         """
-        raise Exception(
+        raise NotImplementedError(
             "Abstract method _build_index called in LayerFile.  "
             "This method needs to be overridden."
         )
@@ -584,7 +584,7 @@ class LayerFile:
         Read data from file
 
         """
-        raise Exception(
+        raise NotImplementedError(
             "Abstract method _read_data called in LayerFile.  "
             "This method needs to be overridden."
         )

--- a/flopy/utils/formattedfile.py
+++ b/flopy/utils/formattedfile.py
@@ -175,7 +175,7 @@ class FormattedLayerFile(LayerFile):
         Return a text header object containing header formatting information
 
         """
-        raise Exception(
+        raise NotImplementedError(
             "Abstract method _get_text_header called in FormattedLayerFile. "
             "This method needs to be overridden."
         )

--- a/flopy/utils/observationfile.py
+++ b/flopy/utils/observationfile.py
@@ -236,7 +236,7 @@ class ObsFiles(FlopyBinaryData):
         Build the recordarray and iposarray, which maps the header information
         to the position in the formatted file.
         """
-        raise Exception(
+        raise NotImplementedError(
             "Abstract method _build_dtype called in BinaryFiles. "
             "This method needs to be overridden."
         )
@@ -246,7 +246,7 @@ class ObsFiles(FlopyBinaryData):
         Build the recordarray and iposarray, which maps the header information
         to the position in the formatted file.
         """
-        raise Exception(
+        raise NotImplementedError(
             "Abstract method _build_index called in BinaryFiles. "
             "This method needs to be overridden."
         )

--- a/flopy/utils/util_list.py
+++ b/flopy/utils/util_list.py
@@ -611,8 +611,6 @@ class MfList(DataInterface, DataListInterface):
                 f"MfList error: unsupported data type: {type(data)}"
             )
 
-            # raise NotImplementedError("MfList.__setitem__() not implemented")
-
     def __fromfile(self, f):
         # d = np.fromfile(f,dtype=self.dtype,count=count)
         try:


### PR DESCRIPTION
This PR raises [`NotImplementedError`](https://docs.python.org/3/library/exceptions.html#NotImplementedError) where appropriate, for example abstract methods. Several instances where a comment or message printing "not implemented" are changed to raise this exception instead.

A few other exceptions from flopy/mbase.py are reclassified to raise [`TypeError`](https://docs.python.org/3/library/exceptions.html#TypeError) where some of the expected types are missing.