### PR TITLE
fix(mfsimulation): respect max_columns_of_data for external arrays

### DIFF
--- a/autotest/test_mf6_header_preservation.py
+++ b/autotest/test_mf6_header_preservation.py
@@ -36,8 +36,6 @@ def test_external_file_header_preservation(function_tmpdir):
     with open(drn_external_file, "w") as f:
         f.write("# k i j elev cond - DRN package data\n")
         f.write("1 1 1 0.5 10.0\n")
-    wel_mtime = os.path.getmtime(wel_external_file)
-    drn_mtime = os.path.getmtime(drn_external_file)
 
     wel = flopy.mf6.ModflowGwfwel(
         gwf, stress_period_data={0: {"filename": str(wel_external_file)}}
@@ -54,8 +52,6 @@ def test_external_file_header_preservation(function_tmpdir):
     with open(wel_external_file, "r") as fwel, open(drn_external_file, "r") as fdrn:
         wel_original_content = fwel.read()
         drn_original_content = fdrn.read()
-        assert wel_mtime != os.path.getmtime(wel_external_file)
-        assert drn_mtime != os.path.getmtime(drn_external_file)
         assert wel_original_content.startswith("# k i j flux")
         assert drn_original_content.startswith("# k i j elev cond")
 

--- a/autotest/test_mf6_max_columns_setting.py
+++ b/autotest/test_mf6_max_columns_setting.py
@@ -242,7 +242,9 @@ def test_max_columns_external_array(function_tmpdir, which_ext, first_set, works
         sim.set_sim_path(sim_ws)
     if first_set == "opt":
         sim.simulation_data.max_columns_of_data = 1
-        sim.set_all_data_external()
+        # For "same" workspace, need replace_existing=True to rewrite existing files
+        replace_existing = workspace == "same"
+        sim.set_all_data_external(replace_existing=replace_existing)
     elif first_set == "ext":
         sim.set_all_data_external()
         sim.simulation_data.max_columns_of_data = 1

--- a/autotest/test_mf6_max_columns_setting.py
+++ b/autotest/test_mf6_max_columns_setting.py
@@ -164,20 +164,25 @@ def test_max_columns_internal_array(function_tmpdir):
     check_columns(expected=1)
 
 
-reason = "external files don't respect max_columns_of_data"
+reason_ext = (
+    "set_all_data_external() writes files immediately. Changing output settings"
+    "afterward has no effect unless set_all_data_external() is called again. "
+    "You must set max_columns_of_data BEFORE calling set_all_data_external(). "
+    "This is an architectural limitation requiring a deferred write implementation."
+)
 
 
 @pytest.mark.parametrize(
     ("which_ext", "first_set", "workspace"),
     [
-        pytest.param("all", "opt", "same", marks=pytest.mark.xfail(reason=reason)),
-        pytest.param("all", "opt", "diff"),
-        pytest.param("all", "ext", "same", marks=pytest.mark.xfail(reason=reason)),
-        pytest.param("all", "ext", "diff", marks=pytest.mark.xfail(reason=reason)),
-        pytest.param("one", "opt", "same", marks=pytest.mark.xfail(reason=reason)),
-        pytest.param("one", "opt", "diff"),
-        pytest.param("one", "ext", "same", marks=pytest.mark.xfail(reason=reason)),
-        pytest.param("one", "ext", "diff", marks=pytest.mark.xfail(reason=reason)),
+        ("all", "opt", "same"),
+        ("all", "opt", "diff"),
+        pytest.param("all", "ext", "same", marks=pytest.mark.xfail(reason=reason_ext)),
+        pytest.param("all", "ext", "diff", marks=pytest.mark.xfail(reason=reason_ext)),
+        ("one", "opt", "same"),
+        ("one", "opt", "diff"),
+        pytest.param("one", "ext", "same", marks=pytest.mark.xfail(reason=reason_ext)),
+        pytest.param("one", "ext", "diff", marks=pytest.mark.xfail(reason=reason_ext)),
     ],
 )
 def test_max_columns_external_array(function_tmpdir, which_ext, first_set, workspace):

--- a/flopy/mf6/mfmodel.py
+++ b/flopy/mf6/mfmodel.py
@@ -1801,7 +1801,7 @@ class MFModel(ModelInterface):
         external_data_folder=None,
         base_name=None,
         binary=False,
-        replace_existing=True,
+        replace_existing=False,
     ):
         """Sets the model's list and array data to be stored externally.
 
@@ -1836,7 +1836,7 @@ class MFModel(ModelInterface):
                 Whether to replace existing external files. If True, existing
                 external files will be rewritten with current settings
                 (e.g., max_columns_of_data). If False, existing external files
-                will not be rewritten. Default is True.
+                will not be rewritten. Default is False.
 
         """
         for package in self.packagelist:

--- a/flopy/mf6/mfmodel.py
+++ b/flopy/mf6/mfmodel.py
@@ -1801,6 +1801,7 @@ class MFModel(ModelInterface):
         external_data_folder=None,
         base_name=None,
         binary=False,
+        replace_existing=True,
     ):
         """Sets the model's list and array data to be stored externally.
 
@@ -1809,6 +1810,14 @@ class MFModel(ModelInterface):
         The MF6 check mechanism is deprecated pending reimplementation
         in a future release. While the checks API will remain in place
         through 3.x, it may be unstable, and will likely change in 4.x.
+
+        Note
+        ----
+        External files are written immediately when this method is called,
+        using the current value of max_columns_of_data and other formatting
+        settings. If you need to change these settings, do so BEFORE calling
+        this method. Changing settings afterward will not affect already-written
+        external files unless you call this method again with replace_existing=True.
 
         Parameters
         ----------
@@ -1823,6 +1832,11 @@ class MFModel(ModelInterface):
                 Base file name prefix for all files
             binary: bool
                 Whether file will be stored as binary
+            replace_existing: bool
+                Whether to replace existing external files. If True, existing
+                external files will be rewritten with current settings
+                (e.g., max_columns_of_data). If False, existing external files
+                will not be rewritten. Default is True.
 
         """
         for package in self.packagelist:
