### PR TITLE
test: don't make test cases at collection time

### DIFF
--- a/autotest/test_binaryfile_reverse.py
+++ b/autotest/test_binaryfile_reverse.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, replace
+from functools import partial
 from itertools import repeat
-from pathlib import Path
 from pprint import pformat
 from typing import Literal, get_args
 
@@ -111,31 +111,30 @@ def disu_sim(case, ws) -> flopy.mf6.MFSimulation:
 
 
 def pytest_generate_tests(metafunc):
-    tmp_path_factory = metafunc.config._tmp_path_factory
     cases = []
-    sims = []
+    makes = []
     names = []
     if "case" in metafunc.fixturenames:
         for case in CASES:
             for dis_type in get_args(DisType):
                 name = f"{case.name}_{dis_type}"
                 case_ = replace(case, name=name)
-                ws = tmp_path_factory.mktemp(name)
                 if dis_type == "dis":
-                    sim = dis_sim(case_, ws)
+                    make = partial(dis_sim, case_)
                 elif dis_type == "disv":
-                    sim = disv_sim(case_, ws)
+                    make = partial(disv_sim, case_)
                 elif dis_type == "disu":
-                    sim = disu_sim(case_, ws)
+                    make = partial(disu_sim, case_)
                 cases.append(case_)
-                sims.append(sim)
+                makes.append(make)
                 names.append(name)
-        metafunc.parametrize("case, sim", zip(cases, sims), ids=names)
+        metafunc.parametrize("case, make_sim", zip(cases, makes), ids=names)
 
 
 @requires_exe("mf6")
 @requires_pkg("shapely")
-def test_reverse(case, sim):
+def test_reverse(case, make_sim, function_tmpdir):
+    sim = make_sim(function_tmpdir)
     gwf = sim.get_model(case.name)
     sim.write_simulation(silent=True)
     success, buff = sim.run_simulation(silent=True, report=True)

--- a/autotest/test_grid.py
+++ b/autotest/test_grid.py
@@ -1195,23 +1195,29 @@ def test_voronoi_vertex_grid(function_tmpdir):
 @requires_exe("triangle")
 @requires_pkg("shapely", "scipy")
 @pytest.mark.parametrize(
-    "grid_info",
-    (
-        [
-            GridCases.voronoi_polygon(),
-            GridCases.voronoi_rectangle(),
-            GridCases.voronoi_circle(),
-            GridCases.voronoi_nested_circles(),
-            GridCases.voronoi_polygons(),
-            GridCases.voronoi_many_polygons(),
-        ]
-        if (has_pkg("shapely", True) and has_pkg("scipy", True))
-        else []
-    ),
+    "grid_case",
+    [
+        GridCases.voronoi_polygon,
+        GridCases.voronoi_rectangle,
+        GridCases.voronoi_circle,
+        GridCases.voronoi_nested_circles,
+        GridCases.voronoi_polygons,
+        GridCases.voronoi_many_polygons,
+    ]
+    if (has_pkg("shapely", True) and has_pkg("scipy", True))
+    else [],
+    ids=[
+        "voronoi_polygon",
+        "voronoi_rectangle",
+        "voronoi_circle",
+        "voronoi_nested_circles",
+        "voronoi_polygons",
+        "voronoi_many_polygons",
+    ],
 )
-def test_voronoi_grid(request, function_tmpdir, grid_info):
+def test_voronoi_grid(request, function_tmpdir, grid_case):
     name = request.node.name.replace("/", "_").replace("\\", "_").replace(":", "_")
-    ncpl, vor, gridprops, grid = grid_info
+    ncpl, vor, gridprops, grid = grid_case()
 
     # TODO: debug off-by-3 issue
     #  could be a rounding error as described here:


### PR DESCRIPTION
Pytest parametrization was set up for a few tests such that collection triggered generation of test cases. This presents as a failure to find binaries needed to generate test models. As below if run directly from `autotest`

```
$ pytest --collect-only
...
ERROR test_binaryfile_reverse.py - OSError: [Errno 8] Exec format error: '/home/wes/dev/flopy/.venv/bin/gridgen'
ERROR test_grid.py - OSError: [Errno 8] Exec format error: '/home/wes/dev/flopy/.venv/bin/triangle'
ERROR test_shapefile_utils.py - OSError: [Errno 8] Exec format error: '/home/wes/dev/flopy/.venv/bin/triangle'
```

Or automatically by e.g. VSCode's test collection

```
[31mERROR[0m autotest/test_binaryfile_reverse.py - FileNotFoundError: The program gridgen does not exist or is not executable.
[31mERROR[0m autotest/test_grid.py - FileNotFoundError: The program triangle does not exist or is not executable.
[31mERROR[0m autotest/test_shapefile_utils.py - FileNotFoundError: The program triangle does not exist or is not executable.
!!!!!!!!!!!!!!!!!!! Interrupted: 3 errors during collection !!!!!!!!!!!!!!!!!!!!
[31m=================== [32m1279 tests collected[0m, [31m3 errors[0m[31m in 4.07s[0m[31m ====================[0m

2025-08-23 18:21:52.404 [error] Subprocess exited unsuccessfully with exit code 2 and signal null on workspace /home/wes/dev/flopy.
2025-08-23 18:21:52.404 [error] Subprocess exited unsuccessfully with exit code 2 and signal null on workspace /home/wes/dev/flopy. Creating and sending error discovery payload
2025-08-23 18:21:52.404 [error] pytest test discovery error for workspace:  /home/wes/dev/flopy 
```

Test cases (models/etc) should only be created when tests are run. At collection time only case names are needed.

This should make flopy play nice with VSCode and other IDEs' integrated test runners.