### PR TITLE
chore(deps): require jupyter_client>=8.4.0 for now

### DIFF
--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -18,6 +18,7 @@ dependencies:
   - flaky
   - filelock
   - jupyter
+  - jupyter_client>=8.4.0
   - jupytext
   - pip:
       - git+https://github.com/MODFLOW-USGS/modflow-devtools.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ test = [
     "flaky",
     "filelock",
     "jupyter",
+    "jupyter_client >=8.4.0", # avoid datetime.utcnow() deprecation warning
     "jupytext",
     "modflow-devtools",
     "pytest !=8.1.0",


### PR DESCRIPTION
Avoid `datetime.utcnow()` deprecation warning to fix broken nbsphinx galleries on RTD.

Another option is a warning filter `warnings.simplefilter("ignore", DeprecationWarning)` in all the examples but pinning is easier and I think we want to know ASAP when something needs an update