### PR TITLE
fix(masked_4D_arrays): allow re-use of preceding spd data if empty

### DIFF
--- a/autotest/test_export.py
+++ b/autotest/test_export.py
@@ -957,9 +957,6 @@ def test_mf6_grid_shp_export(function_tmpdir):
     for c in spd.dtype.names:
         if c in spd6[0].dtype.names:
             spd6[0][c] = spd[c]
-    # MFTransient list apparently requires entries for additional stress periods,
-    # even if they are the same
-    spd6[1] = spd6[0]
     riv6 = flopy.mf6.ModflowGwfriv(gwf, stress_period_data=spd6)
     rch6 = flopy.mf6.ModflowGwfrcha(gwf, recharge=rech)
 

--- a/autotest/test_export.py
+++ b/autotest/test_export.py
@@ -874,8 +874,10 @@ def test_export_contours(function_tmpdir, example_data_path):
 
 
 @pytest.mark.mf6
-@requires_pkg("shapely")
+@requires_pkg("pyshp", "shapely", name_map={"pyshp": "shapefile"})
 def test_mf6_grid_shp_export(function_tmpdir):
+    from shapefile import Reader
+
     nlay = 2
     nrow = 10
     ncol = 10
@@ -968,13 +970,10 @@ def test_mf6_grid_shp_export(function_tmpdir):
         ), f"variable {k} is not equal"
         pass
 
-    if not has_pkg("shapefile"):
-        return
-
     m.export(function_tmpdir / "mfnwt.shp")
     gwf.export(function_tmpdir / "mf6.shp")
 
-    # check that the two shapefiles are the same
+    # check that the shapefiles are the same
     ra = shp2recarray(function_tmpdir / "mfnwt.shp")
     ra6 = shp2recarray(function_tmpdir / "mf6.shp")
 
@@ -998,6 +997,16 @@ def test_mf6_grid_shp_export(function_tmpdir):
                 assert math.isnan(it6)
             else:
                 assert np.abs(it - it6) < 1e-6
+
+    # Compare exported riv shapefiles
+    riv.export(function_tmpdir / "riv.shp")
+    riv6.export(function_tmpdir / "riv6.shp")
+    with Reader(function_tmpdir / "riv.shp") as riv_shp, Reader(
+        function_tmpdir / "riv6.shp"
+    ) as riv6_shp:
+        assert list(riv_shp.shapeRecord(-1).record) == list(
+            riv6_shp.shapeRecord(-1).record
+        )
 
 
 @requires_pkg("pyshp", name_map={"pyshp": "shapefile"})

--- a/autotest/test_export.py
+++ b/autotest/test_export.py
@@ -875,7 +875,7 @@ def test_export_contours(function_tmpdir, example_data_path):
 
 @pytest.mark.mf6
 @requires_pkg("pyshp", "shapely", name_map={"pyshp": "shapefile"})
-def test_mf6_grid_shp_export(function_tmpdir):
+def test_export_mf6_shp(function_tmpdir):
     from shapefile import Reader
 
     nlay = 2
@@ -948,9 +948,6 @@ def test_mf6_grid_shp_export(function_tmpdir):
         gwf, pname="dis", nlay=nlay, nrow=nrow, ncol=ncol, top=top, botm=botm
     )
 
