### PR TITLE
Fix(usg datafile)

### DIFF
--- a/autotest/test_binaryfile.py
+++ b/autotest/test_binaryfile.py
@@ -313,14 +313,17 @@ def test_headu_file_data(function_tmpdir, example_data_path):
 
     # try get_data(mflay=k) mode, across all output times
     kstpkper = headobj.get_kstpkper()
-    hds = headobj.get_alldata(mflay=1) # returns a list for all times
+    hds = headobj.get_alldata(mflay=1)  # returns a list for all times
     assert len(hds) == len(headobj.get_kstpkper())
     assert np.all([isinstance(h, np.ndarray) for h in hds])
 
     # try get_data(mflay=k) mode, for a given output time
     for k in range(headobj.nlay):
-        hds = headobj.get_data(mflay=k, kstpkper=kstpkper[-1]) # returns a numpy ndarray
+        hds = headobj.get_data(
+            mflay=k, kstpkper=kstpkper[-1]
+        )  # returns a numpy ndarray
         assert isinstance(hds, np.ndarray)
+
 
 @pytest.mark.slow
 def test_headufile_get_ts(example_data_path):

--- a/autotest/test_binaryfile.py
+++ b/autotest/test_binaryfile.py
@@ -311,6 +311,16 @@ def test_headu_file_data(function_tmpdir, example_data_path):
         t1 = np.array([d.min(), d.max()])
         assert np.allclose(t1, minmaxtrue[i])
 
+    # try get_data(mflay=k) mode, across all output times
+    kstpkper = headobj.get_kstpkper()
+    hds = headobj.get_alldata(mflay=1) # returns a list for all times
+    assert len(hds) == len(headobj.get_kstpkper())
+    assert np.all([isinstance(h, np.ndarray) for h in hds])
+
+    # try get_data(mflay=k) mode, for a given output time
+    for k in range(headobj.nlay):
+        hds = headobj.get_data(mflay=k, kstpkper=kstpkper[-1]) # returns a numpy ndarray
+        assert isinstance(hds, np.ndarray)
 
 @pytest.mark.slow
 def test_headufile_get_ts(example_data_path):

--- a/flopy/utils/datafile.py
+++ b/flopy/utils/datafile.py
@@ -562,8 +562,10 @@ class LayerFile:
         data = self._get_data_array(totim1)
         if mflay is None:
             return data
+        elif isinstance(data,list): # unstructured model, list form
+            return data[mflay] 
         else:
-            return data[mflay, :, :]
+            return data[mflay, :, :] # structured model, np.array form
 
     def get_alldata(self, mflay=None, nodata=-9999):
         """

--- a/flopy/utils/datafile.py
+++ b/flopy/utils/datafile.py
@@ -562,10 +562,10 @@ class LayerFile:
         data = self._get_data_array(totim1)
         if mflay is None:
             return data
-        elif isinstance(data,list): # unstructured model, list form
-            return data[mflay] 
+        elif isinstance(data, list):  # unstructured model, list form
+            return data[mflay]
         else:
-            return data[mflay, :, :] # structured model, np.array form
+            return data[mflay, :, :]  # structured model, np.array form
 
     def get_alldata(self, mflay=None, nodata=-9999):
         """


### PR DESCRIPTION
For unstructured grids, ```flopy.utils.binaryfile.HeadUFile().get_data()``` fails if the ```mflay``` keyword is specified (i.e., not all layers' data are retreived in one hit). This is because ```flopy.utils.datafile()``` tries to index a 3d numpy array, but unstructured grid models return a (potentially jagged) list of 2d numpy arrays.

* ```flopy.utils.datafile().get_data(mflay=k)``` updated to test and adjust for returned lists vs 3d arrays
* autotest/test_binaryfile.py extended to test such ```flopy.utils.datafile().get_data(mflay=k)``` use cases for unstructured models.