### PR TITLE
refactor(dependencies): support numpy 2

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ 3.9, "3.10", "3.11", "3.12" ]
+        python-version: [ 3.8, 3.9, "3.10", "3.11", "3.12" ]
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,11 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ 3.8, 3.9, "3.10", "3.11", "3.12" ]
-        exclude:
-          # avoid shutil.copytree infinite recursion bug
-          # https://github.com/python/cpython/pull/17098
-          - python-version: '3.8.0'
+        python-version: [ 3.9, "3.10", "3.11", "3.12" ]
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -133,7 +133,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ 3.9, "3.10", "3.11", "3.12" ]
+        python-version: [ 3.8, 3.9, "3.10", "3.11", "3.12" ]
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
           cache: 'pip'
           cache-dependency-path: pyproject.toml
 
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
           cache: 'pip'
           cache-dependency-path: pyproject.toml
 
@@ -84,7 +84,7 @@ jobs:
         shell: bash
     timeout-minutes: 10
     env:
-      PYTHON_VERSION: 3.8
+      PYTHON_VERSION: 3.9
 
     steps:
       - name: Checkout repo
@@ -133,11 +133,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ 3.8, 3.9, "3.10", "3.11", "3.12" ]
-        exclude:
-          # avoid shutil.copytree infinite recursion bug
-          # https://github.com/python/cpython/pull/17098
-          - python-version: '3.8.0'
+        python-version: [ 3.9, "3.10", "3.11", "3.12" ]
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ 3.9, "3.10", "3.11", "3.12" ]
+        python-version: [ 3.8, 3.9, "3.10", "3.11", "3.12" ]
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -12,11 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ 3.8, 3.9, "3.10", "3.11", "3.12" ]
-        exclude:
-          # avoid shutil.copytree infinite recursion bug
-          # https://github.com/python/cpython/pull/17098
-          - python-version: '3.8.0'
+        python-version: [ 3.9, "3.10", "3.11", "3.12" ]
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/mf6.yml
+++ b/.github/workflows/mf6.yml
@@ -49,8 +49,7 @@ jobs:
     - name: Checkout MODFLOW 6
       uses: actions/checkout@v4
       with:
-        repository: wpbonelli/modflow6
-        ref: numpy2-fixes
+        repository: MODFLOW-USGS/modflow6
         path: modflow6
 
     - name: Build and install MF6

--- a/.github/workflows/mf6.yml
+++ b/.github/workflows/mf6.yml
@@ -49,7 +49,8 @@ jobs:
     - name: Checkout MODFLOW 6
       uses: actions/checkout@v4
       with:
-        repository: MODFLOW-USGS/modflow6
+        repository: wpbonelli/modflow6
+        ref: numpy2-fixes
         path: modflow6
 
     - name: Build and install MF6

--- a/.github/workflows/optional.yml
+++ b/.github/workflows/optional.yml
@@ -14,7 +14,7 @@ jobs:
         shell: bash
     timeout-minutes: 10
     env:
-      PYTHON_VERSION: 3.8
+      PYTHON_VERSION: 3.9
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
           cache: 'pip'
           cache-dependency-path: pyproject.toml
 
@@ -211,7 +211,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
           cache: 'pip'
           cache-dependency-path: pyproject.toml
 

--- a/autotest/test_export.py
+++ b/autotest/test_export.py
@@ -410,7 +410,7 @@ def test_export_shapefile_polygon_closed(function_tmpdir):
 
 
 @excludes_platform("Windows")
-@requires_pkg("rasterio", "shapefile", "scipy")
+@requires_pkg("rasterio", "pyshp", "scipy", name_map={"pyshp": "shapefile"})
 def test_export_array(function_tmpdir, example_data_path):
     import rasterio
     from scipy.ndimage import rotate
@@ -1992,7 +1992,7 @@ def test_vtk_export_disu2_grid(function_tmpdir, example_data_path):
 
 @pytest.mark.mf6
 @requires_exe("mf6", "gridgen")
-@requires_pkg("vtk", "shapefile", "shapely")
+@requires_pkg("vtk", "pyshp", "shapely", name_map={"pyshp": "shapefile"})
 def test_vtk_export_disu_model(function_tmpdir):
     from vtkmodules.util.numpy_support import vtk_to_numpy
 

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -6,6 +6,7 @@ dependencies:
 
   # required
   - python>=3.8
+  - numpy>=1.20.3
   - matplotlib>=1.4.0
   - pandas>=2.0.0
 
@@ -21,7 +22,6 @@ dependencies:
   - jupyter_client>=8.4.0
   - jupytext
   - pip:
-      - numpy>=2.0.0
       - git+https://github.com/MODFLOW-USGS/modflow-devtools.git
   - pytest!=8.1.0
   - pytest-benchmark

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -6,7 +6,7 @@ dependencies:
 
   # required
   - python>=3.8
-  - numpy>=1.20.3,<3.0.0
+  - numpy>=2.0.0
   - matplotlib>=1.4.0
   - pandas>=2.0.0
 

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -6,7 +6,6 @@ dependencies:
 
   # required
   - python>=3.8
-  - numpy>=2.0.0
   - matplotlib>=1.4.0
   - pandas>=2.0.0
 
@@ -22,6 +21,7 @@ dependencies:
   - jupyter_client>=8.4.0
   - jupytext
   - pip:
+      - numpy>=2.0.0
       - git+https://github.com/MODFLOW-USGS/modflow-devtools.git
   - pytest!=8.1.0
   - pytest-benchmark

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -6,7 +6,7 @@ dependencies:
 
   # required
   - python>=3.8
-  - numpy>=1.20.3,<2.0.0
+  - numpy>=1.20.3,<3.0.0
   - matplotlib>=1.4.0
   - pandas>=2.0.0
 

--- a/flopy/mf6/data/mfdatastorage.py
+++ b/flopy/mf6/data/mfdatastorage.py
@@ -2535,7 +2535,7 @@ class DataStorage:
             data_array = np.ndarray(shape=dimensions, dtype=np_dtype)
             # fill array
             for index in ArrayIndexIter(dimensions):
-                data_array.itemset(index, next(data_iter))
+                data_array[index] = next(data_iter)
             return data_array
         elif self.data_structure_type == DataStructureType.scalar:
             return next(data_iter)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "numpy >=2.0.0",
+    "numpy>=1.20.3",
     "matplotlib >=1.4.0",
     "pandas >=2.0.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "numpy >=1.20.3,<3.0.0",
+    "numpy >=2.0.0",
     "matplotlib >=1.4.0",
     "pandas >=2.0.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "numpy >=1.20.3,<2.0.0",
+    "numpy >=1.20.3,<3.0.0",
     "matplotlib >=1.4.0",
     "pandas >=2.0.0"
 ]


### PR DESCRIPTION
Remove numpy upper bound to close #2153. Also fix `@requires_pkg` usage in `test_export.py`, replace deprecated `itemset` in `mfdatastorage.py`, and bump some CI jobs to Python 3.9.

This PR required updates on the MF6 side:

* https://github.com/MODFLOW-USGS/modflow6/pull/1886
* https://github.com/MODFLOW-USGS/modflow6/pull/1887