### PR TITLE
refactor: remove get_version_string from MFStructure

### DIFF
--- a/flopy/mf6/coordinates/modelgrid.py
+++ b/flopy/mf6/coordinates/modelgrid.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-from ..data.mfstructure import MFStructure
 from ..utils.mfenums import DiscretizationType
 
 
@@ -428,45 +427,40 @@ class ModelGrid:
         package_recarray = simulation_data.mfdata[
             (model_name, "nam", "packages", "packages")
         ]
-        structure = MFStructure()
         if (
-            package_recarray.search_data(
-                f"dis{structure.get_version_string()}", 0
-            )
+            package_recarray.search_data(f"dis6", 0)
             is not None
         ):
             return DiscretizationType.DIS
         elif (
-            package_recarray.search_data(
-                f"disv{structure.get_version_string()}", 0
-            )
+            package_recarray.search_data(f"disv6", 0)
             is not None
         ):
             return DiscretizationType.DISV
         elif (
             package_recarray.search_data(
-                f"disu{structure.get_version_string()}", 0
+                f"disu6", 0
             )
             is not None
         ):
             return DiscretizationType.DISU
         elif (
             package_recarray.search_data(
-                f"disv1d{structure.get_version_string()}", 0
+                f"disv1d6", 0
             )
             is not None
         ):
             return DiscretizationType.DISV1D
         elif (
             package_recarray.search_data(
-                f"dis2d{structure.get_version_string()}", 0
+                f"dis2d6", 0
             )
             is not None
         ):
             return DiscretizationType.DIS2D
         elif (
             package_recarray.search_data(
-                f"disv2d{structure.get_version_string()}", 0
+                f"disv2d6", 0
             )
             is not None
         ):

--- a/flopy/mf6/data/mfstructure.py
+++ b/flopy/mf6/data/mfstructure.py
@@ -2023,7 +2023,7 @@ class MFSimulationStructure:
             or dfn_file.dfn_type == DfnType.mvr_file
             or dfn_file.dfn_type == DfnType.mvt_file
         ):
-            model_ver = f"{dfn_file.model_type}{MFStructure().get_version_string()}"
+            model_ver = f"{dfn_file.model_type}6"
             if model_ver not in self.model_struct_objs:
                 self.add_model(model_ver)
             if dfn_file.dfn_type == DfnType.model_file:
@@ -2137,8 +2137,6 @@ class MFStructure:
 
     Parameters
     ----------
-    mf_version : int
-        version of MODFLOW
     valid : bool
         whether the structure information loaded from the dfn files is valid
     sim_struct : MFSimulationStructure
@@ -2155,7 +2153,6 @@ class MFStructure:
             cls._instance = super().__new__(cls)
 
             # Initialize variables
-            cls._instance.mf_version = 6
             cls._instance.sim_struct = None
             cls._instance.dimension_dict = {}
             cls._instance.flopy_dict = {}
@@ -2164,9 +2161,6 @@ class MFStructure:
             cls._instance.valid = cls._instance._load_structure()
 
         return cls._instance
-
-    def get_version_string(self):
-        return format(str(self.mf_version))
 
     def _load_structure(self):
         # set up structure classes

--- a/flopy/mf6/data/mfstructure.py
+++ b/flopy/mf6/data/mfstructure.py
@@ -2137,8 +2137,6 @@ class MFStructure:
 
     Parameters
     ----------
-    valid : bool
-        whether the structure information loaded from the dfn files is valid
     sim_struct : MFSimulationStructure
         Object containing file structure for all simulation files
     dimension_dict : dict
@@ -2151,22 +2149,14 @@ class MFStructure:
     def __new__(cls):
         if cls._instance is None:
             cls._instance = super().__new__(cls)
-
-            # Initialize variables
             cls._instance.sim_struct = None
             cls._instance.dimension_dict = {}
             cls._instance.flopy_dict = {}
-
-            # Read metadata from file
-            cls._instance.valid = cls._instance._load_structure()
-
+            cls._instance._load_structure()
         return cls._instance
 
     def _load_structure(self):
-        # set up structure classes
         self.sim_struct = MFSimulationStructure()
