### PR TITLE
fix(cvfdutil): fix skip_hanging_node_check

### DIFF
--- a/flopy/utils/cvfdutil.py
+++ b/flopy/utils/cvfdutil.py
@@ -223,10 +223,11 @@ def to_cvfd(
     # Now, go through each vertex and look at the cells that use the vertex.
     # For quadtree-like grids, there may be a need to add a new hanging node
     # vertex to the larger cell.
+    vertexdict_keys = list(vertexdict.keys())
     if not skip_hanging_node_check:
         if verbose:
             print("Checking for hanging nodes.")
-        
+
         finished = False
         while not finished:
             finished = True
@@ -252,7 +253,6 @@ def to_cvfd(
         if verbose:
             print("Done checking for hanging nodes.")
 
-    vertexdict_keys = list(vertexdict.keys())
     verts = np.array(vertexdict_keys)
     iverts = vertexlist
 

--- a/flopy/utils/cvfdutil.py
+++ b/flopy/utils/cvfdutil.py
@@ -226,7 +226,7 @@ def to_cvfd(
     if not skip_hanging_node_check:
         if verbose:
             print("Checking for hanging nodes.")
-        vertexdict_keys = list(vertexdict.keys())
+        
         finished = False
         while not finished:
             finished = True
@@ -252,6 +252,7 @@ def to_cvfd(
         if verbose:
             print("Done checking for hanging nodes.")
 
+    vertexdict_keys = list(vertexdict.keys())
     verts = np.array(vertexdict_keys)
     iverts = vertexlist
 


### PR DESCRIPTION
vertexdict_keys was put out of the if condition skip_hanging_node_check, to avoid failure if the check is not necessary on some grids
Related to issue #2321
