### PR TITLE
feat(datafile): add .headers property with data frame

### DIFF
--- a/autotest/test_formattedfile.py
+++ b/autotest/test_formattedfile.py
@@ -1,5 +1,6 @@
 import matplotlib.pyplot as plt
 import numpy as np
+import pandas as pd
 import pytest
 from matplotlib.axes import Axes
 
@@ -9,6 +10,58 @@ from flopy.utils import FormattedHeadFile
 @pytest.fixture
 def freyberg_model_path(example_data_path):
     return example_data_path / "freyberg"
+
+
+def test_headfile_build_index(example_data_path):
+    # test low-level FormattedLayerFile._build_index() method
+    pth = example_data_path / "mf2005_test" / "test1tr.githds"
+    with FormattedHeadFile(pth) as hds:
+        pass
+    assert hds.nrow == 15
+    assert hds.ncol == 10
+    assert hds.nlay == 1
+    assert not hasattr(hds, "nper")
+    assert hds.totalbytes == 1613
+    assert len(hds.recordarray) == 1
+    assert type(hds.recordarray) == np.ndarray
+    assert hds.recordarray.dtype == np.dtype(
+        [
+            ("kstp", "i4"),
+            ("kper", "i4"),
+            ("pertim", "f4"),
+            ("totim", "f4"),
+            ("text", "S16"),
+            ("ncol", "i4"),
+            ("nrow", "i4"),
+            ("ilay", "i4"),
+        ]
+    )
+    flt32time = np.float32(1577880000.0)
+    assert hds.recordarray.tolist() == [
+        (50, 1, float(flt32time), float(flt32time), b"HEAD", 10, 15, 1)
+    ]
+    assert hds.times == [flt32time]
+    assert hds.kstpkper == [(50, 1)]
+    np.testing.assert_array_equal(hds.iposarray, [98])
+    assert hds.iposarray.dtype == np.int64
+    pd.testing.assert_frame_equal(
+        hds.headers,
+        pd.DataFrame(
+            [
+                {
+                    "kstp": np.int32(50),
+                    "kper": np.int32(1),
+                    "pertim": flt32time,
+                    "totim": flt32time,
+                    "text": "HEAD",
+                    "ncol": np.int32(10),
+                    "nrow": np.int32(15),
+                    "ilay": np.int32(1),
+                }
+            ],
+            index=[98],
+        ),
+    )
 
 
 def test_formattedfile_reference(example_data_path):

