### PR TITLE
ci(vtk): fix tests for vtk-9.4.0 by parsing XML file and checking attrs

### DIFF
--- a/autotest/test_export.py
+++ b/autotest/test_export.py
@@ -1118,6 +1118,30 @@ def count_lines_in_file(filepath):
     return n
 
 
+def get_vtk_xml_info(filepath):
+    """Read VTK XML file, return dict of basic information."""
+    import xml.etree.ElementTree as ET
+
+    tree = ET.parse(filepath)
+    root = tree.getroot()
+    assert root.tag == "VTKFile"
+    grid_type = root.get("type")
+    grid = root.find(grid_type)
+    assert len(grid) == 1
+    piece = grid[0]
+    assert piece.tag == "Piece"
+    info = {
+        "type": grid_type,
+        "version": root.get("version"),
+        "number_of_cells": int(piece.get("NumberOfCells")),
+        "number_of_points": int(piece.get("NumberOfPoints")),
+    }
+    for elem in piece:
+        names = [subelem.get("Name") for subelem in elem]
+        info[elem.tag.lower() + "_names"] = names
+    return info
+
+
 def is_binary_file(filepath):
     is_binary = False
     with open(filepath) as f:
@@ -1204,14 +1228,25 @@ def test_vtk_transient_array_2d(function_tmpdir, example_data_path):
 
     # export and check
     m.rch.rech.export(ws, fmt="vtk", kpers=kpers, binary=False, xml=True)
-    assert count_lines_in_file(function_tmpdir / "rech_000001.vtk") == 26837
-    assert count_lines_in_file(function_tmpdir / "rech_001096.vtk") == 26837
+    found_fnames = [pth.name for pth in function_tmpdir.iterdir()]
+    expected_fnames = [f"rech_{kper:06d}.vtk" for kper in kpers]
+    assert set(found_fnames) == set(expected_fnames)
+    for fname in expected_fnames:
+        filetocheck = function_tmpdir / fname
+        info = get_vtk_xml_info(filetocheck)
+        assert info["number_of_cells"] == 2400
+        assert info["number_of_points"] == 19200
+        assert info["celldata_names"] == ["rech_"]
+        assert info["pointdata_names"] == []
+        filetocheck.unlink()
 
     # with binary
-
     m.rch.rech.export(ws, fmt="vtk", binary=True, kpers=kpers)
-    assert is_binary_file(function_tmpdir / "rech_000001.vtk")
-    assert is_binary_file(function_tmpdir / "rech_001096.vtk")
+    found_fnames = [pth.name for pth in function_tmpdir.iterdir()]
+    expected_fnames = [f"rech_{kper:06d}.vtk" for kper in kpers]
+    assert set(found_fnames) == set(expected_fnames)
+    for fname in expected_fnames:
+        assert is_binary_file(function_tmpdir / fname)
 
 
 @requires_pkg("vtk")
@@ -1231,12 +1266,19 @@ def test_vtk_add_packages(function_tmpdir, example_data_path):
     # dis export and check
     # todo: pakbase.export() for vtk!!!!
     m.dis.export(ws, fmt="vtk", xml=True, binary=False)
-    filetocheck = function_tmpdir / "DIS.vtk"
-    assert count_lines_in_file(filetocheck) == 27239
+    info = get_vtk_xml_info(function_tmpdir / "DIS.vtk")
+    assert info["number_of_cells"] == 2400
+    assert info["number_of_points"] == 19200
+    assert info["celldata_names"] == ["top", "botm"]
+    assert info["pointdata_names"] == []
 
     # upw with point scalar output
     m.upw.export(ws, fmt="vtk", xml=True, binary=False, point_scalars=True)
-    assert count_lines_in_file(function_tmpdir / "UPW.vtk") == 42445
+    info = get_vtk_xml_info(function_tmpdir / "UPW.vtk")
+    assert info["number_of_cells"] == 2400
+    assert info["number_of_points"] == 19200
+    assert info["celldata_names"] == []
+    assert info["pointdata_names"] == ["hk", "hani", "vka", "ss", "sy"]
 
     # bas with smoothing on
     m.bas6.export(ws, fmt="vtk", binary=False, smooth=True)
@@ -1244,9 +1286,14 @@ def test_vtk_add_packages(function_tmpdir, example_data_path):
 
     # transient package drain
     kpers = [0, 1, 1096]
+    expected_fnames = [f"DRN_{kper:06d}.vtu" for kper in kpers]
     m.drn.export(ws, fmt="vtk", binary=False, xml=True, kpers=kpers, pvd=True)
-    assert count_lines_in_file(function_tmpdir / "DRN_000001.vtu") == 27239
-    assert count_lines_in_file(function_tmpdir / "DRN_001096.vtu") == 27239
+    for fname in expected_fnames:
+        info = get_vtk_xml_info(function_tmpdir / fname)
+        assert info["number_of_cells"] == 2400
+        assert info["number_of_points"] == 19200
+        assert info["celldata_names"] == ["DRN_elev", "DRN_cond"]
+        assert info["pointdata_names"] == []
 
     # dis with binary
     m.dis.export(ws, fmt="vtk", binary=True)
@@ -1302,7 +1349,11 @@ def test_vtk_binary_head_export(function_tmpdir, example_data_path):
     vtkobj.add_heads(heads, kstpkper=[(0, 0), (0, 199), (0, 354), (0, 454), (0, 1089)])
     vtkobj.write(function_tmpdir / "freyberg_head")
 
-    assert count_lines_in_file(filetocheck) == 34
+    info = get_vtk_xml_info(filetocheck)
+    assert info["number_of_cells"] == 2400
+    assert info["number_of_points"] == 19200
+    assert info["celldata_names"] == ["head"]
+    assert info["pointdata_names"] == []
     filetocheck.unlink()
 
     # with point scalars
