### PR TITLE
ci: multiple fixes

### DIFF
--- a/.github/workflows/mf6.yml
+++ b/.github/workflows/mf6.yml
@@ -56,12 +56,18 @@ jobs:
         pixi run --manifest-path=../modflow6/pixi.toml pip install --no-deps -e .
         pixi run --manifest-path=../modflow6/pixi.toml python -m flopy.mf6.utils.generate_classes --dfnpath ../modflow6/doc/mf6io/mf6ivar/dfn
 
-    - name: Build and install MF6
+    - name: Build MF6
       working-directory: modflow6
       run: |
         pixi run meson setup builddir --buildtype=debugoptimized --prefix=$(pwd) --libdir=bin
         pixi run meson install -C builddir
         pixi run meson test --verbose --no-rebuild -C builddir
+      
+    - name: Build mf5to6 converter
+      working-directory: modflow6/utils/mf5to6
+      run: |
+        pixi run meson setup builddir --prefix=$(pwd)/../../ --libdir=bin
+        pixi run meson install -C builddir
 
     - name: Install executables
       working-directory: modflow6/autotest

--- a/.github/workflows/mf6.yml
+++ b/.github/workflows/mf6.yml
@@ -45,6 +45,7 @@ jobs:
         manifest-path: modflow6/pixi.toml
 
     - name: Install FloPy
+      working-directory: flopy
       run: pixi run --manifest-path=../modflow6/pixi.toml pip install --no-deps -e .
 
     - name: Build and install MF6
@@ -89,6 +90,8 @@ jobs:
 
     - name: Checkout flopy repo
       uses: actions/checkout@v4
+      with:
+        path: flopy
 
     - name: Checkout MODFLOW 6
       uses: actions/checkout@v4
@@ -115,6 +118,7 @@ jobs:
         manifest-path: modflow6/pixi.toml
 
     - name: Install FloPy
+      working-directory: flopy
       run: pixi run --manifest-path=../modflow6/pixi.toml pip install --no-deps -e .
 
     - name: Install executables

--- a/.github/workflows/mf6.yml
+++ b/.github/workflows/mf6.yml
@@ -61,10 +61,6 @@ jobs:
         pixi run meson install -C builddir
         pixi run meson test --verbose --no-rebuild -C builddir
 
-    - name: Update package classes
-      working-directory: modflow6/autotest
-      run: pixi run update_flopy.py
-
     - name: Install executables
       working-directory: modflow6/autotest
       env:
@@ -146,4 +142,4 @@ jobs:
 
     - name: Test MF6 examples
       working-directory: modflow6-examples/autotest
-      run: pixi run pytest -v -n=auto --durations=0 test_scripts.py
+      run: pixi run --manifest-path=../modflow6/pixi.toml pytest -v -n=auto --durations=0 test_scripts.py

--- a/.github/workflows/mf6.yml
+++ b/.github/workflows/mf6.yml
@@ -23,8 +23,6 @@ jobs:
 
     - name: Checkout flopy repo
       uses: actions/checkout@v4
-      with:
-        path: flopy
 
     - name: Checkout MODFLOW 6
       uses: actions/checkout@v4
@@ -45,7 +43,6 @@ jobs:
         manifest-path: modflow6/pixi.toml
 
     - name: Install FloPy
-      working-directory: flopy
       run: pixi run pip install --no-deps -e .
 
     - name: Build and install MF6
@@ -87,11 +84,9 @@ jobs:
       run:
         shell: bash
     steps:
-      
+
     - name: Checkout flopy repo
       uses: actions/checkout@v4
-      with:
-        path: flopy
 
     - name: Checkout MODFLOW 6
       uses: actions/checkout@v4
@@ -118,7 +113,6 @@ jobs:
         manifest-path: modflow6/pixi.toml
 
     - name: Install FloPy
-      working-directory: flopy
       run: pixi run pip install --no-deps -e .
 
     - name: Install executables

--- a/.github/workflows/mf6.yml
+++ b/.github/workflows/mf6.yml
@@ -44,6 +44,10 @@ jobs:
         pixi-version: v0.41.4
         manifest-path: modflow6/pixi.toml
 
+    - name: Install dependencies
+      working-directory: modflow6
+      run: pixi run install
+
     - name: Install FloPy
       working-directory: flopy
       run: |
@@ -118,6 +122,10 @@ jobs:
       with:
         pixi-version: v0.41.4
         manifest-path: modflow6/pixi.toml
+
+    - name: Install dependencies
+      working-directory: modflow6
+      run: pixi run install
 
     - name: Install FloPy
       working-directory: flopy

--- a/.github/workflows/mf6.yml
+++ b/.github/workflows/mf6.yml
@@ -23,12 +23,20 @@ jobs:
 
     - name: Checkout flopy repo
       uses: actions/checkout@v4
