### PR TITLE
ci: use pyvista/setup-headless-display-action

### DIFF
--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -136,6 +136,9 @@ jobs:
           compiler: gcc
           version: 13
 
+      - name: Set up headless display
+        uses: pyvista/setup-headless-display-action@v4
+
       - name: Build MODFLOW 6
         working-directory: modflow6
         run: |
@@ -146,13 +149,7 @@ jobs:
 
       - name: Run tutorial and example notebooks
         working-directory: flopy/autotest
-        run: |
-          filters=""
-          if [[ ${{ runner.os }} == "Windows" ]]; then
-            # TODO figure out VTK error: GLSL 1.50 is not supported. Supported versions are: 1.10, 1.20, 1.30, and 1.00 ES
-            filters="not vtk_pathlines"
-          fi
-          pytest -v -n auto test_example_notebooks.py -k "$filters"
+        run: pytest -v -n auto test_example_notebooks.py
 
       - name: Upload notebooks artifact for ReadtheDocs
         if: |


### PR DESCRIPTION
avoid longstanding opengl errors from `vtk_pathlines_example.py` notebook on windows