### PR TITLE
refactor(binarygrid_util): refactor get_iverts to be general

### DIFF
--- a/flopy/mf6/utils/binarygrid_util.py
+++ b/flopy/mf6/utils/binarygrid_util.py
@@ -280,13 +280,10 @@ class MfGrdFile(FlopyBinaryData):
         """
         iverts = None
         if "IAVERT" in self._datadict:
-            if self._grid_type == "DISV":
-                nsize = self.ncpl
-            elif self._grid_type == "DISU":
-                nsize = self.nodes
             iverts = []
             iavert = self.iavert
             javert = self.javert
+            nsize = iavert.shape[0] - 1
             for ivert in range(nsize):
                 i0 = iavert[ivert]
                 i1 = iavert[ivert + 1]


### PR DESCRIPTION
The get_iverts() method can work without knowing the grid type.  The PR uses the shape of iavert rather than grid properties so that the method works for any grid type, including new ones just added for ongoing surface water model development.