### PR TITLE
fix: throw error on invalid crs type

### DIFF
--- a/flopy/utils/rasters.py
+++ b/flopy/utils/rasters.py
@@ -98,7 +98,7 @@ class Raster:
         elif crs is not None:
             crs = CRS.from_user_input(crs)
         else:
-            TypeError("crs type not understood, provide an epsg or proj4")
+            raise TypeError("crs type not understood, provide an epsg or proj4")
 
         meta["crs"] = crs
 


### PR DESCRIPTION
## PR Summary
This really small PR simply adds the missing `raise` to the "invalid crs type" exception.