### PR TITLE
fix(resolve_exe): allow shutil.which() to find exe without suffix in Windows

### DIFF
--- a/autotest/test_mbase.py
+++ b/autotest/test_mbase.py
@@ -135,10 +135,8 @@ def test_run_model_exe_rel_path(mf6_model_path, function_tmpdir, use_ext):
 
     bin_dir = function_tmpdir / "bin"
     bin_dir.mkdir()
-    inner_dir = function_tmpdir / "inner"
-    inner_dir.mkdir()
 
-    with set_dir(inner_dir):
+    with set_dir(ws):
         # copy exe to relative dir
         copy(mf6, bin_dir / "mf6")
         assert (bin_dir / "mf6").is_file()

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -71,16 +71,18 @@ def resolve_exe(exe_name: Union[str, os.PathLike], forgive: bool = False) -> str
         checked.add(exe_name)
 
         # exe_name is found (not None), ensure absolute path is returned
-        if exe := which(exe_name):
-            return which(Path(exe).resolve())
+        if exe := which(str(exe_name)):
+            return which(str(Path(exe).resolve()))
 
         # exe_name has "~", expand first before returning absolute path
-        if "~" in exe_name and (exe := which(Path(exe_name).expanduser().resolve())):
+        if "~" in exe_name and (
+            exe := which(str(Path(exe_name).expanduser().resolve()))
+        ):
             return exe
 
         # exe_name is relative path
         if not Path(exe_name).is_absolute() and (
-            exe := which(Path(exe_name).resolve(), mode=0)
+            exe := which(str(Path(exe_name).resolve()), mode=0)
         ):  # mode=0 effectively allows which() to find exe without suffix in windows
             return exe
 

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -98,7 +98,7 @@ def resolve_exe(exe_name: Union[str, os.PathLike], forgive: bool = False) -> str
             f"The program {exe_name} does not exist or is not executable."
         )
 
-    return exe_path
+    return str(exe_path)
 
 
 # external exceptions for users

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -74,16 +74,12 @@ def resolve_exe(exe_name: Union[str, os.PathLike], forgive: bool = False) -> str
         if exe := which(str(exe_name)):
             return which(str(Path(exe).resolve()))
 
-        # exe_name has "~", expand first before returning absolute path
-        if "~" in exe_name and (
-            exe := which(str(Path(exe_name).expanduser().resolve()))
-        ):
-            return exe
-
         # exe_name is relative path
         if not Path(exe_name).is_absolute() and (
-            exe := which(str(Path(exe_name).resolve()), mode=0)
-        ):  # mode=0 effectively allows which() to find exe without suffix in windows
+            exe := which(str(Path(exe_name).expanduser().resolve()), mode=0)
+        ):
+            # expanduser() in case of ~ in path
+            # mode=0 effectively allows which() to find exe without suffix in windows
             return exe
 
         # try adding/removing .exe suffix

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -72,10 +72,11 @@ def resolve_exe(exe_name: Union[str, os.PathLike], forgive: bool = False) -> str
         else:
             if exe_name.lower().endswith(".exe"):
                 # try removing .exe suffix
-                exe = which(exe_name[:-4])
+                # mode=0 effectively allows which() to return exe without suffix
+                exe = which(exe_name[:-4], mode=0)
             if exe is not None:
                 # in case which() returned a relative path, resolve it
-                exe = which(str(Path(exe).resolve()))
+                exe = which(str(Path(exe).resolve()), mode=0)
             else:
                 # try tilde-expanded abspath
                 exe = which(Path(exe_name).expanduser().absolute())

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -64,7 +64,12 @@ def resolve_exe(exe_name: Union[str, os.PathLike], forgive: bool = False) -> str
         str: absolute path to the executable
     """
 
-    def _resolve(exe_name):
+    def _resolve(exe_name, checked=set()):
+        # Prevent infinite recursion by checking if exe_name has been checked
+        if exe_name in checked:
+            return None
+        checked.add(exe_name)
+
         # exe_name is found (not None), ensure absolute path is returned
         if exe := which(exe_name):
             return which(Path(exe).resolve())
@@ -80,10 +85,10 @@ def resolve_exe(exe_name: Union[str, os.PathLike], forgive: bool = False) -> str
             return exe
 
         # try adding/removing .exe suffix
-        if on_windows and exe_name.lower().endswith(".exe"):
-            return _resolve(exe_name[:-4])
+        if exe_name.lower().endswith(".exe"):
+            return _resolve(exe_name[:-4], checked)
         elif on_windows and "." not in Path(exe_name).stem:
-            return _resolve(f"{exe_name}.exe")
+            return _resolve(f"{exe_name}.exe", checked)
 
     exe_path = _resolve(exe_name)
 

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -79,9 +79,11 @@ def resolve_exe(exe_name: Union[str, os.PathLike], forgive: bool = False) -> str
         ):  # mode=0 effectively allows which() to find exe without suffix in windows
             return exe
 
-        # try removing .exe suffix
-        if exe_name.lower().endswith(".exe"):
+        # try adding/removing .exe suffix
+        if on_windows and exe_name.lower().endswith(".exe"):
             return _resolve(exe_name[:-4])
+        elif on_windows and "." not in Path(exe_name).stem:
+            return _resolve(f"{exe_name}.exe")
 
     exe_path = _resolve(exe_name)
 


### PR DESCRIPTION
This PR aims to address an issue found in local testing in `Windows` with `Python 3.13.1`. The issue is seen in the failing test: `test_mbase.py::test_run_model_exe_rel_path` and is caused by a behavior change in `shutil.which` (in Windows) introduced in https://github.com/python/cpython/pull/127035.

For more context, in `test_run_model_exe_rel_path`, the mf6 executable is copied to a relative path, `../bin/mf6` (without extension). Within the test, `shutil.which` is used to locate the executable path. However, with the new changes in `shutil.which`, by default, it would only search for the path with an extension in `PATHEXT`, excluding paths without extension.