+      with:
+        path: flopy
 
     - name: Checkout MODFLOW 6
       uses: actions/checkout@v4
       with:
         repository: MODFLOW-ORG/modflow6
         path: modflow6
+
+    - name: Setup GNU Fortran
+      uses: fortran-lang/setup-fortran@v1
+      with:
+        compiler: gcc
+        version: 13
 
     - name: Setup pixi
       uses: prefix-dev/setup-pixi@v0.8.8
@@ -37,16 +45,8 @@ jobs:
         manifest-path: modflow6/pixi.toml
 
     - name: Install FloPy
+      working-directory: flopy
       run: pixi run pip install --no-deps -e .
-
-    - name: Install other dependencies from GitHub
-      run: pixi run pip install -r etc/requirements.mf6.txt
-
-    - name: Setup GNU Fortran
-      uses: fortran-lang/setup-fortran@v1
-      with:
-        compiler: gcc
-        version: 13
 
     - name: Build and install MF6
       working-directory: modflow6
@@ -90,6 +90,8 @@ jobs:
       
     - name: Checkout flopy repo
       uses: actions/checkout@v4
+      with:
+        path: flopy
 
     - name: Checkout MODFLOW 6
       uses: actions/checkout@v4
@@ -116,10 +118,8 @@ jobs:
         manifest-path: modflow6/pixi.toml
 
     - name: Install FloPy
+      working-directory: flopy
       run: pixi run pip install --no-deps -e .
-
-    - name: Install other dependencies from GitHub
-      run: pixi run pip install -r etc/requirements.mf6.txt
 
     - name: Install executables
       uses: modflowpy/install-modflow-action@v1

--- a/.github/workflows/mf6.yml
+++ b/.github/workflows/mf6.yml
@@ -48,7 +48,7 @@ jobs:
       working-directory: modflow6
       run: |
         pixi run install
-        pixi run pip install coverage
+        pixi run pip install coverage pytest-cov
 
     - name: Install FloPy
       working-directory: flopy
@@ -123,9 +123,7 @@ jobs:
 
     - name: Install dependencies
       working-directory: modflow6
-      run: |
-        pixi run install
-        pixi run pip install coverage
+      run: pixi run install
 
     - name: Install FloPy
       working-directory: flopy

--- a/.github/workflows/mf6.yml
+++ b/.github/workflows/mf6.yml
@@ -46,7 +46,9 @@ jobs:
 
     - name: Install dependencies
       working-directory: modflow6
-      run: pixi run install
+      run: |
+        pixi run install
+        pixi run pip install coverage
 
     - name: Install FloPy
       working-directory: flopy
@@ -121,7 +123,9 @@ jobs:
 
     - name: Install dependencies
       working-directory: modflow6
-      run: pixi run install
+      run: |
+        pixi run install
+        pixi run pip install coverage
 
     - name: Install FloPy
       working-directory: flopy
@@ -142,4 +146,4 @@ jobs:
 
     - name: Test MF6 examples
       working-directory: modflow6-examples/autotest
-      run: pixi run --manifest-path=../modflow6/pixi.toml pytest -v -n=auto --durations=0 test_scripts.py
+      run: pixi run --manifest-path=../../modflow6/pixi.toml pytest -v -n=auto --durations=0 test_scripts.py

--- a/.github/workflows/mf6.yml
+++ b/.github/workflows/mf6.yml
@@ -42,6 +42,9 @@ jobs:
         pixi-version: v0.41.4
         manifest-path: modflow6/pixi.toml
 
+    - name: List dir
+      run: pixi run ls -l
+
     - name: Install FloPy
       run: pixi run pip install --no-deps -e .
 

--- a/.github/workflows/mf6.yml
+++ b/.github/workflows/mf6.yml
@@ -23,6 +23,8 @@ jobs:
 
     - name: Checkout flopy repo
       uses: actions/checkout@v4
+      with:
+        path: flopy
 
     - name: Checkout MODFLOW 6
       uses: actions/checkout@v4
@@ -42,11 +44,8 @@ jobs:
         pixi-version: v0.41.4
         manifest-path: modflow6/pixi.toml
 
-    - name: List dir
-      run: pixi run ls -l
-
     - name: Install FloPy
-      run: pixi run pip install --no-deps -e .
+      run: pixi run --manifest-path=../modflow6/pixi.toml pip install --no-deps -e .
 
     - name: Build and install MF6
       working-directory: modflow6
@@ -116,7 +115,7 @@ jobs:
         manifest-path: modflow6/pixi.toml
 
     - name: Install FloPy