@@ -1311,7 +1362,11 @@ def test_vtk_binary_head_export(function_tmpdir, example_data_path):
     vtkobj.add_heads(heads, kstpkper=[(0, 0), (0, 199), (0, 354), (0, 454), (0, 1089)])
     vtkobj.write(function_tmpdir / "freyberg_head")
 
-    assert count_lines_in_file(filetocheck) == 34
+    info = get_vtk_xml_info(filetocheck)
+    assert info["number_of_cells"] == 2400
+    assert info["number_of_points"] == 19200
+    assert info["celldata_names"] == []
+    assert info["pointdata_names"] == ["head"]
     filetocheck.unlink()
 
     # with smoothing
@@ -1320,7 +1375,11 @@ def test_vtk_binary_head_export(function_tmpdir, example_data_path):
     vtkobj.add_heads(heads, kstpkper=[(0, 0), (0, 199), (0, 354), (0, 454), (0, 1089)])
     vtkobj.write(function_tmpdir / "freyberg_head")
 
-    assert count_lines_in_file(filetocheck) == 34
+    info = get_vtk_xml_info(filetocheck)
+    assert info["number_of_cells"] == 2400
+    assert info["number_of_points"] == 19200
+    assert info["celldata_names"] == ["head"]
+    assert info["pointdata_names"] == []
 
 
 @requires_pkg("vtk")
@@ -1339,13 +1398,28 @@ def test_vtk_cbc(function_tmpdir, example_data_path):
     vtkobj.add_cell_budget(cbc, kstpkper=[(0, 0), (0, 1), (0, 2)])
     vtkobj.write(function_tmpdir / "freyberg_CBC")
 
-    assert count_lines_in_file(function_tmpdir / "freyberg_CBC_000000.vtu") == 39243
+    info = get_vtk_xml_info(function_tmpdir / "freyberg_CBC_000000.vtu")
+    assert info["number_of_cells"] == 2400
+    assert info["number_of_points"] == 19200
+    assert info["celldata_names"] == []
+    expected_pointdata_names = [
+        "   CONSTANT HEAD",
+        "FLOW RIGHT FACE ",
+        "FLOW FRONT FACE ",
+        "FLOW LOWER FACE ",
+    ]
+    assert info["pointdata_names"] == expected_pointdata_names
 
     # with point scalars and binary
     vtkobj = Vtk(m, xml=True, pvd=True, point_scalars=True)
     vtkobj.add_cell_budget(cbc, kstpkper=[(0, 0), (0, 1), (0, 2)])
     vtkobj.write(function_tmpdir / "freyberg_CBC")
-    assert count_lines_in_file(function_tmpdir / "freyberg_CBC_000000.vtu") == 28
+
+    info = get_vtk_xml_info(function_tmpdir / "freyberg_CBC_000000.vtu")
+    assert info["number_of_cells"] == 2400
+    assert info["number_of_points"] == 19200
+    assert info["celldata_names"] == []
+    assert info["pointdata_names"] == expected_pointdata_names
 
 
 @requires_pkg("vtk")
@@ -1373,7 +1447,11 @@ def test_vtk_vector(function_tmpdir, example_data_path):
     vtkobj.add_vector(q, "discharge")
     vtkobj.write(filenametocheck)
 
-    assert count_lines_in_file(filenametocheck) == 36045
+    info = get_vtk_xml_info(filenametocheck)
+    assert info["number_of_cells"] == 2400
+    assert info["number_of_points"] == 19200
+    assert info["celldata_names"] == []
+    assert info["pointdata_names"] == ["discharge"]
 
     # with point scalars and binary
     vtkobj = Vtk(m, point_scalars=True)
@@ -1390,14 +1468,22 @@ def test_vtk_vector(function_tmpdir, example_data_path):
     vtkobj.add_vector(q, "discharge")
     vtkobj.write(filenametocheck)
 
-    assert count_lines_in_file(filenametocheck) == 27645
+    info = get_vtk_xml_info(filenametocheck)
+    assert info["number_of_cells"] == 2400
+    assert info["number_of_points"] == 19200
+    assert info["celldata_names"] == ["discharge"]
+    assert info["pointdata_names"] == []
 
     # with values directly given at vertices and binary
     vtkobj = Vtk(m, xml=True, binary=True)
     vtkobj.add_vector(q, "discharge")
     vtkobj.write(filenametocheck)
 
-    assert count_lines_in_file(filenametocheck) == 25
+    info = get_vtk_xml_info(filenametocheck)
+    assert info["number_of_cells"] == 2400
+    assert info["number_of_points"] == 19200
+    assert info["celldata_names"] == ["discharge"]
+    assert info["pointdata_names"] == []
 
 
 @requires_pkg("vtk")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,12 +67,12 @@ optional = [
     "pymetis ; platform_system != 'Windows'",
     "pyproj",
     "pyshp",
-    "pyvista ; python_version <'3.13'",
+    "pyvista",
     "rasterio",
     "rasterstats",
     "scipy",
     "shapely >=2.0",
-    "vtk ; python_version <'3.13'",
+    "vtk",
     "xmipy",
 ]
 doc = [


### PR DESCRIPTION
This fixes a recent CI failure that uses the latest VTK package (9.4.0). The tests are changed from simple counting number of lines to checking attributes in the XML file using [built-in XML tools](https://docs.python.org/3/library/xml.etree.elementtree.html), which should be more robust.

Binary wheels for vtk are now available for Python 3.13, so the conditional installs are removed for vtk and pyvista.