--- a/flopy/utils/datafile.py
+++ b/flopy/utils/datafile.py
@@ -221,6 +221,12 @@ class LayerFile:
                 angrot=0.0,
             )
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
     def to_shapefile(
         self,
         filename: Union[str, os.PathLike],

--- a/flopy/utils/formattedfile.py
+++ b/flopy/utils/formattedfile.py
@@ -7,6 +7,7 @@ important classes that can be accessed by the user.
 """
 
 import numpy as np
+import pandas as pd
 
 from ..utils.datafile import Header, LayerFile
 
@@ -153,8 +154,14 @@ class FormattedLayerFile(LayerFile):
 
         # self.recordarray contains a recordarray of all the headers.
         self.recordarray = np.array(self.recordarray, self.header.get_dtype())
-        self.iposarray = np.array(self.iposarray)
+        self.iposarray = np.array(self.iposarray, dtype=np.int64)
         self.nlay = np.max(self.recordarray["ilay"])
+
+        # provide headers as a pandas frame
+        self.headers = pd.DataFrame(self.recordarray, index=self.iposarray)
+        self.headers["text"] = self.headers["text"].str.decode(
+            "ascii", "strict"
+        )
 
     def _store_record(self, header, ipos):
         """


### PR DESCRIPTION
This feature adds a `.headers` property for a pandas data frame of the headers of various data files, including HeadFile, FormattedHeadFile, UcnFile and CellBudgetFile. This is a modern accessor to the headers, which is created internally using:

    pd.DataFrame(self.recordarray, index=self.iposarray)

where the index is the file position to the start of each array. Text fields are decoded to `str` types (rather than dealing with bytes types, which is probably a hang-over from Python2). Int32 types are left as-is, except for iposarray which should be int64 to read large files >2GB. Float32 types are also left as-is, since these would otherwise have a lossy conversion to float64.

With the CellBudgetFile, the headers vary depending on the type of budget file. For instance, "classic" files (created without "COMPACT BUDGET" option) don't have imeth, delt, pertim, or totim columns. Furthermore, only files with imeth=6 have the extra text columns modelnam, paknam, modelnam2, and paknam2, since these fields are always empty.


This PR also adds more checks to the outputs created with `._build_index()` methods. Eventually, I'm planning to deprecate other properties and functions that are using the `.recordarray` structured array, so it is important to have a detailed trace of these outputs before replacing them.

This PR also moves the `__enter__` / `__exit__` methods from `BinaryLayerFile` to `LayerFile` (this feature was from #669). This is so `FormattedHeadFile` can also use the "with" context statement to also auto-close the file.

---
### Examples
E.g. show data frames to markdown with:
```bash
python -c "from flopy.utils import HeadFile; print(HeadFile('examples/data/mf6/create_tests/test004_bcfss/expected_output/bcf2ss.hds').headers.to_markdown())
```

examples/data/mf6/create_tests/test004_bcfss/expected_output/bcf2ss.hds
|      |   kstp |   kper |   pertim |   totim | text   |   ncol |   nrow |   ilay |
|-----:|-------:|-------:|---------:|--------:|:-------|-------:|-------:|-------:|
|   52 |      1 |      1 |        1 |       1 | HEAD   |     15 |     10 |      1 |
| 1304 |      1 |      1 |        1 |       1 | HEAD   |     15 |     10 |      2 |
| 2556 |      1 |      2 |        1 |       2 | HEAD   |     15 |     10 |      1 |
| 3808 |      1 |      2 |        1 |       2 | HEAD   |     15 |     10 |      2 |

examples/data/mt3d_test/mf2kmt3d/reinject/MT3D001.UCN
|       |   ntrans |   kstp |   kper |   totim | text          |   ncol |   nrow |   ilay |
|------:|---------:|-------:|-------:|--------:|:--------------|-------:|-------:|-------:|
|    44 |        2 |      1 |      1 |      25 | CONCENTRATION |     46 |     31 |      1 |
|  5792 |        4 |      1 |      1 |      50 | CONCENTRATION |     46 |     31 |      1 |
| 11540 |        6 |      1 |      1 |      75 | CONCENTRATION |     46 |     31 |      1 |
| 17288 |        8 |      1 |      1 |     100 | CONCENTRATION |     46 |     31 |      1 |
| 23036 |       10 |      1 |      1 |     125 | CONCENTRATION |     46 |     31 |      1 |
| 28784 |       12 |      1 |      1 |     150 | CONCENTRATION |     46 |     31 |      1 |
| 34532 |       14 |      1 |      1 |     175 | CONCENTRATION |     46 |     31 |      1 |
| 40280 |       16 |      1 |      1 |     200 | CONCENTRATION |     46 |     31 |      1 |
| 46028 |       18 |      1 |      1 |     225 | CONCENTRATION |     46 |     31 |      1 |
| 51776 |       20 |      1 |      1 |     250 | CONCENTRATION |     46 |     31 |      1 |
| 57524 |       22 |      1 |      1 |     275 | CONCENTRATION |     46 |     31 |      1 |
| 63272 |       24 |      1 |      1 |     300 | CONCENTRATION |     46 |     31 |      1 |
| 69020 |       26 |      1 |      1 |     325 | CONCENTRATION |     46 |     31 |      1 |
| 74768 |       28 |      1 |      1 |     350 | CONCENTRATION |     46 |     31 |      1 |
| 80516 |       30 |      1 |      1 |     365 | CONCENTRATION |     46 |     31 |      1 |

examples/data/mfusg_test/01A_nestedgrid_nognc/output/flow.cbc
|     |   kstp |   kper | text          |   ncol |   nrow |   nlay |
|----:|-------:|-------:|:--------------|-------:|-------:|-------:|
|  36 |      1 |      1 | CONSTANT HEAD |    121 |      1 |      1 |
| 556 |      1 |      1 | FLOW JA FACE  |    601 |      1 |      1 |

examples/data/mfusg_test/03A_conduit_unconfined/output/ex3A.cbb
|        |   kstp |   kper | text            |   ncol |   nrow |   nlay |   imeth |   delt |   pertim |   totim |
|-------:|-------:|-------:|:----------------|-------:|-------:|-------:|--------:|-------:|---------:|--------:|
|     52 |    160 |      1 | STORAGE         |    100 |    100 |     -2 |       1 |      1 |      160 |     160 |
|  80104 |    160 |      1 | CONSTANT HEAD   |    100 |    100 |     -2 |       2 |      1 |      160 |     160 |
|  80160 |    160 |      1 | FLOW RIGHT FACE |    100 |    100 |     -2 |       1 |      1 |      160 |     160 |
| 160212 |    160 |      1 | FLOW FRONT FACE |    100 |    100 |     -2 |       1 |      1 |      160 |     160 |
| 240264 |    160 |      1 | FLOW LOWER FACE |    100 |    100 |     -2 |       1 |      1 |      160 |     160 |

examples/data/mf6/create_tests/test004_bcfss/expected_output/bcf2ss.cbb
|       |   kstp |   kper | text         |   ncol |   nrow |   nlay |   imeth |   delt |   pertim |   totim | modelnam   | paknam   | modelnam2   | paknam2   |
|------:|-------:|-------:|:-------------|-------:|-------:|-------:|--------:|-------:|---------:|--------:|:-----------|:---------|:------------|:----------|
|    64 |      1 |      1 | FLOW-JA-FACE |   1700 |      1 |     -1 |       1 |      1 |        1 |       1 |            |          |             |           |
| 13792 |      1 |      1 | WEL          |     15 |     10 |     -2 |       6 |      1 |        1 |       1 | GWF_1      | GWF_1    | GWF_1       | WEL-1     |
| 13976 |      1 |      1 | RIV          |     15 |     10 |     -2 |       6 |      1 |        1 |       1 | GWF_1      | GWF_1    | GWF_1       | RIV-1     |
| 14272 |      1 |      1 | RCH          |     15 |     10 |     -2 |       6 |      1 |        1 |       1 | GWF_1      | GWF_1    | GWF_1       | RCH-1     |
| 19176 |      1 |      2 | FLOW-JA-FACE |   1700 |      1 |     -1 |       1 |      1 |        1 |       2 |            |          |             |           |
| 32904 |      1 |      2 | WEL          |     15 |     10 |     -2 |       6 |      1 |        1 |       2 | GWF_1      | GWF_1    | GWF_1       | WEL-1     |
| 33168 |      1 |      2 | RIV          |     15 |     10 |     -2 |       6 |      1 |        1 |       2 | GWF_1      | GWF_1    | GWF_1       | RIV-1     |
| 33464 |      1 |      2 | RCH          |     15 |     10 |     -2 |       6 |      1 |        1 |       2 | GWF_1      | GWF_1    | GWF_1       | RCH-1     |
