### PR TITLE
fix: trap grb in MF6Output

### DIFF
--- a/flopy/mf6/utils/output_util.py
+++ b/flopy/mf6/utils/output_util.py
@@ -35,7 +35,7 @@ class MF6Output:
             "csv": self.__csv,
             "package_convergence": self.__csv,
         }
-        delist = ("ts", "wc", "ncf")
+        delist = ("ts", "wc", "ncf", "grb")
         self._obj = obj
         self._methods = []
         self._sim_ws = obj.simulation_data.mfpath.get_sim_path()


### PR DESCRIPTION
Noticed and fixed by @jlarsen-usgs in https://github.com/modflowpy/flopy/pull/2465/commits/e8118b8702124d2479f19d73f58f391ada0536bb, just getting this in asap to fix CI tests.

This is a result of https://github.com/MODFLOW-ORG/modflow6/pull/2228