### PR TITLE
ci(macos): use intel triangle build for now

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -40,6 +40,14 @@ jobs:
       - name: Install Modflow executables
         uses: modflowpy/install-modflow-action@v1
 
+      - name: Install triangle (macOS workaround)
+        if: runner.os == 'macOS'
+        uses: modflowpy/install-modflow-action@v1
+        with:
+          repo: executables
+          ostag: mac
+          subset: triangle
+
       - name: Run benchmarks
         working-directory: autotest
         run: |

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -166,6 +166,14 @@ jobs:
         with:
           repo: modflow6-nightly-build
 
+      - name: Install triangle (macOS workaround)
+        if: runner.os == 'macOS'
+        uses: modflowpy/install-modflow-action@v1
+        with:
+          repo: executables
+          ostag: mac
+          subset: triangle
+
       - name: Update package classes
         run: python -m flopy.mf6.utils.generate_classes --ref develop --no-backup
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -60,6 +60,14 @@ jobs:
         with:
           repo: modflow6-nightly-build
 
+      - name: Install triangle (macOS workaround)
+        if: runner.os == 'macOS'
+        uses: modflowpy/install-modflow-action@v1
+        with:
+          repo: executables
+          ostag: mac
+          subset: triangle
+
       - name: Update FloPy packages
         run: python -m flopy.mf6.utils.generate_classes --ref develop --no-backup
 

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -82,6 +82,14 @@ jobs:
         with:
           repo: modflow6-nightly-build
 
+      - name: Install triangle (macOS workaround)
+        if: runner.os == 'macOS'
+        uses: modflowpy/install-modflow-action@v1
+        with:
+          repo: executables
+          ostag: mac
+          subset: triangle
+
       - name: Run tutorial and example notebooks
         working-directory: autotest
         run: pytest -v -n auto test_notebooks.py


### PR DESCRIPTION
Workaround https://github.com/MODFLOW-USGS/executables/issues/33.