### PR TITLE
ci(rtd): fix artifact upload sha, update concurrency key, cleanup

### DIFF
--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       ref: ${{ steps.set_ref.outputs.ref }}
+      sha: ${{ steps.set_sha.outputs.sha }}
     steps:
       - name: Set ref
         id: set_ref
@@ -35,6 +36,11 @@ jobs:
             echo "using current ref $ref"
           fi
           echo "ref=$ref" >> $GITHUB_OUTPUT
+      - name: Set sha
+        id: set_sha
+        run: |
+          sha=$(git rev-parse ${{ steps.set_ref.outputs.ref }})
+          echo "sha=$sha" >> $GITHUB_OUTPUT
   rtd_build:
     name: Prepare and test notebooks
     needs: set_options
@@ -131,7 +137,7 @@ jobs:
           )
         uses: actions/upload-artifact@v4
         with:
-          name: notebooks-for-${{ github.sha }}
+          name: notebooks-for-${{ needs.set_options.outputs.sha }}
           path: .docs/Notebooks/*.ipynb
 
   # trigger rtd if previous job was successful

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -39,7 +39,11 @@ jobs:
       - name: Set sha
         id: set_sha
         run: |
-          sha=$(git rev-parse ${{ steps.set_ref.outputs.ref }})
+          if [[ ("${{ github.event_name }}" == "workflow_dispatch") && (-n "${{ inputs.ref }}") ]]; then
+            sha=$(git rev-parse ${{ steps.set_ref.outputs.ref }})
+          else
+            sha="${{ github.sha }}"
+          fi
           echo "sha=$sha" >> $GITHUB_OUTPUT
   rtd_build:
     name: Prepare and test notebooks

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -13,12 +13,11 @@ on:
         type: string
         default: 'refs/heads/develop'
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 jobs:
   set_options:
     name: Set release options
-    if: github.ref_name != 'master'
     runs-on: ubuntu-22.04
     outputs:
       ref: ${{ steps.set_ref.outputs.ref }}


### PR DESCRIPTION
The RTD build integration expects artifacts named according to the pattern `prefix-sha`. Previously the workflow used the current ref's hash, not the hash of the selected ref. Fix it so the RTD build can find the proper artifacts. Also add the workflow trigger to the concurrency group key.