### PR TITLE
fix(mp7particledata): add global_xy to `to_prp`

### DIFF
--- a/autotest/test_grid_cases.py
+++ b/autotest/test_grid_cases.py
@@ -10,7 +10,7 @@ from flopy.utils.voronoi import VoronoiGrid
 
 class GridCases:
     @staticmethod
-    def structured_small():
+    def structured_small(xoff=0.0, yoff=0.0):
         nlay, nrow, ncol = 3, 2, 3
         delc = 1.0 * np.ones(nrow, dtype=float)
         delr = 1.0 * np.ones(ncol, dtype=float)
@@ -29,6 +29,8 @@ class GridCases:
             top=top,
             botm=botm,
             idomain=idomain,
+            xoff=xoff,
+            yoff=yoff,
         )
 
     @staticmethod

--- a/autotest/test_particledata.py
+++ b/autotest/test_particledata.py
@@ -245,6 +245,33 @@ def test_particledata_to_prp_dis_1():
         assert np.isclose(rpt[6], minz + (exp[ci][5] * (maxz - minz)))
 
 
+def test_particledata_to_prp_dis_1_global_xy():
+    # model grid
+    xoff = 100.0
+    yoff = 300.0
+    grid = GridCases().structured_small(xoff=xoff, yoff=yoff)
+
+    # particle data
+    cells = [(0, 1, 1), (0, 1, 2)]
+    part_data = ParticleData(partlocs=cells, structured=True)
+
+    # convert to global coordinates
+    rpts_prt_model_coords = flatten(list(part_data.to_prp(grid)))
+    rpts_prt_global_coords = flatten(list(part_data.to_prp(grid, global_xy=True)))
+
+    # check global and model coords
+    # x
+    assert np.all(
+        np.array(rpts_prt_global_coords)[:, -3] - xoff
+        == np.array(rpts_prt_model_coords)[:, -3]
+    )
+    # y
+    assert np.all(
+        np.array(rpts_prt_global_coords)[:, -2] - yoff
+        == np.array(rpts_prt_model_coords)[:, -2]
+    )
+
+
 def test_particledata_to_prp_dis_9():
     # minimal structured grid
     grid = GridCases().structured_small()

--- a/flopy/modpath/mp7particledata.py
+++ b/flopy/modpath/mp7particledata.py
@@ -792,9 +792,7 @@ def get_extent(
     # get cell coords and span in each dimension
     if not (k is None or i is None or j is None):
         verts = grid.get_cell_vertices(i, j)
-        if not global_xy and (
-            grid.xoffset != 0.0 or grid.yoffset != 0.0 or grid.angrot != 0.0
-        ):
+        if not global_xy and grid._has_ref_coordinates:
             verts = list(zip(*grid.get_local_coords(*np.array(verts).T)))
         minz, maxz = (
             (0, 1)
@@ -806,9 +804,7 @@ def get_extent(
         )
     elif nn is not None:
         verts = grid.get_cell_vertices(nn)
-        if not global_xy and (
-            grid.xoffset != 0.0 or grid.yoffset != 0.0 or grid.angrot != 0.0
-        ):
+        if not global_xy and grid._has_ref_coordinates:
             verts = list(zip(*grid.get_local_coords(*np.array(verts).T)))
         if grid.grid_type == "structured":
             k, i, j = grid.get_lrc([nn])[0]


### PR DESCRIPTION
- default is False which converts vertices to model coordinates
- add simple test

Note: method does get slow when it has to do the vertices conversion for lots of points. This can undoubtedly be optimized by first computing vertices in model coordinates or something along those lines. But I figured that was outside the scope for this PR. 