### PR TITLE
Fix(ZoneFile6.load): Add split statement to input read

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -144,7 +144,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Micromamba
-        uses: mamba-org/setup-micromamba@v2
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: etc/environment.yml
           cache-environment: true

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -80,7 +80,7 @@ jobs:
           echo $GITHUB_EVENT_NAME
 
       - name: Setup Micromamba
-        uses: mamba-org/setup-micromamba@v2
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: etc/environment.yml
           cache-environment: true

--- a/flopy/utils/zonbud.py
+++ b/flopy/utils/zonbud.py
@@ -2289,7 +2289,7 @@ class ZoneFile6:
                 if method == "open/close":
                     fobj = open(os.path.join(pkg_ws, t[1]))
                 while i < ncells:
-                    t = multi_line_strip(fobj)
+                    t = multi_line_strip(fobj).split()
                     if t[0] == "open/close":
                         if fobj != foo:
                             fobj.close()


### PR DESCRIPTION
fix failing CI (setup-micromamba@v2 issue on Windows) 