### PR TITLE
refactor(codegen): skip prerelease variables, adjust default verbosity

### DIFF
--- a/flopy/mf6/utils/codegen/filters.py
+++ b/flopy/mf6/utils/codegen/filters.py
@@ -16,10 +16,10 @@ def _try_get_enum_value(v: Any) -> Any:
     return v.value if isinstance(v, Enum) else v
 
 
-def _get_vars(d: dict) -> dict[str, dict]:
+def _get_vars(d: dict, developmode: bool = True) -> dict[str, dict]:
     vars_ = dict()
     def visit(p, k, v):
-        if isinstance(v, dict) and "type" in v and not v.get("prerelease", False):
+        if isinstance(v, dict) and "type" in v and (developmode or not v.get("prerelease", False)):
             vars_[k] = v
         return True
     def enter(p, k, v):
@@ -225,10 +225,10 @@ def default_value(var: dict) -> Any:
         return _default
     return None
 
-def variables(dfn: dict) -> List[str]:
-    return _get_vars(dfn)
+def variables(dfn: dict, developmode: bool = True) -> List[str]:
+    return _get_vars(dfn, developmode=developmode)
 
-def attrs(dfn: dict, component_name: tuple[str, str]) -> List[str]:
+def attrs(dfn: dict, component_name: tuple[str, str], developmode: bool = True) -> List[str]:
     """
     Map the context's input variables to corresponding class attributes,
     where applicable. TODO: this should get much simpler if we can drop
@@ -240,7 +240,7 @@ def attrs(dfn: dict, component_name: tuple[str, str]) -> List[str]:
         from modflow_devtools.dfn import _SCALAR_TYPES as SCALAR_TYPES  # noqa: PLC2701
 
     component_base = base(component_name)
-    component_vars = variables(dfn)
+    component_vars = variables(dfn, developmode=developmode)
 
     def _attr(var: dict) -> Optional[str]:
         var_name = var["name"]
@@ -365,9 +365,9 @@ def attrs(dfn: dict, component_name: tuple[str, str]) -> List[str]:
 
     return attrs
 
-def init(dfn: dict, component_name: tuple[str, str]) -> List[str]:
+def init(dfn: dict, component_name: tuple[str, str], developmode: bool = True) -> List[str]:
     component_base = base(component_name)
-    component_vars = variables(dfn)
+    component_vars = variables(dfn, developmode=developmode)
 
     def _statements() -> Optional[List[str]]:
         if component_base == "MFSimulationBase":

--- a/flopy/mf6/utils/codegen/filters.py
+++ b/flopy/mf6/utils/codegen/filters.py
@@ -19,7 +19,7 @@ def _try_get_enum_value(v: Any) -> Any:
 def _get_vars(d: dict) -> dict[str, dict]:
     vars_ = dict()
     def visit(p, k, v):
-        if isinstance(v, dict) and "type" in v and v.get("prerelease", "") != "true":
+        if isinstance(v, dict) and "type" in v and not v.get("prerelease", False):
             vars_[k] = v
         return True
     def enter(p, k, v):
@@ -240,7 +240,7 @@ def attrs(dfn: dict, component_name: tuple[str, str]) -> List[str]:
         from modflow_devtools.dfn import _SCALAR_TYPES as SCALAR_TYPES  # noqa: PLC2701
 
     component_base = base(component_name)
-    component_vars = _get_vars(dfn)
+    component_vars = variables(dfn)
 
     def _attr(var: dict) -> Optional[str]:
         var_name = var["name"]
@@ -367,7 +367,7 @@ def attrs(dfn: dict, component_name: tuple[str, str]) -> List[str]:
 
 def init(dfn: dict, component_name: tuple[str, str]) -> List[str]:
     component_base = base(component_name)
-    component_vars = _get_vars(dfn)
+    component_vars = variables(dfn)
 
     def _statements() -> Optional[List[str]]:
         if component_base == "MFSimulationBase":

--- a/flopy/mf6/utils/codegen/filters.py
+++ b/flopy/mf6/utils/codegen/filters.py
@@ -19,7 +19,7 @@ def _try_get_enum_value(v: Any) -> Any:
 def _get_vars(d: dict) -> dict[str, dict]:
     vars_ = dict()
     def visit(p, k, v):
-        if isinstance(v, dict) and "type" in v:
+        if isinstance(v, dict) and "type" in v and v.get("prerelease", "") != "true":
             vars_[k] = v
         return True
     def enter(p, k, v):

--- a/flopy/mf6/utils/generate_classes.py
+++ b/flopy/mf6/utils/generate_classes.py
@@ -75,15 +75,14 @@ def generate_classes(
                 proj_root / "doc" / "mf6io" / "mf6ivar" / "dfn", dfnpath
             )
 
-        if verbose:
-            dfns = list(dfnpath.glob("*.dfn"))
-            module_name = ".".join(_MF6_AUTOGEN_PATH.relative_to(_PROJ_ROOT_PATH).parts)
-            print(
-                f"Generating module {module_name} from {len(dfns)} DFNs in: {dfnpath}"
-            )
-            print()
-            _CMD.columnize([f.name for f in dfns])
-            print()
+        dfns = list(dfnpath.glob("*.dfn"))
+        module_name = ".".join(_MF6_AUTOGEN_PATH.relative_to(_PROJ_ROOT_PATH).parts)
+        print(
+            f"Generating module {module_name} from {len(dfns)} DFNs in: {dfnpath}"
+        )
+        print()
+        _CMD.columnize([f.name for f in dfns])
+        print()
 
         tomlpath = dfnpath / "toml"
         tomlpath.mkdir(exist_ok=True)
@@ -92,12 +91,12 @@ def generate_classes(
         shutil.rmtree(_MF6_AUTOGEN_PATH)
         _MF6_AUTOGEN_PATH.mkdir(parents=True)
         make_all(tomlpath, _MF6_AUTOGEN_PATH, version=2, legacydir=dfnpath, verbose=verbose)
-        if verbose:
-            files = list(_MF6_AUTOGEN_PATH.glob("*.py"))
-            print(f"Generated {len(files)} module files in: {_MF6_AUTOGEN_PATH}")
-            print()
-            _CMD.columnize([f.name for f in files])
-            print()
+
+        files = list(_MF6_AUTOGEN_PATH.glob("*.py"))
+        print(f"Generated {len(files)} module files in: {_MF6_AUTOGEN_PATH}")
+        print()
+        _CMD.columnize([f.name for f in files])
+        print()
 
 
 def cli_main():
@@ -134,7 +133,7 @@ def cli_main():
         "--verbose",
         action=argparse.BooleanOptionalAction,
         default=True,
-        help="Print information about the code generation process; "
+        help="Print extra information about the code generation process; "
         "default shows verbose output.",
     )
     parser.add_argument(

--- a/flopy/mf6/utils/generate_classes.py
+++ b/flopy/mf6/utils/generate_classes.py
@@ -17,6 +17,7 @@ def generate_classes(
     ref=None,
     dfnpath=None,
     verbose=False,
+    developmode=True,
 ):
     """
     Generate Python classes for MODFLOW 6 using definition files fetched
