### PR TITLE
fix(mfsimulation): respect max_columns_of_data for internal arrays

### DIFF
--- a/autotest/test_mf6_max_columns_setting.py
+++ b/autotest/test_mf6_max_columns_setting.py
@@ -1,0 +1,246 @@
+"""
+Test for max_columns_of_data setting behavior (GitHub issues #2419/#2420).
+
+Tests that max_columns_of_data is respected when the simulation is created
+from scratch or loaded from file, and that the user setting is chosen over
+auto-detected values.
+"""
+
+import numpy as np
+import pytest
+
+import flopy
+
+
+def test_backward_compat_user_set_flag(function_tmpdir):
+    sim_ws = function_tmpdir / "test_compat_user_set"
+    sim_ws.mkdir(exist_ok=True)
+
+    sim = flopy.mf6.MFSimulation(sim_name="test_sim", sim_ws=sim_ws)
+
+    assert not sim.simulation_data.max_columns_user_set
+    assert not sim.simulation_data.max_columns_auto_set
+
+    sim.simulation_data.max_columns_of_data = 10
+
+    assert sim.simulation_data.max_columns_user_set
+    assert not sim.simulation_data.max_columns_auto_set
+
+    sim.simulation_data.max_columns_user_set = False
+    assert not sim.simulation_data.max_columns_user_set
+
+
+def test_backward_compat_auto_set_flag(function_tmpdir):
+    sim_ws = function_tmpdir / "test_compat_auto_set"
+    sim_ws.mkdir(exist_ok=True)
+
+    sim = flopy.mf6.MFSimulation(sim_name="test_sim", sim_ws=sim_ws)
+    tdis = flopy.mf6.ModflowTdis(
+        sim, time_units="DAYS", nper=1, perioddata=[(1.0, 1, 1.0)]
+    )
+    model = flopy.mf6.ModflowGwf(sim, modelname="model", model_nam_file="model.nam")
+    dis = flopy.mf6.ModflowGwfdis(
+        model, nlay=1, nrow=10, ncol=25, delr=100.0, delc=100.0, top=100.0, botm=0.0
+    )
+    ic = flopy.mf6.ModflowGwfic(model, strt=100.0)
+    npf = flopy.mf6.ModflowGwfnpf(model, save_flows=True, icelltype=0, k=1.0)
+    ims = flopy.mf6.ModflowIms(sim)
+    sim.register_ims_package(ims, [model.name])
+
+    sim.write_simulation()
+
+    loaded_sim = flopy.mf6.MFSimulation.load(sim_name="test_sim", sim_ws=sim_ws)
+
+    assert loaded_sim.simulation_data.max_columns_auto_set
+    assert not loaded_sim.simulation_data.max_columns_user_set
+
+    loaded_sim.simulation_data.max_columns_auto_set = False
+    assert not loaded_sim.simulation_data.max_columns_auto_set
+
+    loaded_sim.simulation_data.max_columns_of_data = 1
+    assert loaded_sim.simulation_data.max_columns_of_data == 1
+    assert loaded_sim.simulation_data.max_columns_user_set
+
+
+def test_backward_compat_flag_transitions(function_tmpdir):
+    sim_ws = function_tmpdir / "test_compat_transitions"
+    sim_ws.mkdir(exist_ok=True)
+
+    sim = flopy.mf6.MFSimulation(sim_name="test_sim", sim_ws=sim_ws)
+
+    assert not sim.simulation_data.max_columns_user_set
+    assert not sim.simulation_data.max_columns_auto_set
+
+    # manually set auto_set flag (simulate old code path)
+    sim.simulation_data.max_columns_auto_set = True
+    assert sim.simulation_data.max_columns_auto_set
+    assert not sim.simulation_data.max_columns_user_set
+
+    # user sets a value - should transition to user_set
+    sim.simulation_data.max_columns_of_data = 5
+    assert sim.simulation_data.max_columns_user_set
+    assert not sim.simulation_data.max_columns_auto_set
+
+    # clear user_set
+    sim.simulation_data.max_columns_user_set = False
+    assert not sim.simulation_data.max_columns_user_set
+    assert not sim.simulation_data.max_columns_auto_set
+
+
+def test_max_columns_internal_array(function_tmpdir):
+    sim_ws = function_tmpdir / "test_internal"
+    sim_ws.mkdir(exist_ok=True)
+
+    sim = flopy.mf6.MFSimulation(sim_name="test_sim", sim_ws=sim_ws)
+    tdis = flopy.mf6.ModflowTdis(
+        sim, time_units="DAYS", nper=1, perioddata=[(1.0, 1, 1.0)]
+    )
+    gwf = flopy.mf6.ModflowGwf(sim, modelname="model", model_nam_file="model.nam")
+    dis = flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=1,
+        nrow=3,
+        ncol=3,
+        delr=100.0,
+        delc=100.0,
+        top=100.0,
+        botm=0.0,
+    )
+    ic = flopy.mf6.ModflowGwfic(gwf, strt=np.arange(9).reshape(1, 3, 3).astype(float))
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=True, icelltype=0, k=1.0)
+    ims = flopy.mf6.ModflowIms(sim)
+    sim.register_ims_package(ims, [gwf.name])
+    sim.write_simulation()
+
+    ic_file = sim_ws / "model.ic"
+    assert ic_file.exists()
+
+    def check_columns(expected):
+        with open(ic_file) as f:
+            content = f.read()
+
+        content_upper = content.upper()
+        assert "BEGIN GRIDDATA" in content_upper
+        assert "STRT" in content_upper
+
+        lines = content.split("\n")
+        found_strt = False
+        found_internal = False
+        strt_lines = []
+
+        for line in lines:
+            line_upper = line.upper()
+
+            if "STRT" in line_upper and not found_strt:
+                found_strt = True
+                continue
+
+            if found_strt and not found_internal and "INTERNAL" in line_upper:
+                found_internal = True
+                continue
+
+            if found_internal:
+                stripped = line.strip()
+                if (
+                    not stripped
+                    or stripped.upper().startswith("END")
+                    or stripped.upper().startswith("BEGIN")
+                ):
+                    break
+                if stripped:
+                    strt_lines.append(stripped)
+
+        assert len(strt_lines) > 0
+        for i, line in enumerate(strt_lines):
+            values = line.split()
+            assert len(values) == expected
+
+    check_columns(expected=3)
+
+    sim = flopy.mf6.MFSimulation.load(sim_ws=sim_ws)
+    sim.simulation_data.max_columns_of_data = 1
+    sim.write_simulation()
+
+    check_columns(expected=1)
+
+
+reason = "external files don't respect max_columns_of_data"
+
+
+@pytest.mark.parametrize(
+    ("which_ext", "first_set", "workspace"),
+    [
+        pytest.param("all", "opt", "same", marks=pytest.mark.xfail(reason=reason)),
+        pytest.param("all", "opt", "diff"),
+        pytest.param("all", "ext", "same", marks=pytest.mark.xfail(reason=reason)),
+        pytest.param("all", "ext", "diff", marks=pytest.mark.xfail(reason=reason)),
+        pytest.param("one", "opt", "same", marks=pytest.mark.xfail(reason=reason)),
+        pytest.param("one", "opt", "diff"),
+        pytest.param("one", "ext", "same", marks=pytest.mark.xfail(reason=reason)),
+        pytest.param("one", "ext", "diff", marks=pytest.mark.xfail(reason=reason)),
+    ],
+)
+def test_max_columns_external_array(function_tmpdir, which_ext, first_set, workspace):
+    sim_ws = function_tmpdir / "test_external"
+    sim_ws.mkdir(exist_ok=True)
+
+    sim = flopy.mf6.MFSimulation(sim_name="test_sim", sim_ws=sim_ws)
+    tdis = flopy.mf6.ModflowTdis(
+        sim, time_units="DAYS", nper=1, perioddata=[(1.0, 1, 1.0)]
+    )
+    gwf = flopy.mf6.ModflowGwf(sim, modelname="model", model_nam_file="model.nam")
+    dis = flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=1,
+        nrow=5,
+        ncol=5,
+        delr=100.0,
+        delc=100.0,
+        top=100.0,
+        botm=0.0,
+    )
+    ic = flopy.mf6.ModflowGwfic(gwf, strt=np.arange(25).reshape(1, 5, 5).astype(float))
+    if which_ext == "one":
+        ic.strt.store_as_external_file("model.ic_strt.txt")
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=True, icelltype=0, k=1.0)
+    ims = flopy.mf6.ModflowIms(sim)
+    sim.register_ims_package(ims, [gwf.name])
+    if which_ext == "all":
+        sim.set_all_data_external()
+    sim.write_simulation()
+
+    def check_columns(ws, expected):
+        strt_file = ws / "model.ic_strt.txt"
+        assert strt_file.exists()
+        with open(strt_file) as f:
+            lines = f.readlines()
+
+        data_lines = [
+            line.strip()
+            for line in lines
+            if line.strip() and not line.strip().startswith("#")
+        ]
+
+        for i, line in enumerate(data_lines):
+            values = line.split()
+            assert len(values) == expected, (
+                f"Line {i} in external file should have 1 value (max_columns=1), "
+                f"but has {len(values)}: {line}"
+            )
+
+    check_columns(ws=sim_ws, expected=5)
+
+    sim = flopy.mf6.MFSimulation.load(sim_ws=sim_ws)
+    if workspace == "diff":
+        sim_ws = function_tmpdir / "test_external_new"
+        sim_ws.mkdir()
+        sim.set_sim_path(sim_ws)
+    if first_set == "opt":
+        sim.simulation_data.max_columns_of_data = 1
+        sim.set_all_data_external()
+    elif first_set == "ext":
+        sim.set_all_data_external()
+        sim.simulation_data.max_columns_of_data = 1
+    sim.write_simulation()
+
+    check_columns(ws=sim_ws, expected=1)

