### PR TITLE
ci: build mf6 from src in commit-triggered workflows

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -122,26 +122,19 @@ jobs:
         shell: bash -l {0}
     timeout-minutes: 60
     steps:
-
       - name: Checkout repo
         uses: actions/checkout@v4
-
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v6
         with:
-          cache-dependency-glob: "**/pyproject.toml"
-          python-version: ${{ matrix.python-version }}
+          path: flopy
 
-      - name: Install FloPy
-        run: uv sync --all-extras
+      - name: Checkout MODFLOW 6
+        uses: actions/checkout@v4
+        with:
+          repository: MODFLOW-ORG/modflow6
+          path: modflow6
 
       - name: Install Modflow-related executables
         uses: modflowpy/install-modflow-action@v1
-
-      - name: Install Modflow dev build executables
-        uses: modflowpy/install-modflow-action@v1
-        with:
-          repo: modflow6-nightly-build
 
       - name: Install triangle (macOS workaround)
         if: runner.os == 'macOS'
@@ -151,29 +144,57 @@ jobs:
           ostag: mac
           subset: triangle
 
-      - name: Update package classes
-        run: uv run python -m flopy.mf6.utils.generate_classes --ref develop
+      - name: Setup GNU Fortran
+        uses: fortran-lang/setup-fortran@v1
+        with:
+          compiler: gcc
+          version: 13
+
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@v0.8.14
+        with:
+          pixi-version: v0.41.4
+          manifest-path: modflow6/pixi.toml
+
+      - name: Install dependencies
+        working-directory: modflow6
+        run: |
+          pixi run install
+          pixi run pip install coverage pytest-cov
+
+      - name: Install FloPy
+        working-directory: flopy
+        run: |
+          pixi run --manifest-path=../modflow6/pixi.toml pip install --no-deps -e .
+          pixi run --manifest-path=../modflow6/pixi.toml python -m flopy.mf6.utils.generate_classes --dfnpath ../modflow6/doc/mf6io/mf6ivar/dfn
+
+      - name: Build MF6
+        working-directory: modflow6
+        run: |
+          pixi run meson setup builddir --buildtype=debugoptimized --prefix=$(pwd) --libdir=bin
+          pixi run meson install -C builddir
+          pixi run meson test --verbose --no-rebuild -C builddir
 
       - name: Run tests
-        working-directory: autotest
+        working-directory: flopy/autotest
         run: |
-          uv run pytest -v -m="not example" -n=auto --cov=flopy --cov-append --cov-report=xml --durations=0 --keep-failed=.failed --dist loadfile
+          pixi run pytest -v -m="not example" -n=auto --cov=flopy --cov-append --cov-report=xml --durations=0 --keep-failed=.failed --dist loadfile
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Report coverage
-        working-directory: autotest
-        run: uv run coverage report
+        working-directory: flopy/autotest
+        run: pixi run coverage report
 
       - name: Upload failed test outputs
         uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: failed-${{ matrix.os }}-${{ matrix.python-version }}
