### PR TITLE
feat(cell1d): add support for 1D vertex grids

### DIFF
--- a/flopy/discretization/grid.py
+++ b/flopy/discretization/grid.py
@@ -595,7 +595,7 @@ class Grid:
     def cross_section_vertices(self):
         return self.xyzvertices[0], self.xyzvertices[1]
 
-    def geo_dataframe(self, polys):
+    def geo_dataframe(self, features, featuretype="Polygon"):
         """
         Method returns a geopandas GeoDataFrame of the Grid
 
@@ -606,7 +606,7 @@ class Grid:
         from ..utils.geospatial_utils import GeoSpatialCollection
 
         gc = GeoSpatialCollection(
-            polys, shapetype=["Polygon" for _ in range(len(polys))]
+            features, shapetype=[featuretype for _ in range(len(features))]
         )
         gdf = gc.geo_dataframe
         if self.crs is not None:

--- a/flopy/discretization/vertexgrid.py
+++ b/flopy/discretization/vertexgrid.py
@@ -168,7 +168,7 @@ class VertexGrid(Grid):
     def cell1d(self):
         if self._cell1d is not None:
             return [
-                [ivt for ivt in t if ivt is not None] for t in self._cell2d
+                [ivt for ivt in t if ivt is not None] for t in self._cell1d
             ]
 
     @property
@@ -221,15 +221,30 @@ class VertexGrid(Grid):
         xgrid = self.xvertices
         ygrid = self.yvertices
 
+        # close the cell by connecting the last vertex with the first
+        close_cell = True
+        if self.cell1d is not None:
+            close_cell = False
+
+        # go through each cell and create a line segement for each face
         lines = []
-        for ncell, verts in enumerate(xgrid):
-            for ix, vert in enumerate(verts):
+        ncpl = len(xgrid)
+        for icpl in range(ncpl):
+            xcoords = xgrid[icpl]
+            ycoords = ygrid[icpl]
+            npoints = len(xcoords)
+            for ipoint in range(npoints - 1):
                 lines.append(
                     [
-                        (xgrid[ncell][ix - 1], ygrid[ncell][ix - 1]),
-                        (xgrid[ncell][ix], ygrid[ncell][ix]),
+                        (xcoords[ipoint], ycoords[ipoint]),
+                        (xcoords[ipoint + 1], ycoords[ipoint + 1]),
                     ]
                 )
+            if close_cell:
+                lines.append(
+                    [(xcoords[-1], ycoords[-1]), (xcoords[0], ycoords[0])]
+                )
+
         self._copy_cache = True
         return lines
 
@@ -300,8 +315,11 @@ class VertexGrid(Grid):
         -------
             GeoDataFrame
         """
-        polys = [[self.get_cell_vertices(nn)] for nn in range(self.ncpl)]
-        gdf = super().geo_dataframe(polys)
+        cells = [[self.get_cell_vertices(nn)] for nn in range(self.ncpl)]
+        featuretype = "Polygon"
+        if self._cell1d is not None:
+            featuretype = "multilinestring"
+        gdf = super().geo_dataframe(cells, featuretype)
         return gdf
 
     def convert_grid(self, factor):
@@ -458,12 +476,12 @@ class VertexGrid(Grid):
         if self._cell1d is not None:
             zcenters = []
             zvertices = []
-            vertexdict = {v[0]: [v[1], v[2], v[3]] for v in self._vertices}
+            vertexdict = {v[0]: [v[1], v[2]] for v in self._vertices}
             for cell1d in self.cell1d:
                 cell1d = tuple(cell1d)
                 xcenters.append(cell1d[1])
                 ycenters.append(cell1d[2])
-                zcenters.append(cell1d[3])
+                zcenters.append(0.0)
 
                 vert_number = []
                 for i in cell1d[3:]:
@@ -475,7 +493,7 @@ class VertexGrid(Grid):
                 for ix in vert_number:
                     xcellvert.append(vertexdict[ix][0])
                     ycellvert.append(vertexdict[ix][1])
-                    zcellvert.append(vertexdict[ix][2])
+                    zcellvert.append(0.0)
                 xvertices.append(xcellvert)
                 yvertices.append(ycellvert)
                 zvertices.append(zcellvert)


### PR DESCRIPTION
The Channel Flow (CHF) Model simulates one dimensional surface water flow in a connected line network.  This PR adds some minimal support to the VertexGrid class to allow plotting of the 1D network.  There was some older broken support for "cell1d", which is fixed here to work with the new mf6 CHF model.