--- a/flopy/mf6/mfmodel.py
+++ b/flopy/mf6/mfmodel.py
@@ -989,13 +989,12 @@ class MFModel(ModelInterface):
                 # load package
                 instance.load_package(ftype, fname, pname, strict, None)
                 sim_data = simulation.simulation_data
-                if ftype == "dis" and not sim_data.max_columns_user_set:
+                if ftype == "dis" and sim_data._max_columns_set_by != 'user':
                     # set column wrap to ncol
                     dis = instance.get_package("dis", type_only=True)
                     if dis is not None and hasattr(dis, "ncol"):
-                        sim_data.max_columns_of_data = dis.ncol.get_data()
-                        sim_data.max_columns_user_set = False
-                        sim_data.max_columns_auto_set = True
+                        sim_data._max_columns_of_data = dis.ncol.get_data()
+                        sim_data._max_columns_set_by = 'auto'
         # load referenced packages
         if modelname in instance.simulation_data.referenced_files:
             for ref_file in instance.simulation_data.referenced_files[
@@ -1321,12 +1320,11 @@ class MFModel(ModelInterface):
 
         self.name_file.write(ext_file_action=ext_file_action)
 
-        if not self.simulation_data.max_columns_user_set:
+        if self.simulation_data._max_columns_set_by != 'user':
             grid_type = self.get_grid_type()
             if grid_type == DiscretizationType.DIS:
-                self.simulation_data.max_columns_of_data = self.dis.ncol.get_data()
-                self.simulation_data.max_columns_user_set = False
-                self.simulation_data.max_columns_auto_set = True
+                self.simulation_data._max_columns_of_data = self.dis.ncol.get_data()
+                self.simulation_data._max_columns_set_by = 'auto'
 
         # write packages
         for pp in self.packagelist:


### PR DESCRIPTION
Fix #2420, only internal arrays in this PR. Introduce a single underlying variable to track whether `max_columns_of_data` has been set automatically or by the user. Keep the 2 existing user-facing flags for backwards-compatibility, but reimplemented as properties to reflect the neater internal management. This should eliminate the need to ever set these.

And reproduce the external array problem. There are tricky interactions between whether `max_columns_of_data` is set first or data is set external first, and whether the simulation workspace has been changed. Currently the column setting is only respected for external arrays if the simulation workspace has been changed and the column setting is set before setting data external. Ideally the setting would be respected regardless of order of ops or whether the workspace is different.