### PR TITLE
fix(binaryfile): fix head/budget file reversal

### DIFF
--- a/autotest/test_binaryfile_reverse.py
+++ b/autotest/test_binaryfile_reverse.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, replace
 from itertools import repeat
+from pathlib import Path
 from pprint import pformat
 from typing import Literal, get_args
 
@@ -114,21 +115,22 @@ def pytest_generate_tests(metafunc):
     cases = []
     sims = []
     names = []
-    for case in CASES:
-        for dis_type in get_args(DisType):
-            name = f"{case.name}_{dis_type}"
-            case_ = replace(case, name=name)
-            ws = tmp_path_factory.mktemp(name)
-            if dis_type == "dis":
-                sim = dis_sim(case_, ws)
-            elif dis_type == "disv":
-                sim = disv_sim(case_, ws)
-            elif dis_type == "disu":
-                sim = disu_sim(case_, ws)
-            cases.append(case_)
-            sims.append(sim)
-            names.append(name)
-    metafunc.parametrize("case, sim", zip(cases, sims), ids=names)
+    if "case" in metafunc.fixturenames:
+        for case in CASES:
+            for dis_type in get_args(DisType):
+                name = f"{case.name}_{dis_type}"
+                case_ = replace(case, name=name)
+                ws = tmp_path_factory.mktemp(name)
+                if dis_type == "dis":
+                    sim = dis_sim(case_, ws)
+                elif dis_type == "disv":
+                    sim = disv_sim(case_, ws)
+                elif dis_type == "disu":
+                    sim = disu_sim(case_, ws)
+                cases.append(case_)
+                sims.append(sim)
+                names.append(name)
+        metafunc.parametrize("case, sim", zip(cases, sims), ids=names)
 
 
 @requires_exe("mf6")

