### PR TITLE
refactor: resolve ruff check F821 for undefined name

### DIFF
--- a/.docs/Notebooks/vtk_pathlines_example.py
+++ b/.docs/Notebooks/vtk_pathlines_example.py
@@ -321,7 +321,7 @@ p.close()
 # Show the GIF.
 
 # +
-from IPython.core.display import Image
+from IPython.display import Image, display
 
 display(Image(data=open(gif_path, "rb").read(), format="gif"))
 # -

--- a/autotest/test_plot_particle_tracks.py
+++ b/autotest/test_plot_particle_tracks.py
@@ -6,6 +6,7 @@ import pytest
 from matplotlib.collections import LineCollection, PathCollection
 from modflow_devtools.markers import requires_exe
 
+import flopy
 from flopy.modflow import Modflow
 from flopy.modpath import Modpath6, Modpath6Bas
 from flopy.plot import PlotCrossSection, PlotMapView

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,13 +153,12 @@ ignore = [
     "F403", # unable to detect undefined names (star imports)
     "F524", # `.format` missing argument(s) for placeholder(s)
     "F811", # Redefinition of unused variable
-    "F821", # undefined name TODO FIXME
     "F841", # local variable assigned but never used
 ]
 
 [tool.ruff.lint.per-file-ignores]
 ".docs/**/*.py" = ["E501"]
-"flopy/mf6/**/*.py" = ["E501", "ISC001"]
+"flopy/mf6/**/*.py" = ["E501", "F821", "ISC001"]
 
 [tool.codespell]
 skip = "cliff.toml,./examples/data/*"


### PR DESCRIPTION
This is a minor refactor to resolve [F821](https://docs.astral.sh/ruff/rules/undefined-name/) for undefined name.

As with other checks, `"flopy/mf6/**/*.py"` is ignored (which currently has several F821 issues).