-
-        # initialize flopy dict keys
         MFStructure().flopy_dict["solution_packages"] = {}
 
         from ..mfpackage import MFPackage
@@ -2183,5 +2173,3 @@ class MFStructure:
             # process each package
             self.sim_struct.process_dfn(DfnPackage(package))
         self.sim_struct.tag_read_as_arrays()
-
-        return True

--- a/flopy/mf6/mfmodel.py
+++ b/flopy/mf6/mfmodel.py
@@ -933,12 +933,11 @@ class MFModel(ModelInterface):
         instance.name_file.load(strict)
 
         # order packages
-        vnum = mfstructure.MFStructure().get_version_string()
         # FIX: Transport - Priority packages maybe should not be hard coded
         priority_packages = {
-            f"dis{vnum}": 1,
-            f"disv{vnum}": 1,
-            f"disu{vnum}": 1,
+            f"dis6": 1,
+            f"disv6": 1,
+            f"disu6": 1,
         }
         packages_ordered = []
         package_recarray = instance.simulation_data.mfdata[
@@ -1350,44 +1349,32 @@ class MFModel(ModelInterface):
         package_recarray = self.name_file.packages
         structure = mfstructure.MFStructure()
         if (
-            package_recarray.search_data(
-                f"dis{structure.get_version_string()}", 0
-            )
+            package_recarray.search_data(f"dis6", 0)
             is not None
         ):
             return DiscretizationType.DIS
         elif (
-            package_recarray.search_data(
-                f"disv{structure.get_version_string()}", 0
-            )
+            package_recarray.search_data(f"disv6", 0)
             is not None
         ):
             return DiscretizationType.DISV
         elif (
-            package_recarray.search_data(
-                f"disu{structure.get_version_string()}", 0
-            )
+            package_recarray.search_data(f"disu6", 0)
             is not None
         ):
             return DiscretizationType.DISU
         elif (
-            package_recarray.search_data(
-                f"disv1d{structure.get_version_string()}", 0
-            )
+            package_recarray.search_data(f"disv1d6", 0)
             is not None
         ):
             return DiscretizationType.DISV1D
         elif (
-            package_recarray.search_data(
-                f"dis2d{structure.get_version_string()}", 0
-            )
+            package_recarray.search_data(f"dis2d6", 0)
             is not None
         ):
             return DiscretizationType.DIS2D
         elif (
-            package_recarray.search_data(
-                f"disv2d{structure.get_version_string()}", 0
-            )
+            package_recarray.search_data(f"disv2d6", 0)
             is not None
         ):
             return DiscretizationType.DISV2D

--- a/flopy/mf6/mfsimbase.py
+++ b/flopy/mf6/mfsimbase.py
@@ -858,7 +858,7 @@ class MFSimulationBase:
         instance.name_file.load(strict)
 
         # load TDIS file
-        tdis_pkg = f"tdis{mfstructure.MFStructure().get_version_string()}"
+        tdis_pkg = f"tdis6"
         tdis_attr = getattr(instance.name_file, tdis_pkg)
         instance._tdis_file = mftdis.ModflowTdis(
             instance, filename=tdis_attr.get_data()
@@ -1402,8 +1402,7 @@ class MFSimulationBase:
 
                 # associate any models in the model list to this
                 # simulation file
-                version_string = mfstructure.MFStructure().get_version_string()
-                solution_pkg = f"{solution_file.package_abbr}{version_string}"
+                solution_pkg = f"{solution_file.package_abbr}6"
                 new_record = [solution_pkg, solution_file.filename]
                 for model in model_list:
                     new_record.append(model)
@@ -1509,8 +1508,7 @@ class MFSimulationBase:
                     return
 
     def _set_timing_block(self, file_name):
-        struct_root = mfstructure.MFStructure()
-        tdis_pkg = f"tdis{struct_root.get_version_string()}"
+        tdis_pkg = f"tdis6"
         tdis_attr = getattr(self.name_file, tdis_pkg)
         try:
             tdis_attr.set_data(file_name)


### PR DESCRIPTION
Followup to #2333, small step toward replacing `mfstructure.py`