### PR TITLE
ci(commit.yml): fix silently failing test step

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -181,9 +181,12 @@ jobs:
         working-directory: autotest
         run: |
           pytest -v -m="not example" -n=auto --cov=flopy --cov-append --cov-report=xml --durations=0 --keep-failed=.failed --dist loadfile
-          coverage report
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Report coverage
+        working-directory: autotest
+        run: coverage report
 
       - name: Upload failed test outputs
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The test step was suppressing errors, I think because we ran coverage immediately after. Move coverage to a subsequent step. This reveals a few failing tests which are not addressed in this changeset.