### PR TITLE
fix(mf6): filter prerelease variables out of mf6 module

### DIFF
--- a/flopy/mf6/modflow/mfgwe.py
+++ b/flopy/mf6/modflow/mfgwe.py
@@ -42,9 +42,6 @@ class ModflowGwe(MFModel):
     save_flows : keyword
         keyword to indicate that all model package flow terms will be written to the
         file specified with 'budget fileout' in output control.
-    dependent_variable_scaling : keyword
-        flag to scale x and rhs to avoid very large positive or negative dependent
-        variable values
     nc_mesh2d_filerecord : record
         netcdf layered mesh fileout record.
     nc_structured_filerecord : record
@@ -90,7 +87,6 @@ class ModflowGwe(MFModel):
         print_input=None,
         print_flows=None,
         save_flows=None,
-        dependent_variable_scaling=None,
         nc_mesh2d_filerecord=None,
         nc_structured_filerecord=None,
         nc_filerecord=None,
@@ -116,8 +112,6 @@ class ModflowGwe(MFModel):
         self.print_flows = self.name_file.print_flows
         self.name_file.save_flows.set_data(save_flows)
         self.save_flows = self.name_file.save_flows
-        self.name_file.dependent_variable_scaling.set_data(dependent_variable_scaling)
-        self.dependent_variable_scaling = self.name_file.dependent_variable_scaling
         self.name_file.nc_mesh2d_filerecord.set_data(nc_mesh2d_filerecord)
         self.nc_mesh2d_filerecord = self.name_file.nc_mesh2d_filerecord
         self.name_file.nc_structured_filerecord.set_data(nc_structured_filerecord)

--- a/flopy/mf6/modflow/mfgwedis.py
+++ b/flopy/mf6/modflow/mfgwedis.py
@@ -51,13 +51,6 @@ class ModflowGwedis(MFPackage):
     export_array_netcdf : keyword
         keyword that specifies input griddata arrays should be written to the model
         output netcdf file.
-    crs : [string]
-        is a real-world coordinate reference system (crs) for the model, for example,
-        an epsg integer code (e.g. 26915), authority string (i.e. epsg:26915), or open
-        geospatial consortium well-known text (wkt) specification. limited to 5000
-        characters. the entry for crs does not affect the model simulation, but it is
-        written to the binary grid file so that postprocessors can locate the grid in
-        space.
     packagedata : record ncf6 filein ncf6_filename
         Contains data for the ncf package. Data can be passed as a dictionary to the
         ncf package with variable names as keys and package data as values. Data for
