### PR TITLE
refactor(datafile): use len(obj) rather than obj.get_nrecords()

### DIFF
--- a/autotest/test_formattedfile.py
+++ b/autotest/test_formattedfile.py
@@ -78,6 +78,12 @@ def test_formattedfile_read(function_tmpdir, example_data_path):
     h = FormattedHeadFile(mf2005_model_path / "test1tr.githds")
     assert isinstance(h, FormattedHeadFile)
 
+    # check number of records
+    assert len(h) == 1
+    with pytest.deprecated_call():
+        assert h.get_nrecords() == 1
+    assert not hasattr(h, "nrecords")
+
     times = h.get_times()
     assert np.isclose(times[0], 1577880064.0)
 

--- a/flopy/utils/binaryfile.py
+++ b/flopy/utils/binaryfile.py
@@ -705,7 +705,7 @@ class HeadFile(BinaryLayerFile):
             tsimtotal += tpd[0]
 
         # get total number of records
-        nrecords = self.recordarray.shape[0]
+        nrecords = len(self)
 
         # open backward file
         with open(filename, "wb") as fbin:
@@ -1034,7 +1034,6 @@ class CellBudgetFile:
         self.imethlist = []
         self.paknamlist_from = []
         self.paknamlist_to = []
-        self.nrecords = 0
         self.compact = True  # compact budget file flag
 
         self.dis = None
@@ -1087,6 +1086,26 @@ class CellBudgetFile:
     def __exit__(self, *exc):
         self.close()
 
+    def __len__(self):
+        """
+        Return the number of records (headers) in the file.
+        """
+        return len(self.recordarray)
+
+    @property
+    def nrecords(self):
+        """
+        Return the number of records (headers) in the file.
+
+        .. deprecated:: 3.8.0
+           Use :meth:`len` instead.
+        """
+        warnings.warn(
+            "obj.nrecords is deprecated; use len(obj) instead.",
+            DeprecationWarning,
+        )
+        return len(self)
+
     def __reset(self):
         """
         Reset indexing lists when determining precision
@@ -1101,7 +1120,6 @@ class CellBudgetFile:
         self.imethlist = []
         self.paknamlist_from = []
         self.paknamlist_to = []
-        self.nrecords = 0
 
     def _set_precision(self, precision="single"):
         """
@@ -1209,7 +1227,6 @@ class CellBudgetFile:
         while ipos < self.totalbytes:
             self.iposheader.append(ipos)
             header = self._get_header()
-            self.nrecords += 1
             totim = header["totim"]
             # if old-style (non-compact) file,
             # compute totim from kstp and kper
@@ -2117,12 +2134,17 @@ class CellBudgetFile:
 
         Returns
         -------
-
-        out : int
+        int
             Number of records in the file.
 
+        .. deprecated:: 3.8.0
+           Use :meth:`len` instead.
         """
-        return self.recordarray.shape[0]
+        warnings.warn(
+            "get_nrecords is deprecated; use len(obj) instead.",
+            DeprecationWarning,
+        )
+        return len(self)
 
     def get_residual(self, totim, scaled=False):
         """
@@ -2271,7 +2293,7 @@ class CellBudgetFile:
             tsimtotal += tpd[0]
 
         # get number of records
-        nrecords = self.get_nrecords()
+        nrecords = len(self)
 
         # open backward budget file
         with open(filename, "wb") as fbin:

--- a/flopy/utils/datafile.py
+++ b/flopy/utils/datafile.py
@@ -5,6 +5,7 @@ abstract classes that should not be directly accessed.
 """
 
 import os
+import warnings
 from pathlib import Path
 from typing import Union
 
@@ -221,6 +222,12 @@ class LayerFile:
                 angrot=0.0,
             )
 
+    def __len__(self):
+        """
+        Return the number of records (headers) in the file.
+        """
+        return len(self.recordarray)
+
     def __enter__(self):
         return self
 
@@ -431,9 +438,17 @@ class LayerFile:
         return
 
     def get_nrecords(self):
-        if isinstance(self.recordarray, np.recarray):
-            return self.recordarray.shape[0]
-        return 0
+        """
+        Return the number of records (headers) in the file.
+
+        .. deprecated:: 3.8.0
+           Use :meth:`len` instead.
+        """
+        warnings.warn(
+            "get_nrecords is deprecated; use len(obj) instead.",
+            DeprecationWarning,
+        )
+        return len(self)
 
     def _get_data_array(self, totim=0):
         """


### PR DESCRIPTION
This PR has a few aims related to data files, including FormattedHeadFile, HeadFile and CellBudgetFile.

These files have a "number of records" property that was implemented with `get_nrecords()`. This "length of the object" measure is more naturally done with [`__len__`](https://docs.python.org/3/reference/datamodel.html#object.__len__), i.e. `len(headsfile)`.

It is advised to prefer the `len()` approach, so instances of `get_nrecords()` for these files show a DeprecationWarning.

The CellBudgetFile also has a `.nrecords` property. It is also advised to show a DeprecationWarning with this property.

This PR also fixes a bug with `get_nrecords()` shown here:
https://github.com/modflowpy/flopy/blob/ea3e475c2a566872670d067b7c611861d4be8c54/flopy/utils/datafile.py#L427-L430

the bug is that `recordarray` is a structured array (`np.ndarray`), not a record array, so this always silently returns 0. This bug does not apply to CellBudgetFile, which worked fine and matches `obj.nrecords`.

Fixing this bug caused [this test to fail](https://github.com/modflowpy/flopy/blob/ea3e475c2a566872670d067b7c611861d4be8c54/autotest/test_binaryfile.py#L407-L414), since the for-loop was never activated. A "todo" note is added since the reversed header is not the same as the original header.

Another aim of this PR is to re-organize a few CellBudgetFile tests from test_binaryfile.py to test_cellbudgetfile.py. Most of this is copied with perhaps minor simplifications.

Note that none of these changes apply to [`flopy.utils.swroutputfile.SwrBudget.get_nrecords()`](https://github.com/modflowpy/flopy/blob/ea3e475c2a566872670d067b7c611861d4be8c54/flopy/utils/swroutputfile.py#L132-L144), which returns a tuple.

---

There is also still room for discussion if `get_nrecords()` or a dynamic `.nrecords` property should be preferred over `len(obj)`. This PR can be adjusted accordingly. Opinions welcome!