### PR TITLE
fix(HeadFile): fix dis reversal, expand tests

### DIFF
--- a/flopy/utils/binaryfile.py
+++ b/flopy/utils/binaryfile.py
@@ -699,7 +699,7 @@ class HeadFile(BinaryLayerFile):
         # loop over head file records in reverse order and write temp file
         temp_dir_path = Path(tempfile.gettempdir())
         temp_file_path = temp_dir_path / filename.name
-        with open(temp_file_path, "w") as f:
+        with open(temp_file_path, "wb") as f:
             for idx in range(nrecords - 1, -1, -1):
                 # load header array
                 header = self.recordarray[idx].copy()
@@ -2304,7 +2304,7 @@ class CellBudgetFile:
         # open backward budget file
         temp_dir_path = Path(tempfile.gettempdir())
         temp_file_path = temp_dir_path / filename.name
-        with open(temp_file_path, "w") as f:
+        with open(temp_file_path, "wb") as f:
             # loop over budget file records in reverse order
             for idx in range(nrecords - 1, -1, -1):
                 # load header array

--- a/flopy/utils/binaryfile.py
+++ b/flopy/utils/binaryfile.py
@@ -709,8 +709,14 @@ class HeadFile(BinaryLayerFile):
                 tdis_maxtsim = sum([p[0] for p in pd])
         # if we have both, check them against each other
         if tdis_maxkper is not None:
-            assert maxkper == tdis_maxkper
-            assert maxtsim == tdis_maxtsim
+            assert maxkper == tdis_maxkper, (
+                f"Max stress period in binary head file ({maxkper}) != "
+                f"max stress period in provided tdis ({tdis_maxkper})"
+            )
+            assert maxtsim == tdis_maxtsim, (
+                f"Max simulation time in binary head file ({maxtsim}) != "
+                f"max simulation time in provided tdis ({tdis_maxtsim})"
+            )
 
         def reverse_header(header):
             """Reverse period, step and time fields in the record header"""


### PR DESCRIPTION
Fix the write logic for head file reversal to properly write each layer. Add a test for each discretization type. Fix in-place reverse by writing to a temp file first then renaming. Improve docstrings.

@cneyens could you check if this resolves #2246 on your end?