### PR TITLE
refactor: use PathLike and curdir concisely and consistently

### DIFF
--- a/.docs/Notebooks/groundwater2023_watershed_example.py
+++ b/.docs/Notebooks/groundwater2023_watershed_example.py
@@ -22,8 +22,8 @@
 #
 
 import os
-import pathlib as pl
 import sys
+from pathlib import Path
 
 import git
 import matplotlib as mpl
@@ -111,11 +111,11 @@ def set_idomain(grid, boundary):
 # Check if we are in the repository and define the data path.
 
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
 
-data_path = root / "examples" / "data" if root else pl.Path.cwd()
+data_path = root / "examples" / "data" if root else Path.cwd()
 folder_name = "groundwater2023"
 fname = "geometries.yml"
 pooch.retrieve(

--- a/.docs/Notebooks/mf6_support_example.py
+++ b/.docs/Notebooks/mf6_support_example.py
@@ -46,7 +46,7 @@
 # - `sim_ws`: `os.curdir` ('.')
 # - `sim_tdis_file`: 'modflow6.tdis'
 #
-# The `sim_ws` parameter accepts `str` or `os.PathLike` arguments.
+# The `sim_ws` parameter accepts `str` or `PathLike` arguments.
 
 # +
 import os
@@ -495,7 +495,7 @@ pth.mkdir(exist_ok=True)
 model.dis.export(pth / "dis.nc")
 
 # export the botm array to a shapefile
-model.dis.botm.export(str(pth / "botm.shp"))  # supports os.PathLike or str
+model.dis.botm.export(pth / "botm.shp")  # supports PathLike or str
 # -
 
 # ## Loading an Existing MF6 Simulation

--- a/flopy/discretization/grid.py
+++ b/flopy/discretization/grid.py
@@ -3,6 +3,7 @@ import os
 import re
 import warnings
 from collections import defaultdict
+from os import PathLike
 
 import numpy as np
 
@@ -70,7 +71,7 @@ class Grid:
         The value can be anything accepted by
         :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
         such as an authority string (eg "EPSG:26916") or a WKT string.
-    prjfile : str or pathlike, optional if `crs` is specified
+    prjfile : str or PathLike, optional if `crs` is specified
         ESRI-style projection file with well-known text defining the CRS
         for the model grid (must be projected; geographic CRS are not supported).
     xoff : float
@@ -87,7 +88,7 @@ class Grid:
         .. deprecated:: 3.5
            The following keyword options will be removed for FloPy 3.6:
 
-             - ``prj`` (str or pathlike): use ``prjfile`` instead.
+             - ``prj`` (str or PathLike): use ``prjfile`` instead.
              - ``epsg`` (int): use ``crs`` instead.
              - ``proj4`` (str): use ``crs`` instead.
 
@@ -381,7 +382,7 @@ class Grid:
         if prjfile is None:
             self._prjfile = None
             return
-        if not isinstance(prjfile, (str, os.PathLike)):
+        if not isinstance(prjfile, (str, PathLike)):
             raise ValueError("prjfile property must be str, PathLike or None")
         self._prjfile = prjfile
         # If crs was previously unset, use .prj file input
@@ -997,7 +998,7 @@ class Grid:
             The value can be anything accepted by
             :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
             such as an authority string (eg "EPSG:26916") or a WKT string.
-        prjfile : str or pathlike, optional
+        prjfile : str or PathLike, optional
             ESRI-style projection file with well-known text defining the CRS
             for the model grid (must be projected; geographic CRS are not
             supported).

--- a/flopy/discretization/structuredgrid.py
+++ b/flopy/discretization/structuredgrid.py
@@ -1,5 +1,6 @@
 import copy
 import os.path
+from os import PathLike
 from typing import Union
 
 import numpy as np
@@ -102,7 +103,7 @@ class StructuredGrid(Grid):
         The value can be anything accepted by
         :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
         such as an authority string (eg "EPSG:26916") or a WKT string.
-    prjfile : str or pathlike, optional if `crs` is specified
+    prjfile : str or PathLike, optional if `crs` is specified
         ESRI-style projection file with well-known text defining the CRS
         for the model grid (must be projected; geographic CRS are not supported).
     xoff : float
@@ -119,7 +120,7 @@ class StructuredGrid(Grid):
         .. deprecated:: 3.5
            The following keyword options will be removed for FloPy 3.6:
 
-             - ``prj`` (str or pathlike): use ``prjfile`` instead.
+             - ``prj`` (str or PathLike): use ``prjfile`` instead.
              - ``epsg`` (int): use ``crs`` instead.
              - ``proj4`` (str): use ``crs`` instead.
 
@@ -1779,7 +1780,7 @@ class StructuredGrid(Grid):
         )
 
     @classmethod
-    def from_gridspec(cls, file_path: Union[str, os.PathLike], lenuni=0):
+    def from_gridspec(cls, file_path: Union[str, PathLike], lenuni=0):
         """
         Instantiate a StructuredGrid from grid specification file.
 

--- a/flopy/discretization/unstructuredgrid.py
+++ b/flopy/discretization/unstructuredgrid.py
@@ -1,5 +1,6 @@
 import copy
 import os
+from os import PathLike
 from typing import Union
 
 import numpy as np
@@ -56,7 +57,7 @@ class UnstructuredGrid(Grid):
         The value can be anything accepted by
         :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
         such as an authority string (eg "EPSG:26916") or a WKT string.
-    prjfile : str or pathlike, optional if `crs` is specified
+    prjfile : str or PathLike, optional if `crs` is specified
         ESRI-style projection file with well-known text defining the CRS
         for the model grid (must be projected; geographic CRS are not supported).
         beneath the top layer.
@@ -78,7 +79,7 @@ class UnstructuredGrid(Grid):
         .. deprecated:: 3.5
            The following keyword options will be removed for FloPy 3.6:
 
-             - ``prj`` (str or pathlike): use ``prjfile`` instead.
+             - ``prj`` (str or PathLike): use ``prjfile`` instead.
              - ``epsg`` (int): use ``crs`` instead.
              - ``proj4`` (str): use ``crs`` instead.
 
@@ -1118,7 +1119,7 @@ class UnstructuredGrid(Grid):
             )
 
     @classmethod
-    def from_gridspec(cls, file_path: Union[str, os.PathLike]):
+    def from_gridspec(cls, file_path: Union[str, PathLike]):
         """
         Create an UnstructuredGrid from a grid specification file.
 

--- a/flopy/discretization/vertexgrid.py
+++ b/flopy/discretization/vertexgrid.py
@@ -32,7 +32,7 @@ class VertexGrid(Grid):
         The value can be anything accepted by
         :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
         such as an authority string (eg "EPSG:26916") or a WKT string.
-    prjfile : str or pathlike, optional if `crs` is specified
+    prjfile : str or PathLike, optional if `crs` is specified
         ESRI-style projection file with well-known text defining the CRS
         for the model grid (must be projected; geographic CRS are not supported).
     xoff : float
@@ -49,7 +49,7 @@ class VertexGrid(Grid):
         .. deprecated:: 3.5
            The following keyword options will be removed for FloPy 3.6:
 
-             - ``prj`` (str or pathlike): use ``prjfile`` instead.
+             - ``prj`` (str or PathLike): use ``prjfile`` instead.
              - ``epsg`` (int): use ``crs`` instead.
              - ``proj4`` (str): use ``crs`` instead.
 

--- a/flopy/export/netcdf.py
+++ b/flopy/export/netcdf.py
@@ -5,6 +5,7 @@ import platform
 import socket
 import time
 from datetime import datetime
+from os import PathLike
 from pathlib import Path
 from typing import Optional, Union
 
