### PR TITLE
fix(codegen): fix recarray variable docstring rendering

### DIFF
--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -40,7 +40,7 @@ dependencies:
   - pytest-dotenv
   - pytest-xdist
   - pyzmq>=25.1.2
-  - syrupy
+  - syrupy<5.0.0
   - virtualenv
 
   # optional

--- a/flopy/mf6/utils/codegen/filters.py
+++ b/flopy/mf6/utils/codegen/filters.py
@@ -205,9 +205,13 @@ def type(var: dict) -> str:
 
 def children(var: dict) -> Optional[dict]:
     _type = var["type"]
-    items = var.get("items", None)  # TODO: fix to use "item" or "items"
+    item = var.get("item", None)
+    items = var.get("items", None)
     fields = var.get("fields", None)
     choices = var.get("choices", None)
+    if item:
+        assert _type == "recarray"
+        return {item["name"]: item}
     if items:
         assert _type == "recarray"
         return items

--- a/flopy/mf6/utils/codegen/filters.py
+++ b/flopy/mf6/utils/codegen/filters.py
@@ -206,15 +206,11 @@ def type(var: dict) -> str:
 def children(var: dict) -> Optional[dict]:
     _type = var["type"]
     item = var.get("item", None)
-    items = var.get("items", None)
     fields = var.get("fields", None)
     choices = var.get("choices", None)
     if item:
         assert _type == "recarray"
         return {item["name"]: item}
-    if items:
-        assert _type == "recarray"
-        return items
     if fields:
         assert _type == "record"
         return fields

--- a/flopy/mf6/utils/codegen/templates/macros.jinja
+++ b/flopy/mf6/utils/codegen/templates/macros.jinja
@@ -16,9 +16,12 @@
 {{ v.description|clean|math|wordwrap|indent(loop.depth * 4, first=true) }}
 {% endif %}
 {% if recurse and children is not none %}
-{% if v.type == "list" and children|length == 1 and (children.values()|first).type in ["record", "union"] %}
+{% if v.type == "recarray" and children|length == 1 and (children.values()|first).name == v.name and (children.values()|first).type in ["record", "keystring"] %}
+{# For recarray with single record item of same name, show the record's fields directly #}
 {% set grandchildren = (children.values()|first)|children %}
+{% if grandchildren %}
 {{ loop(grandchildren.values())|indent(loop.depth * 4, first=true) }}
+{% endif %}
 {% else %}
 {{ loop(children.values())|indent(loop.depth * 4, first=true) }}
 {% endif %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ test = [
     "pytest-dotenv",
     "pytest-xdist",
     "pyzmq >=25.1.2",
-    "syrupy",
+    "syrupy <5.0.0",
     "tomli",
     "tomli-w",
     "virtualenv"


### PR DESCRIPTION
Fix #2599. Recarray columns were missing. Now `mfgwegwe.py` looks OK. Hopefully didn't break anything else

```
exchangedata : [(cellidm1, cellidm2, ihc, cl1, cl2, hwva, aux, boundname)]
        * cellidm1 : integer
                is the cellid of the cell in model 1 as specified in the simulation name file.
                For a structured grid that uses the DIS input file, CELLIDM1 is the layer, row,
                and column numbers of the cell.   For a grid that uses the DISV input file,
                CELLIDM1 is the layer number and CELL2D number for the two cells.  If the model
                uses the unstructured discretization (DISU) input file, then CELLIDM1 is the
                node number for the cell.
        * cellidm2 : integer
                is the cellid of the cell in model 2 as specified in the simulation name file.
                For a structured grid that uses the DIS input file, CELLIDM2 is the layer, row,
                and column numbers of the cell.   For a grid that uses the DISV input file,
                CELLIDM2 is the layer number and CELL2D number for the two cells.  If the model
                uses the unstructured discretization (DISU) input file, then CELLIDM2 is the
                node number for the cell.
        * ihc : integer
                is an integer flag indicating the direction between node n and all of its m
                connections. If IHC = 0 then the connection is vertical.  If IHC = 1 then the
                connection is horizontal. If IHC = 2 then the connection is horizontal for a
                vertically staggered grid.
        * cl1 : double precision
                is the distance between the center of cell 1 and the its shared face with cell
                2.
        * cl2 : double precision
                is the distance between the center of cell 2 and the its shared face with cell
                1.
        * hwva : double precision
                is the horizontal width of the flow connection between cell 1 and cell 2 if IHC
                > 0, or it is the area perpendicular to flow of the vertical connection between
                cell 1 and cell 2 if IHC = 0.
        * aux : [double precision]
                represents the values of the auxiliary variables for each GWEGWE Exchange. The
                values of auxiliary variables must be present for each exchange. The values
                must be specified in the order of the auxiliary variables specified in the
                OPTIONS block.
        * boundname : string
                name of the GWE Exchange cell.  BOUNDNAME is an ASCII character variable that
                can contain as many as 40 characters.  If BOUNDNAME contains spaces in it, then
                the entire name must be enclosed within single quotes.

```