### PR TITLE
chore: fix conda environment.yml syntax 

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -87,6 +87,9 @@ jobs:
       - name: Install FloPy
         run: uv sync
 
+      - name: Install seaborn
+        run: uv pip install seaborn
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -38,7 +38,7 @@ dependencies:
   - pytest-cov
   - pytest-dotenv
   - pytest-xdist
-  - pyzmq>=25.1.2,
+  - pyzmq>=25.1.2
   - syrupy
   - virtualenv
 


### PR DESCRIPTION
I think the environment file parser got stricter in a recent version of conda/mamba. Errant comma was tolerated before but no longer. Or we just haven't noticed the env was broken.

Also fix the benchmarks CI, the job that collects the results needed seaborn.