### PR TITLE
chore(datafile): ignore lint rule for codacy, pending refactor

### DIFF
--- a/flopy/utils/datafile.py
+++ b/flopy/utils/datafile.py
@@ -4,6 +4,15 @@ abstract classes that should not be directly accessed.
 
 """
 
+# in LayerFile, the recordarray attribute begins its life as
+# a list, which is appended to in subclasses' build_index(),
+# then finally becomes an array, after which it's accessed
+# in this file by column name. this probably deserves some
+# attention, but in the meantime, disable the pylint rule
+# to appease codacy.
+#
+# pylint: disable=invalid-sequence-index
+
 import os
 import warnings
 from pathlib import Path


### PR DESCRIPTION
Codacy began detecting a "severe" pylint E1126 `invalid sequence index` violation in #2362.

> Sequence index is not an int, slice, or instance with __index__

The issue pre-existed that PR, I think the format changes just revealed it. We could just ignore it in the web UI but this is probably worth coming back to, to appease linters and type checkers and to make the code easier to reason about.

Relatedly, there is work ongoing to make ruff work with codacy, so hopefully in future we can use ruff ignore syntax for things like this if/when needed