-      run: pixi run pip install --no-deps -e .
+      run: pixi run --manifest-path=../modflow6/pixi.toml pip install --no-deps -e .
 
     - name: Install executables
       uses: modflowpy/install-modflow-action@v1

--- a/.github/workflows/mf6.yml
+++ b/.github/workflows/mf6.yml
@@ -24,16 +24,23 @@ jobs:
     - name: Checkout flopy repo
       uses: actions/checkout@v4
 
-    - name: Setup Python
-      uses: astral-sh/setup-uv@v6
+    - name: Checkout MODFLOW 6
+      uses: actions/checkout@v4
       with:
-        cache-dependency-glob: "**/pyproject.toml"
+        repository: MODFLOW-ORG/modflow6
+        path: modflow6
+
+    - name: Setup pixi
+      uses: prefix-dev/setup-pixi@v0.8.8
+      with:
+        pixi-version: v0.41.4
+        manifest-path: modflow6/pixi.toml
 
     - name: Install FloPy
-      run: uv sync --all-extras
+      run: pixi run pip install --no-deps -e .
 
     - name: Install other dependencies from GitHub
-      run: uv pip install -r etc/requirements.mf6.txt
+      run: pixi run pip install -r etc/requirements.mf6.txt
 
     - name: Setup GNU Fortran
       uses: fortran-lang/setup-fortran@v1
@@ -41,36 +48,30 @@ jobs:
         compiler: gcc
         version: 13
 
-    - name: Checkout MODFLOW 6
-      uses: actions/checkout@v4
-      with:
-        repository: MODFLOW-ORG/modflow6
-        path: modflow6
-
     - name: Build and install MF6
       working-directory: modflow6
       run: |
-        uv run meson setup builddir --buildtype=debugoptimized --prefix=$(pwd) --libdir=bin
-        uv run meson install -C builddir
-        uv run meson test --verbose --no-rebuild -C builddir
+        pixi run meson setup builddir --buildtype=debugoptimized --prefix=$(pwd) --libdir=bin
+        pixi run meson install -C builddir
+        pixi run meson test --verbose --no-rebuild -C builddir
 
     - name: Update package classes
       working-directory: modflow6/autotest
-      run: uv run update_flopy.py
+      run: pixi run update_flopy.py
 
     - name: Install executables
       working-directory: modflow6/autotest
       env:
         GITHUB_TOKEN: ${{ github.token }}
-      run: uv run pytest -v --durations=0 get_exes.py
+      run: pixi run pytest -v --durations=0 get_exes.py
 
     - name: Run tests
       working-directory: modflow6/autotest
-      run: uv run pytest -v --cov=flopy --cov-report=xml --cov-append --durations=0 -n auto -m "not repo and not regression"
+      run: pixi run pytest -v --cov=flopy --cov-report=xml --cov-append --durations=0 -n auto -m "not repo and not regression"
 
     - name: Print coverage report before upload
       working-directory: ./modflow6/autotest
-      run: uv run coverage report
+      run: pixi run coverage report
 
     - name: Upload coverage to Codecov
       if:
@@ -102,22 +103,23 @@ jobs:
         repository: MODFLOW-ORG/modflow6-examples
         path: modflow6-examples
 
-    - name: Setup Python
-      uses: astral-sh/setup-uv@v6
-      with:
-        cache-dependency-glob: "**/pyproject.toml"
-
-    - name: Install FloPy
-      run: uv sync --all-extras
-
-    - name: Install other dependencies from modflow6-examples and GitHub
-      run: uv pip install -r etc/requirements.mf6.txt -r modflow6-examples/etc/requirements.pip.txt
-
     - name: Setup GNU Fortran
       uses: fortran-lang/setup-fortran@v1
       with:
         compiler: gcc
         version: 13
+
+    - name: Setup pixi
+      uses: prefix-dev/setup-pixi@v0.8.8
+      with:
+        pixi-version: v0.41.4
+        manifest-path: modflow6/pixi.toml
+
+    - name: Install FloPy
+      run: pixi run pip install --no-deps -e .
+
+    - name: Install other dependencies from GitHub
+      run: pixi run pip install -r etc/requirements.mf6.txt
 
     - name: Install executables
       uses: modflowpy/install-modflow-action@v1
@@ -125,15 +127,15 @@ jobs:
     - name: Build and install MF6
       working-directory: modflow6
       run: |
