### PR TITLE
fix(examples): fix modflow boundaries example name

### DIFF
--- a/.docs/Notebooks/mf_boundaries_example.py
+++ b/.docs/Notebooks/mf_boundaries_example.py
@@ -14,7 +14,7 @@
 #     section: mf2005
 # ---
 
-# # Lake Package Example
+# # MODFLOW Boundaries Example
 #
 # First set the path and import the required packages. The flopy path doesn't have to be set if you install flopy from a binary installer. If you want to run this notebook, you have to set the path to your own flopy path.
 


### PR DESCRIPTION
thanks @kerrybardot for pointing out, looks like I did this by accident https://github.com/modflowpy/flopy/commits/1545f6334d6c045856b691a4732a7ae5ba034fad/examples/Notebooks/flopy3_modflow_boundaries.ipynb?browsing_rename_history=true&new_path=.docs/Notebooks/flopy3_lake_example.ipynb&original_branch=0c6e2f797e374d64c60b25cdd73fdfd05d711094