-    def cellid(k, i, j, nrow, ncol):
-        return k * nrow * ncol + i * ncol + j
-
     # Riv6
     spd6 = flopy.mf6.ModflowGwfriv.stress_period_data.empty(
         gwf, maxbound=len(spd)
@@ -1007,6 +1004,18 @@ def test_mf6_grid_shp_export(function_tmpdir):
         assert list(riv_shp.shapeRecord(-1).record) == list(
             riv6_shp.shapeRecord(-1).record
         )
+
+    # Check wel export with timeseries
+    wel_spd_0 = flopy.mf6.ModflowGwfwel.stress_period_data.empty(
+        gwf, maxbound=1, timeseries=True
+    )
+    wel_spd_0[0][0] = ((0, 0, 0), -99.0)
+    wel = flopy.mf6.ModflowGwfwel(
+        gwf,
+        maxbound=1,
+        stress_period_data={0: wel_spd_0[0]},
+    )
+    wel.export(function_tmpdir / "wel_test.shp")
 
 
 @requires_pkg("pyshp", name_map={"pyshp": "shapefile"})

--- a/autotest/test_gridgen.py
+++ b/autotest/test_gridgen.py
@@ -374,6 +374,8 @@ def test_mf6disu(sim_disu_diff_layers):
     gwf.modelgrid.write_shapefile(fname)
     fname = ws / "model.shp"
     gwf.export(fname)
+    fname = ws / "chd.shp"
+    gwf.chd.export(fname)
 
     sim.run_simulation(silent=True)
     head = gwf.output.head().get_data()

--- a/flopy/export/shapefile_utils.py
+++ b/flopy/export/shapefile_utils.py
@@ -380,6 +380,13 @@ def model_attributes_to_shapefile(
                     # Skip empty transientlist
                     if not a.data:
                         continue
+                    # Skip transientlist if all elements are of object type
+                    if all(
+                        dtype == np.object_
+                        for dtype, _ in a.data[0].dtype.fields.values()
+                    ):
+                        continue
+
                     for name, array in a.masked_4D_arrays_itr():
                         n = shape_attr_name(name, length=4)
                         for kper in range(array.shape[0]):

--- a/flopy/export/shapefile_utils.py
+++ b/flopy/export/shapefile_utils.py
@@ -382,9 +382,20 @@ def model_attributes_to_shapefile(
                     except:
                         continue
                     for name, array in a.masked_4D_arrays_itr():
+                        n = shape_attr_name(name, length=4)
                         for kper in range(array.shape[0]):
+                            # guard clause for disu case
+                            # array is (kper, node) only
+                            if len(array.shape) == 2:
+                                aname = f"{n}{kper + 1}"
+                                arr = array[kper]
+                                assert arr.shape == horz_shape
+                                if np.all(np.isnan(arr)):
+                                    continue
+                                array_dict[aname] = arr
+                                continue
+                            # non-disu case
                             for k in range(array.shape[1]):
-                                n = shape_attr_name(name, length=4)
                                 aname = f"{n}{k + 1}{kper + 1}"
                                 arr = array[kper][k]
                                 assert arr.shape == horz_shape

--- a/flopy/export/shapefile_utils.py
+++ b/flopy/export/shapefile_utils.py
@@ -377,6 +377,9 @@ def model_attributes_to_shapefile(
                         assert arr.shape == horz_shape
                         array_dict[name] = arr
                 elif a.data_type == DataType.transientlist:
+                    # Skip empty transientlist
+                    if not a.data:
+                        continue
                     for name, array in a.masked_4D_arrays_itr():
                         n = shape_attr_name(name, length=4)
                         for kper in range(array.shape[0]):

--- a/flopy/export/shapefile_utils.py
+++ b/flopy/export/shapefile_utils.py
@@ -380,10 +380,15 @@ def model_attributes_to_shapefile(
                     # Skip empty transientlist
                     if not a.data:
                         continue
+
+                    # Use first recarray kper to check transientlist
+                    for kper in a.data.keys():
+                        if isinstance(a.data[kper], np.recarray):
+                            break
                     # Skip transientlist if all elements are of object type
                     if all(
                         dtype == np.object_
-                        for dtype, _ in a.data[0].dtype.fields.values()
+                        for dtype, _ in a.data[kper].dtype.fields.values()
                     ):
                         continue
 

--- a/flopy/export/shapefile_utils.py
+++ b/flopy/export/shapefile_utils.py
@@ -377,10 +377,6 @@ def model_attributes_to_shapefile(
                         assert arr.shape == horz_shape
                         array_dict[name] = arr
                 elif a.data_type == DataType.transientlist:
-                    try:
-                        list(a.masked_4D_arrays_itr())
-                    except:
-                        continue
                     for name, array in a.masked_4D_arrays_itr():
                         n = shape_attr_name(name, length=4)
                         for kper in range(array.shape[0]):

--- a/flopy/export/utils.py
+++ b/flopy/export/utils.py
@@ -962,10 +962,14 @@ def mflist_export(f: Union[str, os.PathLike, NetCdf], mfl, **kwargs):
 
     elif isinstance(f, NetCdf) or isinstance(f, dict):
         base_name = mfl.package.name[0].lower()
+        # Use first recarray kper to check mflist
+        for kper in mfl.data.keys():
+            if isinstance(mfl.data[kper], np.recarray):
+                break
         # Skip mflist if all elements are of object type
         if all(
             dtype == np.object_
-            for dtype, _ in mfl.data[0].dtype.fields.values()
+            for dtype, _ in mfl.data[kper].dtype.fields.values()
         ):
             return f
 

--- a/flopy/export/utils.py
+++ b/flopy/export/utils.py
@@ -962,6 +962,12 @@ def mflist_export(f: Union[str, os.PathLike, NetCdf], mfl, **kwargs):
 
     elif isinstance(f, NetCdf) or isinstance(f, dict):
         base_name = mfl.package.name[0].lower()
+        # Skip mflist if all elements are of object type
+        if all(
+            dtype == np.object_
+            for dtype, _ in mfl.data[0].dtype.fields.values()
+        ):
+            return f
 
         for name, array in mfl.masked_4D_arrays_itr():
             var_name = f"{base_name}_{name}"

--- a/flopy/mf6/data/mfdatalist.py
+++ b/flopy/mf6/data/mfdatalist.py
@@ -1546,51 +1546,7 @@ class MFTransientList(MFList, mfdata.MFTransient, DataListInterface):
 
     @property
     def masked_4D_arrays(self):
-        """Returns list data as a masked 4D array."""
-        model_grid = self.data_dimensions.get_model_grid()
-        nper = self.data_dimensions.package_dim.model_dim[
-            0
-        ].simulation_time.get_num_stress_periods()
-        # get the first kper
-        arrays = self.to_array(kper=0, mask=True)
-
-        if arrays is not None:
-            # initialize these big arrays
-            if model_grid.grid_type() == DiscretizationType.DIS:
-                m4ds = {}
-                for name, array in arrays.items():
-                    m4d = np.zeros(
-                        (
-                            nper,
-                            model_grid.num_layers,
-                            model_grid.num_rows,
-                            model_grid.num_columns,
-                        )
-                    )
-                    m4d[0, :, :, :] = array
-                    m4ds[name] = m4d
-                for kper in range(1, nper):
-                    arrays = self.to_array(kper=kper, mask=True)
-                    for name, array in arrays.items():
-                        m4ds[name][kper, :, :, :] = array
-                return m4ds
-            else:
-                m3ds = {}
-                for name, array in arrays.items():
-                    m3d = np.zeros(
-                        (
-                            nper,
-                            model_grid.num_layers,
-                            model_grid.num_cells_per_layer(),
-                        )
-                    )
-                    m3d[0, :, :] = array
-                    m3ds[name] = m3d
-                for kper in range(1, nper):
-                    arrays = self.to_array(kper=kper, mask=True)
-                    for name, array in arrays.items():
-                        m3ds[name][kper, :, :] = array
-                return m3ds
+        return dict(self.masked_4D_arrays_itr())
 
     def masked_4D_arrays_itr(self):
         """Returns list data as an iterator of a masked 4D array."""

--- a/flopy/mfusg/mfusgdisu.py
+++ b/flopy/mfusg/mfusgdisu.py
@@ -500,7 +500,7 @@ class MfUsgDisU(Package):
 
     @property
     def ncpl(self):
-        return self.nodes / self.nlay
+        return self.nodes // self.nlay
 
     @classmethod
     def load(cls, f, model, ext_unit_dict=None, check=True):


### PR DESCRIPTION
This PR aims to address the issue raised in discussion https://github.com/modflowpy/flopy/discussions/2309

- [x] fix(MFPandasTransientList.masked_4D_arrays_itr): allow re-use of preceding spd data if empty (mf6)
  - generalize setting of array shape for different grid types
  - re-use preceding spd array data
  - update relevant test
- [x] fix(MfList.masked_4d_arrays): allow re-use of preceding spd data if empty (non-mf6)
  - generalize setting of array shape for different grid types
  - re-use preceding spd array data
- [x] fix(model_attributes_to_shapefile): fix exporting of transientlist if disu
  - create separate case for disu
  - update relevant test
- [x] test(masked_4D_arrays): add tests
  - compare mf6 and non-mf6 shp export (riv data)
- [x] refactor(MFTransientList): re-use masked_4D_arrays_itr implementation
- [x] refactor(model_attributes_to_shapefile): remove bare except
- [x] refactor(model_attributes_to_shapefile): skip transientlist if empty
- [x] refactor(model_attributes_to_shapefile): skip transientlist if all elements are of object type
  - if package has timeseries data, transientlist elements are all of object type
- [x] refactor(mflist_export): skip mflist if all elements are of object type
  - if package has timeseries data, mflist elements are all of object type
- [x] fix(mfUsgDisU): return ncpl as integer
- [x] refactor(model_attributes_to_shapefile): use first recarray kper to check transientlist
- [x] refactor(mflist_export): use first recarray kper to check mflist

I did remove the bare except clause in `flopy.export.shapefile_utils.model_attributes_to_shapefile` but it caused several tests to fail. These issues were addressed in the last commits. However, in hindsight, I'm not sure if that was worth removing.