-        uv run meson setup builddir --buildtype=debugoptimized --prefix=$(pwd) --libdir=bin
-        uv run meson install -C builddir
-        uv run meson test --verbose --no-rebuild -C builddir
+        pixi run meson setup builddir --buildtype=debugoptimized --prefix=$(pwd) --libdir=bin
+        pixi run meson install -C builddir
+        pixi run meson test --verbose --no-rebuild -C builddir
         cp bin/* ~/.local/bin/modflow/
 
     - name: Update package classes
       working-directory: modflow6/autotest
-      run: uv run update_flopy.py
+      run: pixi run update_flopy.py
 
     - name: Test MF6 examples
       working-directory: modflow6-examples/autotest
-      run: uv run pytest -v -n=auto --durations=0 test_scripts.py
+      run: pixi run pytest -v -n=auto --durations=0 test_scripts.py

--- a/.github/workflows/mf6.yml
+++ b/.github/workflows/mf6.yml
@@ -46,7 +46,9 @@ jobs:
 
     - name: Install FloPy
       working-directory: flopy
-      run: pixi run --manifest-path=../modflow6/pixi.toml pip install --no-deps -e .
+      run: |
+        pixi run --manifest-path=../modflow6/pixi.toml pip install --no-deps -e .
+        pixi run --manifest-path=../modflow6/pixi.toml python -m flopy.mf6.utils.generate_classes --dfnpath ../modflow6/doc/mf6io/mf6ivar
 
     - name: Build and install MF6
       working-directory: modflow6
@@ -119,7 +121,9 @@ jobs:
 
     - name: Install FloPy
       working-directory: flopy
-      run: pixi run --manifest-path=../modflow6/pixi.toml pip install --no-deps -e .
+      run: |
+        pixi run --manifest-path=../modflow6/pixi.toml pip install --no-deps -e .
+        pixi run --manifest-path=../modflow6/pixi.toml python -m flopy.mf6.utils.generate_classes --dfnpath ../modflow6/doc/mf6io/mf6ivar
 
     - name: Install executables
       uses: modflowpy/install-modflow-action@v1
@@ -131,10 +135,6 @@ jobs:
         pixi run meson install -C builddir
         pixi run meson test --verbose --no-rebuild -C builddir
         cp bin/* ~/.local/bin/modflow/
-
-    - name: Update package classes
-      working-directory: modflow6/autotest
-      run: pixi run update_flopy.py
 
     - name: Test MF6 examples
       working-directory: modflow6-examples/autotest

--- a/.github/workflows/mf6.yml
+++ b/.github/workflows/mf6.yml
@@ -48,7 +48,7 @@ jobs:
       working-directory: flopy
       run: |
         pixi run --manifest-path=../modflow6/pixi.toml pip install --no-deps -e .
-        pixi run --manifest-path=../modflow6/pixi.toml python -m flopy.mf6.utils.generate_classes --dfnpath ../modflow6/doc/mf6io/mf6ivar
+        pixi run --manifest-path=../modflow6/pixi.toml python -m flopy.mf6.utils.generate_classes --dfnpath ../modflow6/doc/mf6io/mf6ivar/dfn
 
     - name: Build and install MF6
       working-directory: modflow6
@@ -123,7 +123,7 @@ jobs:
       working-directory: flopy
       run: |
         pixi run --manifest-path=../modflow6/pixi.toml pip install --no-deps -e .
-        pixi run --manifest-path=../modflow6/pixi.toml python -m flopy.mf6.utils.generate_classes --dfnpath ../modflow6/doc/mf6io/mf6ivar
+        pixi run --manifest-path=../modflow6/pixi.toml python -m flopy.mf6.utils.generate_classes --dfnpath ../modflow6/doc/mf6io/mf6ivar/dfn
 
     - name: Install executables
       uses: modflowpy/install-modflow-action@v1

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -137,7 +137,13 @@ jobs:
 
       - name: Run tutorial and example notebooks
         working-directory: autotest
-        run: pytest -v -n auto test_notebooks.py
+        run: |
+          filters=""
+          if [[ ${{ runner.os }} == "Windows" ]]; then
+            # TODO figure out VTK error: GLSL 1.50 is not supported. Supported versions are: 1.10, 1.20, 1.30, and 1.00 ES
+            filters="not vtk_pathlines"
+          fi
+          pytest -v -n auto test_notebooks.py -k "$filters"
 
       - name: Upload notebooks artifact for ReadtheDocs
         if: |

--- a/etc/requirements.mf6.txt
+++ b/etc/requirements.mf6.txt
@@ -1,4 +1,0 @@
-git+https://github.com/modflowpy/pymake@master
-git+https://github.com/Deltares/xmipy@develop
-git+https://github.com/MODFLOW-ORG/modflowapi@develop
-meson==1.3.0


### PR DESCRIPTION
* skip vtk/pyvista pathlines example on windows for now, I think one of the windows-latest (2025) image updates today broke something which pyvista/vtk/opengl rely on
* switch mf6 CI tests to use the mf6 pixi environment, accommodating https://github.com/MODFLOW-ORG/modflow6-examples/pull/275