### PR TITLE
ci(release): explicitly specify files to commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
           git config core.sharedRepository true
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -A
+          git add flopy docs .docs CITATION.cff README.md version.txt 
           git commit -m "ci(release): set version to ${{ steps.version.outputs.version }}, update plugins from DFN files, update changelog"
           git push origin "${{ github.ref_name }}"
 


### PR DESCRIPTION
Explicitly add files to commit after updating the version number and generating the changelog. Previously we used `git add -A`. As of `git-cliff-action@v4` this includes the `git-cliff` binary and related content which is apparently installed to the working directory.