### PR TITLE
chore: use python>=3.10 in conda env, fix map plot example

### DIFF
--- a/.docs/Notebooks/plot_map_view_example.py
+++ b/.docs/Notebooks/plot_map_view_example.py
@@ -56,7 +56,7 @@ exe_mp = "mp6"
 sim_name = "freyberg"
 
 # Set the paths
-tempdir = TemporaryDirectory(delete=False)
+tempdir = TemporaryDirectory()
 modelpth = Path(tempdir.name)
 
 # Check if we are in the repository and define the data path.

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - pip
 
   # required
-  - python>=3.9
+  - python>=3.10
   - numpy>=1.20.3
   - matplotlib>=1.4.0
   - pandas>=2.0.0


### PR DESCRIPTION
Fix a problem in example notebook CI. The `delete` parameter to `TemporaryDirectory` was added in Python 3.12, but we still want to support >=3.10. Also the `environment.yml` still had a lower bound of 3.9, bump it.