### PR TITLE
fix(binaryread): raise/handle EOFError, deprecate vartype=str

### DIFF
--- a/autotest/test_cellbudgetfile.py
+++ b/autotest/test_cellbudgetfile.py
@@ -285,6 +285,18 @@ def test_cellbudgetfile_build_index_mf6(example_data_path):
     )
 
 
+def test_cellbudgetfile_imeth_5(example_data_path):
+    pth = example_data_path / "preserve_unitnums/testsfr2.ghb.cbc"
+    with CellBudgetFile(pth) as cbc:
+        pass
+    # check a few components
+    pd.testing.assert_index_equal(
+        cbc.headers.index, pd.Index(np.arange(12, dtype=np.int64) * 156 + 64)
+    )
+    assert cbc.headers.text.unique().tolist() == ["HEAD DEP BOUNDS"]
+    assert cbc.headers.imeth.unique().tolist() == [5]
+
+
 @pytest.fixture
 def zonbud_model_path(example_data_path):
     return example_data_path / "zonbud_examples"


### PR DESCRIPTION
This fixes issues while reading some binaryfiles with auto precision detection, and also modernizes a few aspects of flopy.utils.binaryfile left-over from python2.

There are two changes to `flopy.utils.binaryfile.binaryread()`:

1. Raises EOFError if attempting to read data beyond the end-of-file
2. Deprecate `vartype=str`, since `bytes` is the the return type with Python3

Other refactors:

- Simplify conventional ASCII range checks by converting `bytes` to a list of int, then check if bytes are within range
- Remove checks if bytes are not str, and use `.encode("ascii")` where appropriate

---
### Examples of issues

#### CellBudgetFile
Reading a cell budget file that contains `imeth=5` with `precision="auto"` (the default):
```
python -c "from flopy.utils import *; print(CellBudgetFile('examples/data/preserve_unitnums/testsfr2.ghb.cbc').headers)"
```
previously this will hang indefinitely since it is attempting to read data at the end of the file without raising any exception. This example is fixed with this PR.

#### HeadFile
And this is not so much a fix, but a less confusing error:
```
python -c "from flopy.utils import *; HeadFile('examples/data/mf6/create_tests/test_transport/expected_output/gwt_mst03.ucn')"
```
the exception is changed from:
> IndexError: index 0 is out of bounds for axis 0 with size 0

to:
> EOFError

I have some pending changes to resolve this issue, due after this one.