### PR TITLE
feat(modeltime): add from_headers and reverse methods

### DIFF
--- a/autotest/test_modeltime.py
+++ b/autotest/test_modeltime.py
@@ -1,4 +1,5 @@
 import datetime
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -6,6 +7,8 @@ import pytest
 
 import flopy
 from flopy.discretization.modeltime import ModelTime
+from flopy.mf6.modflow.mfsimulation import MFSimulation
+from flopy.utils.binaryfile import CellBudgetFile, HeadFile
 
 
 @pytest.mark.parametrize(
@@ -286,3 +289,55 @@ def test_mf6_modeltime():
     result = modeltime.intersect("3/06/2024 23:59:59")
     if result != (2, 0):
         raise AssertionError("ModelTime intersect not working correctly")
+
+
+def test_from_headers_test006_gwf3(example_data_path):
+    ws = example_data_path / "mf6" / "test006_gwf3" / "expected_output"
+    sim = MFSimulation.load(sim_ws=ws.parent)
+    tdis = sim.tdis
+    hf = HeadFile(ws / "flow_adj.hds")
+    mt = ModelTime.from_headers(hf.recordarray)
+
+    assert np.isclose(hf.recordarray[-1]["totim"], sum(mt.perlen))
+    assert np.allclose(mt.perlen, tdis.perioddata.get_data()["perlen"])
+    assert np.allclose(mt.nstp, tdis.perioddata.get_data()["nstp"])
+    assert np.allclose(mt.tsmult, tdis.perioddata.get_data()["tsmult"])
+
+
+def test_from_headers_test027_TimeseriesTest(example_data_path):
+    ws = example_data_path / "mf6" / "test027_TimeseriesTest" / "expected_output"
+    sim = MFSimulation.load(sim_ws=ws.parent)
+    tdis = sim.tdis
+    hf = HeadFile(ws / "timeseriestest_adj.hds")
+    mt = ModelTime.from_headers(hf.recordarray)
+
+    assert np.isclose(hf.recordarray[-1]["totim"], sum(mt.perlen))
+    assert np.allclose(mt.perlen, tdis.perioddata.get_data()["perlen"])
+    assert np.allclose(mt.nstp, tdis.perioddata.get_data()["nstp"])
+    assert np.allclose(mt.tsmult, tdis.perioddata.get_data()["tsmult"])
+
+
+def test_from_headers_test005_advgw_tidal(example_data_path):
+    ws = example_data_path / "mf6" / "test005_advgw_tidal" / "expected_output"
+    sim = MFSimulation.load(sim_ws=ws.parent)
+    tdis = sim.tdis
+    hf = HeadFile(ws / "AdvGW_tidal.hds")
+    mt = ModelTime.from_headers(hf.recordarray)
+
+    assert np.isclose(hf.recordarray[-1]["totim"], sum(mt.perlen))
+    assert np.allclose(mt.perlen, tdis.perioddata.get_data()["perlen"])
+    assert np.allclose(mt.nstp, tdis.perioddata.get_data()["nstp"])
+    assert np.allclose(mt.tsmult, tdis.perioddata.get_data()["tsmult"])
+
+
+def test_reverse(example_data_path):
+    ws = example_data_path / "mf6" / "test005_advgw_tidal" / "expected_output"
+    sim = MFSimulation.load(sim_ws=ws.parent)
+    tdis = sim.tdis
+    hf = HeadFile(ws / "AdvGW_tidal.hds")
+    mt = ModelTime.from_headers(hf.recordarray)
+    rev = mt.reverse()
+
+    assert np.isclose(hf.recordarray[-1]["totim"], sum(rev.perlen))
+    assert np.allclose(rev.perlen[::-1], tdis.perioddata.get_data()["perlen"])
+    assert np.allclose(rev.nstp[::-1], tdis.perioddata.get_data()["nstp"])

--- a/flopy/discretization/modeltime.py
+++ b/flopy/discretization/modeltime.py
@@ -5,8 +5,6 @@ from difflib import SequenceMatcher
 import numpy as np
 import pandas as pd
 
-# TODO standalone function to reverse
-
 
 class ModelTime:
     """
@@ -719,7 +717,7 @@ class ModelTime:
         totim = 0.0
         kper = 0
 
-        def record_tsmult():
+        def set_tsmult():
             nonlocal tslens
             nonlocal tsmult
             tslens = [l for l in tslens if l > 0]
@@ -742,13 +740,13 @@ class ModelTime:
                 perlen[kper] += tdiff
             else:
                 perlen[kper] = tdiff
-                record_tsmult()
+                set_tsmult()
             totim = hdr["totim"]
 
         if i == len(headers) - 1:
             if len(perlen) == 1 and perlen[0] == 0.0:
                 perlen[0] = totim
-            record_tsmult()
+            set_tsmult()
 
         return cls(perlen.values(), nstp.values(), tsmult.values())
 


### PR DESCRIPTION
Add a class method to reconstruct a `ModelTime` from an array of mf6 binary output file headers, and a method to reverse the time discretization. These are useful for binary file reversal.