### PR TITLE
refactor(codegen): store new spec on generated classes

### DIFF
--- a/flopy/mf6/utils/codegen/filters.py
+++ b/flopy/mf6/utils/codegen/filters.py
@@ -350,8 +350,9 @@ def attrs(dfn: dict, component_name: tuple[str, str], developmode: bool = True) 
                 meta_.append(" ".join(s))
         return meta_
 
-    legacy_dfn = dfn.get("legacy_dfn", {})
-    legacy_meta = dfn.get("legacy_meta", [])
+    dfn_copy = dfn.copy()
+    legacy_dfn = dfn_copy.pop("legacy_dfn", {})
+    legacy_meta = dfn_copy.pop("legacy_meta", [])
     legacy_dfn = _dfn(legacy_dfn, _filter_metadata(legacy_meta))
     if component_base == "MFPackage":
         attrs.extend(
@@ -359,7 +360,8 @@ def attrs(dfn: dict, component_name: tuple[str, str], developmode: bool = True) 
                 f"package_abbr = '{package_abbr(component_name)}'",
                 f"_package_type = '{component_name[1]}'",
                 f"dfn_file_name = '{dfn_file_name(component_name)}'",
-                f"dfn = {pformat(legacy_dfn, indent=10, width=sys.maxsize)}"
+                f"dfn = {pformat(legacy_dfn, indent=10, width=sys.maxsize)}",
+                f"spec = {pformat(dfn_copy, indent=10, width=sys.maxsize)}",
             ]
         )
 


### PR DESCRIPTION
More followup on #2333, store the new structured spec on the generated classes beside the old one. This allows gradual substitution and replacement of `mfstructure.py`. Don't replace the generated `flopy.mf6.modflow` module yet, this just clears the way for development