### PR TITLE
fix(mfmodel): fix get_ims_package

### DIFF
--- a/autotest/test_mf6.py
+++ b/autotest/test_mf6.py
@@ -2245,6 +2245,9 @@ def test_multi_model(function_tmpdir):
         assert rec_array[0][3] == model_names[1]
         assert rec_array[1][1] == "transport.ims"
         assert rec_array[1][2] == model_names[2]
+    assert gwf1.get_ims_package() is gwf2.get_ims_package()
+    assert gwf1.get_ims_package().filename == "flow.ims"
+    assert gwt.get_ims_package().filename == "transport.ims"
     # test ssm fileinput
     gwt2 = sim2.get_model("gwt_model_1")
     ssm2 = gwt2.get_package("ssm")

--- a/flopy/mf6/mfmodel.py
+++ b/flopy/mf6/mfmodel.py
@@ -1275,11 +1275,15 @@ class MFModel(PackageContainer, ModelInterface):
         -------
         IMS package : ModflowIms
         """
-        solution_group = self.simulation.name_file.solutiongroup.get_data()
+        solution_group = self.simulation.name_file.solutiongroup.get_data(0)
         for record in solution_group:
-            for model_name in record[2:]:
-                if model_name == self.name:
-                    return self.simulation.get_solution_package(record[1])
+            for name in record.dtype.names:
+                if name == "slntype" or name == "slnfname":
+                    continue
+                if record[name] == self.name:
+                    return self.simulation.get_solution_package(
+                        record.slnfname
+                    )
         return None
 
     def get_steadystate_list(self):


### PR DESCRIPTION
This fixes MFModel.get_ims_package which is a method that returns the relevant IMS through the simulation name files's solution group block.