### PR TITLE
update(Mf6Splitter): change how node mapping is stored and loaded

### DIFF
--- a/autotest/test_model_splitter.py
+++ b/autotest/test_model_splitter.py
@@ -204,6 +204,7 @@ def test_metis_splitting_with_lak_sfr(function_tmpdir):
 
 @requires_exe("mf6")
 @requires_pkg("pymetis")
+@requires_pkg("h5py")
 def test_save_load_node_mapping_structured(function_tmpdir):
     sim_path = get_example_data_path() / "mf6-freyberg"
     new_sim_path = function_tmpdir / "mf6-freyberg/split_model"
@@ -249,6 +250,7 @@ def test_save_load_node_mapping_structured(function_tmpdir):
 
 
 @requires_exe("mf6")
+@requires_pkg("h5py")
 def test_save_load_node_mapping_vertex(function_tmpdir):
     sim_path = get_example_data_path() / "mf6" / "test003_gwftri_disv"
     new_sim_path = function_tmpdir / "split_model"
@@ -290,6 +292,7 @@ def test_save_load_node_mapping_vertex(function_tmpdir):
 
 
 @requires_exe("mf6")
+@requires_pkg("h5py")
 def test_save_load_node_mapping_unstructured(function_tmpdir):
     sim_path = get_example_data_path() / "mf6" / "test006_gwf3"
     new_sim_path = function_tmpdir / "split_model"

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -54,3 +54,4 @@ dependencies:
   - shapely>=2.0
   - vtk
   - xmipy
+  - h5py

--- a/flopy/mf6/utils/model_splitter.py
+++ b/flopy/mf6/utils/model_splitter.py
@@ -495,7 +495,7 @@ class Mf6Splitter:
             -------
                 flopy.discretization.Grid object
             """
-            from ...discretization import StructuredGrid, VertexGrid, UnstructuredGrid
+            from ...discretization import StructuredGrid, UnstructuredGrid, VertexGrid
             grid = f[f"modelgrids/{name}"]
             tmp2 = list(grid.keys())
 

--- a/flopy/mf6/utils/model_splitter.py
+++ b/flopy/mf6/utils/model_splitter.py
@@ -1298,7 +1298,8 @@ class Mf6Splitter:
             "stage_filerecord",
             "obs_filerecord",
             "concentration_filerecord",
-            "ts_filerecord"
+            "ts_filerecord",
+            "temperature_filerecord"
         ):
             value = value.array
             if value is None:
@@ -1754,7 +1755,7 @@ class Mf6Splitter:
             dict
         """
         # self._mvr_remaps = {}
-        if isinstance(package,  (modflow.ModflowGwtmvt, modflow.ModflowGwemve)):
+        if isinstance(package, (modflow.ModflowGwtmvt, modflow.ModflowGwemve)):
             return mapped_data
 
         perioddata = package.perioddata.data
@@ -3127,6 +3128,8 @@ class Mf6Splitter:
                 modflow.ModflowGwfdisu,
                 modflow.ModflowGwtdis,
                 modflow.ModflowGwtdisu,
+                modflow.ModflowGwedis,
+                modflow.ModflowGwedisu
             ),
         ):
             for item, value in package.__dict__.items():
@@ -3664,12 +3667,14 @@ class Mf6Splitter:
 
         Parameters
         ----------
-        mname0 :
-        mname1 :
+        mname0 : str
+            model name of first model in exchange
+        mname1 : str
+            model name of second model in exchange
 
         Returns
         -------
-
+            None
         """
         exchange_classes = {
             "gwfgwt": modflow.ModflowGwfgwt,

--- a/flopy/mf6/utils/model_splitter.py
+++ b/flopy/mf6/utils/model_splitter.py
@@ -487,9 +487,11 @@ class Mf6Splitter:
 
             Parameters
             ----------
-            f :
-            name :
-            grid_type :
+            f : h5py.File object
+            name : str
+                model name string
+            grid_type : str
+                grid type string
 
             Returns
             -------

--- a/flopy/mf6/utils/model_splitter.py
+++ b/flopy/mf6/utils/model_splitter.py
@@ -484,6 +484,7 @@ class Mf6Splitter:
 
         def construct_modelgrid(f, name, grid_type):
             """
+            Method to construct a modelgrid instance from HDF5 stored grid information
 
             Parameters
             ----------
@@ -499,7 +500,6 @@ class Mf6Splitter:
             """
             from ...discretization import StructuredGrid, UnstructuredGrid, VertexGrid
             grid = f[f"modelgrids/{name}"]
-            tmp2 = list(grid.keys())
 
             gridprops = dict()
             gridprops["top"] = grid["top"][:]

--- a/flopy/mf6/utils/output_util.py
+++ b/flopy/mf6/utils/output_util.py
@@ -35,7 +35,7 @@ class MF6Output:
             "csv": self.__csv,
             "package_convergence": self.__csv,
         }
-        delist = ("ts", "wc", "ncf")
+        delist = ("ts", "wc", "ncf", "grb")
         self._obj = obj
         self._methods = []
         self._sim_ws = obj.simulation_data.mfpath.get_sim_path()

--- a/flopy/plot/map.py
+++ b/flopy/plot/map.py
@@ -446,6 +446,7 @@ class PlotMapView:
         kper=0,
         color=None,
         plotAll=False,
+        boundname=None,
         **kwargs,
     ):
         """
@@ -505,7 +506,8 @@ class PlotMapView:
                         raise Exception(f"Not a list-style boundary package: {e!s}")
                     if mflist is None:
                         return
-
+                    if boundname is not None:
+                        mflist = mflist[mflist["boundname"] == boundname]
                     t = np.array([list(i) for i in mflist["cellid"]], dtype=int).T
 
                 if len(idx) == 0:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ optional = [
     "shapely >=2.0",
     "vtk >=9.4.0",
     "xmipy",
+    "h5py",
 ]
 doc = [
     "flopy[optional]",


### PR DESCRIPTION
* `save_node_mapping` now writes a compressed `hdf5` file and stores additional modelgrid reconstruction information for original and split model representations
* `load_node_mapping` changed to a static method that returns a Mf6Splitter object that can be used for array reconstruction
* updated autotests
* added example usage to `mf6_parallel_model_splitting_example.py`
* json node mapping files no longer supported, user must rewrite node mapping files as hdf5 files.
* bugfix for observation file naming convention on remapped obs files