### PR TITLE
Fix open/close bugs

### DIFF
--- a/autotest/test_util_2d_and_3d.py
+++ b/autotest/test_util_2d_and_3d.py
@@ -614,3 +614,28 @@ def test_mflist_fromfile(function_tmpdir):
     flx_array = wel.stress_period_data.array["flux"][0]
     for k, i, j, flx in zip(wel_data.k, wel_data.i, wel_data.j, wel_data.flux):
         assert flx_array[k, i, j] == flx
+
+def test_pathlib_support():
+    import tempfile
+    from pathlib import Path
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model_ws = Path(tmpdir)
+        out_well_spd = {0: model_ws.joinpath('wel.txt')}
+        with open(out_well_spd[0], 'w') as f:
+            f.write('0 2 2 -10\n')
+            f.write('0 1 2 -10\n')
+        m = Modflow('test_model', model_ws=model_ws, exe_name='mf2005')
+        wel = ModflowWel(m, stress_period_data=out_well_spd, ipakcb=740,)
+        m.write_input()
+
+def test_open_close_one_val():
+    import tempfile
+    from pathlib import Path
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model_ws = Path(tmpdir)
+        out_well_spd = {0: model_ws.joinpath('wel.txt')}
+        with open(out_well_spd[0], 'w') as f:
+            f.write('0 2 2 -10\n')
+        m = Modflow('test_model', model_ws=model_ws, exe_name='mf2005')
+        wel = ModflowWel(m, stress_period_data=out_well_spd, ipakcb=740,)
+        m.write_input()

--- a/autotest/test_util_2d_and_3d.py
+++ b/autotest/test_util_2d_and_3d.py
@@ -615,27 +615,39 @@ def test_mflist_fromfile(function_tmpdir):
     for k, i, j, flx in zip(wel_data.k, wel_data.i, wel_data.j, wel_data.flux):
         assert flx_array[k, i, j] == flx
 
+
 def test_pathlib_support():
     import tempfile
     from pathlib import Path
+
     with tempfile.TemporaryDirectory() as tmpdir:
         model_ws = Path(tmpdir)
-        out_well_spd = {0: model_ws.joinpath('wel.txt')}
-        with open(out_well_spd[0], 'w') as f:
-            f.write('0 2 2 -10\n')
-            f.write('0 1 2 -10\n')
-        m = Modflow('test_model', model_ws=model_ws, exe_name='mf2005')
-        wel = ModflowWel(m, stress_period_data=out_well_spd, ipakcb=740,)
+        out_well_spd = {0: model_ws.joinpath("wel.txt")}
+        with open(out_well_spd[0], "w") as f:
+            f.write("0 2 2 -10\n")
+            f.write("0 1 2 -10\n")
+        m = Modflow("test_model", model_ws=model_ws, exe_name="mf2005")
+        wel = ModflowWel(
+            m,
+            stress_period_data=out_well_spd,
+            ipakcb=740,
+        )
         m.write_input()
+
 
 def test_open_close_one_val():
     import tempfile
     from pathlib import Path
+
     with tempfile.TemporaryDirectory() as tmpdir:
         model_ws = Path(tmpdir)
-        out_well_spd = {0: model_ws.joinpath('wel.txt')}
-        with open(out_well_spd[0], 'w') as f:
-            f.write('0 2 2 -10\n')
-        m = Modflow('test_model', model_ws=model_ws, exe_name='mf2005')
-        wel = ModflowWel(m, stress_period_data=out_well_spd, ipakcb=740,)
+        out_well_spd = {0: model_ws.joinpath("wel.txt")}
+        with open(out_well_spd[0], "w") as f:
+            f.write("0 2 2 -10\n")
+        m = Modflow("test_model", model_ws=model_ws, exe_name="mf2005")
+        wel = ModflowWel(
+            m,
+            stress_period_data=out_well_spd,
+            ipakcb=740,
+        )
         m.write_input()

--- a/autotest/test_util_2d_and_3d.py
+++ b/autotest/test_util_2d_and_3d.py
@@ -616,38 +616,30 @@ def test_mflist_fromfile(function_tmpdir):
         assert flx_array[k, i, j] == flx
 
 