@@ -150,7 +151,7 @@ class NetCdf:
 
     def __init__(
         self,
-        output_filename: Union[str, os.PathLike],
+        output_filename: Union[str, PathLike],
         model,
         time_values=None,
         z_positive="up",
@@ -170,9 +171,9 @@ class NetCdf:
             self.logger = Logger(verbose)
         self.var_attr_dict = {}
         self.log = self.logger.log
-        if os.path.exists(output_filename):
+        if output_filename.exists():
             self.logger.warn(f"removing existing nc file: {output_filename}")
-            os.remove(output_filename)
+            output_filename.unlink()
         self.output_filename = output_filename
 
         self.forgive = bool(forgive)

--- a/flopy/export/shapefile_utils.py
+++ b/flopy/export/shapefile_utils.py
@@ -9,6 +9,7 @@ import os
 import shutil
 import sys
 import warnings
+from os import PathLike
 from pathlib import Path
 from typing import Optional, Union
 from warnings import warn
@@ -21,7 +22,7 @@ from ..utils import Util3d, flopy_io, import_optional_dependency
 from ..utils.crs import get_crs
 
 
-def write_gridlines_shapefile(filename: Union[str, os.PathLike], mg):
+def write_gridlines_shapefile(filename: Union[str, PathLike], mg):
     """
     Write a polyline shapefile of the grid lines - a lightweight alternative
     to polygons.
@@ -59,12 +60,12 @@ def write_gridlines_shapefile(filename: Union[str, os.PathLike], mg):
 
 
 def write_grid_shapefile(
-    path: Union[str, os.PathLike],
+    path: Union[str, PathLike],
     mg,
     array_dict,
     nan_val=np.nan,
     crs=None,
-    prjfile: Optional[Union[str, os.PathLike]] = None,
+    prjfile: Union[str, PathLike, None] = None,
     verbose=False,
     **kwargs,
 ):
@@ -87,7 +88,7 @@ def write_grid_shapefile(
         The value can be anything accepted by
         :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
         such as an authority string (eg "EPSG:26916") or a WKT string.
-    prjfile : str or pathlike, optional if `crs` is specified
+    prjfile : str or PathLike, optional if `crs` is specified
         ESRI-style projection file with well-known text defining the CRS
         for the model grid (must be projected; geographic CRS are not supported).
     **kwargs : dict, optional
@@ -224,7 +225,7 @@ def write_grid_shapefile(
 
 
 def model_attributes_to_shapefile(
-    path: Union[str, os.PathLike],
+    path: Union[str, PathLike],
     ml,
     package_names=None,
     array_dict=None,
@@ -259,7 +260,7 @@ def model_attributes_to_shapefile(
             The value can be anything accepted by
             :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
             such as an authority string (eg "EPSG:26916") or a WKT string.
-        prjfile : str or pathlike, optional if `crs` is specified
+        prjfile : str or PathLike, optional if `crs` is specified
             ESRI-style projection file with well-known text defining the CRS
             for the model grid (must be projected; geographic CRS are not supported).
 
@@ -535,7 +536,7 @@ def get_pyshp_field_dtypes(code):
     return dtypes.get(code, object)
 
 
-def shp2recarray(shpname: Union[str, os.PathLike]):
+def shp2recarray(shpname: Union[str, PathLike]):
     """Read a shapefile into a numpy recarray.
 
     Parameters
@@ -566,10 +567,10 @@ def shp2recarray(shpname: Union[str, os.PathLike]):
 def recarray2shp(
     recarray,
     geoms,
-    shpname: Union[str, os.PathLike] = "recarray.shp",
+    shpname: Union[str, PathLike] = "recarray.shp",
     mg=None,
     crs=None,
-    prjfile: Optional[Union[str, os.PathLike]] = None,
+    prjfile: Union[str, PathLike, None] = None,
     verbose=False,
     **kwargs,
 ):
@@ -599,7 +600,7 @@ def recarray2shp(
         The value can be anything accepted by
         :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
         such as an authority string (eg "EPSG:26916") or a WKT string.
-    prjfile : str or pathlike, optional if `crs` is specified
+    prjfile : str or PathLike, optional if `crs` is specified
         ESRI-style projection file with well-known text defining the CRS
         for the model grid (must be projected; geographic CRS are not supported).
     **kwargs : dict, optional

--- a/flopy/export/utils.py
+++ b/flopy/export/utils.py
@@ -1,5 +1,6 @@
 import os
 from itertools import repeat
+from os import PathLike
 from pathlib import Path
 from typing import Union
 
@@ -36,8 +37,8 @@ NC_PRECISION_TYPE = {
 
 
 def ensemble_helper(
-    inputs_filename: Union[str, os.PathLike],
-    outputs_filename: Union[str, os.PathLike],
+    inputs_filename: Union[str, PathLike],
+    outputs_filename: Union[str, PathLike],
     models,
     add_reals=True,
     **kwargs,
@@ -289,7 +290,7 @@ def _add_output_nc_zonebudget_variable(nc, array, var_name, flux, logger=None):
 
 
 def output_helper(
-    f: Union[str, os.PathLike, NetCdf, dict],
+    f: Union[str, PathLike, NetCdf, dict],
     ml,
     oudic,
     verbose=False,
@@ -400,7 +401,7 @@ def output_helper(
         elif verbose:
             print(msg)
     times = list(common_times[::stride])
-    if (isinstance(f, str) or isinstance(f, Path)) and Path(f).suffix.lower() == ".nc":
+    if isinstance(f, (str, PathLike)) and Path(f).suffix.lower() == ".nc":
         f = NetCdf(f, ml, time_values=times, logger=logger, forgive=forgive, **kwargs)
     elif isinstance(f, NetCdf):
         otimes = list(f.nc.variables["time"][:])
@@ -505,9 +506,7 @@ def output_helper(
                 mask_array3d=mask_array3d,
             )
 
-    elif (isinstance(f, str) or isinstance(f, Path)) and Path(
-        f
-    ).suffix.lower() == ".shp":
+    elif isinstance(f, (str, PathLike)) and Path(f).suffix.lower() == ".shp":
         attrib_dict = {}
         for _, out_obj in oudic.items():
             if (
@@ -568,7 +567,7 @@ def output_helper(
     return f
 
 
-def model_export(f: Union[str, os.PathLike, NetCdf, dict], ml, fmt=None, **kwargs):
+def model_export(f: Union[str, PathLike, NetCdf, dict], ml, fmt=None, **kwargs):
     """
     Method to export a model to a shapefile or netcdf file
 
@@ -591,7 +590,7 @@ def model_export(f: Union[str, os.PathLike, NetCdf, dict], ml, fmt=None, **kwarg
             The value can be anything accepted by
             :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
             such as an authority string (eg "EPSG:26916") or a WKT string.
-        prjfile : str or pathlike, optional if `crs` is specified
+        prjfile : str or PathLike, optional if `crs` is specified
             ESRI-style projection file with well-known text defining the CRS
             for the model grid (must be projected; geographic CRS are not supported).
         if fmt is set to 'vtk', parameters of Vtk initializer
@@ -602,10 +601,10 @@ def model_export(f: Union[str, os.PathLike, NetCdf, dict], ml, fmt=None, **kwarg
     if package_names is None:
         package_names = [pak.name[0] for pak in ml.packagelist]
 
-    if (isinstance(f, str) or isinstance(f, Path)) and Path(f).suffix.lower() == ".nc":
+    if isinstance(f, (str, PathLike)) and Path(f).suffix.lower() == ".nc":
         f = NetCdf(f, ml, **kwargs)
 
-    if (isinstance(f, str) or isinstance(f, Path)) and Path(f).suffix.lower() == ".shp":
+    if isinstance(f, (str, PathLike)) and Path(f).suffix.lower() == ".shp":
         shapefile_utils.model_attributes_to_shapefile(
             f, ml, package_names=package_names, **kwargs
         )
@@ -651,7 +650,7 @@ def model_export(f: Union[str, os.PathLike, NetCdf, dict], ml, fmt=None, **kwarg
 
 
 def package_export(
-    f: Union[str, os.PathLike, NetCdf, dict],
+    f: Union[str, PathLike, NetCdf, dict],
     pak,
     fmt=None,
     verbose=False,
@@ -679,7 +678,7 @@ def package_export(
             The value can be anything accepted by
             :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
             such as an authority string (eg "EPSG:26916") or a WKT string.
-        prjfile : str or pathlike, optional if `crs` is specified
+        prjfile : str or PathLike, optional if `crs` is specified
             ESRI-style projection file with well-known text defining the CRS
             for the model grid (must be projected; geographic CRS are not supported).
         if fmt is set to 'vtk', parameters of Vtk initializer
@@ -691,10 +690,10 @@ def package_export(
     """
     assert isinstance(pak, PackageInterface)
 
-    if (isinstance(f, str) or isinstance(f, Path)) and Path(f).suffix.lower() == ".nc":
+    if isinstance(f, (str, PathLike)) and Path(f).suffix.lower() == ".nc":
         f = NetCdf(f, pak.parent, **kwargs)
 
-    if (isinstance(f, str) or isinstance(f, Path)) and Path(f).suffix.lower() == ".shp":
+    if isinstance(f, (str, PathLike)) and Path(f).suffix.lower() == ".shp":
         shapefile_utils.model_attributes_to_shapefile(
             f, pak.parent, package_names=pak.name, verbose=verbose, **kwargs
         )
@@ -756,7 +755,7 @@ def package_export(
 
 
 def generic_array_export(
-    f: Union[str, os.PathLike],
+    f: Union[str, PathLike],
     array,
     var_name="generic_array",
     dimensions=("time", "layer", "y", "x"),
@@ -785,7 +784,7 @@ def generic_array_export(
             flopy model object
 
     """
-    if (isinstance(f, str) or isinstance(f, Path)) and Path(f).suffix.lower() == ".nc":
+    if isinstance(f, (str, PathLike)) and Path(f).suffix.lower() == ".nc":
         assert "model" in kwargs.keys(), (
             "creating a new netCDF using generic_array_helper requires a 'model' kwarg"
         )
@@ -833,7 +832,7 @@ def generic_array_export(
     return f
 
 
-def mflist_export(f: Union[str, os.PathLike, NetCdf], mfl, **kwargs):
+def mflist_export(f: Union[str, PathLike, NetCdf], mfl, **kwargs):
     """
     export helper for MfList instances
 
@@ -851,7 +850,7 @@ def mflist_export(f: Union[str, os.PathLike, NetCdf], mfl, **kwargs):
             The value can be anything accepted by
             :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
             such as an authority string (eg "EPSG:26916") or a WKT string.
-        prjfile : str or pathlike, optional if `crs` is specified
+        prjfile : str or PathLike, optional if `crs` is specified
             ESRI-style projection file with well-known text defining the CRS
             for the model grid (must be projected; geographic CRS are not supported).
 
@@ -864,10 +863,10 @@ def mflist_export(f: Union[str, os.PathLike, NetCdf], mfl, **kwargs):
     if "modelgrid" in kwargs:
         modelgrid = kwargs.pop("modelgrid")
 
-    if (isinstance(f, str) or isinstance(f, Path)) and Path(f).suffix.lower() == ".nc":
+    if isinstance(f, (str, PathLike)) and Path(f).suffix.lower() == ".nc":
         f = NetCdf(f, mfl.model, **kwargs)
 
-    if (isinstance(f, str) or isinstance(f, Path)) and Path(f).suffix.lower() == ".shp":
+    if isinstance(f, (str, PathLike)) and Path(f).suffix.lower() == ".shp":
         sparse = kwargs.get("sparse", False)
         kper = kwargs.get("kper", 0)
         squeeze = kwargs.get("squeeze", True)
@@ -1013,7 +1012,7 @@ def mflist_export(f: Union[str, os.PathLike, NetCdf], mfl, **kwargs):
         raise NotImplementedError(f"unrecognized export argument:{f}")
 
 
-def transient2d_export(f: Union[str, os.PathLike], t2d, fmt=None, **kwargs):
+def transient2d_export(f: Union[str, PathLike], t2d, fmt=None, **kwargs):
     """
     export helper for Transient2d instances
 
@@ -1044,10 +1043,10 @@ def transient2d_export(f: Union[str, os.PathLike], t2d, fmt=None, **kwargs):
     if "modelgrid" in kwargs:
         modelgrid = kwargs.pop("modelgrid")
 
-    if (isinstance(f, str) or isinstance(f, Path)) and Path(f).suffix.lower() == ".nc":
+    if isinstance(f, (str, PathLike)) and Path(f).suffix.lower() == ".nc":
         f = NetCdf(f, t2d.model, **kwargs)
 
-    if (isinstance(f, str) or isinstance(f, Path)) and Path(f).suffix.lower() == ".shp":
+    if isinstance(f, (str, PathLike)) and Path(f).suffix.lower() == ".shp":
         array_dict = {}
         for kper in range(t2d.model.modeltime.nper):
             u2d = t2d[kper]
@@ -1153,7 +1152,7 @@ def transient2d_export(f: Union[str, os.PathLike], t2d, fmt=None, **kwargs):
         raise NotImplementedError(f"unrecognized export argument:{f}")
 
 
-def array3d_export(f: Union[str, os.PathLike], u3d, fmt=None, **kwargs):
+def array3d_export(f: Union[str, PathLike], u3d, fmt=None, **kwargs):
     """
     export helper for Transient2d instances
 
@@ -1184,10 +1183,10 @@ def array3d_export(f: Union[str, os.PathLike], u3d, fmt=None, **kwargs):
     if "modelgrid" in kwargs:
         modelgrid = kwargs.pop("modelgrid")
 
-    if (isinstance(f, str) or isinstance(f, Path)) and Path(f).suffix.lower() == ".nc":
+    if isinstance(f, (str, PathLike)) and Path(f).suffix.lower() == ".nc":
         f = NetCdf(f, u3d.model, **kwargs)
 
-    if (isinstance(f, str) or isinstance(f, Path)) and Path(f).suffix.lower() == ".shp":
+    if isinstance(f, (str, PathLike)) and Path(f).suffix.lower() == ".shp":
         array_dict = {}
         array_shape = u3d.array.shape
 
@@ -1308,7 +1307,7 @@ def array3d_export(f: Union[str, os.PathLike], u3d, fmt=None, **kwargs):
         raise NotImplementedError(f"unrecognized export argument:{f}")
 
 
-def array2d_export(f: Union[str, os.PathLike], u2d, fmt=None, verbose=False, **kwargs):
+def array2d_export(f: Union[str, PathLike], u2d, fmt=None, verbose=False, **kwargs):
     """
     export helper for Util2d instances
 
@@ -1341,19 +1340,17 @@ def array2d_export(f: Union[str, os.PathLike], u2d, fmt=None, verbose=False, **k
     if "modelgrid" in kwargs:
         modelgrid = kwargs.pop("modelgrid")
 
-    if (isinstance(f, str) or isinstance(f, Path)) and Path(f).suffix.lower() == ".nc":
+    if isinstance(f, (str, PathLike)) and Path(f).suffix.lower() == ".nc":
         f = NetCdf(f, u2d.model, **kwargs)
 
-    if (isinstance(f, str) or isinstance(f, Path)) and Path(f).suffix.lower() == ".shp":
+    if isinstance(f, (str, PathLike)) and Path(f).suffix.lower() == ".shp":
         name = shapefile_utils.shape_attr_name(u2d.name, keep_layer=True)
         shapefile_utils.write_grid_shapefile(
             f, modelgrid, {name: u2d.array}, verbose=verbose
         )
         return
 
-    elif (isinstance(f, str) or isinstance(f, Path)) and Path(
-        f
-    ).suffix.lower() == ".asc":
+    elif isinstance(f, (str, PathLike)) and Path(f).suffix.lower() == ".asc":
         export_array(modelgrid, f, u2d.array, **kwargs)
         return
 
@@ -1453,7 +1450,7 @@ def array2d_export(f: Union[str, os.PathLike], u2d, fmt=None, verbose=False, **k
 
 def export_array(
     modelgrid,
-    filename: Union[str, os.PathLike],
+    filename: Union[str, PathLike],
     a,
     nodata=-9999,
     fieldname="value",
@@ -1614,7 +1611,7 @@ def export_array(
 
 
 def export_contours(
-    filename: Union[str, os.PathLike],
+    filename: Union[str, PathLike],
     contours,
     fieldname="level",
     verbose=False,
@@ -1841,7 +1838,7 @@ def export_contourf(filename, contours, fieldname="level", verbose=False, **kwar
 
 def export_array_contours(
     modelgrid,
-    filename: Union[str, os.PathLike],
+    filename: Union[str, PathLike],
     a,
     fieldname="level",
     interval=None,

--- a/flopy/export/vtk.py
+++ b/flopy/export/vtk.py
@@ -3,8 +3,8 @@ The vtk module provides functionality for exporting model inputs and
 outputs to VTK.
 """
 
-import os
 import warnings
+from os import PathLike
 from pathlib import Path
 from typing import Union
 
@@ -53,7 +53,7 @@ class Pvd:
 
         Parameters
         ----------
-        file : os.PathLike or str
+        file : PathLike or str
             vtu file name
         timevalue : float
             time step value in model time
@@ -73,7 +73,7 @@ class Pvd:
 
         Parameters
         ----------
-        f : os.PathLike or str
+        f : PathLike or str
             PVD file name
 
         """
@@ -666,7 +666,7 @@ class Vtk:
         ----------
         index : int, tuple
             integer representing kper or a tuple of (kstp, kper)
-        fname : os.PathLike or str
+        fname : PathLike or str
             path to the vtu file
 
         """
@@ -1367,7 +1367,7 @@ class Vtk:
             vtk_array.SetName(name)
             self.vtk_pathlines.GetPointData().AddArray(vtk_array)
 
-    def write(self, f: Union[str, os.PathLike], kper=None):
+    def write(self, f: Union[str, PathLike], kper=None):
         """
         Method to write a vtk file from the VTK object
 

--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -14,6 +14,7 @@ import sys
 import threading
 import warnings
 from datetime import datetime
+from os import PathLike, curdir
 from pathlib import Path
 from shutil import which
 from subprocess import PIPE, STDOUT, Popen
@@ -45,7 +46,7 @@ iprn = -1
 
 
 def resolve_exe(
-    exe_name: Union[str, os.PathLike], forgive: bool = False
+    exe_name: Union[str, PathLike], forgive: bool = False
 ) -> Union[str, None]:
     """
     Resolves the absolute path of the executable, raising FileNotFoundError
@@ -367,7 +368,7 @@ class BaseModel(ModelInterface):
     exe_name : str or PathLike, default "mf2005"
         Name or path of the modflow executable. If a name is provided,
         the executable must be on the system path.
-    model_ws : str or PathLike, optional, default "."
+    model_ws : str or PathLike, default "." (curdir)
         Path to the model workspace.  Model files will be created in this
         directory.  Default is the current working directory.
     structured : bool, default True
@@ -388,8 +389,8 @@ class BaseModel(ModelInterface):
         self,
         modelname="modflowtest",
         namefile_ext="nam",
-        exe_name: Union[str, os.PathLike] = "mf2005",
-        model_ws: Union[str, os.PathLike] = os.curdir,
+        exe_name: Union[str, PathLike] = "mf2005",
+        model_ws: Union[str, PathLike] = curdir,
         structured=True,
         verbose=False,
         **kwargs,
@@ -500,7 +501,7 @@ class BaseModel(ModelInterface):
         return self._model_ws
 
     @model_ws.setter
-    def model_ws(self, model_ws: Union[str, os.PathLike]):
+    def model_ws(self, model_ws: Union[str, PathLike]):
         self._model_ws = str(Path(model_ws).expanduser().absolute())
 
     @property
@@ -580,7 +581,7 @@ class BaseModel(ModelInterface):
         self._next_ext_unit += 1
         return next_unit
 
-    def export(self, f: Union[str, os.PathLike], **kwargs):
+    def export(self, f: Union[str, PathLike], **kwargs):
         """
         Method to export a model to netcdf or shapefile based on the
         extension of the file name (.shp for shapefile, .nc for netcdf)
@@ -762,7 +763,7 @@ class BaseModel(ModelInterface):
     def add_output_file(
         self,
         unit,
-        fname: Optional[Union[str, os.PathLike]] = None,
+        fname: Union[str, PathLike, None] = None,
         extension="cbc",
         binflag=True,
         package=None,
@@ -828,7 +829,7 @@ class BaseModel(ModelInterface):
             self.add_output(fname, unit, binflag=binflag, package=package)
 
     def add_output(
-        self, fname: Union[str, os.PathLike], unit, binflag=False, package=None
+        self, fname: Union[str, PathLike], unit, binflag=False, package=None
     ):
         """
         Assign an external array so that it will be listed as a DATA or
@@ -871,7 +872,7 @@ class BaseModel(ModelInterface):
         if self.verbose:
             self._output_msg(-1, add=True)
 
-    def remove_output(self, fname: Optional[Union[str, os.PathLike]] = None, unit=None):
+    def remove_output(self, fname: Union[str, PathLike, None] = None, unit=None):
         """
         Remove an output file from the model by specifying either the
         file name or the unit number.
@@ -906,7 +907,7 @@ class BaseModel(ModelInterface):
             msg = "either fname or unit must be passed to remove_output()"
             raise TypeError(msg)
 
-    def get_output(self, fname: Optional[Union[str, os.PathLike]] = None, unit=None):
+    def get_output(self, fname: Union[str, PathLike, None] = None, unit=None):
         """
         Get an output file from the model by specifying either the
         file name or the unit number.
@@ -935,7 +936,7 @@ class BaseModel(ModelInterface):
 
     def set_output_attribute(
         self,
-        fname: Optional[Union[str, os.PathLike]] = None,
+        fname: Union[str, PathLike, None] = None,
         unit=None,
         attr=None,
     ):
@@ -980,7 +981,7 @@ class BaseModel(ModelInterface):
 
     def get_output_attribute(
         self,
-        fname: Optional[Union[str, os.PathLike]] = None,
+        fname: Union[str, PathLike, None] = None,
         unit=None,
         attr=None,
     ):
@@ -1023,7 +1024,7 @@ class BaseModel(ModelInterface):
         return v
 
     def add_external(
-        self, fname: Union[str, os.PathLike], unit, binflag=False, output=False
+        self, fname: Union[str, PathLike], unit, binflag=False, output=False
     ):
         """
         Assign an external array so that it will be listed as a DATA or
@@ -1067,9 +1068,7 @@ class BaseModel(ModelInterface):
         self.external_binflag.append(binflag)
         self.external_output.append(output)
 
-    def remove_external(
-        self, fname: Optional[Union[str, os.PathLike]] = None, unit=None
-    ):
+    def remove_external(self, fname: Union[str, PathLike, None] = None, unit=None):
         """
         Remove an external file from the model by specifying either the
         file name or the unit number.
@@ -1105,7 +1104,7 @@ class BaseModel(ModelInterface):
 
     def add_existing_package(
         self,
-        filename: Union[str, os.PathLike],
+        filename: Union[str, PathLike],
         ptype=None,
         copy_to_model_ws=True,
     ):
@@ -1242,7 +1241,7 @@ class BaseModel(ModelInterface):
 
     def change_model_ws(
         self,
-        new_pth: Optional[Union[str, os.PathLike]] = os.curdir,
+        new_pth: Union[str, PathLike] = curdir,
         reset_external=False,
     ):
         """
@@ -1250,10 +1249,9 @@ class BaseModel(ModelInterface):
 
         Parameters
         ----------
-        new_pth : str or PathLike
+        new_pth : str or PathLike, default "." (curdir)
             Path of the new model workspace. If this path does not exist,
-            it will be created. If no value (None) is given, the default
-            is the present working directory.
+            it will be created. The default is the present working directory.
 
         Returns
         -------
@@ -1263,7 +1261,7 @@ class BaseModel(ModelInterface):
 
         """
         if new_pth is None:
-            new_pth = os.curdir
+            new_pth = curdir
         if not os.path.exists(new_pth):
             try:
                 print(
@@ -1497,7 +1495,7 @@ class BaseModel(ModelInterface):
 
     def check(
         self,
-        f: Optional[Union[str, os.PathLike]] = None,
+        f: Union[str, PathLike, None] = None,
         verbose=True,
         level=1,
     ):
@@ -1506,7 +1504,7 @@ class BaseModel(ModelInterface):
 
         Parameters
         ----------
-        f : str or PathLike, optional, default None
+        f : str or PathLike, optional
             String defining file name or file handle for summary file
             of check method output. If a string is passed a file handle
             is created. If f is None, check method does not write
@@ -1612,9 +1610,9 @@ class BaseModel(ModelInterface):
 
 
 def run_model(
-    exe_name: Union[str, os.PathLike],
+    exe_name: Union[str, PathLike],
     namefile: Optional[str],
-    model_ws: Union[str, os.PathLike] = os.curdir,
+    model_ws: Union[str, PathLike] = curdir,
     silent=False,
     pause=False,
     report=False,
@@ -1639,9 +1637,8 @@ def run_model(
     namefile : str, optional
         Name of the name file of model to run. The name may be None
         to run models that don't require a control file (name file)
-    model_ws : str or PathLike, optional, default '.'
-        Path to the parent directory of the namefile. (default is the
-        current working directory '.')
+    model_ws : str or PathLike, default "." (curdir)
+        Path to the parent directory of the namefile.
     silent : boolean, default True
         Whether to suppress model output. (Default is True)
     pause : boolean, optional, default False

--- a/flopy/mf6/mfbase.py
+++ b/flopy/mf6/mfbase.py
@@ -8,6 +8,7 @@ import traceback
 import warnings
 from collections.abc import Iterable
 from enum import Enum
+from os import PathLike, curdir
 from pathlib import Path
 from shutil import copyfile
 from typing import Union
@@ -191,19 +192,17 @@ class MFFileMgmt:
 
     Parameters
     ----------
-
     path : str or PathLike
         Path on disk to the simulation
 
     Attributes
     ----------
-
     model_relative_path : dict
         Dictionary of relative paths to each model folder
 
     """
 
-    def __init__(self, path: Union[str, os.PathLike], mfsim=None):
+    def __init__(self, path: Union[str, PathLike], mfsim=None):
         self.simulation = mfsim
         self._sim_path = ""
         self.set_sim_path(path, True)
@@ -285,7 +284,7 @@ class MFFileMgmt:
             model_rel_path is None
             or model_rel_path.is_absolute()
             or not any(str(model_rel_path))
-            or str(model_rel_path) == os.curdir
+            or str(model_rel_path) == curdir
         ):
             return path
 
@@ -374,7 +373,7 @@ class MFFileMgmt:
             new_file_path = MFFilePath(file_path, model_name)
             self.existing_file_dict[file_path] = new_file_path
 
-    def set_sim_path(self, path: Union[str, os.PathLike], internal_use=False):
+    def set_sim_path(self, path: Union[str, PathLike], internal_use=False):
         """
         Set the file path to the simulation files.  Internal use only,
         call MFSimulation's set_sim_path method instead.

--- a/flopy/mf6/mfmodel.py
+++ b/flopy/mf6/mfmodel.py
@@ -2,6 +2,7 @@ import inspect
 import os
 import sys
 import warnings
+from os import PathLike, curdir
 from typing import Optional, Union
 
 import numpy as np
@@ -868,9 +869,9 @@ class MFModel(ModelInterface):
         model_nam_file="modflowtest.nam",
         mtype="gwf",
         version="mf6",
-        exe_name: Union[str, os.PathLike] = "mf6",
+        exe_name: Union[str, PathLike] = "mf6",
         strict=True,
-        model_rel_path=os.curdir,
+        model_rel_path=curdir,
         load_only=None,
     ):
         """
@@ -890,11 +891,11 @@ class MFModel(ModelInterface):
             relative path to the model name file from model working folder
         version : str
             version of modflow
-        exe_name : str or PathLike
+        exe_name : str or PathLike, default "mf6"
             model executable name or path
         strict : bool
             strict mode when loading files
-        model_rel_path : str
+        model_rel_path : str, default "." (curdir)
             relative path of model folder to simulation folder
         load_only : list
             list of package abbreviations or package names corresponding to

--- a/flopy/mf6/mfpackage.py
+++ b/flopy/mf6/mfpackage.py
@@ -5,6 +5,7 @@ import inspect
 import os
 import sys
 import warnings
+from os import PathLike
 
 import numpy as np
 
@@ -1823,11 +1824,10 @@ class MFPackage(PackageInterface):
                 # filename uses model base name
                 self._filename = f"{self.model_or_sim.name}.{package_type}"
         else:
-            if not isinstance(filename, (str, os.PathLike)):
+            if not isinstance(filename, (str, PathLike)):
                 message = (
-                    "Invalid fname parameter. Expecting type str. "
-                    'Instead type "{}" was '
-                    "given.".format(type(filename))
+                    "Invalid fname parameter. Expecting type str or PathLike. "
+                    f'Instead type "{type(filename)}" was given.'
                 )
                 type_, value_, traceback_ = sys.exc_info()
                 raise MFDataException(

--- a/flopy/mf6/mfsimbase.py
+++ b/flopy/mf6/mfsimbase.py
@@ -1,8 +1,9 @@
 import errno
 import inspect
-import os.path
+import os
 import sys
 import warnings
+from os import PathLike, curdir
 from pathlib import Path
 from typing import Optional, Union, cast
 
@@ -238,7 +239,7 @@ class MFSimulationData:
 
     """
 
-    def __init__(self, path: Union[str, os.PathLike], mfsim):
+    def __init__(self, path: Union[str, PathLike], mfsim):
         # --- formatting variables ---
         self.indent_string = "  "
         self.constant_formatting = ["constant", ""]
@@ -462,8 +463,8 @@ class MFSimulationBase:
         self,
         sim_name="sim",
         version="mf6",
-        exe_name: Union[str, os.PathLike] = "mf6",
-        sim_ws: Union[str, os.PathLike] = os.curdir,
+        exe_name: Union[str, PathLike] = "mf6",
+        sim_ws: Union[str, PathLike] = curdir,
         verbosity_level=1,
         continue_=None,
         nocheck=None,
@@ -762,8 +763,8 @@ class MFSimulationBase:
         cls_child: type["MFSimulationBase"],
         sim_name="modflowsim",
         version="mf6",
-        exe_name: Union[str, os.PathLike] = "mf6",
-        sim_ws: Union[str, os.PathLike] = os.curdir,
+        exe_name: Union[str, PathLike] = "mf6",
+        sim_ws: Union[str, PathLike] = curdir,
         strict=True,
         verbosity_level=1,
         load_only=None,
@@ -1078,7 +1079,7 @@ class MFSimulationBase:
 
     def check(
         self,
-        f: Optional[Union[str, os.PathLike]] = None,
+        f: Union[str, PathLike, None] = None,
         verbose=True,
         level=1,
     ):
@@ -1095,7 +1096,7 @@ class MFSimulationBase:
         ----------
         f : str or PathLike, optional
             String defining file name or file handle for summary file
-            of check method output. If str or pathlike, a file handle
+            of check method output. If str or PathLike, a file handle
             is created. If None, the method does not write results to
             a summary file. (default is None)
         verbose : bool
@@ -1162,10 +1163,10 @@ class MFSimulationBase:
     def load_package(
         self,
         ftype,
-        fname: Union[str, os.PathLike],
+        fname: Union[str, PathLike],
         pname,
         strict,
-        ref_path: Union[str, os.PathLike],
+        ref_path: Union[str, PathLike],
         dict_package_name=None,
         parent_package: Optional[MFPackage] = None,
     ):
@@ -1742,7 +1743,7 @@ class MFSimulationBase:
         if silent:
             self.simulation_data.verbosity_level = saved_verb_lvl
 
-    def set_sim_path(self, path: Union[str, os.PathLike]):
+    def set_sim_path(self, path: Union[str, PathLike]):
         """Return a list of output data keys.
 
         Parameters
@@ -2633,7 +2634,7 @@ class MFSimulationBase:
 
     def plot(
         self,
-        model_list: Optional[Union[str, list[str]]] = None,
+        model_list: Union[str, list[str], None] = None,
         SelPackList=None,
         **kwargs,
     ):
@@ -2645,28 +2646,28 @@ class MFSimulationBase:
 
         Parameters
         ----------
-            model_list: list, optional
-                List of model names to plot, if none all models will be plotted
-            SelPackList: list, optional
-                List of package names to plot, if none all packages will be
-                plotted
-            kwargs:
-                filename_base : str
-                    Base file name that will be used to automatically
-                    generate file names for output image files. Plots will be
-                    exported as image files if file_name_base is not None.
-                    (default is None)
-                file_extension : str
-                    Valid matplotlib.pyplot file extension for savefig().
-                    Only used if filename_base is not None. (default is 'png')
-                mflay : int
-                    MODFLOW zero-based layer number to return.  If None, then
-                    all layers will be included. (default is None)
-                kper : int
-                    MODFLOW zero-based stress period number to return.
-                    (default is zero)
-                key : str
-                    MFList dictionary key. (default is None)
+        model_list : list, optional
+            List of model names to plot, if none all models will be plotted
+        SelPackList : list, optional
+            List of package names to plot, if none all packages will be
+            plotted
+        **kwargs : dict, optional
+            filename_base : str
+                Base file name that will be used to automatically
+                generate file names for output image files. Plots will be
+                exported as image files if file_name_base is not None.
+                (default is None)
+            file_extension : str
+                Valid matplotlib.pyplot file extension for savefig().
+                Only used if filename_base is not None. (default is 'png')
+            mflay : int
+                MODFLOW zero-based layer number to return.  If None, then
+                all layers will be included. (default is None)
+            kper : int
+                MODFLOW zero-based stress period number to return.
+                (default is zero)
+            key : str
+                MFList dictionary key. (default is None)
 
         Returns
         -------

--- a/flopy/mf6/utils/mfsimlistfile.py
+++ b/flopy/mf6/utils/mfsimlistfile.py
@@ -1,16 +1,16 @@
-import os
-import pathlib as pl
 import re
 import warnings
+from os import PathLike
+from pathlib import Path
 
 import numpy as np
 
 
 class MfSimulationList:
-    def __init__(self, file_name: os.PathLike):
+    def __init__(self, file_name: PathLike):
         # Set up file reading
         if isinstance(file_name, str):
-            file_name = pl.Path(file_name)
+            file_name = Path(file_name)
         if not file_name.is_file():
             raise FileNotFoundError(f"file_name `{file_name}` not found")
         self.file_name = file_name

--- a/flopy/mfusg/mfusg.py
+++ b/flopy/mfusg/mfusg.py
@@ -1,7 +1,8 @@
 """Mfusg module."""
 
-import os
+import os.path
 from inspect import getfullargspec
+from os import PathLike, curdir
 from typing import Union
 
 import flopy
@@ -16,7 +17,7 @@ class MfUsg(Modflow):
 
     Parameters
     ----------
-    modelname : str or PathLike, default "modflowusgtest".
+    modelname : str or PathLike, default "modflowusgtest"
         Name of model.  This string will be used to name the MODFLOW input
         that are created with write_model.
     namefile_ext : str, default "nam"
@@ -27,9 +28,8 @@ class MfUsg(Modflow):
         Specify if model grid is structured (default) or unstructured.
     listunit : int, default 2
         Unit number for the list file.
-    model_ws : str, default "."
+    model_ws : str, default "." (curdir)
         Model workspace.  Directory name to create model data sets.
-        Default is the present working directory.
     external_path : str, optional
         Location for external files.
     verbose : bool, default False
@@ -59,10 +59,10 @@ class MfUsg(Modflow):
         modelname="mfusgtest",
         namefile_ext="nam",
         version="mfusg",
-        exe_name: Union[str, os.PathLike] = "mfusg",
+        exe_name: Union[str, PathLike] = "mfusg",
         structured=True,
         listunit=2,
-        model_ws: Union[str, os.PathLike] = os.curdir,
+        model_ws: Union[str, PathLike] = curdir,
         external_path=None,
         verbose=False,
         **kwargs,
@@ -150,9 +150,9 @@ class MfUsg(Modflow):
         cls,
         f: str,
         version="mfusg",
-        exe_name: Union[str, os.PathLike] = "mfusg",
+        exe_name: Union[str, PathLike] = "mfusg",
         verbose=False,
-        model_ws: Union[str, os.PathLike] = os.curdir,
+        model_ws: Union[str, PathLike] = curdir,
         load_only=None,
         forgive=False,
         check=True,
@@ -169,7 +169,7 @@ class MfUsg(Modflow):
             MODFLOW executable name.
         verbose : bool, default False
             Show messages that can be useful for debugging.
-        model_ws : str or PathLike, default "."
+        model_ws : str or PathLike, default "." (curdir)
             Model workspace path. Default is the current directory.
         load_only : list, str or None
             List of case insensitive packages to load, e.g. ["bas6", "lpf"].

--- a/flopy/mfusg/mfusgdis.py
+++ b/flopy/mfusg/mfusgdis.py
@@ -94,7 +94,7 @@ class MfUsgDis(Package):
         The value can be anything accepted by
         :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
         such as an authority string (eg "EPSG:26916") or a WKT string.
-    prjfile : str or pathlike, optional if `crs` is specified
+    prjfile : str or PathLike, optional if `crs` is specified
         ESRI-style projection file with well-known text defining the CRS
         for the model grid (must be projected; geographic CRS are not supported).
     start_datetime : str

--- a/flopy/modflow/mf.py
+++ b/flopy/modflow/mf.py
@@ -7,6 +7,7 @@ mf module.  Contains the ModflowGlobal, ModflowList, and Modflow classes.
 import os
 import warnings
 from inspect import getfullargspec
+from os import PathLike, curdir
 from pathlib import Path
 from typing import Optional, Union
 
@@ -75,9 +76,8 @@ class Modflow(BaseModel):
         Specify if model grid is structured (default) or unstructured.
     listunit : int, default 2
         Unit number for the list file.
-    model_ws : str or PathLike, default "."
+    model_ws : str or PathLike, default "." (curdir)
         Model workspace.  Directory name to create model data sets.
-        (default is the present working directory).
     external_path : str or PathLike, optional
         Location for external files.
     verbose : bool, default False
@@ -110,11 +110,11 @@ class Modflow(BaseModel):
         modelname="modflowtest",
         namefile_ext="nam",
         version="mf2005",
-        exe_name: Union[str, os.PathLike] = "mf2005",
+        exe_name: Union[str, PathLike] = "mf2005",
         structured=True,
         listunit=2,
-        model_ws: Union[str, os.PathLike] = os.curdir,
-        external_path: Optional[Union[str, os.PathLike]] = None,
+        model_ws: Union[str, PathLike] = curdir,
+        external_path: Union[str, PathLike, None] = None,
         verbose=False,
         extra_pkgs: Optional[dict] = None,
         **kwargs,
@@ -629,9 +629,9 @@ class Modflow(BaseModel):
         cls,
         f: str,
         version="mf2005",
-        exe_name: Union[str, os.PathLike] = "mf2005",
+        exe_name: Union[str, PathLike] = "mf2005",
         verbose=False,
-        model_ws: Union[str, os.PathLike] = os.curdir,
+        model_ws: Union[str, PathLike] = curdir,
         load_only=None,
         forgive=False,
         check=True,
@@ -652,8 +652,8 @@ class Modflow(BaseModel):
             MODFLOW executable name or path.
         verbose : bool, default False
             Show messages that can be useful for debugging.
-        model_ws : str or PathLike, default "."
-            Model workspace path. Default is the current directory.
+        model_ws : str or PathLike, default "." (curdir)
+            Model workspace path.
         load_only : list, str or None
             List of case insensitive packages to load, e.g. ["bas6", "lpf"].
             One package can also be specified, e.g. "rch". Default is None,

--- a/flopy/modflow/mfdis.py
+++ b/flopy/modflow/mfdis.py
@@ -94,7 +94,7 @@ class ModflowDis(Package):
         The value can be anything accepted by
         :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
         such as an authority string (eg "EPSG:26916") or a WKT string.
-    prjfile : str or pathlike, optional if `crs` is specified
+    prjfile : str or PathLike, optional if `crs` is specified
         ESRI-style projection file with well-known text defining the CRS
         for the model grid (must be projected; geographic CRS are not supported).
     start_datetime : str

--- a/flopy/modflow/mfsfr2.py
+++ b/flopy/modflow/mfsfr2.py
@@ -3,6 +3,7 @@ __author__ = "aleaf"
 import copy
 import os
 import warnings
+from os import PathLike
 
 import numpy as np
 import pandas as pd
@@ -1012,7 +1013,7 @@ class ModflowSfr2(Package):
 
         Parameters
         ----------
-        f : str or file handle
+        f : str, PathLike or file handle
             String defining file name or file handle for summary file
             of check method output. If a string is passed a file handle
             is created. If f is None, check method does not write
@@ -1045,7 +1046,7 @@ class ModflowSfr2(Package):
         chk.slope()
 
         if f is not None:
-            if isinstance(f, str):
+            if isinstance(f, (str, PathLike)):
                 pth = os.path.join(self.parent.model_ws, f)
                 f = open(pth, "w")
             f.write(f"{chk.txt}\n")
@@ -1875,6 +1876,8 @@ class ModflowSfr2(Package):
         f_sfr.close()
 
     def export(self, f, **kwargs):
+        if isinstance(f, PathLike):
+            f = str(f)
         if isinstance(f, str) and f.lower().endswith(".shp"):
             from ..export.shapefile_utils import recarray2shp
             from ..utils.geometry import Polygon

--- a/flopy/modflowlgr/mflgr.py
+++ b/flopy/modflowlgr/mflgr.py
@@ -5,6 +5,7 @@ mflgr module.
 """
 
 import os
+from os import PathLike, curdir
 
 from ..mbase import BaseModel
 from ..modflow import Modflow
@@ -81,9 +82,8 @@ class ModflowLgr(BaseModel):
         List of instances of 1 or more Modflow objects.
     children_data : list, optional
         List of LgrChild objects.
-    model_ws : str, default "."
+    model_ws : str or PathLike, default "." (curdir)
         Model workspace.  Directory name to create model data sets.
-        Default is the present working directory.
     external_path : str, optional
         Location for external files.
     verbose : bool, default False
@@ -120,7 +120,7 @@ class ModflowLgr(BaseModel):
         parent=None,
         children=None,
         children_data=None,
-        model_ws=".",
+        model_ws=curdir,
         external_path=None,
         verbose=False,
         **kwargs,
@@ -245,7 +245,7 @@ class ModflowLgr(BaseModel):
         lpth = os.path.abspath(bpth)
         mpth = os.path.abspath(pth)
         rpth = os.path.relpath(mpth, lpth)
-        if rpth == ".":
+        if rpth == curdir:
             rpth = fpth
         else:
             rpth = os.path.join(rpth, fpth)
@@ -455,7 +455,7 @@ class ModflowLgr(BaseModel):
         version="mflgr",
         exe_name="mflgr",
         verbose=False,
-        model_ws=".",
+        model_ws=curdir,
         load_only=None,
         forgive=False,
         check=True,
@@ -473,9 +473,8 @@ class ModflowLgr(BaseModel):
             The name of the executable to use.
         verbose : bool, default False
             Print additional information to the screen.
-        model_ws : str, default "."
+        model_ws : str or PathLike, default "." (curdir)
             Model workspace.  Directory name to create model data sets.
-            Default is the present working directory.
         load_only : list of str, optional
             Packages to load (e.g. ["bas6", "lpf"]). Default None
             means that all packages will be loaded.
@@ -491,6 +490,8 @@ class ModflowLgr(BaseModel):
 
         """
         # test if name file is passed with extension (i.e., is a valid file)
+        if isinstance(f, PathLike):
+            f = str(f)
         if os.path.isfile(os.path.join(model_ws, f)):
             modelname = f.rpartition(".")[0]
         else:

--- a/flopy/modpath/mp6.py
+++ b/flopy/modpath/mp6.py
@@ -1,4 +1,5 @@
 import os
+from os import PathLike
 from typing import Optional, Union
 
 import numpy as np
@@ -43,14 +44,16 @@ class Modpath6(BaseModel):
         The name of the executable to use.
     modflowmodel : flopy.modflow.Modflow
         MODFLOW model object with one of LPF, BCF6, or UPW packages.
-    dis_file : str or PathLike
-        Required dis file name.
+    dis_file : str or PathLike, optional
+        dis file name. If not provided, this is obtained from modflowmodel.
     dis_unit : int, default 87
         Optional dis file unit number.
-    head_file : str or PathLike
-        Required filename of the MODFLOW output head file.
-    budget_file : str or PathLike
-        Required filename of the MODFLOW output cell-by-cell budget file.
+    head_file : str or PathLike, optional
+        Filename of the MODFLOW output head file.
+        If not provided, this is obtained from modflowmodel.
+    budget_file : str or PathLike, optional
+        Filename of the MODFLOW output cell-by-cell budget file.
+        If not provided, this is obtained from modflowmodel.
     model_ws : str or PathLike, optional
         Model workspace.  Directory name to create model data sets.
         Default is the current working directory.
@@ -71,14 +74,14 @@ class Modpath6(BaseModel):
         simfile_ext="mpsim",
         namefile_ext="mpnam",
         version="modpath",
-        exe_name: Union[str, os.PathLike] = "mp6",
+        exe_name: Union[str, PathLike] = "mp6",
         modflowmodel=None,
-        dis_file: Optional[Union[str, os.PathLike]] = None,
+        dis_file: Union[str, PathLike, None] = None,
         dis_unit=87,
-        head_file: Optional[Union[str, os.PathLike]] = None,
-        budget_file: Optional[Union[str, os.PathLike]] = None,
-        model_ws: Optional[Union[str, os.PathLike]] = None,
-        external_path: Optional[Union[str, os.PathLike]] = None,
+        head_file: Union[str, PathLike, None] = None,
+        budget_file: Union[str, PathLike, None] = None,
+        model_ws: Union[str, PathLike, None] = None,
+        external_path: Union[str, PathLike, None] = None,
         verbose=False,
         load=True,
         listunit=7,

--- a/flopy/modpath/mp7.py
+++ b/flopy/modpath/mp7.py
@@ -3,7 +3,8 @@ mp7 module.  Contains the Modpath7List and Modpath7 classes.
 
 """
 
-import os
+import os.path
+from os import curdir
 
 import numpy as np
 
@@ -63,9 +64,8 @@ class Modpath7(BaseModel):
         Filename of the MODFLOW output cell-by-cell budget file.
         If budgetfilename is not provided then it will be set
         from the flowmodel.
-    model_ws : str, default "."
+    model_ws : str or PathLike, default "." (curdir)
         Model workspace.  Directory name to create model data sets.
-        Default is the current working directory.
     verbose : bool, default False
         Print additional information to the screen.
 
@@ -87,7 +87,7 @@ class Modpath7(BaseModel):
         flowmodel=None,
         headfilename=None,
         budgetfilename=None,
-        model_ws=None,
+        model_ws=curdir,
         verbose=False,
     ):
         super().__init__(
@@ -385,7 +385,7 @@ class Modpath7(BaseModel):
         trackdir="forward",
         flowmodel=None,
         exe_name="mp7",
-        model_ws=".",
+        model_ws=curdir,
         verbose=False,
         columncelldivisions=2,
         rowcelldivisions=2,
@@ -411,9 +411,8 @@ class Modpath7(BaseModel):
             MODFLOW model
         exe_name : str
             The name of the executable to use (the default is 'mp7').
-        model_ws : str
+        model_ws : str or PathLike, default "." (curdir)
             model workspace.  Directory name to create model data sets.
-            (default is the current working directory).
         verbose : bool
             Print additional information to the screen (default is False).
         columncelldivisions : int

--- a/flopy/mt3d/mt.py
+++ b/flopy/mt3d/mt.py
@@ -1,4 +1,5 @@
 import os
+from os import curdir
 
 import numpy as np
 
@@ -68,9 +69,8 @@ class Mt3dms(BaseModel):
         Unit number for the list file.
     ftlunit : int, default 10
         Unit number for flow-transport link file.
-    model_ws : str, optional
+    model_ws : str or PathLike, default "." (curdir)
         Model workspace.  Directory name to create model data sets.
-        Default is the present working directory.
     external_path : str, optional
         Location for external files.
     verbose : bool, default False
@@ -112,7 +112,7 @@ class Mt3dms(BaseModel):
         structured=True,
         listunit=16,
         ftlunit=10,
-        model_ws=".",
+        model_ws=curdir,
         external_path=None,
         verbose=False,
         load=True,
@@ -416,7 +416,7 @@ class Mt3dms(BaseModel):
         version="mt3dms",
         exe_name="mt3dms",
         verbose=False,
-        model_ws=".",
+        model_ws=curdir,
         load_only=None,
         forgive=False,
         modflowmodel=None,
@@ -434,8 +434,8 @@ class Mt3dms(BaseModel):
             The name of the executable to use.
         verbose : bool, default False
             Print information on the load process if True.
-        model_ws : str, default "."
-            Model workspace path. Default is the current directory.
+        model_ws : str or PathLike, default "." (curdir)
+            Model workspace path.
         load_only : list of str, optional
             Packages to load (e.g. ['btn', 'adv']). Default None
             means that all packages will be loaded.

--- a/flopy/pakbase.py
+++ b/flopy/pakbase.py
@@ -6,9 +6,10 @@ pakbase module
 """
 
 import abc
-import os
+import os.path
 import webbrowser as wb
 from itertools import takewhile
+from os import PathLike
 from typing import Union
 
 import numpy as np
@@ -287,18 +288,18 @@ class PackageInterface:
 
         Parameters
         ----------
-        f : str or file handle
+        f : str, PathLike or file handle, optional
             String defining file name or file handle for summary file
             of check method output. If a string is passed a file handle
             is created. If f is None, check method does not write
             results to a summary file. (default is None)
-        verbose : bool
+        verbose : bool, default True
             Boolean flag used to determine if check method results are
             written to the screen
-        level : int
+        level : int, default 1
             Check method analysis level. If level=0, summary checks are
             performed. If level=1, full checks are performed.
-        checktype : check
+        checktype : check, optional
             Checker type to be used. By default class check is used from
             check.py.
 
@@ -334,7 +335,7 @@ class PackageInterface:
         else:
             txt = f"check method not implemented for {self.name[0]} Package."
             if f is not None:
-                if isinstance(f, str):
+                if isinstance(f, (str, PathLike)):
                     pth = os.path.join(self.parent.model_ws, f)
                     f = open(pth, "w")
                     f.write(txt)
@@ -848,7 +849,7 @@ class Package(PackageInterface):
 
     @staticmethod
     def load(
-        f: Union[str, bytes, os.PathLike],
+        f: Union[str, bytes, PathLike],
         model,
         pak_type,
         ext_unit_dict=None,

--- a/flopy/plot/map.py
+++ b/flopy/plot/map.py
@@ -574,7 +574,7 @@ class PlotMapView:
 
         Parameters
         ----------
-        shp : str, os.PathLike or pyshp shapefile object
+        shp : str, PathLike or pyshp shapefile object
             Path of the shapefile to plot
 
         kwargs : dictionary

--- a/flopy/plot/plotutil.py
+++ b/flopy/plot/plotutil.py
@@ -5,9 +5,10 @@ shapefiles are also included.
 
 """
 
-import os
+import os.path
 import warnings
 from itertools import repeat
+from os import PathLike
 from typing import Union
 
 import matplotlib.pyplot as plt
@@ -1999,7 +2000,7 @@ def shapefile_get_vertices(shp):
     return vertices
 
 
-def shapefile_to_patch_collection(shp: Union[str, os.PathLike], radius=500.0, idx=None):
+def shapefile_to_patch_collection(shp: Union[str, PathLike], radius=500.0, idx=None):
     """
     Create a patch collection from the shapes in a shapefile
 
@@ -2125,7 +2126,7 @@ def plot_shapefile(
 
     Parameters
     ----------
-    shp : string or os.PathLike
+    shp : str or PathLike
         Path of the shapefile to plot.
     ax : matplolib.pyplot.axes object
 

--- a/flopy/seawat/swt.py
+++ b/flopy/seawat/swt.py
@@ -1,4 +1,5 @@
 import os
+from os import PathLike, curdir
 from typing import Union
 
 from ..discretization.modeltime import ModelTime
@@ -50,9 +51,8 @@ class Seawat(BaseModel):
         Specify if model grid is structured (default) or unstructured.
     listunit : int, default 2
         Unit number for the list file.
-    model_ws : str, default "."
+    model_ws : str or PathLike, default "." (curdir)
         Model workspace.  Directory name to create model data sets.
-        Default is the present working directory.
     external_path : str, optional
         Location for external files.
     verbose : bool, default False
@@ -91,7 +91,7 @@ class Seawat(BaseModel):
         exe_name="swtv4",
         structured=True,
         listunit=2,
-        model_ws=".",
+        model_ws=curdir,
         external_path=None,
         verbose=False,
         load=True,
@@ -403,9 +403,9 @@ class Seawat(BaseModel):
         cls,
         f: str,
         version="seawat",
-        exe_name: Union[str, os.PathLike] = "swtv4",
+        exe_name: Union[str, PathLike] = "swtv4",
         verbose=False,
-        model_ws: Union[str, os.PathLike] = os.curdir,
+        model_ws: Union[str, PathLike] = curdir,
         load_only=None,
     ):
         """
@@ -421,9 +421,8 @@ class Seawat(BaseModel):
             The name of the executable to use.
         verbose : bool, default False
             Print additional information to the screen.
-        model_ws : str or PathLike, default "."
+        model_ws : str or PathLike, default "." (curdir)
             Model workspace.  Directory to create model data sets.
-            Default is the present working directory.
         load_only : list of str, optional
             Packages to load (e.g. ["lpf", "adv"]). Default None
             means that all packages will be loaded.

--- a/flopy/utils/binaryfile/__init__.py
+++ b/flopy/utils/binaryfile/__init__.py
@@ -9,9 +9,9 @@ important classes that can be accessed by the user.
 
 """
 
-import os
 import tempfile
 import warnings
+from os import PathLike
 from pathlib import Path
 from shutil import move
 from typing import Optional, Union
@@ -226,7 +226,7 @@ def join_struct_arrays(arrays):
     return newrecarray
 
 
-def get_headfile_precision(filename: Union[str, os.PathLike]):
+def get_headfile_precision(filename: Union[str, PathLike]):
     """
     Determine precision of a MODFLOW head file.
 
@@ -310,7 +310,7 @@ class BinaryLayerFile(LayerFile):
     pointing to the 1st byte of data for the corresponding data arrays.
     """
 
-    def __init__(self, filename: Union[str, os.PathLike], precision, verbose, **kwargs):
+    def __init__(self, filename: Union[str, PathLike], precision, verbose, **kwargs):
         super().__init__(filename, precision, verbose, **kwargs)
 
     def _build_index(self):
@@ -493,7 +493,7 @@ class HeadFile(BinaryLayerFile):
 
     def __init__(
         self,
-        filename: Union[str, os.PathLike],
+        filename: Union[str, PathLike],
         text="head",
         precision="auto",
         verbose=False,
@@ -509,7 +509,7 @@ class HeadFile(BinaryLayerFile):
         self.header_dtype = BinaryHeader.set_dtype(bintype="Head", precision=precision)
         super().__init__(filename, precision, verbose, **kwargs)
 
-    def reverse(self, filename: Optional[os.PathLike] = None):
+    def reverse(self, filename: Optional[PathLike] = None):
         """
         Reverse the time order of the currently loaded binary head file. If a head
         file name is not provided or the provided name is the same as the existing
@@ -518,7 +518,7 @@ class HeadFile(BinaryLayerFile):
         Parameters
         ----------
 
-        filename : str or PathLike
+        filename : str or PathLike, optional
             Path of the reversed binary head file.
         """
 
@@ -712,7 +712,7 @@ class HeadUFile(BinaryLayerFile):
 
     def __init__(
         self,
-        filename: Union[str, os.PathLike],
+        filename: Union[str, PathLike],
         text="headu",
         precision="auto",
         verbose=False,
@@ -860,7 +860,7 @@ class CellBudgetFile:
 
     def __init__(
         self,
-        filename: Union[str, os.PathLike],
+        filename: Union[str, PathLike],
         precision="auto",
         verbose=False,
         **kwargs,
@@ -2058,7 +2058,7 @@ class CellBudgetFile:
         """
         self.file.close()
 
-    def reverse(self, filename: Optional[os.PathLike] = None):
+    def reverse(self, filename: Optional[PathLike] = None):
         """
         Reverse the time order and signs of the currently loaded binary cell budget
         file. If a file name is not provided or if the provided name is the same as

--- a/flopy/utils/check.py
+++ b/flopy/utils/check.py
@@ -1,5 +1,6 @@
 import os
-from typing import Optional, Union
+from os import PathLike
+from typing import Union
 from warnings import warn
 
 import numpy as np
@@ -95,7 +96,7 @@ class check:
     def __init__(
         self,
         package,
-        f: Optional[Union[str, os.PathLike]] = None,
+        f: Union[str, PathLike, None] = None,
         verbose=True,
         level=1,
         property_threshold_values={},
@@ -122,7 +123,7 @@ class check:
 
         self.f = None
         if f is not None:
-            if isinstance(f, (str, os.PathLike)):
+            if isinstance(f, (str, PathLike)):
                 if os.path.split(f)[0] == "":
                     self.summaryfile = os.path.join(self.model.model_ws, f)
                 else:  # if a path is supplied with summary file, save there

--- a/flopy/utils/compare.py
+++ b/flopy/utils/compare.py
@@ -1,6 +1,7 @@
 import os
 import textwrap
-from typing import Optional, Union
+from os import PathLike
+from typing import Union
 
 import numpy as np
 
@@ -79,13 +80,13 @@ def _difftol(v1, v2, tol):
 
 
 def compare_budget(
-    namefile1: Optional[Union[str, os.PathLike]],
-    namefile2: Optional[Union[str, os.PathLike]],
+    namefile1: Union[str, PathLike, None] = None,
+    namefile2: Union[str, PathLike, None] = None,
     max_cumpd=0.01,
     max_incpd=0.01,
-    outfile: Optional[Union[str, os.PathLike]] = None,
-    files1: Optional[Union[str, os.PathLike, list[Union[str, os.PathLike]]]] = None,
-    files2: Optional[Union[str, os.PathLike, list[Union[str, os.PathLike]]]] = None,
+    outfile: Union[str, PathLike, None] = None,
+    files1: Union[str, PathLike, list[Union[str, PathLike]], None] = None,
+    files2: Union[str, PathLike, list[Union[str, PathLike]], None] = None,
 ):
     """Compare the budget results from two simulations.
 
@@ -136,7 +137,7 @@ def compare_budget(
         lst_file = get_entries_from_namefile(namefile1, "list")
         lst_file1 = lst_file[0][0] if any(lst_file) else None
     else:
-        if isinstance(files1, (str, os.PathLike)):
+        if isinstance(files1, (str, PathLike)):
             files1 = [files1]
         for file in files1:
             if (
@@ -150,7 +151,7 @@ def compare_budget(
         lst_file = get_entries_from_namefile(namefile2, "list")
         lst_file2 = lst_file[0][0] if any(lst_file) else None
     else:
-        if isinstance(files2, (str, os.PathLike)):
+        if isinstance(files2, (str, PathLike)):
             files2 = [files2]
         for file in files2:
             if (
@@ -279,13 +280,13 @@ def compare_budget(
 
 
 def compare_swrbudget(
-    namefile1: Optional[Union[str, os.PathLike]],
-    namefile2: Optional[Union[str, os.PathLike]],
+    namefile1: Union[str, PathLike, None] = None,
+    namefile2: Union[str, PathLike, None] = None,
     max_cumpd=0.01,
     max_incpd=0.01,
-    outfile: Optional[Union[str, os.PathLike]] = None,
-    files1: Optional[Union[str, os.PathLike, list[Union[str, os.PathLike]]]] = None,
-    files2: Optional[Union[str, os.PathLike, list[Union[str, os.PathLike]]]] = None,
+    outfile: Union[str, PathLike, None] = None,
+    files1: Union[str, PathLike, list[Union[str, PathLike]], None] = None,
+    files2: Union[str, PathLike, list[Union[str, PathLike]], None] = None,
 ):
     """Compare the SWR budget results from two simulations.
 
@@ -471,18 +472,18 @@ def compare_swrbudget(
 
 
 def compare_heads(
-    namefile1: Optional[Union[str, os.PathLike]],
-    namefile2: Optional[Union[str, os.PathLike]],
+    namefile1: Union[str, PathLike, None] = None,
+    namefile2: Union[str, PathLike, None] = None,
     precision="auto",
     text="head",
     text2=None,
     htol=0.001,
-    outfile: Optional[Union[str, os.PathLike]] = None,
-    files1: Optional[Union[str, os.PathLike, list[Union[str, os.PathLike]]]] = None,
-    files2: Optional[Union[str, os.PathLike, list[Union[str, os.PathLike]]]] = None,
+    outfile: Union[str, PathLike, None] = None,
+    files1: Union[str, PathLike, list[Union[str, PathLike]], None] = None,
+    files2: Union[str, PathLike, list[Union[str, PathLike]], None] = None,
     difftol=False,
     verbose=False,
-    exfile: Optional[Union[str, os.PathLike]] = None,
+    exfile: Union[str, PathLike, None] = None,
     exarr=None,
     maxerr=None,
 ):
@@ -560,7 +561,7 @@ def compare_heads(
             status1 = entries[0][1] if any(entries) else None
 
     else:
-        if isinstance(files1, (str, os.PathLike)):
+        if isinstance(files1, (str, PathLike)):
             files1 = [files1]
         for file in files1:
             if text.lower() == "head":
@@ -601,7 +602,7 @@ def compare_heads(
             hfpth2 = entries[0][0] if any(entries) else None
             status2 = entries[0][1] if any(entries) else None
     else:
-        if isinstance(files2, (str, os.PathLike)):
+        if isinstance(files2, (str, PathLike)):
             files2 = [files2]
         for file in files2:
             if text2.lower() == "head":
@@ -665,7 +666,7 @@ def compare_heads(
     # get data from exclusion file
     if exfile is not None:
         e = None
-        if isinstance(exfile, (str, os.PathLike)):
+        if isinstance(exfile, (str, PathLike)):
             try:
                 exd = np.genfromtxt(exfile).flatten()
             except:
@@ -853,13 +854,13 @@ def compare_heads(
 
 
 def compare_concentrations(
-    namefile1: Union[str, os.PathLike],
-    namefile2: Union[str, os.PathLike],
+    namefile1: Union[str, PathLike],
+    namefile2: Union[str, PathLike],
     precision="auto",
     ctol=0.001,
-    outfile: Optional[Union[str, os.PathLike]] = None,
-    files1: Optional[Union[str, os.PathLike, list[Union[str, os.PathLike]]]] = None,
-    files2: Optional[Union[str, os.PathLike, list[Union[str, os.PathLike]]]] = None,
+    outfile: Union[str, PathLike, None] = None,
+    files1: Union[str, PathLike, list[Union[str, PathLike]], None] = None,
+    files2: Union[str, PathLike, list[Union[str, PathLike]], None] = None,
     difftol=False,
     verbose=False,
 ):
@@ -926,7 +927,7 @@ def compare_concentrations(
         if ufpth1 is None:
             ufpth1 = os.path.join(os.path.dirname(namefile1), "MT3D001.UCN")
     else:
-        if isinstance(files1, (str, os.PathLike)):
+        if isinstance(files1, (str, PathLike)):
             files1 = [files1]
         for file in files1:
             for ext in valid_ext:
@@ -946,7 +947,7 @@ def compare_concentrations(
         if ufpth2 is None:
             ufpth2 = os.path.join(os.path.dirname(namefile2), "MT3D001.UCN")
     else:
-        if isinstance(files2, (str, os.PathLike)):
+        if isinstance(files2, (str, PathLike)):
             files2 = [files2]
         for file in files2:
             for ext in valid_ext:
@@ -1083,12 +1084,12 @@ def compare_concentrations(
 
 
 def compare_stages(
-    namefile1: Optional[Union[str, os.PathLike]] = None,
-    namefile2: Optional[Union[str, os.PathLike]] = None,
-    files1: Optional[Union[str, os.PathLike, list[Union[str, os.PathLike]]]] = None,
-    files2: Optional[Union[str, os.PathLike, list[Union[str, os.PathLike]]]] = None,
+    namefile1: Union[str, PathLike, None] = None,
+    namefile2: Union[str, PathLike, None] = None,
+    files1: Union[str, PathLike, list[Union[str, PathLike]], None] = None,
+    files2: Union[str, PathLike, list[Union[str, PathLike]], None] = None,
     htol=0.001,
-    outfile: Optional[Union[str, os.PathLike]] = None,
+    outfile: Union[str, PathLike, None] = None,
     difftol=False,
     verbose=False,
 ):
@@ -1148,7 +1149,7 @@ def compare_stages(
                 sfpth1 = sfpth
                 break
     elif files1 is not None:
-        if isinstance(files1, (str, os.PathLike)):
+        if isinstance(files1, (str, PathLike)):
             files1 = [files1]
         for file in files1:
             for ext in valid_ext:
@@ -1166,7 +1167,7 @@ def compare_stages(
                 sfpth2 = sfpth
                 break
     elif files2 is not None:
-        if isinstance(files2, (str, os.PathLike)):
+        if isinstance(files2, (str, PathLike)):
             files2 = [files2]
         for file in files2:
             for ext in valid_ext:
@@ -1295,16 +1296,16 @@ def compare_stages(
 
 
 def compare(
-    namefile1: Optional[Union[str, os.PathLike]] = None,
-    namefile2: Optional[Union[str, os.PathLike]] = None,
+    namefile1: Union[str, PathLike, None] = None,
+    namefile2: Union[str, PathLike, None] = None,
     precision="auto",
     max_cumpd=0.01,
     max_incpd=0.01,
     htol=0.001,
-    outfile1: Optional[Union[str, os.PathLike]] = None,
-    outfile2: Optional[Union[str, os.PathLike]] = None,
-    files1: Optional[Union[str, os.PathLike, list[Union[str, os.PathLike]]]] = None,
-    files2: Optional[Union[str, os.PathLike, list[Union[str, os.PathLike]]]] = None,
+    outfile1: Union[str, PathLike, None] = None,
+    outfile2: Union[str, PathLike, None] = None,
+    files1: Union[str, PathLike, list[Union[str, PathLike]], None] = None,
+    files2: Union[str, PathLike, list[Union[str, PathLike]], None] = None,
 ):
     """Compare the budget and head results for two MODFLOW-based model
     simulations.
@@ -1374,7 +1375,7 @@ def compare(
     return success
 
 
-def eval_bud_diff(fpth: Union[str, os.PathLike], b0, b1, ia=None, dtol=1e-6):
+def eval_bud_diff(fpth: Union[str, PathLike], b0, b1, ia=None, dtol=1e-6):
     # To use this eval_bud_diff function on a gwf or gwt budget file,
     # the function may need ia, in order to exclude comparison of the residual
     # term, which is stored in the diagonal position of the flowja array.

--- a/flopy/utils/crs.py
+++ b/flopy/utils/crs.py
@@ -52,7 +52,7 @@ def get_shapefile_crs(shapefile):
 
     Parameters
     ----------
-    shapefile : str or pathlike
+    shapefile : str or PathLike
         Path to a shapefile or an associated projection (.prj) file.
 
     Returns
@@ -83,7 +83,7 @@ def get_crs(prjfile=None, crs=None, **kwargs):
 
     Parameters
     ----------
-    prjfile : str or pathlike, optional
+    prjfile : str or PathLike, optional
         ESRI-style projection file with well-known text defining the CRS
         for the model grid (must be projected; geographic CRS are not supported).
     crs : pyproj.CRS, int, str, optional if `prjfile` is specified
@@ -98,7 +98,7 @@ def get_crs(prjfile=None, crs=None, **kwargs):
         .. deprecated:: 3.4
            The following keyword options will be removed for FloPy 3.6:
 
-             - ``prj`` (str or pathlike): use ``prjfile`` instead.
+             - ``prj`` (str or PathLike): use ``prjfile`` instead.
              - ``epsg`` (int): use ``crs`` instead.
              - ``proj4`` (str): use ``crs`` instead.
              - ``wkt_string`` (str): use ``crs`` instead.

--- a/flopy/utils/datafile.py
+++ b/flopy/utils/datafile.py
@@ -13,8 +13,8 @@ abstract classes that should not be directly accessed.
 #
 # pylint: disable=invalid-sequence-index
 
-import os
 import warnings
+from os import PathLike
 from pathlib import Path
 from typing import Union
 
@@ -166,7 +166,7 @@ class LayerFile:
 
     """
 
-    def __init__(self, filename: Union[str, os.PathLike], precision, verbose, **kwargs):
+    def __init__(self, filename: Union[str, PathLike], precision, verbose, **kwargs):
         from ..discretization.structuredgrid import StructuredGrid
 
         self.filename = Path(filename).expanduser().absolute()
@@ -242,7 +242,7 @@ class LayerFile:
 
     def to_shapefile(
         self,
-        filename: Union[str, os.PathLike],
+        filename: Union[str, PathLike],
         kstpkper=None,
         totim=None,
         mflay=None,

--- a/flopy/utils/flopy_io.py
+++ b/flopy/utils/flopy_io.py
@@ -5,6 +5,7 @@ Module for input/output utilities
 import os
 import platform
 import sys
+from os import PathLike, curdir
 from pathlib import Path
 from shutil import which
 from typing import Union
@@ -543,8 +544,8 @@ def get_ts_sp(line):
 
 
 def relpath_safe(
-    path: Union[str, os.PathLike],
-    start: Union[str, os.PathLike] = os.curdir,
+    path: Union[str, PathLike],
+    start: Union[str, PathLike] = curdir,
     scrub: bool = False,
 ) -> str:
     """
@@ -560,7 +561,7 @@ def relpath_safe(
     ----------
     path : str or PathLike
         the path to truncate relative to the start path
-    start : str or PathLike, default "."
+    start : str or PathLike, default "." (curdir)
         the starting path, defaults to the current working directory
     scrub : bool, default False
         whether to remove the current login name from paths
@@ -571,7 +572,7 @@ def relpath_safe(
         with elements before and including usernames removed and obfuscated
     """
 
-    if start == os.curdir:
+    if start == curdir:
         start = os.getcwd()
 
     if platform.system() == "Windows":

--- a/flopy/utils/geospatial_utils.py
+++ b/flopy/utils/geospatial_utils.py
@@ -1,4 +1,4 @@
-import os
+from os import PathLike
 from pathlib import Path
 
 import numpy as np
@@ -312,7 +312,7 @@ class GeoSpatialCollection:
                     self.__collection.append(GeoSpatialUtil(geom, shapetype[ix]))
 
         elif self.__shapefile is not None:
-            if isinstance(obj, (str, os.PathLike)):
+            if isinstance(obj, (str, PathLike)):
                 with self.__shapefile.Reader(
                     str(Path(obj).expanduser().absolute())
                 ) as r:

--- a/flopy/utils/gridgen.py
+++ b/flopy/utils/gridgen.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import warnings
+from os import PathLike, curdir
 from pathlib import Path
 from typing import Union
 
@@ -38,7 +39,7 @@ def read1d(f, a):
     return a
 
 
-def features_to_shapefile(features, featuretype, filename: Union[str, os.PathLike]):
+def features_to_shapefile(features, featuretype, filename: Union[str, PathLike]):
     """
     Write a shapefile for the features of type featuretype.
 
@@ -99,7 +100,7 @@ def features_to_shapefile(features, featuretype, filename: Union[str, os.PathLik
     wr.close()
 
 
-def ndarray_to_asciigrid(fname: Union[str, os.PathLike], a, extent, nodata=1.0e30):
+def ndarray_to_asciigrid(fname: Union[str, PathLike], a, extent, nodata=1.0e30):
     # extent info
     xmin, xmax, ymin, ymax = extent
     ncol, nrow = a.shape
@@ -175,8 +176,8 @@ class Gridgen:
         Flopy StructuredGrid object. Note this also accepts ModflowDis and
         ModflowGwfdis objects, however it is deprecated and support will be
         removed in version 3.3.7
-    model_ws : str or PathLike
-        workspace location for creating gridgen files (default is '.')
+    model_ws : str or PathLike, default "." (curdir)
+        workspace location for creating gridgen files
     exe_name : str
         path and name of the gridgen program. (default is gridgen)
     surface_interpolation : str
@@ -206,8 +207,8 @@ class Gridgen:
     def __init__(
         self,
         modelgrid,
-        model_ws: Union[str, os.PathLike] = os.curdir,
-        exe_name: Union[str, os.PathLike] = "gridgen",
+        model_ws: Union[str, PathLike] = curdir,
+        exe_name: Union[str, PathLike] = "gridgen",
         surface_interpolation="replicate",
         vertical_pass_through=False,
         **kwargs,
@@ -350,9 +351,9 @@ class Gridgen:
         """
         Parameters
         ----------
-        feature : str, path-like or array-like
+        feature : str, PathLike or array-like
             feature can be:
-                a shapefile name (str) or Pathlike
+                a shapefile name (str) or PathLike
                 a list of polygons
                 a flopy.utils.geometry.Collection object of Polygons
                 a shapely.geometry.Collection object of Polygons
@@ -373,14 +374,14 @@ class Gridgen:
         self.nja = 0
 
         # expand shapefile path or create one from polygon feature
-        if isinstance(feature, (str, os.PathLike)):
+        if isinstance(feature, (str, PathLike)):
             shapefile_path = self.resolve_shapefile_path(feature)
         elif isinstance(feature, (list, tuple, np.ndarray)):
             shapefile_path = self.model_ws / f"ad{len(self._addict)}.shp"
             features_to_shapefile(feature, "polygon", shapefile_path)
         else:
             raise ValueError(
-                "Feature must be a pathlike (shapefile) or array-like of geometries"
+                "Feature must be a PathLike (shapefile) or array-like of geometries"
             )
 
         # make sure shapefile exists
@@ -397,9 +398,9 @@ class Gridgen:
         """
         Parameters
         ----------
-        features : str, path-like or array-like
+        features : str, PathLike or array-like
             features can be
-                a shapefile name (str) or Pathlike
+                a shapefile name (str) or PathLike
                 a list of points, lines, or polygons
                 a flopy.utils.geometry.Collection object
                 a list of flopy.utils.geometry objects
@@ -425,14 +426,14 @@ class Gridgen:
         self.nja = 0
 
         # Create shapefile or set shapefile to feature
-        if isinstance(features, (str, os.PathLike)):
+        if isinstance(features, (str, PathLike)):
             shapefile_path = self.resolve_shapefile_path(features)
         elif isinstance(features, (list, tuple, np.ndarray)):
             shapefile_path = self.model_ws / f"rf{len(self._rfdict)}.shp"
             features_to_shapefile(features, featuretype, shapefile_path)
         else:
             raise ValueError(
-                "Features must be a pathlike (shapefile) or array-like of geometries"
+                "Features must be a PathLike (shapefile) or array-like of geometries"
             )
 
         # make sure shapefile exists
@@ -1830,12 +1831,12 @@ class Gridgen:
             self._vertdict[nodenumber] = shapes[i].points
 
     @staticmethod
-    def read_qtg_nod(model_ws: Union[str, os.PathLike], nodes_only: bool = False):
+    def read_qtg_nod(model_ws: Union[str, PathLike], nodes_only: bool = False):
         """Read qtg.nod file
 
         Parameters
         ----------
-        model_ws : Union[str, os.PathLike]
+        model_ws : str or PathLike
             Directory where file is stored
         nodes_only : bool, optional
             Read only the number of nodes from file, by default False which
@@ -1873,12 +1874,12 @@ class Gridgen:
             return nodes
 
     @staticmethod
-    def read_qtgrid_shp(model_ws: Union[str, os.PathLike]):
+    def read_qtgrid_shp(model_ws: Union[str, PathLike]):
         """Read qtgrid.shp file
 
         Parameters
         ----------
-        model_ws : Union[str, os.PathLike]
+        model_ws : str or PathLike
             Directory where file is stored
 
         Returns
@@ -1893,12 +1894,12 @@ class Gridgen:
         return shapefile.Reader(fname)
 
     @staticmethod
-    def read_qtg_nodesperlay_dat(model_ws: Union[str, os.PathLike], nlay: int):
+    def read_qtg_nodesperlay_dat(model_ws: Union[str, PathLike], nlay: int):
         """Read qtgrid.shp file
 
         Parameters
         ----------
-        model_ws : Union[str, os.PathLike]
+        model_ws : str or PathLike
             Directory where file is stored
         nlay : int
             Number of layers
@@ -1913,13 +1914,13 @@ class Gridgen:
 
     @staticmethod
     def read_quadtreegrid_top_dat(
-        model_ws: Union[str, os.PathLike], nodelay: list[int], lay: int
+        model_ws: Union[str, PathLike], nodelay: list[int], lay: int
     ):
         """Read quadtreegrid.top_.dat file
 
         Parameters
         ----------
-        model_ws : Union[str, os.PathLike]
+        model_ws : str or PathLike
             Directory where file is stored
         nodelay : list[int]
             Number of nodes in each layer
@@ -1936,13 +1937,13 @@ class Gridgen:
 
     @staticmethod
     def read_quadtreegrid_bot_dat(
-        model_ws: Union[str, os.PathLike], nodelay: list[int], lay: int
+        model_ws: Union[str, PathLike], nodelay: list[int], lay: int
     ):
         """Read quadtreegrid.bot_.dat file
 
         Parameters
         ----------
-        model_ws : Union[str, os.PathLike]
+        model_ws : str or PathLike
             Directory where file is stored
         nodelay : list[int]
             Number of nodes in each layer
@@ -1958,12 +1959,12 @@ class Gridgen:
             return read1d(f=f, a=np.empty((nodelay[lay]), dtype=np.float32))
 
     @staticmethod
-    def read_qtg_area_dat(model_ws: Union[str, os.PathLike], nodes: int):
+    def read_qtg_area_dat(model_ws: Union[str, PathLike], nodes: int):
         """Read qtg.area.dat file
 
         Parameters
         ----------
-        model_ws : Union[str, os.PathLike]
+        model_ws : str or PathLike
             Directory where file is stored
         nodes : int
             Number of nodes
@@ -1977,12 +1978,12 @@ class Gridgen:
             return read1d(f=f, a=np.empty((nodes), dtype=np.float32))
 
     @staticmethod
-    def read_qtg_iac_dat(model_ws: Union[str, os.PathLike], nodes: int):
+    def read_qtg_iac_dat(model_ws: Union[str, PathLike], nodes: int):
         """Read qtg.iac.dat file
 
         Parameters
         ----------
-        model_ws : Union[str, os.PathLike]
+        model_ws : str or PathLike
             Directory where file is stored
         nodes : int
             Number of nodes
@@ -1996,12 +1997,12 @@ class Gridgen:
             return read1d(f=f, a=np.empty((nodes), dtype=int))
 
     @staticmethod
-    def read_qtg_ja_dat(model_ws: Union[str, os.PathLike], nja: int):
+    def read_qtg_ja_dat(model_ws: Union[str, PathLike], nja: int):
         """Read qtg.ja.dat file
 
         Parameters
         ----------
-        model_ws : Union[str, os.PathLike]
+        model_ws : str or PathLike
             Directory where file is stored
         nja : int
             Number of connections
@@ -2016,12 +2017,12 @@ class Gridgen:
             return ja
 
     @staticmethod
-    def read_qtg_fldr_dat(model_ws: Union[str, os.PathLike], nja: int):
+    def read_qtg_fldr_dat(model_ws: Union[str, PathLike], nja: int):
         """Read qtg.fldr.dat file
 
         Parameters
         ----------
-        model_ws : Union[str, os.PathLike]
+        model_ws : str or PathLike
             Directory where file is stored
         nja : int
             Number of connections
@@ -2035,12 +2036,12 @@ class Gridgen:
             return read1d(f=f, a=np.empty((nja), dtype=int))
 
     @staticmethod
-    def read_qtg_cl_dat(model_ws: Union[str, os.PathLike], nja: int):
+    def read_qtg_cl_dat(model_ws: Union[str, PathLike], nja: int):
         """Read qtg.c1.dat file
 
         Parameters
         ----------
-        model_ws : Union[str, os.PathLike]
+        model_ws : str or PathLike
             Directory where file is stored
         nja : int
             Number of connections
@@ -2054,12 +2055,12 @@ class Gridgen:
             return read1d(f=f, a=np.empty((nja), dtype=np.float32))
 
     @staticmethod
-    def read_qtg_fahl_dat(model_ws: Union[str, os.PathLike], nja: int):
+    def read_qtg_fahl_dat(model_ws: Union[str, PathLike], nja: int):
         """Read qtg.fahl.dat file
 
         Parameters
         ----------
-        model_ws : Union[str, os.PathLike]
+        model_ws : str or PathLike
             Directory where file is stored
         nja : int
             Number of connections

--- a/flopy/utils/modpathfile.py
+++ b/flopy/utils/modpathfile.py
@@ -3,7 +3,7 @@ Support for MODPATH output files.
 """
 
 import itertools
-import os
+from os import PathLike
 from typing import Optional, Union
 
 import numpy as np
@@ -17,7 +17,7 @@ from ..utils.flopy_io import loadtxt
 class ModpathFile(ParticleTrackFile):
     """Provides MODPATH output file support."""
 
-    def __init__(self, filename: Union[str, os.PathLike], verbose: bool = False):
+    def __init__(self, filename: Union[str, PathLike], verbose: bool = False):
         super().__init__(filename, verbose)
         self.output_type = self.__class__.__name__.lower().replace("file", "")
         (self.modpath, self.compact, self.skiprows, self.version, self.direction) = (
@@ -26,7 +26,7 @@ class ModpathFile(ParticleTrackFile):
 
     @staticmethod
     def parse(
-        file_path: Union[str, os.PathLike], file_type: str
+        file_path: Union[str, PathLike], file_type: str
     ) -> tuple[bool, int, int, Optional[int]]:
         """
         Extract preliminary information from a MODPATH output file:
@@ -222,7 +222,7 @@ class PathlineFile(ModpathFile):
         "sequencenumber",
     ]
 
-    def __init__(self, filename: Union[str, os.PathLike], verbose: bool = False):
+    def __init__(self, filename: Union[str, PathLike], verbose: bool = False):
         super().__init__(filename, verbose=verbose)
         self.dtype, self._data = self._load()
         self.nid = np.unique(self._data["particleid"])
@@ -535,7 +535,7 @@ class EndpointFile(ModpathFile):
         "zone",
     ]
 
-    def __init__(self, filename: Union[str, os.PathLike], verbose: bool = False):
+    def __init__(self, filename: Union[str, PathLike], verbose: bool = False):
         super().__init__(filename, verbose)
         self.dtype, self._data = self._load()
         self.nid = np.unique(self._data["particleid"])

--- a/flopy/utils/particletrackfile.py
+++ b/flopy/utils/particletrackfile.py
@@ -2,8 +2,8 @@
 Utilities for parsing particle tracking output files.
 """
 
-import os
 from abc import ABC, abstractmethod
+from os import PathLike
 from pathlib import Path
 from typing import Union
 
@@ -49,7 +49,7 @@ class ParticleTrackFile(ABC):
 
     def __init__(
         self,
-        filename: Union[str, os.PathLike],
+        filename: Union[str, PathLike],
         verbose: bool = False,
     ):
         self.fname = Path(filename).expanduser().absolute()

--- a/flopy/utils/rasters.py
+++ b/flopy/utils/rasters.py
@@ -1,5 +1,5 @@
-import os
 import warnings
+from os import PathLike
 from typing import Union
 
 import numpy as np
@@ -846,7 +846,7 @@ class Raster:
                 foo.write(arr, band)
 
     @staticmethod
-    def load(raster: Union[str, os.PathLike]):
+    def load(raster: Union[str, PathLike]):
         """
         Static method to load a raster file
         into the raster object

--- a/flopy/utils/triangle.py
+++ b/flopy/utils/triangle.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+from os import curdir
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -17,8 +18,8 @@ class Triangle:
 
     Parameters
     ----------
-    model_ws : str
-        workspace location for creating triangle files (default is '.')
+    model_ws : str or PathLike, default "." (curdir)
+        workspace location for creating triangle files
     exe_name : str
         path and name of the triangle program. (default is triangle, which
         means that the triangle program must be in your path)
@@ -43,7 +44,7 @@ class Triangle:
 
     def __init__(
         self,
-        model_ws=".",
+        model_ws=curdir,
         exe_name="triangle",
         maximum_area=None,
         angle=20.0,

--- a/flopy/utils/util_array.py
+++ b/flopy/utils/util_array.py
@@ -7,8 +7,9 @@ util_array module.  Contains the util_2d, util_3d and transient_2d classes.
 """
 
 import copy
-import os
+import os.path
 import shutil
+from os import PathLike
 from warnings import warn
 
 import numpy as np
@@ -2665,7 +2666,7 @@ class Util2d(DataInterface):
                     )
             else:
                 raise Exception("Util2d:value type is bool, but dtype not set as bool")
-        elif isinstance(value, (str, os.PathLike)):
+        elif isinstance(value, (str, PathLike)):
             if os.path.exists(value):
                 self.__value = str(value)
                 return

--- a/flopy/utils/zonbud.py
+++ b/flopy/utils/zonbud.py
@@ -1,6 +1,7 @@
 import copy
-import os
+import os.path
 from itertools import groupby
+from os import PathLike, curdir
 from typing import Union
 
 import numpy as np
@@ -16,7 +17,7 @@ class ZoneBudget:
 
     Parameters
     ----------
-    cbc_file : str or CellBudgetFile object
+    cbc_file : str, PathLike or CellBudgetFile object
         The file name or CellBudgetFile object for which budgets will be
         computed.
     z : ndarray
@@ -61,7 +62,7 @@ class ZoneBudget:
 
         if isinstance(cbc_file, CellBudgetFile):
             self.cbc = cbc_file
-        elif isinstance(cbc_file, (str, os.PathLike)) and os.path.isfile(cbc_file):
+        elif isinstance(cbc_file, (str, PathLike)) and os.path.isfile(cbc_file):
             self.cbc = CellBudgetFile(cbc_file)
         else:
             raise Exception(f"Cannot load cell budget file: {cbc_file}.")
@@ -1545,7 +1546,7 @@ class ZoneBudget:
 
         Parameters
         ----------
-        f : str or flopy.export.netcdf.NetCdf object
+        f : str, PathLike or flopy.export.netcdf.NetCdf object
         ml : flopy.modflow.Modflow or flopy.mf6.ModflowGwf object
         **kwargs :
             logger : flopy.export.netcdf.Logger instance
@@ -1559,7 +1560,8 @@ class ZoneBudget:
         """
         from ..export.utils import output_helper
 
-        if isinstance(f, str):
+        if isinstance(f, (str, PathLike)):
+            f = str(f)
             if not f.endswith(".nc"):
                 raise AssertionError(
                     "File extension must end with .nc to export a netcdf file"
@@ -1649,7 +1651,7 @@ class ZoneBudget6:
     ----------
     name : str
         model name for zonebudget
-    model_ws : str
+    model_ws : str or PathLike, default "." (curdir)
         path to model
     exe_name : str
         executable name
@@ -1660,7 +1662,7 @@ class ZoneBudget6:
     def __init__(
         self,
         name="zonebud",
-        model_ws=".",
+        model_ws=curdir,
         exe_name="zbud6",
         extension=".zbnam",
     ):
@@ -1777,7 +1779,7 @@ class ZoneBudget6:
 
         Parameters
         ----------
-        model_ws : str
+        model_ws : str or PathLike
             new model directory
 
         """
@@ -1958,7 +1960,7 @@ class ZoneBudget6:
             foo.write("END ZONEBUDGET\n")
 
     @staticmethod
-    def load(nam_file, model_ws: Union[str, os.PathLike] = os.curdir):
+    def load(nam_file, model_ws: Union[str, PathLike] = curdir):
         """
         Method to load a zonebudget model from namefile
 
@@ -1966,7 +1968,7 @@ class ZoneBudget6:
         ----------
         nam_file : str
             zonebudget name file
-        model_ws : str or PathLike, default "."
+        model_ws : str or PathLike, default "." (curdir)
             model workspace path
 
         Returns
@@ -2011,7 +2013,7 @@ class ZoneBudget6:
         """
         from ..export.utils import output_helper
 
-        if isinstance(f, (str, os.PathLike)):
+        if isinstance(f, (str, PathLike)):
             f = str(f)
             if not f.endswith(".nc"):
                 raise AssertionError(
@@ -2116,7 +2118,7 @@ class ZoneFile6:
             foo.write("\nEND GRIDDATA\n")
 
     @staticmethod
-    def load(f: Union[str, os.PathLike], model):
+    def load(f: Union[str, PathLike], model):
         """
         Method to load a Zone file for zonebudget 6.
 


### PR DESCRIPTION
This refactor is mostly related to [`PathLike`](https://docs.python.org/3/library/os.html#os.PathLike) and [`curdir`](https://docs.python.org/3/library/os.html#os.curdir) from the `os` module.

- Import these items to use as (e.g.) `PathLike` rather than `os.PathLike`
- Try to make docstrings related to these more consistent
- Replace typing `Optional[Union[...]]` with `Union[..., None]`