### PR TITLE
ci: pin meson to 1.3.0 in requirements.mf6.txt

### DIFF
--- a/etc/requirements.mf6.txt
+++ b/etc/requirements.mf6.txt
@@ -1,3 +1,4 @@
 git+https://github.com/modflowpy/pymake@master
 git+https://github.com/Deltares/xmipy@develop
 git+https://github.com/MODFLOW-ORG/modflowapi@develop
+meson==1.3.0


### PR DESCRIPTION
Fix some CI failures. Same underlying root cause as https://github.com/MODFLOW-ORG/modflow6-examples/pull/274. We need to get to the bottom of why meson 1.8.0 broke the mf5to6 converter build, and see if we can unpin meson upstream and here.