-def test_pathlib_support():
-    import tempfile
-    from pathlib import Path
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        model_ws = Path(tmpdir)
-        out_well_spd = {0: model_ws.joinpath("wel.txt")}
-        with open(out_well_spd[0], "w") as f:
-            f.write("0 2 2 -10\n")
-            f.write("0 1 2 -10\n")
-        m = Modflow("test_model", model_ws=model_ws, exe_name="mf2005")
-        wel = ModflowWel(
-            m,
-            stress_period_data=out_well_spd,
-            ipakcb=740,
-        )
-        m.write_input()
+def test_pathlib_support(function_tmpdir):
+    model_ws = function_tmpdir
+    out_well_spd = {0: model_ws.joinpath("wel.txt")}
+    with open(out_well_spd[0], "w") as f:
+        f.write("0 2 2 -10\n")
+        f.write("0 1 2 -10\n")
+    m = Modflow("test_model", model_ws=model_ws, exe_name="mf2005")
+    wel = ModflowWel(
+        m,
+        stress_period_data=out_well_spd,
+        ipakcb=740,
+    )
+    m.write_input()
 
 
-def test_open_close_one_val():
-    import tempfile
-    from pathlib import Path
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        model_ws = Path(tmpdir)
-        out_well_spd = {0: model_ws.joinpath("wel.txt")}
-        with open(out_well_spd[0], "w") as f:
-            f.write("0 2 2 -10\n")
-        m = Modflow("test_model", model_ws=model_ws, exe_name="mf2005")
-        wel = ModflowWel(
-            m,
-            stress_period_data=out_well_spd,
-            ipakcb=740,
-        )
-        m.write_input()
+def test_open_close_one_val(function_tmpdir):
+    model_ws = function_tmpdir
+    out_well_spd = {0: model_ws.joinpath("wel.txt")}
+    with open(out_well_spd[0], "w") as f:
+        f.write("0 2 2 -10\n")
+    m = Modflow("test_model", model_ws=model_ws, exe_name="mf2005")
+    wel = ModflowWel(
+        m,
+        stress_period_data=out_well_spd,
+        ipakcb=740,
+    )
+    m.write_input()

--- a/flopy/utils/util_list.py
+++ b/flopy/utils/util_list.py
@@ -11,6 +11,7 @@ util_list module.  Contains the mflist class.
 import os
 import warnings
 from pathlib import Path
+
 import numpy as np
 import pandas as pd
 

--- a/flopy/utils/util_list.py
+++ b/flopy/utils/util_list.py
@@ -349,7 +349,7 @@ class MfList(DataInterface, DataListInterface):
                     self.__cast_dataframe(kper, d)
                 elif isinstance(d, int):
                     self.__cast_int(kper, d)
-                elif isinstance(d, str) or isinstance(d, Path):
+                elif isinstance(d, (str, PathLike):
                     self.__cast_str(kper, d)
                 elif d is None:
                     self.__data[kper] = -1

--- a/flopy/utils/util_list.py
+++ b/flopy/utils/util_list.py
@@ -10,7 +10,7 @@ util_list module.  Contains the mflist class.
 
 import os
 import warnings
-from pathlib import Path
+from os import PathLike
 
 import numpy as np
 import pandas as pd

--- a/flopy/utils/util_list.py
+++ b/flopy/utils/util_list.py
@@ -349,7 +349,7 @@ class MfList(DataInterface, DataListInterface):
                     self.__cast_dataframe(kper, d)
                 elif isinstance(d, int):
                     self.__cast_int(kper, d)
-                elif isinstance(d, (str, PathLike):
+                elif isinstance(d, (str, PathLike)):
                     self.__cast_str(kper, d)
                 elif d is None:
                     self.__data[kper] = -1

--- a/flopy/utils/util_list.py
+++ b/flopy/utils/util_list.py
@@ -10,7 +10,7 @@ util_list module.  Contains the mflist class.
 
 import os
 import warnings
-
+from pathlib import Path
 import numpy as np
 import pandas as pd
 
@@ -234,7 +234,12 @@ class MfList(DataInterface, DataListInterface):
                 return -1
         # If an external file, have to load it
         if self.__vtype[kper] == str:
-            return self.__fromfile(self.__data[kper]).shape[0]
+            t = self.__fromfile(self.__data[kper])
+            if t.shape == ():
+                out = 1
+            else:
+                out = t.shape[0]
+            return out
         if self.__vtype[kper] == np.recarray:
             return self.__data[kper].shape[0]
         # If not any of the above, it must be an int
@@ -343,7 +348,7 @@ class MfList(DataInterface, DataListInterface):
                     self.__cast_dataframe(kper, d)
                 elif isinstance(d, int):
                     self.__cast_int(kper, d)
-                elif isinstance(d, str):
+                elif isinstance(d, str) or isinstance(d, Path):
                     self.__cast_str(kper, d)
                 elif d is None:
                     self.__data[kper] = -1


### PR DESCRIPTION
Fix 2 bugs regarding MFList when reading external files.

First, allow the use of pathlib.Path objects rather than just strings

Second, fix a bug where calculating mxact raises an error when reading a stress period file with only one feature.

Created two new tests to support these features and ran all automated tests.  The only failures were:

- autotest.test_mbase.test_resolve_exe_by_abs_path
- autotest.test_mbase.test_resolve_exe_by_name
- autotest.test_example_notebooks.test_notebooks
- autotest.regression.test_mf6.test006_2models_different_dis
- autotest.regression.test_mf6.test006_create_tests_2models_gnc

From the traceback I belive that these failures are based on my configuration and setup not the changes (note  that many of these are not related to Modflow2005/nwt