### PR TITLE
Fix: Strip quotes from filenames in OPEN/CLOSE statements (when present) making ulstrd function a bit more forgiving with external input files

### DIFF
--- a/flopy/utils/flopy_io.py
+++ b/flopy/utils/flopy_io.py
@@ -440,6 +440,8 @@ def ulstrd(f, nlist, ra, model, sfac_columns, ext_unit_dict):
     elif line.strip().lower().startswith("open/close"):
         raw = line.strip().split()
         fname = raw[1]
+        # Strip quotes (single and double) from the filename ends, if present
+        fname = fname.strip("'\"")
         if "/" in fname:
             raw = fname.split("/")
         elif "\\" in fname:


### PR DESCRIPTION
This PR adds a small safety fix to handle filenames in `OPEN/CLOSE` lines that are surrounded by quotes, which can sometimes  be present in MODFLOW input files. For example:

_OPEN/CLOSE 'external_data.dat'
OPEN/CLOSE "external_data.dat"_

If that is the case, in the attempt to load the data we might get an error similar to the following:

_Package.load() error: open/close filename /.../'external_data.dat' not found_