-          path: autotest/.failed/**
+          path: flopy/autotest/.failed/**
 
       - name: Upload coverage
         if: github.repository_owner == 'modflowpy' && (github.event_name == 'push' || github.event_name == 'pull_request')
         uses: codecov/codecov-action@v5
         with:
-          files: autotest/coverage.xml
+          files: flopy/autotest/coverage.xml

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -178,13 +178,13 @@ jobs:
       - name: Run tests
         working-directory: flopy/autotest
         run: |
-          pixi run pytest -v -m="not example" -n=auto --cov=flopy --cov-append --cov-report=xml --durations=0 --keep-failed=.failed --dist loadfile
+          pixi run --manifest-path=../../modflow6/pixi.toml pytest -v -m="not example" -n=auto --cov=flopy --cov-append --cov-report=xml --durations=0 --keep-failed=.failed --dist loadfile
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Report coverage
         working-directory: flopy/autotest
-        run: pixi run coverage report
+        run: pixi run --manifest-path=../../modflow6/pixi.toml coverage report
 
       - name: Upload failed test outputs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -3,8 +3,6 @@ name: Example script & notebook tests
 on:
   schedule:
     - cron: '0 8 * * *' # run at 8 AM UTC (12 am PST)
-  push:
-  pull_request:
 
 jobs:
   examples:
@@ -55,17 +53,6 @@ jobs:
           $ErrorActionPreference = "Stop"
           $PSDefaultParameterValues['*:ErrorAction']='Stop'
           powershell .github/install_opengl.ps1
-
-      - name: Set software rendering environment for Windows
-        if: runner.os == 'Windows'
-        run: |
-          echo "PYVISTA_OFF_SCREEN=true" >> $GITHUB_ENV
-          echo "PYVISTA_USE_PANEL=false" >> $GITHUB_ENV
-          echo "VTK_USE_OFFSCREEN=1" >> $GITHUB_ENV
-          echo "VTK_GLSL_VERSION=130" >> $GITHUB_ENV
-          echo "VTK_GL_VERSION=3.0" >> $GITHUB_ENV
-          echo "LIBGL_ALWAYS_SOFTWARE=1" >> $GITHUB_ENV
-          echo "GALLIUM_DRIVER=softpipe" >> $GITHUB_ENV
 
       - name: Install Modflow-related executables
         uses: modflowpy/install-modflow-action@v1

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: '0 8 * * *' # run at 8 AM UTC (12 am PST)
   push:
+  pull_request:
 
 jobs:
   examples:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -61,6 +61,11 @@ jobs:
         run: |
           echo "PYVISTA_OFF_SCREEN=true" >> $GITHUB_ENV
           echo "PYVISTA_USE_PANEL=false" >> $GITHUB_ENV
+          echo "VTK_USE_OFFSCREEN=1" >> $GITHUB_ENV
+          echo "MESA_GL_VERSION_OVERRIDE=3.3" >> $GITHUB_ENV
+          echo "MESA_GLSL_VERSION_OVERRIDE=330" >> $GITHUB_ENV
+          echo "LIBGL_ALWAYS_SOFTWARE=1" >> $GITHUB_ENV
+          echo "GALLIUM_DRIVER=softpipe" >> $GITHUB_ENV
 
       - name: Install Modflow-related executables
         uses: modflowpy/install-modflow-action@v1

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -62,8 +62,8 @@ jobs:
           echo "PYVISTA_OFF_SCREEN=true" >> $GITHUB_ENV
           echo "PYVISTA_USE_PANEL=false" >> $GITHUB_ENV
           echo "VTK_USE_OFFSCREEN=1" >> $GITHUB_ENV
-          echo "MESA_GL_VERSION_OVERRIDE=3.3" >> $GITHUB_ENV
-          echo "MESA_GLSL_VERSION_OVERRIDE=330" >> $GITHUB_ENV
+          echo "VTK_GLSL_VERSION=130" >> $GITHUB_ENV
+          echo "VTK_GL_VERSION=3.0" >> $GITHUB_ENV
           echo "LIBGL_ALWAYS_SOFTWARE=1" >> $GITHUB_ENV
           echo "GALLIUM_DRIVER=softpipe" >> $GITHUB_ENV
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -3,6 +3,7 @@ name: Example script & notebook tests
 on:
   schedule:
     - cron: '0 8 * * *' # run at 8 AM UTC (12 am PST)
+  push:
 
 jobs:
   examples:
@@ -53,6 +54,12 @@ jobs:
           $ErrorActionPreference = "Stop"
           $PSDefaultParameterValues['*:ErrorAction']='Stop'
           powershell .github/install_opengl.ps1
+
+      - name: Set software rendering environment for Windows
+        if: runner.os == 'Windows'
+        run: |
+          echo "PYVISTA_OFF_SCREEN=true" >> $GITHUB_ENV
+          echo "PYVISTA_USE_PANEL=false" >> $GITHUB_ENV
 
       - name: Install Modflow-related executables
         uses: modflowpy/install-modflow-action@v1

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -125,7 +125,7 @@ jobs:
           Set-StrictMode -Version Latest
           $ErrorActionPreference = "Stop"
           $PSDefaultParameterValues['*:ErrorAction']='Stop'
-          powershell .github/install_opengl.ps1
+          powershell flopy/.github/install_opengl.ps1
 
       - name: Install Modflow-related executables
         uses: modflowpy/install-modflow-action@v1

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Setup Micromamba
         uses: mamba-org/setup-micromamba@v1
         with:
-          environment-file: etc/environment.yml
+          environment-file: flopy/etc/environment.yml
           cache-environment: true
           cache-downloads: true
           create-args: >-

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -86,6 +86,18 @@ jobs:
           echo $GITHUB_REF
           echo $GITHUB_EVENT_NAME
 
+      - name: Setup Micromamba
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: etc/environment.yml
+          cache-environment: true
+          cache-downloads: true
+          create-args: >-
+            python=3.12
+          init-shell: >-
+            bash
+            powershell
+
       - name: Install Python dependencies
         run: |
           pip install --upgrade pip

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -99,6 +99,7 @@ jobs:
             powershell
 
       - name: Install Python dependencies
+        working-directory: flopy
         run: |
           pip install --upgrade pip
           pip install .

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -71,6 +71,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.set_options.outputs.ref }}
+          path: flopy
+
+      - name: Checkout MODFLOW 6
+        uses: actions/checkout@v4
+        with:
+          repository: MODFLOW-ORG/modflow6
+          path: modflow6
 
       - name: Output repo information
         run: |
@@ -79,22 +86,11 @@ jobs:
           echo $GITHUB_REF
           echo $GITHUB_EVENT_NAME
 
-      - name: Setup Micromamba
-        uses: mamba-org/setup-micromamba@v1
-        with:
-          environment-file: etc/environment.yml
-          cache-environment: true
-          cache-downloads: true
-          create-args: >-
-            python=3.12
-          init-shell: >-
-            bash
-            powershell
-
       - name: Install Python dependencies
         run: |
           pip install --upgrade pip
           pip install .
+          pip install meson ninja
       
       - name: Workaround OpenGL issue on Linux
         if: runner.os == 'Linux'
@@ -122,11 +118,6 @@ jobs:
       - name: Install Modflow-related executables
         uses: modflowpy/install-modflow-action@v1
 
-      - name: Install Modflow dev build executables
-        uses: modflowpy/install-modflow-action@v1
-        with:
-          repo: modflow6-nightly-build
-
       - name: Install triangle (macOS workaround)
         if: runner.os == 'macOS'
         uses: modflowpy/install-modflow-action@v1
@@ -135,8 +126,22 @@ jobs:
           ostag: mac
           subset: triangle
 
+      - name: Setup GNU Fortran
+        uses: fortran-lang/setup-fortran@v1
+        with:
+          compiler: gcc
+          version: 13
+
+      - name: Build MODFLOW 6
+        working-directory: modflow6
+        run: |
+          meson setup builddir --buildtype=debugoptimized --prefix=$(pwd) --libdir=bin
+          meson install -C builddir
+          meson test --verbose --no-rebuild -C builddir
+          echo "$(pwd)/bin" >> $GITHUB_PATH
+
       - name: Run tutorial and example notebooks
-        working-directory: autotest
+        working-directory: flopy/autotest
         run: |
           filters=""
           if [[ ${{ runner.os }} == "Windows" ]]; then
@@ -156,7 +161,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: notebooks-for-${{ needs.set_options.outputs.sha }}
-          path: .docs/Notebooks/*.ipynb
+          path: flopy/.docs/Notebooks/*.ipynb
 
   # trigger rtd if previous job was successful
   rtd:


### PR DESCRIPTION
Up to now we've been using the nightly build, better to get the absolute latest