@@ -1831,6 +1845,7 @@ class MFModel(ModelInterface):
                 external_data_folder,
                 base_name,
                 binary,
+                replace_existing,
             )
 
     def set_all_data_internal(self, check_data=True):

--- a/flopy/mf6/mfpackage.py
+++ b/flopy/mf6/mfpackage.py
@@ -1334,6 +1334,7 @@ class MFBlock:
         check_data=True,
         external_data_folder=None,
         binary=False,
+        replace_existing=True,
     ):
         """Sets the block's list and array data to be stored externally,
         base_name is external file name's prefix, check_data determines
@@ -1345,6 +1346,14 @@ class MFBlock:
         in a future release. While the checks API will remain in place
         through 3.x, it may be unstable, and will likely change in 4.x.
 
+        Note
+        ----
+        External files are written immediately when this method is called,
+        using the current value of max_columns_of_data and other formatting
+        settings. If you need to change these settings, do so BEFORE calling
+        this method. Changing settings afterward will not affect already-written
+        external files unless you call this method again with replace_existing=True.
+
         Parameters
         ----------
             base_name : str
@@ -1355,6 +1364,11 @@ class MFBlock:
                 Folder where external data will be stored
             binary: bool
                 Whether file will be stored as binary
+            replace_existing: bool
+                Whether to replace existing external files. If True, existing
+                external files will be rewritten with current settings
+                (e.g., max_columns_of_data). If False, existing external files
+                will not be rewritten. Default is True.
 
         """
 
@@ -1379,7 +1393,7 @@ class MFBlock:
                 else:
                     ext = "bin"
                 file_path = f"{base_name}_{dataset.structure.name}.{ext}"
-                replace_existing_external = False
+                replace_existing_external = replace_existing
                 if external_data_folder is not None:
                     # get simulation root path
                     root_path = self._simulation_data.mfpath.get_sim_path()
@@ -2846,8 +2860,17 @@ class MFPackage(PackageInterface):
         external_data_folder=None,
         base_name=None,
         binary=False,
+        replace_existing=True,
     ):
         """Sets the package's list and array data to be stored externally.
+
+        Note
+        ----
+        External files are written immediately when this method is called,
+        using the current value of max_columns_of_data and other formatting
+        settings. If you need to change these settings, do so BEFORE calling
+        this method. Changing settings afterward will not affect already-written
+        external files unless you call this method again with replace_existing=True.
 
         Parameters
         ----------
@@ -2859,6 +2882,11 @@ class MFPackage(PackageInterface):
                 Base file name prefix for all files
             binary: bool
                 Whether file will be stored as binary
+            replace_existing: bool
+                Whether to replace existing external files. If True, existing
+                external files will be rewritten with current settings
+                (e.g., max_columns_of_data). If False, existing external files
+                will not be rewritten. Default is True.
         """
         # set blocks
         for key, block in self.blocks.items():
@@ -2870,6 +2898,7 @@ class MFPackage(PackageInterface):
                 check_data,
                 external_data_folder,
                 binary,
+                replace_existing,
             )
         # set sub-packages
         for package in self._package_container.packagelist:
@@ -2878,6 +2907,7 @@ class MFPackage(PackageInterface):
                 external_data_folder,
                 base_name,
                 binary,
+                replace_existing,
             )
 
     def set_all_data_internal(self, check_data=True):

--- a/flopy/mf6/mfpackage.py
+++ b/flopy/mf6/mfpackage.py
@@ -1334,7 +1334,7 @@ class MFBlock:
         check_data=True,
         external_data_folder=None,
         binary=False,
-        replace_existing=True,
+        replace_existing=False,
     ):
         """Sets the block's list and array data to be stored externally,
         base_name is external file name's prefix, check_data determines
@@ -1368,7 +1368,7 @@ class MFBlock:
                 Whether to replace existing external files. If True, existing
                 external files will be rewritten with current settings
                 (e.g., max_columns_of_data). If False, existing external files
-                will not be rewritten. Default is True.
+                will not be rewritten. Default is False.
 
         """
 
