### PR TITLE
update(optimize_splitting_mask): add `active_only` flag

### DIFF
--- a/autotest/test_model_splitter.py
+++ b/autotest/test_model_splitter.py
@@ -221,6 +221,7 @@ def test_metis_splitting_with_lak_sfr(function_tmpdir):
 @requires_exe("mf6")
 @requires_pkg("pymetis")
 @requires_pkg("h5py")
+@requires_pkg("scipy")
 def test_save_load_node_mapping_structured(function_tmpdir):
     sim_path = get_example_data_path() / "mf6-freyberg"
     new_sim_path = function_tmpdir / "mf6-freyberg/split_model"
@@ -235,7 +236,7 @@ def test_save_load_node_mapping_structured(function_tmpdir):
     original_heads = sim.get_model().output.head().get_alldata()[-1]
 
     mfsplit = Mf6Splitter(sim)
-    array = mfsplit.optimize_splitting_mask(nparts=nparts)
+    array = mfsplit.optimize_splitting_mask(nparts=nparts, active_only=True)
     new_sim = mfsplit.split_model(array)
     new_sim.set_sim_path(new_sim_path)
     new_sim.write_simulation()

--- a/autotest/test_model_splitter.py
+++ b/autotest/test_model_splitter.py
@@ -223,6 +223,7 @@ def test_metis_splitting_with_lak_sfr(function_tmpdir):
 @requires_pkg("h5py")
 @requires_pkg("scipy")
 def test_save_load_node_mapping_structured(function_tmpdir):
+    import pymetis
     sim_path = get_example_data_path() / "mf6-freyberg"
     new_sim_path = function_tmpdir / "mf6-freyberg/split_model"
     hdf_file = new_sim_path / "node_map.hdf5"
@@ -236,7 +237,9 @@ def test_save_load_node_mapping_structured(function_tmpdir):
     original_heads = sim.get_model().output.head().get_alldata()[-1]
 
     mfsplit = Mf6Splitter(sim)
-    array = mfsplit.optimize_splitting_mask(nparts=nparts, active_only=True)
+    array = mfsplit.optimize_splitting_mask(
+        nparts=nparts, active_only=True, options=pymetis.Options(seed=42, contig=1)
+    )
     new_sim = mfsplit.split_model(array)
     new_sim.set_sim_path(new_sim_path)
     new_sim.write_simulation()

--- a/autotest/test_model_splitter.py
+++ b/autotest/test_model_splitter.py
@@ -224,6 +224,7 @@ def test_metis_splitting_with_lak_sfr(function_tmpdir):
 @requires_pkg("scipy")
 def test_save_load_node_mapping_structured(function_tmpdir):
     import pymetis
+
     sim_path = get_example_data_path() / "mf6-freyberg"
     new_sim_path = function_tmpdir / "mf6-freyberg/split_model"
     hdf_file = new_sim_path / "node_map.hdf5"

--- a/autotest/test_model_splitter.py
+++ b/autotest/test_model_splitter.py
@@ -221,7 +221,7 @@ def test_metis_splitting_with_lak_sfr(function_tmpdir):
 @requires_exe("mf6")
 @requires_pkg("pymetis")
 @requires_pkg("h5py")
-@requires_pkg("scipy")
+# @requires_pkg("sklearn")
 def test_save_load_node_mapping_structured(function_tmpdir):
     import pymetis
 

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -64,3 +64,4 @@ dependencies:
   - vtk
   - xmipy
   - h5py
+  - scikit-learn

--- a/flopy/discretization/grid.py
+++ b/flopy/discretization/grid.py
@@ -647,7 +647,7 @@ class Grid:
         ----------
         reset : bool
             flag to recalculate neighbors
-        method: str
+        method : str
             "rook" for shared edges and "queen" for shared vertex
 
         Returns
