### PR TITLE
chore(git-cliff): trim leading whitespace in commit messages

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -20,6 +20,9 @@ trim = true
 conventional_commits = true
 filter_unconventional = true
 split_commits = false
+commit_preprocessors = [
+    { pattern = "^ *", replace = ""}
+]
 commit_parsers = [
     { message = "^[fF]eat", group = "feat"},
     { message = "^[fF]ix", group = "fix"},


### PR DESCRIPTION
Commit messages were omitted from the generated changelog if they had any leading whitespace. Fix it.