### PR TITLE
chore: skip vtk/pyvista pathlines example on windows

### DIFF
--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -137,7 +137,13 @@ jobs:
 
       - name: Run tutorial and example notebooks
         working-directory: autotest
-        run: pytest -v -n auto test_notebooks.py
+        run: |
+          filters=""
+          if [[ ${{ runner.os }} == "Windows" ]]; then
+            # TODO figure out VTK error: GLSL 1.50 is not supported. Supported versions are: 1.10, 1.20, 1.30, and 1.00 ES
+            filters="not vtk_pathlines"
+          fi
+          pytest -v -n auto test_notebooks.py -k "$filters"
 
       - name: Upload notebooks artifact for ReadtheDocs
         if: |


### PR DESCRIPTION
I think one of the `windows-latest` (2025) image updates today broke something which pyvista/vtk/opengl rely on