### PR TITLE
test: reenable parametrization in gridgen tests, update markers

### DIFF
--- a/autotest/regression/test_mf6.py
+++ b/autotest/regression/test_mf6.py
@@ -2317,7 +2317,7 @@ def test035_create_tests_fhb(function_tmpdir, example_data_path):
 
 
 @requires_exe("mf6")
-@requires_pkg("shapefile")
+@requires_pkg("pyshp", name_map={"pyshp": "shapefile"})
 @pytest.mark.regression
 def test006_create_tests_gwf3_disv(function_tmpdir, example_data_path):
     # init paths

--- a/autotest/test_export.py
+++ b/autotest/test_export.py
@@ -177,7 +177,7 @@ def unstructured_grid(example_data_path):
     )
 
 
-@requires_pkg("shapefile")
+@requires_pkg("pyshp", name_map={"pyshp": "shapefile"})
 @pytest.mark.parametrize("pathlike", (True, False))
 def test_output_helper_shapefile_export(
     pathlike, function_tmpdir, example_data_path
@@ -202,7 +202,7 @@ def test_output_helper_shapefile_export(
     )
 
 
-@requires_pkg("shapefile")
+@requires_pkg("pyshp", name_map={"pyshp": "shapefile"})
 @pytest.mark.slow
 def test_freyberg_export(function_tmpdir, example_data_path):
     # steady state
@@ -296,7 +296,7 @@ def test_freyberg_export(function_tmpdir, example_data_path):
                 assert part.read_text() == wkt
 
 
-@requires_pkg("shapefile")
+@requires_pkg("pyshp", name_map={"pyshp": "shapefile"})
 @pytest.mark.parametrize("missing_arrays", [True, False])
 @pytest.mark.slow
 def test_disu_export(function_tmpdir, missing_arrays):
@@ -353,7 +353,7 @@ def test_export_output(crs, function_tmpdir, example_data_path):
     assert read_crs == get_authority_crs(4326)
 
 
-@requires_pkg("shapefile")
+@requires_pkg("pyshp", name_map={"pyshp": "shapefile"})
 def test_write_gridlines_shapefile(function_tmpdir):
     import shapefile
 
@@ -379,7 +379,7 @@ def test_write_gridlines_shapefile(function_tmpdir):
         assert len(sf) == 22
 
 
-@requires_pkg("shapefile")
+@requires_pkg("pyshp", name_map={"pyshp": "shapefile"})
 def test_export_shapefile_polygon_closed(function_tmpdir):
     from shapefile import Reader
 
@@ -501,7 +501,7 @@ def test_netcdf_classmethods(function_tmpdir, example_data_path):
     new_f.nc.close()
 
 
-@requires_pkg("shapefile")
+@requires_pkg("pyshp", name_map={"pyshp": "shapefile"})
 def test_shapefile_ibound(function_tmpdir, example_data_path):
     from shapefile import Reader
 
@@ -524,7 +524,7 @@ def test_shapefile_ibound(function_tmpdir, example_data_path):
     shape.close()
 
 
-@requires_pkg("shapefile")
+@requires_pkg("pyshp", name_map={"pyshp": "shapefile"})
 @pytest.mark.slow
 @pytest.mark.parametrize("namfile", namfiles())
 def test_shapefile(function_tmpdir, namfile):
@@ -549,7 +549,7 @@ def test_shapefile(function_tmpdir, namfile):
     ), f"wrong number of records in shapefile {fnc_name}"
 
 
-@requires_pkg("shapefile")
+@requires_pkg("pyshp", name_map={"pyshp": "shapefile"})
 @pytest.mark.slow
 @pytest.mark.parametrize("namfile", namfiles())
 def test_shapefile_export_modelgrid_override(function_tmpdir, namfile):
@@ -616,7 +616,7 @@ def test_export_netcdf(function_tmpdir, namfile):
     nc.close()
 
 
-@requires_pkg("shapefile")
+@requires_pkg("pyshp", name_map={"pyshp": "shapefile"})
 def test_export_array2(function_tmpdir):
     nrow = 7
     ncol = 11
@@ -650,7 +650,7 @@ def test_export_array2(function_tmpdir):
     assert os.path.isfile(filename), "did not create array shapefile"
 
 
-@requires_pkg("shapefile", "shapely")
+@requires_pkg("pyshp", "shapely", name_map={"pyshp": "shapefile"})
 def test_export_array_contours_structured(function_tmpdir):
     nrow = 7
     ncol = 11
@@ -686,7 +686,7 @@ def test_export_array_contours_structured(function_tmpdir):
     assert os.path.isfile(filename), "did not create contour shapefile"
 
 