--- a/autotest/test_binaryfile_reverse.py
+++ b/autotest/test_binaryfile_reverse.py
@@ -1,0 +1,190 @@
+from dataclasses import dataclass, replace
+from itertools import repeat
+from pprint import pformat
+from typing import Literal, get_args
+
+import numpy as np
+from modflow_devtools.markers import requires_exe, requires_pkg
+
+import flopy
+from flopy.utils import CellBudgetFile, HeadFile
+from flopy.utils.gridutil import get_disv_kwargs
+
+DisType = Literal["dis", "disv", "disu"]
+
+
+@dataclass
+class Case:
+    name: str
+    tdis: list  # of tuples (perlen, nstp, tsmult)
+    # expected results
+    forward: list  # of tuples (kstp, kper, time)
+    reverse: list  # of tuples (kstp, kper, time)
+
+
+BUDTXT = "FLOW-JA-FACE"
+CASES = [
+    Case(
+        name="sym",
+        tdis=[(1, 1, 1.0), (1, 1, 1.0), (1, 1, 1.0)],
+        forward=[(0, 0, 1.0), (0, 1, 2.0), (0, 2, 3.0)],
+        reverse=[(0, 0, 1.0), (0, 1, 2.0), (0, 2, 3.0)],
+    ),
+    Case(
+        name="asym",
+        tdis=[(1.0, 2, 1.0), (1.0, 1, 1.0), (1.0, 1, 1.0)],
+        forward=[(0, 0, 0.5), (1, 0, 1.0), (0, 1, 2.0), (0, 2, 3.0)],
+        reverse=[(0, 0, 1.0), (0, 1, 2.0), (0, 2, 2.5), (1, 2, 3.0)],
+    ),
+    Case(
+        name="asym_tsm",
+        tdis=[(1.0, 1, 1.0), (1.0, 2, 1.5), (1.0, 1, 1.0)],
+        forward=[(0, 0, 1.0), (0, 1, 1.4), (1, 1, 2.0), (0, 2, 3.0)],
+        reverse=[(0, 0, 1.0), (0, 1, 1.6), (1, 1, 2.0), (0, 2, 3.0)],
+    ),
+]
+
+
+def dis_sim(case, ws) -> flopy.mf6.MFSimulation:
+    sim = flopy.mf6.MFSimulation(sim_name=case.name, sim_ws=ws, exe_name="mf6")
+    nper = len(case.tdis)
+    tdis = flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=case.tdis)
+    ims = flopy.mf6.ModflowIms(sim)
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=case.name, save_flows=True)
+    dis = flopy.mf6.ModflowGwfdis(gwf, nrow=10, ncol=10)
+    dis = gwf.get_package("DIS")
+    nlay = 2
+    botm = [1 - (k + 1) for k in range(nlay)]
+    botm_data = np.array([list(repeat(b, 10 * 10)) for b in botm]).reshape(
+        (nlay, 10, 10)
+    )
+    dis.nlay = nlay
+    dis.botm.set_data(botm_data)
+    ic = flopy.mf6.ModflowGwfic(gwf)
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_specific_discharge=True)
+    chd = flopy.mf6.ModflowGwfchd(
+        gwf, stress_period_data=[[(0, 0, 0), 1.0], [(0, 9, 9), 0.0]]
+    )
+    budget_file = case.name + ".bud"
+    head_file = case.name + ".hds"
+    oc = flopy.mf6.ModflowGwfoc(
+        gwf,
+        budget_filerecord=budget_file,
+        head_filerecord=head_file,
+        saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+    )
+    return sim
+
+
+def disv_sim(case, ws) -> flopy.mf6.MFSimulation:
+    sim = flopy.mf6.MFSimulation(sim_name=case.name, sim_ws=ws, exe_name="mf6")
+    nper = len(case.tdis)
+    tdis = flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=case.tdis)
+    ims = flopy.mf6.ModflowIms(sim)
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=case.name, save_flows=True)
+    dis = flopy.mf6.ModflowGwfdisv(
+        gwf, **get_disv_kwargs(2, 10, 10, 1.0, 1.0, 25.0, [20.0, 15.0])
+    )
+    ic = flopy.mf6.ModflowGwfic(gwf)
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_specific_discharge=True)
+    chd = flopy.mf6.ModflowGwfchd(
+        gwf, stress_period_data=[[(0, 0, 0), 1.0], [(0, 9, 9), 0.0]]
+    )
+    budget_file = case.name + ".bud"
+    head_file = case.name + ".hds"
+    oc = flopy.mf6.ModflowGwfoc(
+        gwf,
+        budget_filerecord=budget_file,
+        head_filerecord=head_file,
+        saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+    )
+    return sim
+
+
+def disu_sim(case, ws) -> flopy.mf6.MFSimulation:
+    from autotest.test_export import disu_sim as _disu_sim
+
+    sim = _disu_sim(case.name, ws)
+    tdis = flopy.mf6.ModflowTdis(sim, nper=len(case.tdis), perioddata=case.tdis)
+    return sim
+
+
+def pytest_generate_tests(metafunc):
+    tmp_path_factory = metafunc.config._tmp_path_factory
+    cases = []
+    sims = []
+    names = []
+    for case in CASES:
+        for dis_type in get_args(DisType):
+            name = f"{case.name}_{dis_type}"
+            case_ = replace(case, name=name)
+            ws = tmp_path_factory.mktemp(name)
+            if dis_type == "dis":
+                sim = dis_sim(case_, ws)
+            elif dis_type == "disv":
+                sim = disv_sim(case_, ws)
+            elif dis_type == "disu":
+                sim = disu_sim(case_, ws)
+            cases.append(case_)
+            sims.append(sim)
+            names.append(name)
+    metafunc.parametrize("case, sim", zip(cases, sims), ids=names)
+
+
+@requires_exe("mf6")
+@requires_pkg("shapely")
+def test_reverse(case, sim):
+    gwf = sim.get_model(case.name)
+    sim.write_simulation(silent=True)
+    success, buff = sim.run_simulation(silent=True, report=True)
+    assert success, pformat(buff)
+
+    # reverse and compare head file headers
+    head_file_path = sim.sim_path / gwf.oc.head_filerecord.get_data()[0][0]
+    head_file_rev_path = sim.sim_path / f"{head_file_path.name}_rev.hds"
+    head_file = HeadFile(head_file_path)
+    head_file.reverse(filename=head_file_rev_path)
+    head_file_rev = HeadFile(head_file_rev_path)
+    fwd_heads = head_file.get_alldata()
+    fwd_times = head_file.get_times()
+    fwd_kstpkper = head_file.get_kstpkper()
+    rev_heads = head_file_rev.get_alldata()
+    rev_times = head_file_rev.get_times()
+    rev_kstpkper = head_file_rev.get_kstpkper()
+    fwd_result = [
+        (int(kper), int(kstp), float(time))
+        for (kper, kstp), time in zip(fwd_kstpkper, fwd_times)
+    ]
+    rev_result = [
+        (int(kper), int(kstp), float(time))
+        for (kper, kstp), time in zip(rev_kstpkper, rev_times)
+    ]
+    assert len(fwd_kstpkper) == len(rev_kstpkper)
+    assert len(fwd_times) == len(rev_times)
+    assert fwd_result == case.forward
+    assert rev_result == case.reverse
+
+    # reverse and compare budget file headers
+    budget_file_path = sim.sim_path / gwf.oc.budget_filerecord.get_data()[0][0]
+    budget_file_rev_path = sim.sim_path / f"{budget_file_path.name}_rev.cbb"
+    budget_file = CellBudgetFile(budget_file_path)
+    budget_file.reverse(budget_file_rev_path)
+    budget_file_rev = CellBudgetFile(budget_file_rev_path)
+    rev_times = head_file_rev.get_times()
+    rev_kstpkper = head_file_rev.get_kstpkper()
+    nuniq = len(budget_file.get_unique_record_names())
+    ntimes = len(fwd_times)
+    assert len(budget_file_rev) == ntimes * nuniq
+    assert len(fwd_kstpkper) == len(rev_kstpkper)
+    assert len(fwd_times) == len(rev_times)
+    assert rev_result == case.reverse
+
+    for i, t in enumerate(fwd_times):
+        # compare head
+        assert np.allclose(fwd_heads[i], rev_heads[-(i + 1)])
+
+        # compare budget
+        rt = rev_times[-(i + 1)]
+        bud = budget_file.get_data(text=BUDTXT, totim=t)[0]
+        bud_rev = budget_file_rev.get_data(text=BUDTXT, totim=rt)[0]
+        assert np.allclose(bud, -bud_rev)

