### PR TITLE
ci: add concurrency groups to commit-triggered workflows

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
       - develop
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   build:
     name: Build

--- a/.github/workflows/mf6.yml
+++ b/.github/workflows/mf6.yml
@@ -8,7 +8,9 @@ on:
     branches:
       - master
       - develop
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
 
   test:

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -6,7 +6,9 @@ on:
     branches:
       - master
       - develop
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
 
   rtd_build:


### PR DESCRIPTION
* only allow one concurrent workflow run per branch