### PR TITLE
test: mark tests requiring optional dependencies

### DIFF
--- a/autotest/test_mf6.py
+++ b/autotest/test_mf6.py
@@ -2332,6 +2332,8 @@ def test_remove_model(function_tmpdir, example_data_path):
             break
 
 
+@requires_pkg("shapely")
+@requires_exe("triangle")
 def test_flopy_2283(function_tmpdir):
     # create triangular grid
     triangle_ws = function_tmpdir / "triangle"

--- a/autotest/test_model_splitter.py
+++ b/autotest/test_model_splitter.py
@@ -158,8 +158,8 @@ def test_model_with_lak_sfr_mvr(function_tmpdir):
     np.testing.assert_allclose(new_heads, original_heads, err_msg=err_msg)
 
 
-@requires_pkg("pymetis")
 @requires_exe("mf6")
+@requires_pkg("pymetis")
 @pytest.mark.slow
 def test_metis_splitting_with_lak_sfr(function_tmpdir):
     sim_path = get_example_data_path() / "mf6" / "test045_lake2tr"
@@ -848,8 +848,7 @@ def test_unstructured_complex_disu(function_tmpdir):
 
 
 @requires_exe("mf6")
-@requires_pkg("pymetis")
-@requires_pkg("scipy")
+@requires_pkg("pymetis", "scipy")
 def test_multi_model(function_tmpdir):
     from scipy.spatial import KDTree
 
@@ -1301,6 +1300,7 @@ def test_multi_model(function_tmpdir):
 
 
 @requires_exe("mf6")
+@requires_pkg("pymetis")
 def test_timeseries(function_tmpdir):
     sim = MFSimulation(
         sim_name="np001",

--- a/autotest/test_plot_cross_section.py
+++ b/autotest/test_plot_cross_section.py
@@ -217,6 +217,7 @@ def test_plot_limits():
     plt.close(fig)
 
 
+@requires_pkg("shapely")
 def test_plot_centers():
     from matplotlib.collections import PathCollection
 

--- a/autotest/test_plot_map_view.py
+++ b/autotest/test_plot_map_view.py
@@ -276,6 +276,7 @@ def test_plot_limits():
     plt.close(fig)
 
 
+@requires_pkg("shapely")
 def test_plot_centers():
     nlay = 1
     nrow = 10


### PR DESCRIPTION
This should fix the [failing optional dependency CI tests](https://github.com/modflowpy/flopy/actions/runs/12686192812/job/35358012973). There are still failures afflicting the main CI tests, to be fixed shortly