### PR TITLE
chore: replace setuptools with hatchling, remove 'build' extra

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,0 @@
-include CITATION.cff
-include pyproject.toml
-include docs/*.md
-include flopy/mf6/data/dfn/*.dfn
-include flopy/plot/mplstyle/*.mplstyle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
-requires = [
-    "setuptools >=61",
-]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling", "hatch-fancy-pypi-readme"]
+build-backend = "hatchling.build"
 
 [project]
 name = "flopy"
@@ -36,9 +34,8 @@ dependencies = [
 dynamic = ["version", "readme"]
 
 [project.optional-dependencies]
-dev = ["flopy[build,lint,test,optional,doc]", "tach"]
-build = ["build", "twine"]
-lint = ["cffconvert", "codespell[toml] >=2.2.2", "ruff"]
+dev = ["flopy[lint,test,optional,doc]", "tach"]
+lint = ["ruff"]
 test = [
     "flopy[lint]",
     "coverage !=7.6.5",
@@ -100,20 +97,28 @@ Documentation = "https://flopy.readthedocs.io"
 "Bug Tracker" = "https://github.com/modflowpy/flopy/issues"
 "Source Code" = "https://github.com/modflowpy/flopy"
 
-[tool.setuptools]
-include-package-data = true
-zip-safe = false
+[tool.hatch.build.targets.sdist]
+only-include = [
+    "CITATION.cff",
+    "README.md",
+    "docs",
+    "flopy",
+]
 
-[tool.setuptools.dynamic]
-version = {attr = "flopy.version.__version__"}
-readme = {file = ["docs/PyPI_release.md", "LICENSE.md"], content-type = "text/markdown"}
+[tool.hatch.build.targets.wheel]
+packages = ["flopy"]
 
-[tool.setuptools.packages.find]
-include = ["flopy", "flopy.*"]
+[tool.hatch.metadata.hooks.fancy-pypi-readme]
+content-type = "text/markdown"
 
-[tool.setuptools.package-data]
-"flopy.mf6.data" = ["dfn/*.dfn"]
-"flopy.plot" = ["mplstyle/*.mplstyle"]
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+path = "docs/PyPI_release.md"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+path = "LICENSE.md"
+
+[tool.hatch.version]
+path = "flopy/version.py"
 
 [tool.ruff]
 line-length = 88


### PR DESCRIPTION
This PR does the following:

- Changes the [build backend](https://packaging.python.org/en/latest/glossary/#term-Build-Backend) from [setuptools](https://setuptools.pypa.io) to [hatch's hatchling](https://hatch.pypa.io/latest/config/build/). Why?
  - While both are [PyPA projects](https://packaging.python.org/en/latest/key_projects/#pypa-projects), setuptools has some odd legacy concepts like MANIFEST.in and egg-info directories, that are not used with modern builds. It's an old system that is primarily maintained to maintain legacy behaviour and not to embrace modern enhancements.
  - Hatchling is a common and modern build backend, e.g. [demonstrated as a default in guidelines](https://packaging.python.org/en/latest/tutorials/packaging-projects/#choosing-a-build-backend). New features and plugins are actively developed for hatch and hatchling by Python core developers.
- Use the [hatch-fancy-pypi-readme](https://github.com/hynek/hatch-fancy-pypi-readme) plug-in to stitch content for the documentation in PyPI. (There is more potential to this plug-in, such as amending changelog info from each release). See preview via `uvx hatch project metadata readme`.
- Remove the 'build' optional dependency (or extra), as this a prerequisite only for packaging builds, not an optional dependency. Builds can happen using several methods, e.g. `python3 -m build` or `uv build` or `uvx hatch build` etc.

I've done some comparisons of the sdist (.tar.gz) and bdist (.whl) outputs, and the contents are nearly identical.