### PR TITLE
ci(release): remove --approve from update_version.py call

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
           if [[ "$ver" == *"rc"* ]]; then
             python scripts/update_version.py -v "${ver%"rc"}"
           else
-            python scripts/update_version.py -v "$ver" --approve
+            python scripts/update_version.py -v "$ver"
           fi
           
           # show version and set output


### PR DESCRIPTION
This is no longer needed/supported as of #2240