@@ -721,6 +721,7 @@ class Grid:
         """
         method = kwargs.pop("method", None)
         reset = kwargs.pop("reset", False)
+
         if method is None:
             self._set_neighbors(reset=reset)
         else:

--- a/flopy/discretization/grid.py
+++ b/flopy/discretization/grid.py
@@ -744,6 +744,32 @@ class Grid:
 
         return self._neighbors
 
+    def get_shared_edge(self, node0, node1, iverts=True):
+        """
+        Method to get the shared iverts or vertices between two cells. The shared
+        edge defines the shared cell face.
+
+        Parameters
+        ----------
+        node0 : int
+        node1 : int
+        iverts : bool
+            boolean flag to return shared iverts (True) or shared vertices (False)
+
+        Returns
+        -------
+            tuple : iverts or vertices that define the shared face
+        """
+        iv0 = set(self.iverts[node0])
+        iv1 = set(self.iverts[node1])
+        shared = tuple(iv0 & iv1)
+
+        if iverts:
+            return tuple(shared)
+        else:
+            verts = [self.verts[shared[0]], self.verts[shared[1]]]
+            return tuple(verts)
+
     def remove_confining_beds(self, array):
         """
         Method to remove confining bed layers from an array

--- a/flopy/discretization/structuredgrid.py
+++ b/flopy/discretization/structuredgrid.py
@@ -883,6 +883,7 @@ class StructuredGrid(Grid):
         dict
         """
         from collections import defaultdict
+
         if self._neighbors is None or kwargs.pop("reset", False):
             nrow = self.nrow
             ncol = self.ncol
@@ -894,10 +895,10 @@ class StructuredGrid(Grid):
             # general case
             arr2 = arr[1:-1, 1:-1].ravel()
             neighs2 = np.empty((4, (nrow - 2) * (ncol - 2)), dtype=np.int32)
-            neighs2[0] = arr2 - ncol # u
-            neighs2[1] = arr2 + 1 # r
-            neighs2[2] = arr2 + ncol # d
-            neighs2[3] = arr2 - 1 # l
+            neighs2[0] = arr2 - ncol  # u
+            neighs2[1] = arr2 + 1  # r
+            neighs2[2] = arr2 + ncol  # d
+            neighs2[3] = arr2 - 1  # l
             neighs2 = neighs2.T.tolist()
             neighbors = {v: neighs2[ix] for ix, v in enumerate(arr2)}
 
@@ -905,32 +906,32 @@ class StructuredGrid(Grid):
             arr2 = arr[0, 1:-1].ravel()
             neighs2 = np.empty((3, ncol - 2), dtype=np.int32)
             # no up
-            neighs2[0] = arr2 + 1 # r
-            neighs2[1] = arr2 + ncol # d
-            neighs2[2] = arr2 - 1 # l
+            neighs2[0] = arr2 + 1  # r
+            neighs2[1] = arr2 + ncol  # d
+            neighs2[2] = arr2 - 1  # l
             neighs2 = neighs2.T.tolist()
 
             for ix, v in enumerate(arr2):
                 neighbors[v] = neighs2[ix]
 
             # ecase 2
-            arr2 = arr[-1, 1: -1].ravel()
+            arr2 = arr[-1, 1:-1].ravel()
             neighs2 = np.empty((3, ncol - 2), dtype=np.int32)
             neighs2[0] = arr2 - ncol  # u
-            neighs2[1] = arr2 + 1 # r
+            neighs2[1] = arr2 + 1  # r
             # no down
-            neighs2[2] = arr2 - 1 # l
+            neighs2[2] = arr2 - 1  # l
             neighs2 = neighs2.T.tolist()
 
             for ix, v in enumerate(arr2):
                 neighbors[v] = neighs2[ix]
 
             # ecase 3
-            arr2 = arr[1: -1, 0].ravel()
+            arr2 = arr[1:-1, 0].ravel()
             neighs2 = np.empty((3, nrow - 2), dtype=np.int32)
-            neighs2[0] = arr2 - ncol # u
-            neighs2[1] = arr2 + 1 # r
-            neighs2[2] = arr2 + ncol # d
+            neighs2[0] = arr2 - ncol  # u
+            neighs2[1] = arr2 + 1  # r
+            neighs2[2] = arr2 + ncol  # d
             # no left
             neighs2 = neighs2.T.tolist()
 
@@ -938,12 +939,12 @@ class StructuredGrid(Grid):
                 neighbors[v] = neighs2[ix]
 
             # ecase 4
-            arr2 = arr[1: -1, -1].ravel()
+            arr2 = arr[1:-1, -1].ravel()
             neighs2 = np.empty((3, nrow - 2), dtype=np.int32)
             neighs2[0] = arr2 - ncol  # u
             # no right
-            neighs2[1] = arr2 + ncol # d
-            neighs2[2] = arr2 - 1 # l
+            neighs2[1] = arr2 + ncol  # d
+            neighs2[2] = arr2 - 1  # l
 
             neighs2 = neighs2.T.tolist()
 
@@ -953,10 +954,10 @@ class StructuredGrid(Grid):
             del arr
 
             # corners
-            neighbors[0] = [1, ncol] # r, d
-            neighbors[ncol - 1] = [(ncol - 1) + ncol, ncol - 2] # d, l
-            neighbors[ncpl - ncol] = [(ncpl - ncol) - ncol, (ncpl - ncol) + 1] # u, r
-            neighbors[ncpl - 1] = [(ncpl - 1) - ncol, ncpl - 2] # u, l
+            neighbors[0] = [1, ncol]  # r, d
+            neighbors[ncol - 1] = [(ncol - 1) + ncol, ncol - 2]  # d, l
+            neighbors[ncpl - ncol] = [(ncpl - ncol) - ncol, (ncpl - ncol) + 1]  # u, r
+            neighbors[ncpl - 1] = [(ncpl - 1) - ncol, ncpl - 2]  # u, l
 
             self._neighbors = neighbors
 

--- a/flopy/discretization/structuredgrid.py
+++ b/flopy/discretization/structuredgrid.py
@@ -834,6 +834,7 @@ class StructuredGrid(Grid):
         """
         nn = None
         as_nodes = kwargs.pop("as_nodes", False)
