### PR TITLE
ci(dependencies): add temporary upper bound for coverage

### DIFF
--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - ruff
 
   # test
-  - coverage
+  - coverage<=7.6.4
   - flaky
   - filelock
   - jupyter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ lint = [
 ]
 test = [
     "flopy[lint]",
-    "coverage",
+    "coverage <=7.6.4",
     "flaky",
     "filelock",
     "jupyter",


### PR DESCRIPTION
Workaround https://github.com/nedbat/coveragepy/issues/1891