### PR TITLE
fix(MfUsgWel): add get_empty() override to support WELLBOT parameter

### DIFF
--- a/flopy/mfusg/mfusgwel.py
+++ b/flopy/mfusg/mfusgwel.py
@@ -259,6 +259,7 @@ class MfUsgWel(ModflowWel):
             Empty recarray for well data
         """
         import numpy as np
+
         from ..modflow.mfwel import ModflowWel
         from ..pakbase import Package
         from ..utils import create_empty_recarray

--- a/flopy/mfusg/mfusgwel.py
+++ b/flopy/mfusg/mfusgwel.py
@@ -238,6 +238,44 @@ class MfUsgWel(ModflowWel):
         if add_package:
             self.parent.add_package(self)
 
+    @staticmethod
+    def get_empty(ncells=0, aux_names=None, structured=True, wellbot=False):
+        """Get empty recarray for MFUSG wells.
+
+        Parameters
+        ----------
+        ncells : int
+            Number of cells
+        aux_names : list
+            Auxiliary variable names
+        structured : bool
+            Whether grid is structured
+        wellbot : bool
+            Whether WELLBOT option is used
+
+        Returns
+        -------
+        recarray
+            Empty recarray for well data
+        """
+        from ..modflow.mfwel import ModflowWel
+        from ..pakbase import Package
+        from ..utils import create_empty_recarray
+        import numpy as np
+
+        # Get base dtype
+        dtype = ModflowWel.get_default_dtype(structured=structured)
+
+        # Add wellbot field if specified
+        if wellbot:
+            dtype = Package.add_to_dtype(dtype, ["wellbot"], np.float32)
+
+        # Add auxiliary fields
+        if aux_names is not None:
+            dtype = Package.add_to_dtype(dtype, aux_names, np.float32)
+
+        return create_empty_recarray(ncells, dtype, default_value=-1.0e10)
+
     def _check_for_aux(self, options, cln=False):
         """Check dtype for auxiliary variables, and add to options.
 

--- a/flopy/mfusg/mfusgwel.py
+++ b/flopy/mfusg/mfusgwel.py
@@ -258,10 +258,10 @@ class MfUsgWel(ModflowWel):
         recarray
             Empty recarray for well data
         """
+        import numpy as np
         from ..modflow.mfwel import ModflowWel
         from ..pakbase import Package
         from ..utils import create_empty_recarray
-        import numpy as np
 
         # Get base dtype
         dtype = ModflowWel.get_default_dtype(structured=structured)


### PR DESCRIPTION
- Fixes TypeError when loading MFUSG models with WELLBOT option
- Adds static method get_empty() that accepts wellbot parameter
- WELLBOT option was already parsed in pakbase.py but not handled in dtype creation
- Enables loading of USG-Transport models with well bottom elevations

Resolves issue where models using 'WELLBOT' option in WEL package would fail with: TypeError: ModflowWel.get_empty() got an unexpected keyword argument 'wellbot'