+        memhog = kwargs.pop("fast", False)
 
         if kwargs:
             if "node" in kwargs:
@@ -863,11 +864,103 @@ class StructuredGrid(Grid):
         else:
             as_nodes = True
 
-        neighbors = super().neighbors(nn, **kwargs)
-        if not as_nodes:
-            neighbors = self.get_lrc(neighbors)
+        if memhog:
+            neighbors = self._fast_neighbors(**kwargs)
+        else:
+            neighbors = super().neighbors(nn, **kwargs)
+            if not as_nodes:
+                neighbors = self.get_lrc(neighbors)
 
         return neighbors
+
+    def _fast_neighbors(self, **kwargs):
+        """
+        Memory intensive and not elegent in any sense, but very fast method to get
+        neighbors for Structured Grids
+
+        Returns
+        -------
+        dict
+        """
+        from collections import defaultdict
+        if self._neighbors is None or kwargs.pop("reset", False):
+            nrow = self.nrow
+            ncol = self.ncol
+
+            ncpl = nrow * ncol
+
+            arr = np.arange(ncpl, dtype=np.int32).reshape((nrow, ncol))
+
+            # general case
+            arr2 = arr[1:-1, 1:-1].ravel()
+            neighs2 = np.empty((4, (nrow - 2) * (ncol - 2)), dtype=np.int32)
+            neighs2[0] = arr2 - ncol # u
+            neighs2[1] = arr2 + 1 # r
+            neighs2[2] = arr2 + ncol # d
+            neighs2[3] = arr2 - 1 # l
+            neighs2 = neighs2.T.tolist()
+            neighbors = {v: neighs2[ix] for ix, v in enumerate(arr2)}
+
+            # ecase 1
+            arr2 = arr[0, 1:-1].ravel()
+            neighs2 = np.empty((3, ncol - 2), dtype=np.int32)
+            # no up
+            neighs2[0] = arr2 + 1 # r
+            neighs2[1] = arr2 + ncol # d
+            neighs2[2] = arr2 - 1 # l
+            neighs2 = neighs2.T.tolist()
+
+            for ix, v in enumerate(arr2):
+                neighbors[v] = neighs2[ix]
+
+            # ecase 2
+            arr2 = arr[-1, 1: -1].ravel()
+            neighs2 = np.empty((3, ncol - 2), dtype=np.int32)
+            neighs2[0] = arr2 - ncol  # u
+            neighs2[1] = arr2 + 1 # r
+            # no down
+            neighs2[2] = arr2 - 1 # l
+            neighs2 = neighs2.T.tolist()
+
+            for ix, v in enumerate(arr2):
+                neighbors[v] = neighs2[ix]
+
+            # ecase 3
+            arr2 = arr[1: -1, 0].ravel()
+            neighs2 = np.empty((3, nrow - 2), dtype=np.int32)
+            neighs2[0] = arr2 - ncol # u
+            neighs2[1] = arr2 + 1 # r
+            neighs2[2] = arr2 + ncol # d
+            # no left
+            neighs2 = neighs2.T.tolist()
+
+            for ix, v in enumerate(arr2):
+                neighbors[v] = neighs2[ix]
+
+            # ecase 4
+            arr2 = arr[1: -1, -1].ravel()
+            neighs2 = np.empty((3, nrow - 2), dtype=np.int32)
+            neighs2[0] = arr2 - ncol  # u
+            # no right
+            neighs2[1] = arr2 + ncol # d
+            neighs2[2] = arr2 - 1 # l
+
+            neighs2 = neighs2.T.tolist()
+
+            for ix, v in enumerate(arr2):
+                neighbors[v] = neighs2[ix]
+
+            del arr
+
+            # corners
+            neighbors[0] = [1, ncol] # r, d
+            neighbors[ncol - 1] = [(ncol - 1) + ncol, ncol - 2] # d, l
+            neighbors[ncpl - ncol] = [(ncpl - ncol) - ncol, (ncpl - ncol) + 1] # u, r
+            neighbors[ncpl - 1] = [(ncpl - 1) - ncol, ncpl - 2] # u, l
+
+            self._neighbors = neighbors
+
+        return self._neighbors
 
     def intersect(self, x, y, z=None, local=False, forgive=False):
         """
@@ -1681,11 +1774,15 @@ class StructuredGrid(Grid):
         pair for each vertex
 
         """
