### PR TITLE
feat(compare_cell_budget): move cbb comparison function from mf6 tests

### DIFF
--- a/autotest/regression/test_mfnwt.py
+++ b/autotest/regression/test_mfnwt.py
@@ -6,7 +6,7 @@ from modflow_devtools.markers import requires_exe
 from autotest.conftest import get_example_data_path
 from flopy.modflow import Modflow, ModflowNwt, ModflowUpw
 from flopy.utils import parsenamefile
-from flopy.utils.compare import compare_budget, compare_heads
+from flopy.utils.compare import compare_heads, compare_list_budget
 
 
 def get_nfnwt_namfiles():
@@ -137,6 +137,6 @@ def test_run_mfnwt_model(function_tmpdir, namfile):
     assert compare_heads(fn0, fn1, outfile=fsum), "head comparison failure"
 
     fsum = function_tmpdir / f"{base_name}.budget.out"
-    assert compare_budget(fn0, fn1, max_incpd=0.1, max_cumpd=0.1, outfile=fsum), (
+    assert compare_list_budget(fn0, fn1, max_incpd=0.1, max_cumpd=0.1, outfile=fsum), (
         "budget comparison failure"
     )

--- a/autotest/regression/test_modflow.py
+++ b/autotest/regression/test_modflow.py
@@ -8,7 +8,7 @@ from modflow_devtools.markers import requires_exe, requires_pkg
 
 from autotest.conftest import get_example_data_path
 from flopy.modflow import Modflow, ModflowOc
-from flopy.utils.compare import compare_budget, compare_heads
+from flopy.utils.compare import compare_heads, compare_list_budget
 
 
 @pytest.fixture
@@ -74,7 +74,7 @@ def test_uzf_unit_numbers(function_tmpdir, uzf_example_path):
 
     # compare budget terms
     fsum = join(function_tmpdir, f"{splitext(mfnam)[0]}.budget.out")
-    success = compare_budget(fn0, fn1, max_incpd=0.1, max_cumpd=0.1, outfile=fsum)
+    success = compare_list_budget(fn0, fn1, max_incpd=0.1, max_cumpd=0.1, outfile=fsum)
     assert success, "budget comparison failure"
 
 
@@ -112,7 +112,7 @@ def test_unitnums(function_tmpdir, mf2005_test_path):
     fn1 = join(model_ws2, mfnam)
 
     fsum = join(ws, f"{splitext(mfnam)[0]}.budget.out")
-    success = compare_budget(fn0, fn1, max_incpd=0.1, max_cumpd=0.1, outfile=fsum)
+    success = compare_list_budget(fn0, fn1, max_incpd=0.1, max_cumpd=0.1, outfile=fsum)
     assert success, "budget comparison failure"
 
 
@@ -201,7 +201,7 @@ def test_mf2005pcgn(function_tmpdir, namfile):
     assert success, "head comparison failure"
 
     fsum = function_tmpdir / f"{Path(namfile).stem}.budget.out"
-    success = compare_budget(fn0, fn1, max_incpd=0.1, max_cumpd=0.1, outfile=fsum)
+    success = compare_list_budget(fn0, fn1, max_incpd=0.1, max_cumpd=0.1, outfile=fsum)
     assert success, "budget comparison failure"
 
 
@@ -241,7 +241,7 @@ def test_mf2005gmg(function_tmpdir, namfile):
     assert success, "head comparison failure"
 
     fsum = function_tmpdir / f"{Path(namfile).stem}.budget.out"
-    success = compare_budget(fn0, fn1, max_incpd=0.1, max_cumpd=0.1, outfile=fsum)
+    success = compare_list_budget(fn0, fn1, max_incpd=0.1, max_cumpd=0.1, outfile=fsum)
     assert success, "budget comparison failure"
 
 
@@ -307,7 +307,7 @@ def test_mf2005(function_tmpdir, namfile):
 
     # compare budgets
     fsum = ws / f"{Path(namfile).stem}.budget.out"
-    success = compare_budget(fn0, fn1, max_incpd=0.1, max_cumpd=0.1, outfile=fsum)
+    success = compare_list_budget(fn0, fn1, max_incpd=0.1, max_cumpd=0.1, outfile=fsum)
     assert success, "budget comparison failure"
 
 
@@ -351,7 +351,7 @@ def test_mf2005fhb(function_tmpdir, namfile):
     assert success, "head comparison failure"
 
     fsum = join(ws, f"{Path(namfile).stem}.budget.out")
-    success = compare_budget(fn0, fn1, max_incpd=0.1, max_cumpd=0.1, outfile=fsum)
+    success = compare_list_budget(fn0, fn1, max_incpd=0.1, max_cumpd=0.1, outfile=fsum)
     assert success, "budget comparison failure"
 
 
@@ -393,5 +393,5 @@ def test_mf2005_lake(function_tmpdir, namfile, mf2005_test_path):
 
     fsum = join(ws, f"{Path(namfile).stem}.budget.out")
 
-    success = compare_budget(fn0, fn1, max_incpd=0.1, max_cumpd=0.1, outfile=fsum)
+    success = compare_list_budget(fn0, fn1, max_incpd=0.1, max_cumpd=0.1, outfile=fsum)
     assert success, "budget comparison failure"

--- a/autotest/regression/test_swi2.py
+++ b/autotest/regression/test_swi2.py
@@ -5,7 +5,7 @@ import pytest
 from modflow_devtools.markers import requires_exe
 
 from flopy.modflow import Modflow
-from flopy.utils.compare import compare_budget
+from flopy.utils.compare import compare_list_budget
 
 
 @pytest.fixture
@@ -44,6 +44,6 @@ def test_mf2005swi2(function_tmpdir, swi_path, namfile):
     fn1 = os.path.join(model_ws2, namfile)
 
     fsum = os.path.join(ws, f"{os.path.splitext(namfile)[0]}.budget.out")
-    success = compare_budget(fn0, fn1, max_incpd=0.1, max_cumpd=0.1, outfile=fsum)
+    success = compare_list_budget(fn0, fn1, max_incpd=0.1, max_cumpd=0.1, outfile=fsum)
 
     assert success, "budget comparison failure"

--- a/autotest/regression/test_wel.py
+++ b/autotest/regression/test_wel.py
@@ -13,7 +13,7 @@ from flopy.modflow import (
     ModflowPcg,
     ModflowWel,
 )
-from flopy.utils.compare import compare_budget, compare_heads
+from flopy.utils.compare import compare_heads, compare_list_budget
 
 
 @requires_exe("mf2005")
@@ -99,6 +99,6 @@ def test_binary_well(function_tmpdir):
     assert compare_heads(fn0, fn1, outfile=fsum), "head comparison failure"
 
     fsum = os.path.join(function_tmpdir, f"{os.path.splitext(mfnam)[0]}.budget.out")
-    assert compare_budget(fn0, fn1, max_incpd=0.1, max_cumpd=0.1, outfile=fsum), (
+    assert compare_list_budget(fn0, fn1, max_incpd=0.1, max_cumpd=0.1, outfile=fsum), (
         "budget comparison failure"
     )

--- a/autotest/test_compare.py
+++ b/autotest/test_compare.py
@@ -17,8 +17,8 @@ from flopy.modflow import (
 from flopy.utils.compare import (
     _diffmax,  # noqa: PLC2701
     _difftol,  # noqa: PLC2701
-    compare_budget,
     compare_heads,
+    compare_list_budget,
 )
 
 
@@ -144,36 +144,9 @@ def test_compare_budget_and_heads(comparison_model_1):
     assert compare_heads(str(fn0), str(fn1), outfile=fhsum), (
         "head comparison failure (str path)"
     )
-    assert compare_budget(fn0, fn1, max_incpd=0.1, max_cumpd=0.1, outfile=fbsum), (
+    assert compare_list_budget(fn0, fn1, max_incpd=0.1, max_cumpd=0.1, outfile=fbsum), (
         "budget comparison failure (pathlib.Path)"
     )
-    assert compare_budget(
+    assert compare_list_budget(
         str(fn0), str(fn1), max_incpd=0.1, max_cumpd=0.1, outfile=str(fbsum)
     ), "budget comparison failure (str path)"
-
-    # todo test with files1 and files2 arguments
-
-
-@pytest.mark.skip(reason="todo")
-def test_compare_swrbudget():
-    pass
-
-
-@pytest.mark.skip(reason="todo")
-def test_compare_heads():
-    pass
-
-
-@pytest.mark.skip(reason="todo")
-def test_compare_concs():
-    pass
-
-
-@pytest.mark.skip(reason="todo")
-def test_compare_stages():
-    pass
-
-
-@pytest.mark.skip(reason="todo")
-def test_compare():
-    pass


### PR DESCRIPTION
Rehome cell by cell budget comparison function [from MF6 autotests](https://github.com/MODFLOW-ORG/modflow6/blob/173a3ed53cdbcb143ba1058770cea69455dacf25/autotest/framework.py#L430). Rename the old `compare_budget` to `compare_list_budget` to clarify but leave an alias to `compare_budget`.