### PR TITLE
chore(git-cliff): relax changelog patterns to accomodate 'updates' type

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -26,7 +26,7 @@ commit_parsers = [
     { message = "^[bB]ug", group = "fix"},
     { message = "^[pP]erf", group = "perf"},
     { message = "^[rR]efactor", group = "refactor"},
-    { message = "^[uU]pdate", group = "refactor"},
+    { message = "^[uU]pdate.*", group = "refactor"},
     { message = "^[dD]oc.*", group = "docs", skip = true},
     { message = "^[bB]inder", group = "docs", skip = true},
     { message = "^[nN]otebook.*", group = "docs", skip = true},


### PR DESCRIPTION
Relax the patterns in `cliff.toml` so commit messages like `updates(...): ...` are included in the refactor group in the auto-generated changelog at release time