@@ -99,7 +92,6 @@ class ModflowGwedis(MFPackage):
     """
 
     grb_filerecord = ListTemplateGenerator(("gwe6", "dis", "options", "grb_filerecord"))
-    crs = ArrayTemplateGenerator(("gwe6", "dis", "options", "crs"))
     ncf_filerecord = ListTemplateGenerator(("gwe6", "dis", "options", "ncf_filerecord"))
     delr = ArrayTemplateGenerator(("gwe6", "dis", "griddata", "delr"))
     delc = ArrayTemplateGenerator(("gwe6", "dis", "griddata", "delc"))
@@ -335,7 +327,6 @@ class ModflowGwedis(MFPackage):
         angrot=None,
         export_array_ascii=None,
         export_array_netcdf=None,
-        crs=None,
         packagedata=None,
         nlay=1,
         nrow=2,
@@ -371,7 +362,6 @@ class ModflowGwedis(MFPackage):
         self.export_array_netcdf = self.build_mfdata(
             "export_array_netcdf", export_array_netcdf
         )
-        self.crs = self.build_mfdata("crs", crs)
         self._ncf_filerecord = self.build_mfdata("ncf_filerecord", None)
         self._ncf_package = self.build_child_package(
             "ncf", packagedata, "packagedata", self._ncf_filerecord

--- a/flopy/mf6/modflow/mfgwedisu.py
+++ b/flopy/mf6/modflow/mfgwedisu.py
@@ -58,13 +58,6 @@ class ModflowGwedisu(MFPackage):
     export_array_ascii : keyword
         keyword that specifies input griddata arrays should be written to layered ascii
         output files.
-    crs : [string]
-        is a real-world coordinate reference system (crs) for the model, for example,
-        an epsg integer code (e.g. 26915), authority string (i.e. epsg:26915), or open
-        geospatial consortium well-known text (wkt) specification. limited to 5000
-        characters. the entry for crs does not affect the model simulation, but it is
-        written to the binary grid file so that postprocessors can locate the grid in
-        space.
     nodes : integer
         is the number of cells in the model grid.
     nja : integer
@@ -184,7 +177,6 @@ class ModflowGwedisu(MFPackage):
     grb_filerecord = ListTemplateGenerator(
         ("gwe6", "disu", "options", "grb_filerecord")
     )
-    crs = ArrayTemplateGenerator(("gwe6", "disu", "options", "crs"))
     top = ArrayTemplateGenerator(("gwe6", "disu", "griddata", "top"))
     bot = ArrayTemplateGenerator(("gwe6", "disu", "griddata", "bot"))
     area = ArrayTemplateGenerator(("gwe6", "disu", "griddata", "area"))
@@ -506,7 +498,6 @@ class ModflowGwedisu(MFPackage):
         angrot=None,
         vertical_offset_tolerance=0.0,
         export_array_ascii=None,
-        crs=None,
         nodes=None,
         nja=None,
         nvert=None,
@@ -548,7 +539,6 @@ class ModflowGwedisu(MFPackage):
         self.export_array_ascii = self.build_mfdata(
             "export_array_ascii", export_array_ascii
         )
-        self.crs = self.build_mfdata("crs", crs)
         self.nodes = self.build_mfdata("nodes", nodes)
         self.nja = self.build_mfdata("nja", nja)
         self.nvert = self.build_mfdata("nvert", nvert)

--- a/flopy/mf6/modflow/mfgwedisv.py
+++ b/flopy/mf6/modflow/mfgwedisv.py
@@ -54,13 +54,6 @@ class ModflowGwedisv(MFPackage):
     export_array_netcdf : keyword
         keyword that specifies input griddata arrays should be written to the model
         output netcdf file.
-    crs : [string]
-        is a real-world coordinate reference system (crs) for the model, for example,
-        an epsg integer code (e.g. 26915), authority string (i.e. epsg:26915), or open
-        geospatial consortium well-known text (wkt) specification. limited to 5000
-        characters. the entry for crs does not affect the model simulation, but it is
-        written to the binary grid file so that postprocessors can locate the grid in
-        space.
     packagedata : record ncf6 filein ncf6_filename
         Contains data for the ncf package. Data can be passed as a dictionary to the
         ncf package with variable names as keys and package data as values. Data for
@@ -127,7 +120,6 @@ class ModflowGwedisv(MFPackage):
     grb_filerecord = ListTemplateGenerator(
         ("gwe6", "disv", "options", "grb_filerecord")
     )
-    crs = ArrayTemplateGenerator(("gwe6", "disv", "options", "crs"))
     ncf_filerecord = ListTemplateGenerator(
         ("gwe6", "disv", "options", "ncf_filerecord")
     )
@@ -434,7 +426,6 @@ class ModflowGwedisv(MFPackage):
         angrot=None,
         export_array_ascii=None,
         export_array_netcdf=None,
-        crs=None,
         packagedata=None,
         nlay=None,
         ncpl=None,
@@ -470,7 +461,6 @@ class ModflowGwedisv(MFPackage):
         self.export_array_netcdf = self.build_mfdata(
             "export_array_netcdf", export_array_netcdf
         )
-        self.crs = self.build_mfdata("crs", crs)
         self._ncf_filerecord = self.build_mfdata("ncf_filerecord", None)
         self._ncf_package = self.build_child_package(
             "ncf", packagedata, "packagedata", self._ncf_filerecord

--- a/flopy/mf6/modflow/mfgwenam.py
+++ b/flopy/mf6/modflow/mfgwenam.py
@@ -36,9 +36,6 @@ class ModflowGwenam(MFPackage):
     save_flows : keyword
         keyword to indicate that all model package flow terms will be written to the
         file specified with 'budget fileout' in output control.
-    dependent_variable_scaling : keyword
-        flag to scale x and rhs to avoid very large positive or negative dependent
-        variable values
     nc_mesh2d_filerecord : (ncmesh2dfile)
         netcdf layered mesh fileout record.
         * ncmesh2dfile : string
@@ -293,7 +290,6 @@ class ModflowGwenam(MFPackage):
         print_input=None,
         print_flows=None,
         save_flows=None,
-        dependent_variable_scaling=None,
         nc_mesh2d_filerecord=None,
         nc_structured_filerecord=None,
         nc_filerecord=None,
@@ -316,9 +312,6 @@ class ModflowGwenam(MFPackage):
         self.print_input = self.build_mfdata("print_input", print_input)
         self.print_flows = self.build_mfdata("print_flows", print_flows)
         self.save_flows = self.build_mfdata("save_flows", save_flows)
-        self.dependent_variable_scaling = self.build_mfdata(
-            "dependent_variable_scaling", dependent_variable_scaling
-        )
         self.nc_mesh2d_filerecord = self.build_mfdata(
             "nc_mesh2d_filerecord", nc_mesh2d_filerecord
         )

--- a/flopy/mf6/modflow/mfgwfdis.py
+++ b/flopy/mf6/modflow/mfgwfdis.py
@@ -51,13 +51,6 @@ class ModflowGwfdis(MFPackage):
     export_array_netcdf : keyword
         keyword that specifies input griddata arrays should be written to the model
         output netcdf file.
-    crs : [string]
-        is a real-world coordinate reference system (crs) for the model, for example,
-        an epsg integer code (e.g. 26915), authority string (i.e. epsg:26915), or open
-        geospatial consortium well-known text (wkt) specification. limited to 5000
-        characters. the entry for crs does not affect the model simulation, but it is
-        written to the binary grid file so that postprocessors can locate the grid in
-        space.
     packagedata : record ncf6 filein ncf6_filename
         Contains data for the ncf package. Data can be passed as a dictionary to the
         ncf package with variable names as keys and package data as values. Data for
@@ -99,7 +92,6 @@ class ModflowGwfdis(MFPackage):
     """
 
     grb_filerecord = ListTemplateGenerator(("gwf6", "dis", "options", "grb_filerecord"))
