### PR TITLE
fix(gridintersect): typo shapely function call within gridintersect #2342

### DIFF
--- a/autotest/test_gridintersect.py
+++ b/autotest/test_gridintersect.py
@@ -483,29 +483,6 @@ def test_rect_grid_linestring_starting_on_vertex():
     assert np.allclose(result.lengths.sum(), np.sqrt(50))
     assert result.cellids[0] == (1, 1)
 
-
-# @requires_pkg("shapely")
-# def test_rect_grid_linestring_geomcolletion():
-#     gr = get_rect_grid()
-#     ix = GridIntersect(gr, method="structured")
-#     ls = LineString(
-#         [
-#             (20.0, 0.0),
-#             (5.0, 5.0),
-#             (15.0, 7.5),
-#             (10.0, 10.0),
-#             (5.0, 15.0),
-#             (10.0, 19.0),
-#             (10.0, 20.0),
-#         ]
-#     )
-#     result = ix.intersect(ls)
-#     assert len(result) == 3  # TODO: currently returns 4
-#     assert np.allclose(
-#         result.lengths.sum(), ls.length
-#     )  # TODO: length is 1m longer than ls
-
-
 # %% test linestring shapely
 
 

--- a/autotest/test_gridintersect.py
+++ b/autotest/test_gridintersect.py
@@ -501,6 +501,7 @@ def test_rect_grid_linestring_starting_on_vertex():
     assert np.allclose(result.lengths.sum(), np.sqrt(50))
     assert result.cellids[0] == (1, 1)
 
+
 # %% test linestring shapely
 
 

--- a/autotest/test_gridintersect.py
+++ b/autotest/test_gridintersect.py
@@ -484,6 +484,28 @@ def test_rect_grid_linestring_starting_on_vertex():
     assert result.cellids[0] == (1, 1)
 
 
+# @requires_pkg("shapely")
+# def test_rect_grid_linestring_geomcolletion():
+#     gr = get_rect_grid()
+#     ix = GridIntersect(gr, method="structured")
+#     ls = LineString(
+#         [
+#             (20.0, 0.0),
+#             (5.0, 5.0),
+#             (15.0, 7.5),
+#             (10.0, 10.0),
+#             (5.0, 15.0),
+#             (10.0, 19.0),
+#             (10.0, 20.0),
+#         ]
+#     )
+#     result = ix.intersect(ls)
+#     assert len(result) == 3  # TODO: currently returns 4
+#     assert np.allclose(
+#         result.lengths.sum(), ls.length
+#     )  # TODO: length is 1m longer than ls
+
+
 # %% test linestring shapely
 
 
@@ -735,6 +757,26 @@ def test_tri_grid_linestring_cell_boundary_return_all_ix_shapely(rtree):
     ls = LineString(ix._vtx_grid_to_geoms_cellids()[0][0].exterior.coords)
     r = ix.intersect(ls, return_all_intersections=True)
     assert len(r) == 3
+
+
+@requires_pkg("shapely")
+def test_rect_vertex_grid_linestring_geomcollection():
+    gr = get_rect_vertex_grid()
+    ix = GridIntersect(gr, method="vertex")
+    ls = LineString(
+        [
+            (20.0, 0.0),
+            (5.0, 5.0),
+            (15.0, 7.5),
+            (10.0, 10.0),
+            (5.0, 15.0),
+            (10.0, 19.0),
+            (10.0, 20.0),
+        ]
+    )
+    result = ix.intersect(ls)
+    assert len(result) == 3
+    assert np.allclose(result.lengths.sum(), ls.length)
 
 
 # %% test polygon structured
@@ -1555,14 +1597,3 @@ def test_create_raster_from_array_transform(example_data_path):
         or not ((ymax - ymin) / (rymax - rymin)) == 2
     ):
         raise AssertionError("Transform based raster not working properly")
-
-
-if __name__ == "__main__":
-    sgr = get_rect_grid(angrot=45.0, xyoffset=10.0)
-    ls = LineString([(5, 10.0 + np.sqrt(200.0)), (15, 10.0 + np.sqrt(200.0))])
-    ix = GridIntersect(sgr, method="structured")
-    result = ix.intersect(ls)
-    assert len(result) == 2
-    ix = GridIntersect(sgr, method="structured", local=True)
-    result = ix.intersect(ls)
-    assert len(result) == 0


### PR DESCRIPTION
Fix for #2342

- fix typo in shapely.multilinestrings
- fix issue with np.apply_along_axis
- consider geometry collections when computing overlaps
- add test for vertex mode
- add inactive test for structured mode (not yet working)

Notes: 

`np.apply_along_axis` was reducing result from multiple GeometryCollections to a single MultiLineString causing duplication of shapes in the intersection result. 

~~The test for GeometryCollections in "structured"-mode is commented out as it was failing and I don't have the time at the moment to figure that out. I will open a separate issue, along with some other GridIntersect to-do's (see #2344).~~

EDIT: structured support will be dropped in future releases (see #2344). 
