### PR TITLE
perf(tutorials): skip some writes in export_vtk_tutorial.py

### DIFF
--- a/.docs/Notebooks/export_vtk_tutorial.py
+++ b/.docs/Notebooks/export_vtk_tutorial.py
@@ -122,13 +122,6 @@ ml.dis.top.export(model_top_dir, fmt="vtk")
 model_bottom_dir = output_dir / "BOTM"
 ml.dis.botm.export(model_bottom_dir, fmt="vtk")
 
-# ### Export transient array recharge
-
-# transient 2d array
-# export recharge
-model_recharge_dir = output_dir / "RECH"
-ml.rch.rech.export(model_recharge_dir, fmt="vtk", pvd=True)
-
 # ### Export HK with point scalars
 #
 
@@ -245,7 +238,8 @@ vtkobj.write(output_dir / "Array_example" / "model.vtu")
 vtkobj = vtk.Vtk(ml, xml=True, pvd=True, vertical_exageration=10)
 
 ## add recharge to the VTK object
-recharge = ml.rch.rech.transient_2ds
+subset = list(range(10))
+recharge = {k: v for k, v in ml.rch.rech.transient_2ds.items() if k in subset}
 vtkobj.add_transient_array(recharge, "recharge", masked_values=[0])
 
 ## write vtk files
@@ -268,8 +262,8 @@ vtkobj = vtk.Vtk(ml, xml=True, pvd=True, vertical_exageration=10)
 spd = ml.wel.stress_period_data
 vtkobj.add_transient_list(spd, masked_values=[0])
 
-## write vtk files
-vtkobj.write(output_dir / "tr_list_example" / "wel_flux.vtu")
+## write vtk files (skipped, slow)
+# vtkobj.write(output_dir / "tr_list_example" / "wel_flux.vtu")
 # -
 
 # ### Adding packages to the `Vtk` object
@@ -320,7 +314,9 @@ hds = HeadFile(head_file)
 # create the vtk object and export heads
 vtkobj = vtk.Vtk(ml, xml=True, pvd=True, vertical_exageration=10)
 vtkobj.add_heads(hds)
-vtkobj.write(workspace / "heads_output_test" / "freyberg_head.vtu")
+
+# skipped, slow
+# vtkobj.write(workspace / "heads_output_test" / "freyberg_head.vtu")
 # -
 
 # ### Export heads as point scalar arrays

--- a/autotest/test_notebooks.py
+++ b/autotest/test_notebooks.py
@@ -31,13 +31,12 @@ def get_notebooks(pattern=None, exclude=None):
     + get_notebooks(pattern="example"),
 )
 def test_notebooks(notebook):
-    in_ci = is_in_ci()
     args = ["jupytext", "--from", "py", "--to", "ipynb", "--execute", notebook]
     stdout, stderr, returncode = run_cmd(*args, verbose=True)
 
     # allow notebooks to fail for lack of optional dependencies in local runs,
     # expect all dependencies to be present and notebooks to pass in ci tests.
-    if returncode != 0 and not in_ci:
+    if returncode != 0 and not is_in_ci():
         if "Missing optional dependency" in stderr:
             pkg = re.findall("Missing optional dependency '(.*)'", stderr)[0]
             pytest.skip(f"notebook requires optional dependency {pkg!r}")


### PR DESCRIPTION
Since exporting a transient array looks the same as exporting a normal array, I removed that cell. And commented out 2 more write statements that were each taking ~45s. This brings the runtime from >2 minutes down to ~30 seconds on my machine.

The goal here (eventually) is to get the notebooks to run fast enough for the RTD build service, so we don't have to run them on GH actions and then upload to RTD. Also just for convenience &mdash; it seems a bit daunting and unexpected for a tutorial notebook to spin for minutes. Is there a different transient model we could swap into the VTK export example to avoid commenting out the write statements?

The next slowest are

```
142.58s call     test_notebooks.py::test_notebooks[/Users/wbonelli/dev/flopy/.docs/Notebooks/swi2package_example5.py]
117.58s call     test_notebooks.py::test_notebooks[/Users/wbonelli/dev/flopy/.docs/Notebooks/swi2package_example2.py]
66.68s call     test_notebooks.py::test_notebooks[/Users/wbonelli/dev/flopy/.docs/Notebooks/plot_array_example.py]
65.77s call     test_notebooks.py::test_notebooks[/Users/wbonelli/dev/flopy/.docs/Notebooks/feat_working_stack_examples.py]
63.09s call     test_notebooks.py::test_notebooks[/Users/wbonelli/dev/flopy/.docs/Notebooks/plot_cross_section_example.py]
42.40s call     test_notebooks.py::test_notebooks[/Users/wbonelli/dev/flopy/.docs/Notebooks/raster_intersection_example.py]
```

But this PR does not attempt anything on these yet