-@requires_pkg("shapefile", "shapely")
+@requires_pkg("pyshp", "shapely", name_map={"pyshp": "shapefile"})
 def test_export_array_contours_unstructured(
     function_tmpdir, unstructured_grid
 ):
@@ -712,7 +712,7 @@ def test_export_array_contours_unstructured(
 from autotest.test_gridgen import sim_disu_diff_layers
 
 
-@requires_pkg("shapefile", "shapely")
+@requires_pkg("pyshp", "shapely", name_map={"pyshp": "shapefile"})
 def test_export_array_contours_unstructured_diff_layers(
     function_tmpdir, sim_disu_diff_layers
 ):
@@ -741,7 +741,7 @@ def test_export_array_contours_unstructured_diff_layers(
     # plt.show()
 
 
-@requires_pkg("shapefile", "shapely")
+@requires_pkg("pyshp", "shapely", name_map={"pyshp": "shapefile"})
 def test_export_contourf(function_tmpdir, example_data_path):
     from shapefile import Reader
 
@@ -784,7 +784,7 @@ def test_export_contourf(function_tmpdir, example_data_path):
 
 
 @pytest.mark.mf6
-@requires_pkg("shapefile", "shapely")
+@requires_pkg("pyshp", "shapely", name_map={"pyshp": "shapefile"})
 def test_export_contours(function_tmpdir, example_data_path):
     from shapefile import Reader
 
@@ -952,7 +952,7 @@ def test_mf6_grid_shp_export(function_tmpdir):
                 assert np.abs(it - it6) < 1e-6
 
 
-@requires_pkg("shapefile")
+@requires_pkg("pyshp", name_map={"pyshp": "shapefile"})
 @pytest.mark.slow
 def test_export_huge_shapefile(function_tmpdir):
     nlay = 2

--- a/autotest/test_geospatial_util.py
+++ b/autotest/test_geospatial_util.py
@@ -153,7 +153,7 @@ def test_import_geospatial_utils():
     )
 
 
-@requires_pkg("shapefile", "shapely")
+@requires_pkg("pyshp", "shapely", name_map={"pyshp": "shapefile"})
 def test_geospatial_collection_load_shpfile(example_data_path):
     # with Path
     shp = example_data_path / "freyberg" / "gis" / "bedrock_outcrop_hole.shp"

--- a/autotest/test_gridgen.py
+++ b/autotest/test_gridgen.py
@@ -59,98 +59,88 @@ def get_structured_grid():
 
 
 @requires_exe("gridgen")
-@requires_pkg("shapefile")
-# GRIDGEN seems not to like paths containing "[" or "]", as
-# function_tmpdir does with parametrization, do it manually
-# @pytest.mark.parametrize("grid_type", ["vertex", "unstructured"])
-def test_add_active_domain(function_tmpdir):  # , grid_type):
+@requires_pkg("pyshp", name_map={"pyshp": "shapefile"})
+@pytest.mark.parametrize("grid_type", ["vertex", "unstructured"])
+def test_add_active_domain(function_tmpdir, grid_type):
     bgrid = get_structured_grid()
 
-    # test providing active domain various ways
-    for grid_type in ["vertex", "unstructured"]:
-        grids = []
-        for feature in [
-            [[[(0, 0), (0, 60), (40, 80), (60, 0), (0, 0)]]],
-            function_tmpdir / "ad0.shp",
-            function_tmpdir / "ad0",
-            "ad0.shp",
-            "ad0",
-        ]:
-            print(
-                "Testing add_active_domain() for",
-                grid_type,
-                "grid with features",
-                feature,
-            )
-            gridgen = Gridgen(bgrid, model_ws=function_tmpdir)
-            gridgen.add_active_domain(
-                feature,
-                range(bgrid.nlay),
-            )
-            gridgen.build()
-            grid = (
-                VertexGrid(**gridgen.get_gridprops_vertexgrid())
-                if grid_type == "vertex"
-                else UnstructuredGrid(
-                    **gridgen.get_gridprops_unstructuredgrid()
-                )
-            )
-            grid.plot()
-            grids.append(grid)
-            # plt.show()
+    # test providing active domain in various ways
+    grids = []
+    for feature in [
+        [[[(0, 0), (0, 60), (40, 80), (60, 0), (0, 0)]]],
+        function_tmpdir / "ad0.shp",
+        function_tmpdir / "ad0",
+        "ad0.shp",
+        "ad0",
+    ]:
+        print(
+            "Testing add_active_domain() for",
+            grid_type,
+            "grid with features",
+            feature,
+        )
+        gridgen = Gridgen(bgrid, model_ws=function_tmpdir)
+        gridgen.add_active_domain(
+            feature,
+            range(bgrid.nlay),
+        )
+        gridgen.build()
+        grid = (
+            VertexGrid(**gridgen.get_gridprops_vertexgrid())
+            if grid_type == "vertex"
+            else UnstructuredGrid(**gridgen.get_gridprops_unstructuredgrid())
+        )
+        grid.plot()
+        grids.append(grid)
+        # plt.show()
 
-            assert grid.nnodes < bgrid.nnodes
-            assert not np.array_equal(grid.ncpl, bgrid.ncpl)
-            assert all(np.array_equal(grid.ncpl, g.ncpl) for g in grids)
-            assert all(grid.nnodes == g.nnodes for g in grids)
+        assert grid.nnodes < bgrid.nnodes
+        assert not np.array_equal(grid.ncpl, bgrid.ncpl)
+        assert all(np.array_equal(grid.ncpl, g.ncpl) for g in grids)
+        assert all(grid.nnodes == g.nnodes for g in grids)
 
 
 @requires_exe("gridgen")
-@requires_pkg("shapefile")
-# GRIDGEN seems not to like paths containing "[" or "]", as
-# function_tmpdir does with parametrization, do it manually
-# @pytest.mark.parametrize("grid_type", ["vertex", "unstructured"])
-def test_add_refinement_feature(function_tmpdir):  # , grid_type):
+@requires_pkg("pyshp", name_map={"pyshp": "shapefile"})
+@pytest.mark.parametrize("grid_type", ["vertex", "unstructured"])
+def test_add_refinement_feature(function_tmpdir, grid_type):
     bgrid = get_structured_grid()
 
-    # test providing refinement feature various ways
-    for grid_type in ["vertex", "unstructured"]:
-        grids = []
-        for features in [
-            [[[(0, 0), (0, 60), (40, 80), (60, 0), (0, 0)]]],
-            function_tmpdir / "rf0.shp",
-            function_tmpdir / "rf0",
-            "rf0.shp",
-            "rf0",
-        ]:
-            print(
-                "Testing add_refinement_feature() for",
-                grid_type,
-                "grid with features",
-                features,
-            )
-            gridgen = Gridgen(bgrid, model_ws=function_tmpdir)
-            gridgen.add_refinement_features(
-                features,
-                "polygon",
-                1,
-                range(bgrid.nlay),
-            )
-            gridgen.build()
-            grid = (
-                VertexGrid(**gridgen.get_gridprops_vertexgrid())
-                if grid_type == "vertex"
-                else UnstructuredGrid(
-                    **gridgen.get_gridprops_unstructuredgrid()
-                )
-            )
-            grid.plot()
-            # plt.show()
+    # test providing refinement features in various ways
+    grids = []
+    for features in [
+        [[[(0, 0), (0, 60), (40, 80), (60, 0), (0, 0)]]],
+        function_tmpdir / "rf0.shp",
+        function_tmpdir / "rf0",
+        "rf0.shp",
+        "rf0",
+    ]:
+        print(
+            "Testing add_refinement_feature() for",
+            grid_type,
+            "grid with features",
+            features,
+        )
+        gridgen = Gridgen(bgrid, model_ws=function_tmpdir)
+        gridgen.add_refinement_features(
+            features,
+            "polygon",
+            1,
+            range(bgrid.nlay),
+        )
+        gridgen.build()
+        grid = (
+            VertexGrid(**gridgen.get_gridprops_vertexgrid())
+            if grid_type == "vertex"
+            else UnstructuredGrid(**gridgen.get_gridprops_unstructuredgrid())
+        )
+        grid.plot()
+        # plt.show()
 
-            assert grid.nnodes > bgrid.nnodes
-            assert not np.array_equal(grid.ncpl, bgrid.ncpl)
-            assert all(np.array_equal(grid.ncpl, g.ncpl) for g in grids)
-            assert all(grid.nnodes == g.nnodes for g in grids)
+        assert grid.nnodes > bgrid.nnodes
+        assert not np.array_equal(grid.ncpl, bgrid.ncpl)
+        assert all(np.array_equal(grid.ncpl, g.ncpl) for g in grids)
+        assert all(grid.nnodes == g.nnodes for g in grids)
 
 
 @pytest.mark.slow
@@ -364,7 +354,7 @@ def sim_disu_diff_layers(function_tmpdir):
 
 @pytest.mark.slow
 @requires_exe("mf6", "gridgen")
-@requires_pkg("shapely", "shapefile")
+@requires_pkg("shapely", "pyshp", name_map={"pyshp": "shapefile"})
 def test_mf6disu(sim_disu_diff_layers):
     sim = sim_disu_diff_layers
     ws = sim.sim_path
@@ -474,7 +464,7 @@ def test_mf6disu(sim_disu_diff_layers):
 
 @pytest.mark.slow
 @requires_exe("mfusg", "gridgen")
-@requires_pkg("shapely", "shapefile")
+@requires_pkg("shapely", "pyshp", name_map={"pyshp": "shapefile"})
 def test_mfusg(function_tmpdir):
     from shapely.geometry import Polygon
 
@@ -855,7 +845,7 @@ def test_gridgen(function_tmpdir):
 
 
 @requires_exe("mf6", "gridgen")
-@requires_pkg("shapely", "shapefile")
+@requires_pkg("shapely", "pyshp", name_map={"pyshp": "shapefile"})
 def test_flopy_issue_1492(function_tmpdir):
     """
     Submitted by David Brakenhoff in

--- a/autotest/test_modpathfile.py
+++ b/autotest/test_modpathfile.py
@@ -313,7 +313,7 @@ def test_get_destination_endpoint_data(
 
 @pytest.mark.parametrize("longfieldname", [True, False])
 @requires_exe("mf6", "mp7")
-@requires_pkg("shapefile", "shapely")
+@requires_pkg("pyshp", "shapely", name_map={"pyshp": "shapefile"})
 def test_write_shapefile(function_tmpdir, mp7_small, longfieldname):
     from shapefile import Reader
 

--- a/autotest/test_mp6.py
+++ b/autotest/test_mp6.py
@@ -131,7 +131,7 @@ def test_mpsim(function_tmpdir, mp6_test_path):
         assert stllines[6].strip().split()[-1] == "p2"
 
 
-@requires_pkg("shapefile", "shapely")
+@requires_pkg("pyshp", "shapely", name_map={"pyshp": "shapefile"})
 def test_get_destination_data(function_tmpdir, mp6_test_path):
     copy_modpath_files(mp6_test_path, function_tmpdir, "EXAMPLE.")
     copy_modpath_files(mp6_test_path, function_tmpdir, "EXAMPLE-3.")

--- a/autotest/test_particledata.py
+++ b/autotest/test_particledata.py
@@ -658,7 +658,7 @@ def test_nodeparticledata_to_prp_dis_1_per_face():
     assert len(rpts) == num_cells * 6
 
 
-@requires_pkg("shapefile")
+@requires_pkg("pyshp", name_map={"pyshp": "shapefile"})
 def test_nodeparticledata_prp_disv_big(function_tmpdir):
     Lx = 10000.0
     Ly = 10500.0

--- a/autotest/test_sfr.py
+++ b/autotest/test_sfr.py
@@ -373,7 +373,7 @@ def test_const(sfr_data):
     assert True
 
 
-@requires_pkg("shapefile", "shapely")
+@requires_pkg("pyshp", "shapely", name_map={"pyshp": "shapefile"})
 def test_export(function_tmpdir, sfr_data):
     m = Modflow()
     dis = ModflowDis(m, 1, 10, 10, lenuni=2, itmuni=4)

--- a/autotest/test_shapefile_utils.py
+++ b/autotest/test_shapefile_utils.py
@@ -53,7 +53,7 @@ def test_model_attributes_to_shapefile(example_data_path, function_tmpdir):
     assert shpfile_path.exists()
 
 
-@requires_pkg("pyproj", "pyshp", "shapely", name_map={"pyshp", "shapefile"})
+@requires_pkg("pyproj", "pyshp", "shapely", name_map={"pyshp": "shapefile"})
 def test_write_grid_shapefile(
     minimal_unstructured_grid_info, minimal_vertex_grid_info, function_tmpdir
 ):

--- a/autotest/test_shapefile_utils.py
+++ b/autotest/test_shapefile_utils.py
@@ -17,7 +17,7 @@ from .test_export import disu_sim
 from .test_grid import minimal_unstructured_grid_info, minimal_vertex_grid_info
 
 
-@requires_pkg("shapefile", "shapely")
+@requires_pkg("pyshp", "shapely", name_map={"pyshp": "shapefile"})
 def test_model_attributes_to_shapefile(example_data_path, function_tmpdir):
     # freyberg mf2005 model
     name = "freyberg"
@@ -53,7 +53,7 @@ def test_model_attributes_to_shapefile(example_data_path, function_tmpdir):
     assert shpfile_path.exists()
 
 
-@requires_pkg("pyproj", "shapefile", "shapely")
+@requires_pkg("pyproj", "pyshp", "shapely", name_map={"pyshp", "shapefile"})
 def test_write_grid_shapefile(
     minimal_unstructured_grid_info, minimal_vertex_grid_info, function_tmpdir
 ):


### PR DESCRIPTION
* devtools now [replaces square brackets](https://github.com/MODFLOW-USGS/modflow-devtools/commit/90316a1cca281ac36062da946374145bda421d52) from parametrization in path names
* also need to `name_map` pyshp -> shapefile since `requires_pkg` is strict now