### PR TITLE
chore: remove unused setup.py wrapper

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,0 @@
-from setuptools import setup
-
-# See pyproject.toml for project metadata
-setup(name="flopy")


### PR DESCRIPTION
The `setup.py` file was converted to a setuptools wrapper with #1678. This file is not used in this project, and modern pip/setuptools don't look for it anymore, so it can be cleaned up.