### PR TITLE
ci: skip pyvista notebooks on mac/windows

### DIFF
--- a/autotest/test_example_notebooks.py
+++ b/autotest/test_example_notebooks.py
@@ -37,7 +37,7 @@ def get_notebooks(pattern=None, exclude=None):
 @pytest.mark.example
 @pytest.mark.parametrize(
     "notebook",
-    get_notebooks(pattern="tutorial", exclude=["mf6_lgr"])
+    get_notebooks(pattern="tutorial", exclude=EXCLUDE)
     + get_notebooks(pattern="example"),
 )
 def test_notebooks(notebook):

--- a/autotest/test_example_notebooks.py
+++ b/autotest/test_example_notebooks.py
@@ -1,11 +1,22 @@
 import re
 from pprint import pprint
+from platform import system
 
 import pytest
 from flaky import flaky
 from modflow_devtools.misc import is_in_ci, run_cmd
 
 from autotest.conftest import get_project_root_path
+
+
+EXCLUDE = [
+    "mf6_lgr",
+]
+# skip pyvista notebooks on windows/mac in CI due to persistent issues
+# first with offscreen rendering, then with finding pyvista even after
+# using pyvista/setup-headless-display-action
+if is_in_ci() and system() != "Linux":
+    EXCLUDE.append("vtk_pathlines")
 
 
 def get_notebooks(pattern=None, exclude=None):

--- a/autotest/test_example_notebooks.py
+++ b/autotest/test_example_notebooks.py
@@ -1,13 +1,12 @@
 import re
-from pprint import pprint
 from platform import system
+from pprint import pprint
 
 import pytest
 from flaky import flaky
 from modflow_devtools.misc import is_in_ci, run_cmd
 
 from autotest.conftest import get_project_root_path
-
 
 EXCLUDE = [
     "mf6_lgr",

--- a/autotest/test_example_notebooks.py
+++ b/autotest/test_example_notebooks.py
@@ -38,7 +38,7 @@ def get_notebooks(pattern=None, exclude=None):
 @pytest.mark.parametrize(
     "notebook",
     get_notebooks(pattern="tutorial", exclude=EXCLUDE)
-    + get_notebooks(pattern="example"),
+    + get_notebooks(pattern="example", exclude=EXCLUDE),
 )
 def test_notebooks(notebook):
     args = ["jupytext", "--from", "py", "--to", "ipynb", "--execute", notebook]


### PR DESCRIPTION
#2574 was evidently not sufficient to fix all pyvista notebook issues in CI. for some reason `pyvista` now [can't be found](https://github.com/modflowpy/flopy/actions/runs/17782588200/job/50544344309) on mac and windows. problem does not occur on linux. just skip the pyvista notebook on mac and windows