--- a/autotest/test_export.py
+++ b/autotest/test_export.py
@@ -31,6 +31,7 @@ from flopy.mf6 import (
     ModflowGwfdisv,
     ModflowGwfic,
     ModflowGwfnpf,
+    ModflowGwfoc,
     ModflowIms,
     ModflowTdis,
 )
@@ -109,6 +110,12 @@ def disu_sim(name, tmpdir, missing_arrays=False):
 
     ic = ModflowGwfic(gwf, strt=np.random.random_sample(gwf.modelgrid.nnodes) * 350)
     npf = ModflowGwfnpf(gwf, k=np.random.random_sample(gwf.modelgrid.nnodes) * 10)
+    oc = ModflowGwfoc(
+        gwf,
+        budget_filerecord=f"{name}.bud",
+        head_filerecord=f"{name}.hds",
+        saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+    )
 
     return sim
 

--- a/flopy/discretization/modeltime.py
+++ b/flopy/discretization/modeltime.py
@@ -139,7 +139,9 @@ class ModelTime:
         Returns a tuple of period data for the MF6 TDIS package containing records
         of [(perlen, nstp, tsmult), ....] for each stress period
         """
-        return [(per, self.nstp[ix], self.tsmult[ix]) for ix, per in self.perlen]
+        return [
+            (per, self.nstp[ix], self.tsmult[ix]) for ix, per in enumerate(self.perlen)
+        ]
 
     @property
     def steady_state(self):

--- a/flopy/utils/binaryfile/__init__.py
+++ b/flopy/utils/binaryfile/__init__.py
@@ -1025,7 +1025,7 @@ class CellBudgetFile:
 
         try:
             self._build_index()
-        except (BudgetIndexError, EOFError):
+        except (BudgetIndexError, EOFError) as e:
             success = False
             self.__reset()
 
@@ -2194,7 +2194,7 @@ class CellBudgetFile:
                     h.tofile(f)
                 elif header["imeth"] == 1:
                     # Load data
-                    data = self.get_data(idx)[0][0][0]
+                    data = self.get_data(idx)[0]
                     data = np.array(data, dtype=np.float64)
                     # Negate flows
                     data = -data

--- a/flopy/utils/binaryfile/reverse.py
+++ b/flopy/utils/binaryfile/reverse.py
@@ -1,31 +1,94 @@
 import argparse
 from pathlib import Path
 
-from flopy.utils.binaryfile import CellBudgetFile, HeadFile
-
 if __name__ == "__main__":
-    """Reverse head or budget files."""
+    """Reverse a TDIS (ASCII) input file or a head or budget (binary) output file."""
 
-    parser = argparse.ArgumentParser(description="Reverse head or budget files.")
+    parser = argparse.ArgumentParser(description="Reverse head, budget, or TDIS files.")
     parser.add_argument(
-        "--infile",
-        "-i",
+        "--head",
         type=str,
-        help="Input file.",
+        help="Head file",
     )
     parser.add_argument(
-        "--outfile",
-        "-o",
+        "--budget",
         type=str,
-        help="Output file.",
+        help="Budget file",
     )
+    parser.add_argument(
+        "--tdis",
+        type=str,
+        help="TDIS file",
+    )
+    parser.add_argument(
+        "--head-output",
+        type=str,
+        help="Reversed head file",
+    )
+    parser.add_argument(
+        "--budget-output",
+        type=str,
+        help="Reversed budget file",
+    )
+    parser.add_argument(
+        "--tdis-output",
+        type=str,
+        help="Reversed TDIS file",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Verbose output",
+    )
+
     args = parser.parse_args()
-    infile = Path(args.infile)
-    outfile = Path(args.outfile)
-    suffix = infile.suffix.lower()
-    if suffix in [".hds", ".hed"]:
-        HeadFile(infile).reverse(outfile)
-    elif suffix in [".bud", ".cbc"]:
-        CellBudgetFile(infile).reverse(outfile)
-    else:
-        raise ValueError(f"Unrecognized file suffix: {suffix}")
+
+    if args.head:
+        from flopy.utils.binaryfile import HeadFile
+
+        head_input = Path(args.head).expanduser().absolute()
+        if not head_input.is_file():
+            raise FileNotFoundError(f"Head file {head_input} not found.")
+        if args.head_output:
+            head_output = Path(args.head_output).expanduser().absolute()
+        else:
+            head_output = head_input.with_suffix(".reversed.hds")
+        if args.verbose:
+            print(f"Reversing head file {head_input} to {head_output}")
+        HeadFile(head_input).reverse(head_output)
+
+    if args.budget:
+        from flopy.utils.binaryfile import CellBudgetFile
+
+        budget_input = Path(args.budget).expanduser().absolute()
+        if not budget_input.is_file():
+            raise FileNotFoundError(f"Budget file {budget_input} not found.")
+        if args.budget_output:
+            budget_output = Path(args.budget_output).expanduser().absolute()
+        else:
+            budget_output = budget_input.with_suffix(".reversed.cbc")
+        if args.verbose:
+            print(f"Reversing budget file {budget_input} to {budget_output}")
+        CellBudgetFile(budget_input).reverse(budget_output)
+
+    if args.tdis:
+        from flopy.discretization.modeltime import ModelTime
+        from flopy.mf6 import MFSimulation, ModflowTdis
+
+        tdis_input = Path(args.tdis).expanduser().absolute()
+        if not tdis_input.is_file():
+            raise FileNotFoundError(f"TDIS file {tdis_input} not found.")
+        if args.tdis_output:
+            tdis_output = Path(args.tdis_output).expanduser().absolute()
+        else:
+            tdis_output = tdis_input.with_suffix(".reversed.tdis")
+        if args.verbose:
+            print(f"Reversing TDIS file {tdis_input} to {tdis_output}")
+        tdis = ModflowTdis(MFSimulation(), filename=tdis_input)
+        tdis.load()
+        time = ModelTime.from_perioddata(tdis.perioddata.get_data())
+        trev = time.reverse()
+        tdis.perioddata.set_data(trev.perioddata)
+        tdis._filename = tdis_output
+        tdis.write()


### PR DESCRIPTION
Following up on #2475. Fixes #2473. #2480 was extracted from this changeset for tidiness.

Up to now the reversal methods have worked for our backwards particle tracking examples, which have very simple time discretizations. But they didn't work in the general case &mdash; only for "symmetric" tdis with no time step multiplier. 

Fix several issues with binary output file reversal.  Clean up and expand tests to include dis/disv/disu with both trivial and a couple non-trivial time discretizations. Make a small (but consequential) fix for #2481: when reversing we need to take the reciprocal of tsmult. Fix an issue with the `ModelTime` class `perioddata` property and add a `pertim` property like the `totim` property.