@@ -41,6 +42,9 @@ def generate_classes(
         timestamp from when the definition files were replaced.
     verbose : bool, default False
         If True, print information about the code generation process.
+    developmode : bool, default True
+        If True, include all variables, including prerelease variables.
+        If False, omit prerelease variables from generated modules.
     """
 
     if dfnpath is None and ref is None:
@@ -90,7 +94,7 @@ def generate_classes(
 
         shutil.rmtree(_MF6_AUTOGEN_PATH)
         _MF6_AUTOGEN_PATH.mkdir(parents=True)
-        make_all(tomlpath, _MF6_AUTOGEN_PATH, version=2, legacydir=dfnpath, verbose=verbose)
+        make_all(tomlpath, _MF6_AUTOGEN_PATH, version=2, legacydir=dfnpath, verbose=verbose, developmode=developmode)
 
         files = list(_MF6_AUTOGEN_PATH.glob("*.py"))
         print(f"Generated {len(files)} module files in: {_MF6_AUTOGEN_PATH}")
@@ -147,7 +151,16 @@ def cli_main():
         "dfn_backup with a date and timestamp from when the definition "
         "files were replaced.",
     )
+    parser.add_argument(
+        "-r",
+        "--releasemode",
+        required=False,
+        action="store_true",
+        help="Omit prerelease variables from generated modules. "
+        "Only relevant if --dfnpath is provided. Defaults false.",
+    )
     args = vars(parser.parse_args())
+    args["developmode"] = not args.pop("releasemode", False)
 
     # ignore/warn removed options
     exclude = args.pop("exclude", None)

--- a/flopy/mf6/utils/generate_classes.py
+++ b/flopy/mf6/utils/generate_classes.py
@@ -132,7 +132,7 @@ def cli_main():
     parser.add_argument(
         "--verbose",
         action=argparse.BooleanOptionalAction,
-        default=True,
+        default=False,
         help="Print extra information about the code generation process; "
         "default shows verbose output.",
     )


### PR DESCRIPTION
Accommodate https://github.com/MODFLOW-ORG/modflow6/pull/2499. Add a `--releasemode` option to the codegen tool. By default everything is included, release mode filters out prerelease variables.

Also just print summaries by default. Make verbose mode opt-in