### PR TITLE
fix(mfusg): fix duplicate unit numbers in NAM file for MFUSG external files

### DIFF
--- a/flopy/mfusg/mfusg.py
+++ b/flopy/mfusg/mfusg.py
@@ -445,7 +445,7 @@ class MfUsg(Modflow):
             print(f"      {os.path.basename(item.filename)}")
         if key not in model.pop_key_list:
             # do not add unit number (key) if it already exists
-            if key not in model.external_units:
+            if key not in model.external_units and key not in model.output_units:
                 model.external_fnames.append(item.filename)
                 model.external_units.append(key)
                 model.external_binflag.append("binary" in item.filetype.lower())


### PR DESCRIPTION
When loading a model, DATA entries from the NAM file were being added to external_units even when they already existed in output_units (e.g., IUNITAFR from WEL package). This caused duplicate entries in the written NAM file.

Added check for output_units in _prepare_external_files() to prevent adding unit numbers that are already registered as output files.