### PR TITLE
ci: install netcdf4 in test environment

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -160,7 +160,7 @@ jobs:
         working-directory: modflow6
         run: |
           pixi run install
-          pixi run pip install coverage pytest-cov
+          pixi run pip install coverage pytest-cov netcdf4
 
       - name: Install FloPy
         working-directory: flopy

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -78,6 +78,10 @@ jobs:
         run: pytest -v test_example_notebooks.py -n=auto -s --durations=0 --keep-failed=.failed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VTK_OPENGL_FORCE_CORE_PROFILE: "0"
+          VTK_SHADER_CACHE_PATH: ""
+          MESA_GL_VERSION_OVERRIDE: "3.0"
+          MESA_GLSL_VERSION_OVERRIDE: "130"
 
       - name: Upload failed test outputs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -78,10 +78,6 @@ jobs:
         run: pytest -v test_example_notebooks.py -n=auto -s --durations=0 --keep-failed=.failed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VTK_OPENGL_FORCE_CORE_PROFILE: "0"
-          VTK_SHADER_CACHE_PATH: ""
-          MESA_GL_VERSION_OVERRIDE: "3.0"
-          MESA_GLSL_VERSION_OVERRIDE: "130"
 
       - name: Upload failed test outputs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -146,10 +146,13 @@ jobs:
 
       - name: Run tutorial and example notebooks
         working-directory: flopy/autotest
-        run: pytest -v -n auto test_example_notebooks.py -k "$filters"
-        env:
-          MESA_GL_VERSION_OVERRIDE: "3.2"
-          MESA_GLSL_VERSION_OVERRIDE: "150"
+        run: |
+          filters=""
+          if [[ ${{ runner.os }} == "Windows" ]]; then
+            # TODO figure out VTK error: GLSL 1.50 is not supported. Supported versions are: 1.10, 1.20, 1.30, and 1.00 ES
+            filters="not vtk_pathlines"
+          fi
+          pytest -v -n auto test_example_notebooks.py -k "$filters"
 
       - name: Upload notebooks artifact for ReadtheDocs
         if: |

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -119,17 +119,6 @@ jobs:
           sudo apt-get install ttf-mscorefonts-installer fonts-liberation
           sudo rm -rf ~/.cache/matplotlib
 
-      - name: Install OpenGL on Windows
-        if: runner.os == 'Windows'
-        shell: cmd
-        run: |
-          curl.exe -L --output mesa.7z --url https://github.com/pal1000/mesa-dist-win/releases/download/24.3.4/mesa3d-24.3.4-release-msvc.7z
-          "C:\Program Files\7-Zip\7z.exe" x mesa.7z
-          copy x64\opengl32.dll x64\mesa_opengl32.dll
-          echo "MESA_GL_VERSION_OVERRIDE=3.3" >> %GITHUB_ENV%
-          echo "GALLIUM_DRIVER=llvmpipe" >> %GITHUB_ENV%
-          echo "%GITHUB_WORKSPACE%\x64" >> %GITHUB_PATH%
-
       - name: Install Modflow-related executables
         uses: modflowpy/install-modflow-action@v1
 
@@ -158,16 +147,13 @@ jobs:
       - name: Run tutorial and example notebooks
         if: runner.os != 'Windows'
         working-directory: flopy/autotest
-        run: pytest -v -n auto test_example_notebooks.py
-
-      - name: Run tutorial and example notebooks
-        if: runner.os == 'Windows'
-        working-directory: flopy/autotest
-        run: pytest -v -n auto test_example_notebooks.py
-        env:
-          VTK_USE_OSMESA: "1"
-          PYVISTA_OFF_SCREEN: "true"
-          PYVISTA_USE_PANEL: "false"
+        run: |
+          filters=""
+          if [[ ${{ runner.os }} == "Windows" ]]; then
+            # TODO figure out VTK error: GLSL 1.50 is not supported. Supported versions are: 1.10, 1.20, 1.30, and 1.00 ES
+            filters="not vtk_pathlines"
+          fi
+          pytest -v -n auto test_example_notebooks.py -k "$filters"
 
       - name: Upload notebooks artifact for ReadtheDocs
         if: |

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -118,15 +118,17 @@ jobs:
           echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
           sudo apt-get install ttf-mscorefonts-installer fonts-liberation
           sudo rm -rf ~/.cache/matplotlib
