### PR TITLE
refactor(Modpath7.create_mp7): expose porosity parameter of Modpath7Bas

### DIFF
--- a/flopy/modpath/mp7.py
+++ b/flopy/modpath/mp7.py
@@ -412,6 +412,7 @@ class Modpath7(BaseModel):
         rowcelldivisions=2,
         layercelldivisions=2,
         nodes=None,
+        porosity=0.30,
     ):
         """
         Create a default MODPATH 7 model using a passed flowmodel with
@@ -447,6 +448,8 @@ class Modpath7(BaseModel):
             direction (default is 2).
         nodes : int, list of ints, tuple of ints, or np.ndarray
             Nodes (zero-based) with particles. If  (default is node 0).
+        porosity: float or array of floats (nlay, nrow, ncol)
+            The porosity array (the default is 0.30).
 
         Returns
         -------
@@ -477,7 +480,7 @@ class Modpath7(BaseModel):
 
         # create MODPATH 7 basic file and add to the MODPATH 7
         # model instance (mp)
-        Modpath7Bas(mp, defaultiface=defaultiface)
+        Modpath7Bas(mp, porosity=porosity, defaultiface=defaultiface)
 
         # create particles
         if nodes is None:


### PR DESCRIPTION
This PR exposes the porosity parameter of Modpath7Bas in Modpath7's convenience method, create_mp7. This idea is raised in https://github.com/modflowpy/flopy/discussions/2339.