### PR TITLE
refactor(resolve_exe): also fix tests

### DIFF
--- a/autotest/test_modflow.py
+++ b/autotest/test_modflow.py
@@ -290,7 +290,8 @@ def test_exe_selection(example_data_path, function_tmpdir):
         ml = Modflow.load(namfile_path, exe_name=exe_name, model_ws=model_path)
 
     # run should error if exe does not exist
-    ml = Modflow.load(namfile_path, exe_name=exe_name, model_ws=model_path)
+    with pytest.warns(UserWarning):
+        ml = Modflow.load(namfile_path, exe_name=exe_name, model_ws=model_path)
     ml.change_model_ws(function_tmpdir)
     ml.write_input()
     with pytest.raises(ValueError):

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -44,7 +44,9 @@ iconst = 1
 iprn = -1
 
 
-def resolve_exe(exe_name: Union[str, os.PathLike], forgive: bool = False) -> str:
+def resolve_exe(
+    exe_name: Union[str, os.PathLike], forgive: bool = False
+) -> Union[str, None]:
     """
     Resolves the absolute path of the executable, raising FileNotFoundError
     if the executable cannot be found (set forgive to True to return None
@@ -55,16 +57,21 @@ def resolve_exe(exe_name: Union[str, os.PathLike], forgive: bool = False) -> str
     exe_name : str or PathLike
         The executable's name or path. If only the name is provided,
         the executable must be on the system path.
-    forgive : bool
+    forgive : bool, default False
         If True and executable cannot be found, return None and warn
         rather than raising a FileNotFoundError. Defaults to False.
 
     Returns
     -------
-        str: absolute path to the executable
+    str or None
+        Absolute path to the executable, or None if not found and
+        ``forgive=True``.
     """
 
     def _resolve(exe_name, checked=set()):
+        exe_pth = Path(exe_name)
+        exe_name = str(exe_name)
+
         # Prevent infinite recursion by checking if exe_name has been checked
         if exe_name in checked:
             return None
@@ -75,8 +82,8 @@ def resolve_exe(exe_name: Union[str, os.PathLike], forgive: bool = False) -> str
             return which(str(Path(exe).resolve()))
 
         # exe_name is relative path
-        if not Path(exe_name).is_absolute() and (
-            exe := which(str(Path(exe_name).expanduser().resolve()), mode=0)
+        if not exe_pth.is_absolute() and (
+            exe := which(str(exe_pth.expanduser().resolve()), mode=0)
         ):
             # expanduser() in case of ~ in path
             # mode=0 effectively allows which() to find exe without suffix in windows
@@ -85,25 +92,24 @@ def resolve_exe(exe_name: Union[str, os.PathLike], forgive: bool = False) -> str
         # try adding/removing .exe suffix
         if exe_name.lower().endswith(".exe"):
             return _resolve(exe_name[:-4], checked)
-        elif on_windows and "." not in Path(exe_name).stem:
+        elif on_windows and "." not in exe_pth.stem:
             return _resolve(f"{exe_name}.exe", checked)
 
-    exe_path = _resolve(str(exe_name))
+    # return path if found
+    if exe_path := _resolve(exe_name):
+        return str(exe_path)
 
     # raise if we are unforgiving, otherwise return None
-    if exe_path is None:
-        if forgive:
-            warn(
-                f"The program {exe_name} does not exist or is not executable.",
-                category=UserWarning,
-            )
-            return None
-
-        raise FileNotFoundError(
-            f"The program {exe_name} does not exist or is not executable."
+    if forgive:
+        warn(
+            f"The program {exe_name} does not exist or is not executable.",
+            category=UserWarning,
         )
+        return None
 
-    return str(exe_path)
+    raise FileNotFoundError(
+        f"The program {exe_name} does not exist or is not executable."
+    )
 
 
 # external exceptions for users


### PR DESCRIPTION
This extends a bit further than #2457 to resolve #2455 to use the str and PathLib versions of exe paths in the method. It also improves the docstring and return typing info.

But it also fixes `autotest/test_mbase.py` which was broken on Linux for paths that have mixed case to the repo. Paths don't need to be converted to `lower()` for equality comparisons, as this breaks mixed-case paths. The tests are written to compare pathlib objects, which works for the host path, e.g. Windows paths:
```pycon
>>> from pathlib import PureWindowsPath
>>> PureWindowsPath(r"C:\dir\program.EXE") == PureWindowsPath(r"c:\Dir\program.exe")
True
```
This also catches a missing warning thrown in `autotest/test_modflow.py`.