### PR TITLE
chore(dependencies): add upper bounds for numpy/pandas

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -83,8 +83,7 @@ jobs:
           cache-dependency-glob: "**/pyproject.toml"
 
       - name: Install Python dependencies
-        # temp. allow prereleases for vtk on aarch64
-        run: uv sync --all-extras --prerelease=allow
+        run: uv sync --all-extras
 
       - name: Install Modflow executables
         uses: modflowpy/install-modflow-action@v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,9 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "numpy>=1.20.3",
+    "numpy>=1.20.3,<3.0",
     "matplotlib >=1.4.0",
-    "pandas >=2.0.0",
+    "pandas >=2.0.0,<3.0",
 ]
 dynamic = ["version", "readme"]
 


### PR DESCRIPTION
Add upper bounds to numpy and pandas in `pyproject.toml`, and remove `--prerelease-allow` from `uv sync` command in smoke tests. CI was failing because these two factors combined to allow prerelease versions of numpy and pandas, which broke some tests. The intent behind `--allow-prerelease` was to get a prerelease version of vtk on ARM macs, but seems a full version is now available on PyPI.

I think this might clear the way to switch CI to pixi if we want, as described in #2424