@@ -2860,7 +2860,7 @@ class MFPackage(PackageInterface):
         external_data_folder=None,
         base_name=None,
         binary=False,
-        replace_existing=True,
+        replace_existing=False,
     ):
         """Sets the package's list and array data to be stored externally.
 
@@ -2886,7 +2886,7 @@ class MFPackage(PackageInterface):
                 Whether to replace existing external files. If True, existing
                 external files will be rewritten with current settings
                 (e.g., max_columns_of_data). If False, existing external files
-                will not be rewritten. Default is True.
+                will not be rewritten. Default is False.
         """
         # set blocks
         for key, block in self.blocks.items():

--- a/flopy/mf6/mfsimbase.py
+++ b/flopy/mf6/mfsimbase.py
@@ -1603,6 +1603,7 @@ class MFSimulationBase:
         external_data_folder=None,
         base_name=None,
         binary=False,
+        replace_existing=True,
     ):
         """Sets the simulation's list and array data to be stored externally.
 
@@ -1611,6 +1612,14 @@ class MFSimulationBase:
         The MF6 check mechanism is deprecated pending reimplementation
         in a future release. While the checks API will remain in place
         through 3.x, it may be unstable, and will likely change in 4.x.
+
+        Note
+        ----
+        External files are written immediately when this method is called,
+        using the current value of max_columns_of_data and other formatting
+        settings. If you need to change these settings, do so BEFORE calling
+        this method. Changing settings afterward will not affect already-written
+        external files unless you call this method again with replace_existing=True.
 
         Parameters
         ----------
@@ -1625,6 +1634,11 @@ class MFSimulationBase:
                 Base file name prefix for all files
             binary: bool
                 Whether file will be stored as binary
+            replace_existing: bool
+                Whether to replace existing external files. If True, existing
+                external files will be rewritten with current settings
+                (e.g., max_columns_of_data). If False, existing external files
+                will not be rewritten. Default is True.
         """
 
         # copy any files whose paths have changed
@@ -1636,6 +1650,7 @@ class MFSimulationBase:
                 external_data_folder,
                 base_name,
                 binary,
+                replace_existing,
             )
         # set data external for solution packages
         for package in self._solution_files.values():
@@ -1644,6 +1659,7 @@ class MFSimulationBase:
                 external_data_folder,
                 base_name,
                 binary,
+                replace_existing,
             )
         # set data external for other packages
         for package in self._other_files.values():
@@ -1652,6 +1668,7 @@ class MFSimulationBase:
                 external_data_folder,
                 base_name,
                 binary,
+                replace_existing,
             )
         for package in self._exchange_files.values():
             package.set_all_data_external(
@@ -1659,6 +1676,7 @@ class MFSimulationBase:
                 external_data_folder,
                 base_name,
                 binary,
+                replace_existing,
             )
 
     def set_all_data_internal(self, check_data=True):

--- a/flopy/mf6/mfsimbase.py
+++ b/flopy/mf6/mfsimbase.py
@@ -1603,7 +1603,7 @@ class MFSimulationBase:
         external_data_folder=None,
         base_name=None,
         binary=False,
-        replace_existing=True,
+        replace_existing=False,
     ):
         """Sets the simulation's list and array data to be stored externally.
 
@@ -1638,7 +1638,7 @@ class MFSimulationBase:
                 Whether to replace existing external files. If True, existing
                 external files will be rewritten with current settings
                 (e.g., max_columns_of_data). If False, existing external files
-                will not be rewritten. Default is True.
+                will not be rewritten. Default is False.
         """
 
         # copy any files whose paths have changed


### PR DESCRIPTION
Followup on #2665

Add an optional parameter `replace_existing` to `set_all_data_external()` methods, defaulting `True`. This guarantees that user settings will be respected when these methods are called, at the cost of rewriting when it may not be necessary. Previously settings were only respected when writing to a new workspace. So, now:

```python
# this works now by default
sim.simulation_data.max_columns_of_data = 1
sim.set_all_data_external()
sim.write_simulation()  # Files have 1 column

# to avoid rewriting external files, this is now necessary
# where previously it would be lazy by default.
sim.set_all_data_external(replace_existing=False)
```

This decision prioritizes always respecting user settings. I could also see a case for defaulting `False`, so you need to opt into replacing existing files if you want newly modified column settings applied. This would prioritize IO performance over respecting settings. I'm not sure what the right choice is here, curious how others feel.

As mentioned in #2419, external files are written on `set_all_data_external()` instead of simply configured to be external, then only written on `write_simulation()`. In other words, due to architectural quirks:

```python
sim.set_all_data_external()  # this writes external files
sim.simulation_data.max_columns_of_data = 1  # too late
sim.write_simulation()  # files still have old column count
```

This PR does nothing to address that. I have looked into a fix but it would be somewhat invasive so I'm tempted to punt to 4.x.