### PR TITLE
fix(PlotMapView): default to all layers in plot_pathline()

### DIFF
--- a/flopy/plot/map.py
+++ b/flopy/plot/map.py
@@ -797,7 +797,7 @@ class PlotMapView:
                 else:
                     kon = self.layer
         else:
-            kon = self.layer
+            kon = -1
 
         # configure plot settings
         marker = kwargs.pop("marker", None)


### PR DESCRIPTION
Defaulting to layer 0 for arrays where each cell is assigned a color is sensible but for pathlines it seems more natural to include all layers for complete pathlines. This might (pragmatically) be seen as a bugfix rather than a breaking change?