### PR TITLE
fix(Raster): reclassify np.float64 correctly

### DIFF
--- a/flopy/utils/rasters.py
+++ b/flopy/utils/rasters.py
@@ -45,7 +45,7 @@ class Raster:
 
     """
 
-    FLOAT32 = (float, np.float32, np.float64)
+    FLOAT32 = (float, np.float32)
     FLOAT64 = (np.float64,)
     INT8 = (np.int8, np.uint8)
     INT16 = (np.int16, np.uint16)


### PR DESCRIPTION
Just a small fix on dtype reclassification when creating a `Raster` object.

I was also tempted to reclassify `float` as `FLOAT64` and `int` as `INT64` because based on my quick search, Python's `float` is represented as 64-bit, and `int` is pretty much unbounded. But then maybe these might be intended for optimization purposes as `FLOAT32` and `INT32` are practically sufficient in most cases.