### PR TITLE
refactor(mfstructure): add inspection utils, use for solution pkgs

### DIFF
--- a/flopy/mf6/data/mfstructure.py
+++ b/flopy/mf6/data/mfstructure.py
@@ -2463,6 +2463,11 @@ class MFSimulationStructure:
                     package_struct.read_as_arrays = True
 
 
+def _get_solution_packages():
+    pkgs = get_solution_packages()
+    return {k.lower().replace("modflow", ""): "*" for k in pkgs.keys()}
+
+
 class MFStructure:
     """
     Singleton class for accessing the contents of the json structure file
@@ -2495,7 +2500,7 @@ class MFStructure:
             cls._instance.dimension_dict = {}
             cls._instance.load_from_dfn_files = load_from_dfn_files
             cls._instance.flopy_dict = {
-                "solution_packages": get_solution_packages()
+                "solution_packages": _get_solution_packages()
             }
 
             # Read metadata from file

--- a/flopy/mf6/inspect.py
+++ b/flopy/mf6/inspect.py
@@ -1,0 +1,31 @@
+def get_classes(predicate=None):
+    import flopy.mf6.modflow as modflow
+    from flopy.utils.inspect import get_classes as _get_classes
+
+    return _get_classes(
+        modflow,
+        lambda cls: hasattr(cls, "dfn") and (predicate(cls) if predicate else True),
+    )
+
+
+def get_multi_packages():
+    def _filter(cls):
+        return (
+            len(cls.dfn) > 0
+            and len(cls.dfn[0]) >= 2
+            and cls.dfn[0][1] == "multi-package"
+        )
+
+    return get_classes(_filter)
+
+
+def get_solution_packages():
+    def _filter(cls):
+        return (
+            len(cls.dfn) > 0
+            and len(cls.dfn[0]) >= 2
+            and len(cls.dfn[0][1]) > 0
+            and cls.dfn[0][1][0] == "solution_package"
+        )
+
+    return get_classes(_filter)

--- a/flopy/mf6/inspect.py
+++ b/flopy/mf6/inspect.py
@@ -1,4 +1,7 @@
-def get_classes(predicate=None):
+from collections.abc import Mapping
+
+
+def get_classes(predicate=None) -> Mapping[str, type]:
     import flopy.mf6.modflow as modflow
     from flopy.utils.inspect import get_classes as _get_classes
 
@@ -8,7 +11,7 @@ def get_classes(predicate=None):
     )
 
 
-def get_multi_packages():
+def get_multi_packages() -> Mapping[str, type]:
     def _filter(cls):
         return (
             len(cls.dfn) > 0
@@ -19,7 +22,7 @@ def get_multi_packages():
     return get_classes(_filter)
 
 
-def get_solution_packages():
+def get_solution_packages() -> Mapping[str, type]:
     def _filter(cls):
         return (
             len(cls.dfn) > 0
@@ -31,7 +34,7 @@ def get_solution_packages():
     return get_classes(_filter)
 
 
-def get_sub_packages():
+def get_sub_packages() -> Mapping[str, type]:
     def _filter(cls):
         return (
             len(cls.dfn) > 0

--- a/flopy/mf6/inspect.py
+++ b/flopy/mf6/inspect.py
@@ -29,3 +29,15 @@ def get_solution_packages():
         )
 
     return get_classes(_filter)
+
+
+def get_sub_packages():
+    def _filter(cls):
+        return (
+            len(cls.dfn) > 0
+            and len(cls.dfn[0]) >= 2
+            and len(cls.dfn[0][1]) > 0
+            and cls.dfn[0][1][0] == "subpackage"
+        )
+    
+    return get_classes(_filter)

--- a/flopy/utils/inspect.py
+++ b/flopy/utils/inspect.py
@@ -1,0 +1,7 @@
+import inspect
+
+
+def get_classes(module, predicate=None):
+    """Find classes in a module which satisfy a predicate."""
+    classes = inspect.getmembers(module, inspect.isclass)
+    return [cls for name, cls in classes if predicate(cls)]

--- a/flopy/utils/inspect.py
+++ b/flopy/utils/inspect.py
@@ -1,7 +1,8 @@
 import inspect
+from collections.abc import Mapping
 
 
-def get_classes(module, predicate=None):
+def get_classes(module, predicate=None) -> Mapping[str, type]:
     """Find classes in a module which satisfy a predicate."""
     classes = inspect.getmembers(module, inspect.isclass)
-    return [cls for name, cls in classes if predicate(cls)]
+    return {name: cls for name, cls in classes if predicate(cls)}


### PR DESCRIPTION
The `MFStructure` specification needs to know which packages are solutions. Find this out by reflection. This is a "wedge" to start deconstructing `mfstructure.py` and the same idea should work for other introspection cases e.g. subpackages, also `sim_struct`, though that will be more complicated.

Once #2333 merges we can add a dedicated class attribute to the template for this (and other attributes) and then read them off the class instead of parsing them from the `dfn` attribute.