-    crs = ArrayTemplateGenerator(("gwf6", "dis", "options", "crs"))
     ncf_filerecord = ListTemplateGenerator(("gwf6", "dis", "options", "ncf_filerecord"))
     delr = ArrayTemplateGenerator(("gwf6", "dis", "griddata", "delr"))
     delc = ArrayTemplateGenerator(("gwf6", "dis", "griddata", "delc"))
@@ -335,7 +327,6 @@ class ModflowGwfdis(MFPackage):
         angrot=None,
         export_array_ascii=None,
         export_array_netcdf=None,
-        crs=None,
         packagedata=None,
         nlay=1,
         nrow=2,
@@ -371,7 +362,6 @@ class ModflowGwfdis(MFPackage):
         self.export_array_netcdf = self.build_mfdata(
             "export_array_netcdf", export_array_netcdf
         )
-        self.crs = self.build_mfdata("crs", crs)
         self._ncf_filerecord = self.build_mfdata("ncf_filerecord", None)
         self._ncf_package = self.build_child_package(
             "ncf", packagedata, "packagedata", self._ncf_filerecord

--- a/flopy/mf6/modflow/mfgwfdisu.py
+++ b/flopy/mf6/modflow/mfgwfdisu.py
@@ -58,13 +58,6 @@ class ModflowGwfdisu(MFPackage):
     export_array_ascii : keyword
         keyword that specifies input griddata arrays should be written to layered ascii
         output files.
-    crs : [string]
-        is a real-world coordinate reference system (crs) for the model, for example,
-        an epsg integer code (e.g. 26915), authority string (i.e. epsg:26915), or open
-        geospatial consortium well-known text (wkt) specification. limited to 5000
-        characters. the entry for crs does not affect the model simulation, but it is
-        written to the binary grid file so that postprocessors can locate the grid in
-        space.
     nodes : integer
         is the number of cells in the model grid.
     nja : integer
@@ -184,7 +177,6 @@ class ModflowGwfdisu(MFPackage):
     grb_filerecord = ListTemplateGenerator(
         ("gwf6", "disu", "options", "grb_filerecord")
     )
-    crs = ArrayTemplateGenerator(("gwf6", "disu", "options", "crs"))
     top = ArrayTemplateGenerator(("gwf6", "disu", "griddata", "top"))
     bot = ArrayTemplateGenerator(("gwf6", "disu", "griddata", "bot"))
     area = ArrayTemplateGenerator(("gwf6", "disu", "griddata", "area"))
@@ -506,7 +498,6 @@ class ModflowGwfdisu(MFPackage):
         angrot=None,
         vertical_offset_tolerance=0.0,
         export_array_ascii=None,
-        crs=None,
         nodes=None,
         nja=None,
         nvert=None,
@@ -548,7 +539,6 @@ class ModflowGwfdisu(MFPackage):
         self.export_array_ascii = self.build_mfdata(
             "export_array_ascii", export_array_ascii
         )
-        self.crs = self.build_mfdata("crs", crs)
         self.nodes = self.build_mfdata("nodes", nodes)
         self.nja = self.build_mfdata("nja", nja)
         self.nvert = self.build_mfdata("nvert", nvert)

--- a/flopy/mf6/modflow/mfgwfdisv.py
+++ b/flopy/mf6/modflow/mfgwfdisv.py
@@ -54,13 +54,6 @@ class ModflowGwfdisv(MFPackage):
     export_array_netcdf : keyword
         keyword that specifies input griddata arrays should be written to the model
         output netcdf file.
-    crs : [string]
-        is a real-world coordinate reference system (crs) for the model, for example,
-        an epsg integer code (e.g. 26915), authority string (i.e. epsg:26915), or open
-        geospatial consortium well-known text (wkt) specification. limited to 5000
-        characters. the entry for crs does not affect the model simulation, but it is
-        written to the binary grid file so that postprocessors can locate the grid in
-        space.
     packagedata : record ncf6 filein ncf6_filename
         Contains data for the ncf package. Data can be passed as a dictionary to the
         ncf package with variable names as keys and package data as values. Data for
@@ -127,7 +120,6 @@ class ModflowGwfdisv(MFPackage):
     grb_filerecord = ListTemplateGenerator(
         ("gwf6", "disv", "options", "grb_filerecord")
     )
-    crs = ArrayTemplateGenerator(("gwf6", "disv", "options", "crs"))
     ncf_filerecord = ListTemplateGenerator(
         ("gwf6", "disv", "options", "ncf_filerecord")
     )
@@ -434,7 +426,6 @@ class ModflowGwfdisv(MFPackage):
         angrot=None,
         export_array_ascii=None,
         export_array_netcdf=None,
-        crs=None,
         packagedata=None,
         nlay=None,
         ncpl=None,
@@ -470,7 +461,6 @@ class ModflowGwfdisv(MFPackage):
         self.export_array_netcdf = self.build_mfdata(
             "export_array_netcdf", export_array_netcdf
         )
-        self.crs = self.build_mfdata("crs", crs)
         self._ncf_filerecord = self.build_mfdata("ncf_filerecord", None)
         self._ncf_package = self.build_child_package(
             "ncf", packagedata, "packagedata", self._ncf_filerecord

--- a/flopy/mf6/modflow/mfgwt.py
+++ b/flopy/mf6/modflow/mfgwt.py
@@ -42,9 +42,6 @@ class ModflowGwt(MFModel):
     save_flows : keyword
         keyword to indicate that all model package flow terms will be written to the
         file specified with 'budget fileout' in output control.
-    dependent_variable_scaling : keyword
-        flag to scale x and rhs to avoid very large positive or negative dependent
-        variable values
     nc_mesh2d_filerecord : record
         netcdf layered mesh fileout record.
     nc_structured_filerecord : record
@@ -90,7 +87,6 @@ class ModflowGwt(MFModel):
         print_input=None,
         print_flows=None,
         save_flows=None,
-        dependent_variable_scaling=None,
         nc_mesh2d_filerecord=None,
         nc_structured_filerecord=None,
         nc_filerecord=None,
@@ -116,8 +112,6 @@ class ModflowGwt(MFModel):
         self.print_flows = self.name_file.print_flows
         self.name_file.save_flows.set_data(save_flows)
         self.save_flows = self.name_file.save_flows
-        self.name_file.dependent_variable_scaling.set_data(dependent_variable_scaling)
-        self.dependent_variable_scaling = self.name_file.dependent_variable_scaling
         self.name_file.nc_mesh2d_filerecord.set_data(nc_mesh2d_filerecord)
         self.nc_mesh2d_filerecord = self.name_file.nc_mesh2d_filerecord
         self.name_file.nc_structured_filerecord.set_data(nc_structured_filerecord)

--- a/flopy/mf6/modflow/mfgwtdis.py
+++ b/flopy/mf6/modflow/mfgwtdis.py
@@ -51,13 +51,6 @@ class ModflowGwtdis(MFPackage):
     export_array_netcdf : keyword
         keyword that specifies input griddata arrays should be written to the model
         output netcdf file.
-    crs : [string]
-        is a real-world coordinate reference system (crs) for the model, for example,
-        an epsg integer code (e.g. 26915), authority string (i.e. epsg:26915), or open
-        geospatial consortium well-known text (wkt) specification. limited to 5000
-        characters. the entry for crs does not affect the model simulation, but it is
-        written to the binary grid file so that postprocessors can locate the grid in
-        space.
     packagedata : record ncf6 filein ncf6_filename
         Contains data for the ncf package. Data can be passed as a dictionary to the
         ncf package with variable names as keys and package data as values. Data for
@@ -99,7 +92,6 @@ class ModflowGwtdis(MFPackage):
     """
 
     grb_filerecord = ListTemplateGenerator(("gwt6", "dis", "options", "grb_filerecord"))
-    crs = ArrayTemplateGenerator(("gwt6", "dis", "options", "crs"))
     ncf_filerecord = ListTemplateGenerator(("gwt6", "dis", "options", "ncf_filerecord"))
     delr = ArrayTemplateGenerator(("gwt6", "dis", "griddata", "delr"))
     delc = ArrayTemplateGenerator(("gwt6", "dis", "griddata", "delc"))
@@ -335,7 +327,6 @@ class ModflowGwtdis(MFPackage):
         angrot=None,
         export_array_ascii=None,
         export_array_netcdf=None,
-        crs=None,
         packagedata=None,
         nlay=1,
         nrow=2,
@@ -371,7 +362,6 @@ class ModflowGwtdis(MFPackage):
         self.export_array_netcdf = self.build_mfdata(
             "export_array_netcdf", export_array_netcdf
         )
-        self.crs = self.build_mfdata("crs", crs)
         self._ncf_filerecord = self.build_mfdata("ncf_filerecord", None)
         self._ncf_package = self.build_child_package(
             "ncf", packagedata, "packagedata", self._ncf_filerecord

--- a/flopy/mf6/modflow/mfgwtdisu.py
+++ b/flopy/mf6/modflow/mfgwtdisu.py
@@ -58,13 +58,6 @@ class ModflowGwtdisu(MFPackage):
     export_array_ascii : keyword
         keyword that specifies input griddata arrays should be written to layered ascii
         output files.
-    crs : [string]
-        is a real-world coordinate reference system (crs) for the model, for example,
-        an epsg integer code (e.g. 26915), authority string (i.e. epsg:26915), or open
-        geospatial consortium well-known text (wkt) specification. limited to 5000
-        characters. the entry for crs does not affect the model simulation, but it is
-        written to the binary grid file so that postprocessors can locate the grid in
-        space.
     nodes : integer
         is the number of cells in the model grid.
     nja : integer
@@ -184,7 +177,6 @@ class ModflowGwtdisu(MFPackage):
     grb_filerecord = ListTemplateGenerator(
         ("gwt6", "disu", "options", "grb_filerecord")
     )
-    crs = ArrayTemplateGenerator(("gwt6", "disu", "options", "crs"))
     top = ArrayTemplateGenerator(("gwt6", "disu", "griddata", "top"))
     bot = ArrayTemplateGenerator(("gwt6", "disu", "griddata", "bot"))
     area = ArrayTemplateGenerator(("gwt6", "disu", "griddata", "area"))
@@ -506,7 +498,6 @@ class ModflowGwtdisu(MFPackage):
         angrot=None,
         vertical_offset_tolerance=0.0,
         export_array_ascii=None,
-        crs=None,
         nodes=None,
         nja=None,
         nvert=None,
@@ -548,7 +539,6 @@ class ModflowGwtdisu(MFPackage):
         self.export_array_ascii = self.build_mfdata(
             "export_array_ascii", export_array_ascii
         )
-        self.crs = self.build_mfdata("crs", crs)
         self.nodes = self.build_mfdata("nodes", nodes)
         self.nja = self.build_mfdata("nja", nja)
         self.nvert = self.build_mfdata("nvert", nvert)

--- a/flopy/mf6/modflow/mfgwtdisv.py
+++ b/flopy/mf6/modflow/mfgwtdisv.py
@@ -54,13 +54,6 @@ class ModflowGwtdisv(MFPackage):
     export_array_netcdf : keyword
         keyword that specifies input griddata arrays should be written to the model
         output netcdf file.
-    crs : [string]
-        is a real-world coordinate reference system (crs) for the model, for example,
-        an epsg integer code (e.g. 26915), authority string (i.e. epsg:26915), or open
-        geospatial consortium well-known text (wkt) specification. limited to 5000
-        characters. the entry for crs does not affect the model simulation, but it is
-        written to the binary grid file so that postprocessors can locate the grid in
-        space.
     packagedata : record ncf6 filein ncf6_filename
         Contains data for the ncf package. Data can be passed as a dictionary to the
         ncf package with variable names as keys and package data as values. Data for
@@ -127,7 +120,6 @@ class ModflowGwtdisv(MFPackage):
     grb_filerecord = ListTemplateGenerator(
         ("gwt6", "disv", "options", "grb_filerecord")
     )
-    crs = ArrayTemplateGenerator(("gwt6", "disv", "options", "crs"))
     ncf_filerecord = ListTemplateGenerator(
         ("gwt6", "disv", "options", "ncf_filerecord")
     )
@@ -434,7 +426,6 @@ class ModflowGwtdisv(MFPackage):
         angrot=None,
         export_array_ascii=None,
         export_array_netcdf=None,
-        crs=None,
         packagedata=None,
         nlay=None,
         ncpl=None,
@@ -470,7 +461,6 @@ class ModflowGwtdisv(MFPackage):
         self.export_array_netcdf = self.build_mfdata(
             "export_array_netcdf", export_array_netcdf
         )
-        self.crs = self.build_mfdata("crs", crs)
         self._ncf_filerecord = self.build_mfdata("ncf_filerecord", None)
         self._ncf_package = self.build_child_package(
             "ncf", packagedata, "packagedata", self._ncf_filerecord

--- a/flopy/mf6/modflow/mfgwtnam.py
+++ b/flopy/mf6/modflow/mfgwtnam.py
@@ -36,9 +36,6 @@ class ModflowGwtnam(MFPackage):
     save_flows : keyword
         keyword to indicate that all model package flow terms will be written to the
         file specified with 'budget fileout' in output control.
-    dependent_variable_scaling : keyword
-        flag to scale x and rhs to avoid very large positive or negative dependent
-        variable values
     nc_mesh2d_filerecord : (ncmesh2dfile)
         netcdf layered mesh fileout record.
         * ncmesh2dfile : string
@@ -293,7 +290,6 @@ class ModflowGwtnam(MFPackage):
         print_input=None,
         print_flows=None,
         save_flows=None,
-        dependent_variable_scaling=None,
         nc_mesh2d_filerecord=None,
         nc_structured_filerecord=None,
         nc_filerecord=None,
@@ -316,9 +312,6 @@ class ModflowGwtnam(MFPackage):
         self.print_input = self.build_mfdata("print_input", print_input)
         self.print_flows = self.build_mfdata("print_flows", print_flows)
         self.save_flows = self.build_mfdata("save_flows", save_flows)
-        self.dependent_variable_scaling = self.build_mfdata(
-            "dependent_variable_scaling", dependent_variable_scaling
-        )
         self.nc_mesh2d_filerecord = self.build_mfdata(
             "nc_mesh2d_filerecord", nc_mesh2d_filerecord
         )

--- a/flopy/mf6/modflow/mfgwtsrc.py
+++ b/flopy/mf6/modflow/mfgwtsrc.py
@@ -57,20 +57,6 @@ class ModflowGwtsrc(MFPackage):
         obs package with variable names as keys and package data as values. Data for
         the observations variable is also acceptable. See obs package documentation for
         more information.
-    highest_saturated : keyword
-        apply mass source loading rate to specified cellid or highest underlying cell
-        with a cell saturation greater than zero. the highest_saturated option has an
-        additional complication for certain types of grids specified using the disu
-        package. when the disu package is used, a cell may have more than one cell
-        underlying it. if the overlying cell were to become inactive, there is no
-        straightforward method for determining how to apportion the mass source loading
-        rate to the underlying cells. in this case, the approach described by
-        cite{modflowusg} is used. the mass source loading rate is assigned to the first
-        active cell encountered (determined by searching through the underlying cell
-        numbers from the lowest number to the highest number). in this manner, the
-        total mass source loading rate is conserved; however, the spatial distribution
-        of the applied mass source loading rate may not be maintained as layers become
-        dry or wet during a simulation.
     maxbound : integer
         integer value specifying the maximum number of sources cells that will be
         specified for use during any stress period.
@@ -334,7 +320,6 @@ class ModflowGwtsrc(MFPackage):
         save_flows=None,
         timeseries=None,
         observations=None,
-        highest_saturated=None,
         maxbound=None,
         stress_period_data=None,
         filename=None,
@@ -364,9 +349,6 @@ class ModflowGwtsrc(MFPackage):
         self._obs_filerecord = self.build_mfdata("obs_filerecord", None)
         self._obs_package = self.build_child_package(
             "obs", observations, "continuous", self._obs_filerecord
-        )
-        self.highest_saturated = self.build_mfdata(
-            "highest_saturated", highest_saturated
         )
         self.maxbound = self.build_mfdata("maxbound", maxbound)
         self.stress_period_data = self.build_mfdata(

--- a/flopy/mf6/modflow/mfprtdis.py
+++ b/flopy/mf6/modflow/mfprtdis.py
@@ -51,13 +51,6 @@ class ModflowPrtdis(MFPackage):
     export_array_netcdf : keyword
         keyword that specifies input griddata arrays should be written to the model
         output netcdf file.
-    crs : [string]
-        is a real-world coordinate reference system (crs) for the model, for example,
-        an epsg integer code (e.g. 26915), authority string (i.e. epsg:26915), or open
-        geospatial consortium well-known text (wkt) specification. limited to 5000
-        characters. the entry for crs does not affect the model simulation, but it is
-        written to the binary grid file so that postprocessors can locate the grid in
-        space.
     packagedata : record ncf6 filein ncf6_filename
         Contains data for the ncf package. Data can be passed as a dictionary to the
         ncf package with variable names as keys and package data as values. Data for
@@ -99,7 +92,6 @@ class ModflowPrtdis(MFPackage):
     """
 
     grb_filerecord = ListTemplateGenerator(("prt6", "dis", "options", "grb_filerecord"))
-    crs = ArrayTemplateGenerator(("prt6", "dis", "options", "crs"))
     ncf_filerecord = ListTemplateGenerator(("prt6", "dis", "options", "ncf_filerecord"))
     delr = ArrayTemplateGenerator(("prt6", "dis", "griddata", "delr"))
     delc = ArrayTemplateGenerator(("prt6", "dis", "griddata", "delc"))
@@ -327,7 +319,6 @@ class ModflowPrtdis(MFPackage):
         angrot=None,
         export_array_ascii=None,
         export_array_netcdf=None,
-        crs=None,
         packagedata=None,
         nlay=1,
         nrow=2,
@@ -363,7 +354,6 @@ class ModflowPrtdis(MFPackage):
         self.export_array_netcdf = self.build_mfdata(
             "export_array_netcdf", export_array_netcdf
         )
-        self.crs = self.build_mfdata("crs", crs)
         self._ncf_filerecord = self.build_mfdata("ncf_filerecord", None)
         self._ncf_package = self.build_child_package(
             "ncf", packagedata, "packagedata", self._ncf_filerecord

--- a/flopy/mf6/modflow/mfprtdisv.py
+++ b/flopy/mf6/modflow/mfprtdisv.py
@@ -52,13 +52,6 @@ class ModflowPrtdisv(MFPackage):
     export_array_netcdf : keyword
         keyword that specifies input griddata arrays should be written to the model
         output netcdf file.
-    crs : [string]
-        is a real-world coordinate reference system (crs) for the model, for example,
-        an epsg integer code (e.g. 26915), authority string (i.e. epsg:26915), or open
-        geospatial consortium well-known text (wkt) specification. limited to 5000
-        characters. the entry for crs does not affect the model simulation, but it is
-        written to the binary grid file so that postprocessors can locate the grid in
-        space.
     packagedata : record ncf6 filein ncf6_filename
         Contains data for the ncf package. Data can be passed as a dictionary to the
         ncf package with variable names as keys and package data as values. Data for
@@ -125,7 +118,6 @@ class ModflowPrtdisv(MFPackage):
     grb_filerecord = ListTemplateGenerator(
         ("prt6", "disv", "options", "grb_filerecord")
     )
-    crs = ArrayTemplateGenerator(("prt6", "disv", "options", "crs"))
     ncf_filerecord = ListTemplateGenerator(
         ("prt6", "disv", "options", "ncf_filerecord")
     )
@@ -426,7 +418,6 @@ class ModflowPrtdisv(MFPackage):
         angrot=None,
         export_array_ascii=None,
         export_array_netcdf=None,
-        crs=None,
         packagedata=None,
         nlay=None,
         ncpl=None,
@@ -462,7 +453,6 @@ class ModflowPrtdisv(MFPackage):
         self.export_array_netcdf = self.build_mfdata(
             "export_array_netcdf", export_array_netcdf
         )
-        self.crs = self.build_mfdata("crs", crs)
         self._ncf_filerecord = self.build_mfdata("ncf_filerecord", None)
         self._ncf_package = self.build_child_package(
             "ncf", packagedata, "packagedata", self._ncf_filerecord

--- a/flopy/mf6/modflow/mfprtprp.py
+++ b/flopy/mf6/modflow/mfprtprp.py
@@ -124,10 +124,6 @@ class ModflowPrtprp(MFPackage):
         releasesetting selections. if none of these are provided, a single release time
         is configured at the beginning of the first time step of the simulation's first
         stress period.
-    coordinate_check_method : string
-        approach for verifying that release point coordinates are in the cell with the
-        specified id. by default, release point coordinates are checked at release
-        time.
     dev_cycle_detection_window : integer
         integer value defining the size of the window (number of consecutive exit
         events) used for cycle detection. defaults to 0, disabling cycle detection.
@@ -721,7 +717,6 @@ class ModflowPrtprp(MFPackage):
         dev_forceternary=None,
         release_time_tolerance=None,
         release_time_frequency=None,
-        coordinate_check_method="eager",
         dev_cycle_detection_window=None,
         nreleasepts=None,
         nreleasetimes=None,
@@ -778,9 +773,6 @@ class ModflowPrtprp(MFPackage):
         )
         self.release_time_frequency = self.build_mfdata(
             "release_time_frequency", release_time_frequency
-        )
-        self.coordinate_check_method = self.build_mfdata(
-            "coordinate_check_method", coordinate_check_method
         )
         self.dev_cycle_detection_window = self.build_mfdata(
             "dev_cycle_detection_window", dev_cycle_detection_window


### PR DESCRIPTION
#2618 failed to filter out prerelease variables