### PR TITLE
Bug: Fix shape assignment for DISU package

### DIFF
--- a/flopy/modpath/mp7.py
+++ b/flopy/modpath/mp7.py
@@ -144,7 +144,7 @@ class Modpath7(BaseModel):
                     shape = (nlay, ncpl)
                 elif dis.package_name.lower() == "disu":
                     nodes = dis.nodes.array
-                    shape = tuple(nodes)
+                    shape = tuple([nodes])
                 else:
                     raise TypeError(
                         "DIS, DISV, or DISU packages must be "

--- a/flopy/modpath/mp7.py
+++ b/flopy/modpath/mp7.py
@@ -144,7 +144,7 @@ class Modpath7(BaseModel):
                     shape = (nlay, ncpl)
                 elif dis.package_name.lower() == "disu":
                     nodes = dis.nodes.array
-                    shape = tuple([nodes])
+                    shape = (nodes,)
                 else:
                     raise TypeError(
                         "DIS, DISV, or DISU packages must be "


### PR DESCRIPTION
changing the int to a list of int avoids the TypeError: 'int' object is not iterable