-        iverts = []
-        for i in range(self.nrow):
-            for j in range(self.ncol):
-                iverts.append(self._build_structured_iverts(i, j))
-        self._iverts = iverts
+        rowarr = np.repeat(np.arange(self.nrow, dtype=int), self.ncol)
+        colarr = np.tile(np.arange(self.ncol, dtype=int), self.nrow)
+
+        iverts = np.empty((4, self.ncpl), dtype=int)
+        iverts[0] = rowarr * (self.ncol + 1) + colarr
+        iverts[1] = rowarr * (self.ncol + 1) + colarr + 1
+        iverts[2] = (rowarr + 1) * (self.ncol + 1) + colarr + 1
+        iverts[3] = (rowarr + 1) * (self.ncol + 1) + colarr
+        self._iverts = iverts.T.tolist()
         return
 
     def _build_structured_iverts(self, i, j):

--- a/flopy/mf6/utils/model_splitter.py
+++ b/flopy/mf6/utils/model_splitter.py
@@ -613,7 +613,7 @@ class Mf6Splitter:
         nparts: int
             number of parts to split the model in to
         active_only : bool
-            only consider active cells when building adjancency graph. Default is False
+            only consider active cells when building adjacency graph. Default is False
 
         Returns
         -------

--- a/flopy/mf6/utils/model_splitter.py
+++ b/flopy/mf6/utils/model_splitter.py
@@ -602,7 +602,7 @@ class Mf6Splitter:
         mfs._allow_splitting = False
         return mfs
 