-      
+
       - name: Install OpenGL on Windows
         if: runner.os == 'Windows'
-        shell: pwsh
+        shell: cmd
         run: |
-          Set-StrictMode -Version Latest
-          $ErrorActionPreference = "Stop"
-          $PSDefaultParameterValues['*:ErrorAction']='Stop'
-          powershell flopy/.github/install_opengl.ps1
+          curl.exe -L --output mesa.7z --url https://github.com/pal1000/mesa-dist-win/releases/download/25.1.6/mesa3d-25.1.6-release-msvc.7z
+          "C:\Program Files\7-Zip\7z.exe" x mesa.7z
+          copy x64\opengl32.dll x64\mesa_opengl32.dll
+          echo "MESA_GL_VERSION_OVERRIDE=3.3" >> %GITHUB_ENV%
+          echo "GALLIUM_DRIVER=llvmpipe" >> %GITHUB_ENV%
+          echo "%GITHUB_WORKSPACE%\x64" >> %GITHUB_PATH%
 
       - name: Install Modflow-related executables
         uses: modflowpy/install-modflow-action@v1
@@ -154,14 +156,18 @@ jobs:
           echo "$(pwd)/bin" >> $GITHUB_PATH
 
       - name: Run tutorial and example notebooks
+        if: runner.os != 'Windows'
         working-directory: flopy/autotest
-        run: |
-          filters=""
-          if [[ ${{ runner.os }} == "Windows" ]]; then
-            # TODO figure out VTK error: GLSL 1.50 is not supported. Supported versions are: 1.10, 1.20, 1.30, and 1.00 ES
-            filters="not vtk_pathlines"
-          fi
-          pytest -v -n auto test_example_notebooks.py -k "$filters"
+        run: pytest -v -n auto test_example_notebooks.py
+
+      - name: Run tutorial and example notebooks
+        if: runner.os == 'Windows'
+        working-directory: flopy/autotest
+        run: pytest -v -n auto test_example_notebooks.py
+        env:
+          VTK_USE_OSMESA: "1"
+          PYVISTA_OFF_SCREEN: "true"
+          PYVISTA_USE_PANEL: "false"
 
       - name: Upload notebooks artifact for ReadtheDocs
         if: |

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -123,7 +123,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: cmd
         run: |
-          curl.exe -L --output mesa.7z --url https://github.com/pal1000/mesa-dist-win/releases/download/25.1.6/mesa3d-25.1.6-release-msvc.7z
+          curl.exe -L --output mesa.7z --url https://github.com/pal1000/mesa-dist-win/releases/download/24.3.4/mesa3d-24.3.4-release-msvc.7z
           "C:\Program Files\7-Zip\7z.exe" x mesa.7z
           copy x64\opengl32.dll x64\mesa_opengl32.dll
           echo "MESA_GL_VERSION_OVERRIDE=3.3" >> %GITHUB_ENV%

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -145,15 +145,11 @@ jobs:
           echo "$(pwd)/bin" >> $GITHUB_PATH
 
       - name: Run tutorial and example notebooks
-        if: runner.os != 'Windows'
         working-directory: flopy/autotest
-        run: |
-          filters=""
-          if [[ ${{ runner.os }} == "Windows" ]]; then
-            # TODO figure out VTK error: GLSL 1.50 is not supported. Supported versions are: 1.10, 1.20, 1.30, and 1.00 ES
-            filters="not vtk_pathlines"
-          fi
-          pytest -v -n auto test_example_notebooks.py -k "$filters"
+        run: pytest -v -n auto test_example_notebooks.py -k "$filters"
+        env:
+          MESA_GL_VERSION_OVERRIDE: "3.2"
+          MESA_GLSL_VERSION_OVERRIDE: "150"
 
       - name: Upload notebooks artifact for ReadtheDocs
         if: |


### PR DESCRIPTION
After flailing for a while to try and install an alternative OpenGL to fix the GLSL version error on Windows / PyVista / VTK, admit defeat for now and just fix an unrelated issue: lack of netcdf4 in the testing environment in `commit.yml` (since we use mf6's pixi env to build mf6 and run the tests)