### PR TITLE
fixes(Mf6Splitter): multiple bug fixes and added support

### DIFF
--- a/flopy/mf6/utils/model_splitter.py
+++ b/flopy/mf6/utils/model_splitter.py
@@ -88,6 +88,13 @@ OBS_ID1_LUT = {
     "lkt": "ifno",
     "mwt": "mawno",
     "uzt": "ifno",
+    # energy
+    "gwe": "cellid",
+    "ctp": "cellid",
+    "sfe": "ifno",
+    "uze": "ifno",
+
+
 }
 
 OBS_ID2_LUT = {
@@ -114,6 +121,10 @@ OBS_ID2_LUT = {
     },
     "mwt": None,
     "uzt": "ifno",
+    "gwe": "cellid",
+    "sfe": "ifno",
+    "uze": "ifno"
+
 }
 
 
@@ -383,13 +394,19 @@ class Mf6Splitter:
                     modflow.ModflowGwfuzf,
                     modflow.ModflowGwflak,
                     modflow.ModflowGwfhfb,
+                    modflow.ModflowGwtsft,
+                    modflow.ModflowGwtuzt,
+                    modflow.ModflowGwtlkt,
+                    modflow.ModflowGwesfe,
+                    modflow.ModflowGweuze,
+                    modflow.ModflowGwelke
                 ),
             ):
                 if isinstance(package, modflow.ModflowGwfhfb):
                     hfbs.append(package)
                     continue
 
-                if isinstance(package, modflow.ModflowGwflak):
+                if isinstance(package, (modflow.ModflowGwflak, modflow.ModflowGwtlkt, modflow.ModflowGwelke)):
                     cellids = package.connectiondata.array.cellid
                 else:
                     cellids = package.packagedata.array.cellid
@@ -401,7 +418,7 @@ class Mf6Splitter:
                 else:
                     nodes = [i[0] for i in cellids]
 
-                if isinstance(package, modflow.ModflowGwflak):
+                if isinstance(package, (modflow.ModflowGwflak, modflow.ModflowGwtlkt, modflow.ModflowGwelke)):
                     lakenos = package.connectiondata.array.ifno + 1
                     lak_array[nodes] = lakenos
                     laks += [i for i in np.unique(lakenos)]
@@ -1025,7 +1042,8 @@ class Mf6Splitter:
             "stage_filerecord",
             "obs_filerecord",
             "concentration_filerecord",
-            "ts_filerecord"
+            "ts_filerecord",
+            "temperature_filerecord"
         ):
             value = value.array
             if value is None:
@@ -1481,7 +1499,7 @@ class Mf6Splitter:
             dict
         """
         # self._mvr_remaps = {}
-        if isinstance(package, modflow.ModflowGwtmvt):
+        if isinstance(package, (modflow.ModflowGwtmvt, modflow.ModflowGwemve)):
             return mapped_data
 
         perioddata = package.perioddata.data
@@ -2853,6 +2871,8 @@ class Mf6Splitter:
                 modflow.ModflowGwfdisu,
                 modflow.ModflowGwtdis,
                 modflow.ModflowGwtdisu,
+                modflow.ModflowGwedis,
+                modflow.ModflowGwedisu
             ),
         ):
             for item, value in package.__dict__.items():
@@ -2921,12 +2941,12 @@ class Mf6Splitter:
             mapped_data = self._remap_buy(package, mapped_data)
 
         elif isinstance(
-            package, (modflow.ModflowGwfuzf, modflow.ModflowGwtuzt)
+            package, (modflow.ModflowGwfuzf, modflow.ModflowGwtuzt, modflow.ModflowGweuze)
         ):
             mapped_data = self._remap_uzf(package, mapped_data)
 
         elif isinstance(
-            package, (modflow.ModflowGwfmaw, modflow.ModflowGwtmwt)
+            package, (modflow.ModflowGwfmaw, modflow.ModflowGwtmwt, modflow.ModflowGwemwe)
         ):
             mapped_data = self._remap_maw(package, mapped_data)
 
@@ -2934,18 +2954,18 @@ class Mf6Splitter:
             self._remap_mvr(package, mapped_data)
 
         elif isinstance(
-            package, (modflow.ModflowGwfmvr, modflow.ModflowGwtmvt)
+            package, (modflow.ModflowGwfmvr, modflow.ModflowGwtmvt, modflow.ModflowGwemve)
         ):
             self._mover = True
             return {}
 
         elif isinstance(
-            package, (modflow.ModflowGwflak, modflow.ModflowGwtlkt)
+            package, (modflow.ModflowGwflak, modflow.ModflowGwtlkt, modflow.ModflowGwelke)
         ):
             mapped_data = self._remap_lak(package, mapped_data)
 
         elif isinstance(
-            package, (modflow.ModflowGwfsfr, modflow.ModflowGwtsft)
+            package, (modflow.ModflowGwfsfr, modflow.ModflowGwtsft, modflow.ModflowGwesfe)
         ):
             mapped_data = self._remap_sfr(package, mapped_data)
 

--- a/flopy/mf6/utils/model_splitter.py
+++ b/flopy/mf6/utils/model_splitter.py
@@ -3410,12 +3410,14 @@ class Mf6Splitter:
 
         Parameters
         ----------
-        mname0 :
-        mname1 :
+        mname0 : str
+            model name of first model in exchange
+        mname1 : str
+            model name of second model in exchange
 
         Returns
         -------
-
+            None
         """
         exchange_classes = {
             "gwfgwt": modflow.ModflowGwfgwt,
@@ -3575,7 +3577,7 @@ class Mf6Splitter:
 
         gwf_base = model_names[0]
         model_labels = [
-            f"{i :{self._fdigits}d}" for i in sorted(np.unique(array))
+            f"{i :0{self._fdigits}d}" for i in sorted(np.unique(array))
         ]
 
         self._multimodel_exchange_gwf_names = {


### PR DESCRIPTION
* add support for GWE models
* fix zero padding issue in `split_multi_model`. Padding issue caused splitting arrays with 10 or more model domains to crash.

Closes #2415