### PR TITLE
refactor(datafile): ignore "text" parameter, add attributes from file

### DIFF
--- a/autotest/test_formattedfile.py
+++ b/autotest/test_formattedfile.py
@@ -21,6 +21,7 @@ def test_headfile_build_index(example_data_path):
     assert hds.ncol == 10
     assert hds.nlay == 1
     assert not hasattr(hds, "nper")
+    assert hds.text == "head"
     assert hds.totalbytes == 1613
     assert len(hds.recordarray) == 1
     assert type(hds.recordarray) == np.ndarray

--- a/flopy/export/utils.py
+++ b/flopy/export/utils.py
@@ -161,6 +161,9 @@ def _add_output_nc_variable(
     )
     array[:] = np.nan
 
+    if isinstance(text, bytes):
+        text = text.decode("ascii")
+
     if isinstance(out_obj, ZBNetOutput):
         a = np.asarray(out_obj.zone_array, dtype=np.float32)
         if mask_array3d is not None:
@@ -179,7 +182,7 @@ def _add_output_nc_variable(
                     else:
                         a = out_obj.get_data(totim=t)
                 except Exception as e:
-                    nme = var_name + text.decode().strip().lower()
+                    nme = var_name + text
                     estr = f"error getting data for {nme} at time {t}:{e!s}"
                     if logger:
                         logger.warn(estr)
@@ -191,7 +194,7 @@ def _add_output_nc_variable(
                 try:
                     array[i, :, :, :] = a.astype(np.float32)
                 except Exception as e:
-                    nme = var_name + text.decode().strip().lower()
+                    nme = var_name + text
                     estr = f"error assigning {nme} data to array for time {t}:{e!s}"
                     if logger:
                         logger.warn(estr)
@@ -209,7 +212,7 @@ def _add_output_nc_variable(
 
     if isinstance(nc, dict):
         if text:
-            var_name = text.decode().strip().lower()
+            var_name = text
         nc[var_name] = array
         return nc
 
@@ -219,7 +222,7 @@ def _add_output_nc_variable(
     precision_str = "f4"
 
     if text:
-        var_name = text.decode().strip().lower()
+        var_name = text
     attribs = {"long_name": var_name}
     attribs["coordinates"] = "time layer latitude longitude"
     attribs["min"] = mn
@@ -434,7 +437,7 @@ def output_helper(
                     times,
                     shape3d,
                     out_obj,
-                    "concentration",
+                    out_obj.text,
                     logger=logger,
                     mask_vals=mask_vals,
                     mask_array3d=mask_array3d,
@@ -446,7 +449,7 @@ def output_helper(
                     times,
                     shape3d,
                     out_obj,
-                    out_obj.text.decode(),
+                    out_obj.text,
                     logger=logger,
                     mask_vals=mask_vals,
                     mask_array3d=mask_array3d,

--- a/flopy/export/vtk.py
+++ b/flopy/export/vtk.py
@@ -1228,14 +1228,12 @@ class Vtk:
         kstpkpers = hds.get_kstpkper()
         self._totim = {ki: time for (ki, time) in zip(kstpkpers, times)}
 
-        text = hds.text.decode()
-
         d = dict()
         for ki in kstpkper:
             d[ki] = hds.get_data(ki)
 
         self.__transient_output_data = False
-        self.add_transient_array(d, name=text, masked_values=masked_values)
+        self.add_transient_array(d, name=hds.text, masked_values=masked_values)
         self.__transient_output_data = True
 
     def add_cell_budget(

--- a/flopy/mf6/utils/binaryfile_utils.py
+++ b/flopy/mf6/utils/binaryfile_utils.py
@@ -192,7 +192,7 @@ class MFOutputRequester:
 
         elif bintype == "DDN":
             try:
-                return bf.HeadFile(path, text="drawdown", precision="double")
+                return bf.HeadFile(path, precision="double")
             except AssertionError:
                 raise AssertionError(f"{self.dataDict[key]} does not exist")
 
@@ -333,9 +333,7 @@ class MFOutputRequester:
 
             elif key[1] == "DDN":
                 try:
-                    readddn = bf.HeadFile(
-                        path, text="drawdown", precision="double"
-                    )
+                    readddn = bf.HeadFile(path, precision="double")
                     self.dataDict[(key[0], key[1], "DRAWDOWN")] = path
                     readddn.close()
 

--- a/flopy/utils/datafile.py
+++ b/flopy/utils/datafile.py
@@ -205,8 +205,13 @@ class LayerFile:
             args = ",".join(kwargs.keys())
             raise Exception(f"LayerFile error: unrecognized kwargs: {args}")
 
-        # read through the file and build the pointer index
-        self._build_index()
+        try:
+            # read through the file and build the pointer index
+            self._build_index()
+        except EOFError:
+            raise ValueError(
+                f"cannot read file with {self.__class__.__name__}"
+            )
 
         # now that we read the data and know nrow and ncol,
         # we can make a generic mg if needed


### PR DESCRIPTION
This PR ignores the `text=` parameter from `HeadFile`, `HeadUFile` and `UcnFile`, since this should be read from the file and is constant for all records. This PR adds these attributes:

- `obj.text_bytes`, the 16-byte char bytes obtained from the file
- `obj.text`, a `str` version of this field, .e.g., used by `flopy.export` for NetCDF variable names

There are instances where other binary files can be attempted to be read (e.g. "mt3d_test/mf96mt3d/P01/case1b/MT3D001.UCN" with HeadFile), but these are now caught with exceptions raised. Warnings are raised if the text records are inconsistent, which shouldn't happen (unless I've misunderstood something!)