-    def optimize_splitting_mask(self, nparts, active_only=False):
+    def optimize_splitting_mask(self, nparts, active_only=False, options=None):
         """
         Method to create a splitting array with a balanced number of active
         cells per model. This method uses the program METIS and pymetis to
@@ -614,6 +614,10 @@ class Mf6Splitter:
             number of parts to split the model in to
         active_only : bool
             only consider active cells when building adjacency graph. Default is False
+        options : None or pymetis.Options
+            optional pymetis.Options class that gets passed through to the
+            pymetis.part_graph() function. Example
+            `options=pymetis.Options(seed=42, contig=1)`
 
         Returns
         -------
@@ -715,7 +719,7 @@ class Mf6Splitter:
             graph.append(np.array(neigh, dtype=int))
 
         n_cuts, membership = pymetis.part_graph(
-            nparts, adjacency=graph, vweights=weights
+            nparts, adjacency=graph, vweights=weights, options=options
         )
         membership = np.array(membership, dtype=int)
 

--- a/flopy/mf6/utils/model_splitter.py
+++ b/flopy/mf6/utils/model_splitter.py
@@ -3517,9 +3517,9 @@ class Mf6Splitter:
         paks = {}
         for mdl, data in mapped_data.items():
             _ = mapped_data.pop("maxbound", None)
-            if mapped_data[mdl]:
-                if "stress_period_data" in mapped_data[mdl]:
-                    if not mapped_data[mdl]["stress_period_data"]:
+            if data:
+                if "stress_period_data" in data:
+                    if not data["stress_period_data"]:
                         continue
                 paks[mdl] = pak_cls(
                     self._model_dict[mdl], pname=package.name[0], **data

--- a/flopy/mf6/utils/model_splitter.py
+++ b/flopy/mf6/utils/model_splitter.py
@@ -143,8 +143,12 @@ class Mf6Splitter:
         if self._model_type.endswith("6"):
             self._model_type = self._model_type[:-1]
         self._modelgrid = self._model.modelgrid
+        self._fast_neighbors = False
         if self._modelgrid.grid_type in ("structured", "vertex"):
             self._ncpl = self._modelgrid.ncpl
+            if self._modelgrid.grid_type == "structured":
+                if self._modelgrid.nrow > 2 and self._modelgrid.ncol > 2:
+                    self._fast_neighbors = True
         else:
             self._ncpl = self._modelgrid.nnodes
         self._shape = self._modelgrid.shape
@@ -159,7 +163,6 @@ class Mf6Splitter:
         self._uconnection = None
         self._usg_metadata = None
         self._has_angldegx = False
-        self._connection_ivert = None
         self._model_dict = None
         self._ivert_vert_remap = None
         self._sfr_mover_connections = []
@@ -229,7 +232,6 @@ class Mf6Splitter:
             self._uconnection = None
             self._usg_metadata = None
             self._has_angldegx = False
-            self._connection_ivert = None
             self._ivert_vert_remap = None
             self._sfr_mover_connections = []
             self._mover = False
@@ -602,7 +604,7 @@ class Mf6Splitter:
         mfs._allow_splitting = False
         return mfs
 
-    def optimize_splitting_mask(self, nparts, active_only=False, options=None):
+    def optimize_splitting_mask(self, nparts, active_only=False, options=None, verbose=False):
         """
         Method to create a splitting array with a balanced number of active
         cells per model. This method uses the program METIS and pymetis to
@@ -618,14 +620,15 @@ class Mf6Splitter:
             optional pymetis.Options class that gets passed through to the
             pymetis.part_graph() function. Example
             `options=pymetis.Options(seed=42, contig=1)`
-
+        verbose : bool
+            Default False. Prints progress statements if True
         Returns
         -------
             np.ndarray
         """
         if active_only:
-            import_optional_dependency("scipy")
-            from scipy.interpolate import griddata
+            import_optional_dependency("sklearn")
+            from sklearn.neighbors import NearestNeighbors
 
         pymetis = import_optional_dependency(
             "pymetis",
@@ -633,8 +636,6 @@ class Mf6Splitter:
             "conda install -c conda-forge pymetis",
         )
         # create graph of nodes
-        graph = []
-        weights = []
         nlay = self._modelgrid.nlay
         if self._modelgrid.grid_type in ("structured", "vertex"):
             ncpl = self._modelgrid.ncpl
@@ -690,52 +691,58 @@ class Mf6Splitter:
                     laks += [i for i in np.unique(lakenos)]
                 else:
                     adv_pkg_weights[nodes] += 1
-
-        # filter active cells here to avoid changes in the mapping algorithm
-        neighbors = self._modelgrid.neighbors(reset=True)
+        if verbose:
+            print("Mapping neighbors")
+        neighbors = self._modelgrid.neighbors(reset=True, fast=self._fast_neighbors)
 
         if active_only:
-            node_map = {}
+            if verbose:
+                print("Filtering inactive cells")
+            # filter out inactive cells here to avoid messing with neighbor algo.
             iact = np.where(np.sum(idomain, axis=0), 1, 0)
-            inactive = np.where(iact == 0)[0]
-            for k in inactive:
-                neighbors.pop(k)
+            # set this to a dict because key lookup is O(1) vs O(n) for lists
+            inactive = dict.fromkeys([int(i) for i in np.where(iact == 0)[0]])
+            # for k in inactive:
+            [neighbors.pop(k) for k in inactive]
+            node_map = {i: ix for ix, i in enumerate(np.where(iact > 0)[0])}
             neighbors = {
-                k : [i for i in v if i not in inactive] for k, v in neighbors.items()
+                k : [node_map[i] for i in v if i not in inactive] for k, v in neighbors.items()
             }
 
-            cnt = 0
-            for ix, isact in enumerate(iact):
-                if isact > 0:
-                    node_map[ix] = cnt
-                    cnt += 1
+        if verbose:
+            print("Creating graph and weights")
+        neighbors = dict(sorted(neighbors.items()))
+        weights = [np.count_nonzero(idomain[:, nn]) + adv_pkg_weights[nn] for nn in neighbors.keys()]
+        graph = [np.array(neigh, dtype=int) for neigh in neighbors.values()]
 
-        for nn, neigh in sorted(neighbors.items()):
-            weight = np.count_nonzero(idomain[:, nn])
-            adv_weight = adv_pkg_weights[nn]
-            weights.append(weight + adv_weight)
-            if active_only:
-                neigh = [node_map[n] for n in neigh]
-            graph.append(np.array(neigh, dtype=int))
-
+        if verbose:
+            print("Running Metis")
         n_cuts, membership = pymetis.part_graph(
             nparts, adjacency=graph, vweights=weights, options=options
         )
         membership = np.array(membership, dtype=int)
 
         if active_only:
+            # reamp everything to original domain
+            if verbose:
+                print("Remapping inactive to model domains")
             if len(inactive) > 0:
                 xc = self._modelgrid.xcellcenters.ravel()
                 yc = self._modelgrid.ycellcenters.ravel()
                 axc = xc[list(node_map.keys())]
                 ayc = yc[list(node_map.keys())]
-                ixc = xc[inactive]
-                iyc = yc[inactive]
-                data = griddata((axc, ayc), membership, (ixc, iyc), method="nearest")
+                fit_points = np.array(list(zip(axc, ayc)))
+                ixc = xc[list(inactive.keys())]
+                iyc = yc[list(inactive.keys())]
+                pred_points = np.array(list(zip(ixc, iyc)))
 
+                nn = NearestNeighbors(n_neighbors=1, algorithm="auto")
+                nn.fit(fit_points)
+                ind = nn.kneighbors(pred_points, return_distance=False).ravel()
+                data = membership[ind]
                 member_array = np.full((ncpl,), -1)
                 member_array[list(node_map.keys())] = membership[list(node_map.values())]
-                member_array[inactive] = data
+                member_array[list(inactive.keys())] = data
                 membership = member_array
 
         if laks:
@@ -991,9 +998,8 @@ class Mf6Splitter:
             self._map_iac_ja_connections()
         else:
             self._connection = self._modelgrid.neighbors(
-                reset=True, method="rook"
+                reset=True, method="rook", fast=self._fast_neighbors
             )
-            self._connection_ivert = self._modelgrid._edge_set
 
         grid_info = {}
         if self._modelgrid.grid_type == "structured":
@@ -1111,7 +1117,7 @@ class Mf6Splitter:
                             exchange_meta[mdl][nnode][cnnode] = [
                                 node,
                                 cnode,
-                                self._connection_ivert[node][ix],
+                                self._modelgrid.get_shared_edge(node, cnode)
                             ]
                         else:
                             exchange_meta[mdl][nnode][cnnode] = [
@@ -1130,7 +1136,7 @@ class Mf6Splitter:
                                 cnnode: [
                                     node,
                                     cnode,
-                                    self._connection_ivert[node][ix],
+                                    self._modelgrid.get_shared_edge(node, cnode)
                                 ]
                             }
                         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ optional = [
     "vtk >=9.4.0",
     "xmipy",
     "h5py",
+    "scikit-learn"
 ]
 doc = [
     "flopy[optional]",


### PR DESCRIPTION
* when True, the `active_only` flag creates an adjacency graph for metis that only includes active cells. Inactive cell membership is later assigned a model via nearest neighbor.
* fix layer count for UnstructuredGrid splitting in `optimize_splitting_mask` and `reconstruct_array`
* add `options` parameter to support `pymetis.Options` input

Closes #2576 