### PR TITLE
feat(lgr): add from_parent_grid classmethod to Lgr class

### DIFF
--- a/autotest/test_lgrutil.py
+++ b/autotest/test_lgrutil.py
@@ -358,8 +358,8 @@ def test_lgr_nested_refinement_grandchild():
     lgr_child = Lgr.from_parent_grid(parent_grid, parent_refine_mask, ncpp=3)
     assert lgr_child.get_shape() == (1, 9, 9)
 
-    # Get child grid as StructuredGrid
-    child_grid = lgr_child.child.modelgrid
+    # Get child grid (SimpleRegularGrid now inherits from StructuredGrid)
+    child_grid = lgr_child.child
     assert isinstance(child_grid, StructuredGrid)
     assert (child_grid.nlay, child_grid.nrow, child_grid.ncol) == (1, 9, 9)
 
@@ -423,3 +423,54 @@ def test_lgr_multiple_child_regions():
     gridprops1 = lgr1.to_disv_gridprops()
     gridprops2 = lgr2.to_disv_gridprops()
     assert gridprops1["ncpl"] == gridprops2["ncpl"]
+
+
+def test_simple_regular_grid_deprecation():
+    """Test that SimpleRegularGrid deprecation warnings are raised."""
+    from flopy.discretization import StructuredGrid
+    from flopy.utils.lgrutil import SimpleRegularGrid
+
+    nlay, nrow, ncol = 1, 5, 5
+    delr = delc = 100.0 * np.ones(5)
+    top = np.zeros((nrow, ncol))
+    botm = -100.0 * np.ones((nlay, nrow, ncol))
+    idomain = np.ones((nlay, nrow, ncol), dtype=int)
+    xorigin = 0.0
+    yorigin = 0.0
+
+    # Test that SimpleRegularGrid instantiation raises deprecation warning
+    with pytest.warns(
+        DeprecationWarning, match="SimpleRegularGrid is deprecated.*StructuredGrid"
+    ):
+        grid = SimpleRegularGrid(
+            nlay, nrow, ncol, delr, delc, top, botm, idomain, xorigin, yorigin
+        )
+
+    # Verify it's an instance of StructuredGrid
+    assert isinstance(grid, StructuredGrid)
+    assert isinstance(grid, SimpleRegularGrid)
+
+    # Test that modelgrid property raises deprecation warning
+    with pytest.warns(
+        DeprecationWarning, match="modelgrid.*deprecated.*use the instance directly"
+    ):
+        mg = grid.modelgrid
+
+    # Verify modelgrid returns self
+    assert mg is grid
+
+    # Test that get_gridprops_dis6 raises deprecation warning
+    with pytest.warns(DeprecationWarning, match="get_gridprops_dis6.*deprecated"):
+        gridprops = grid.get_gridprops_dis6()
+
+    # Verify gridprops contains expected keys
+    assert "nlay" in gridprops
+    assert "nrow" in gridprops
+    assert "ncol" in gridprops
+    assert gridprops["nlay"] == nlay
+    assert gridprops["nrow"] == nrow
+    assert gridprops["ncol"] == ncol
+
+    # Verify backward compatibility attributes
+    assert grid.xorigin == xorigin
+    assert grid.yorigin == yorigin

--- a/autotest/test_lgrutil.py
+++ b/autotest/test_lgrutil.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from flopy.utils.lgrutil import Lgr, LgrToDisv
 
@@ -233,24 +234,25 @@ def test_lgr_from_parent_grid():
         delr=delr, delc=delc, top=top, botm=botm, idomain=idomain
     )
 
-    # Create Lgr using the classmethod
+    # Create Lgr using the classmethod (no warning - uses new API)
     lgr_from_classmethod = Lgr.from_parent_grid(parent_grid, idomain, ncpp=3, ncppl=1)
 
-    # Create Lgr using the traditional constructor
-    lgr_traditional = Lgr(
-        nlayp=nlay,
-        nrowp=nrow,
-        ncolp=ncol,
-        delrp=delr,
-        delcp=delc,
-        topp=top,
-        botmp=botm,
-        idomainp=idomain,
-        ncpp=3,
-        ncppl=1,
-        xllp=0.0,
-        yllp=0.0,
-    )
+    # Create Lgr using the traditional constructor with deprecated parameter
+    with pytest.warns(DeprecationWarning, match="idomainp.*deprecated"):
+        lgr_traditional = Lgr(
+            nlayp=nlay,
+            nrowp=nrow,
+            ncolp=ncol,
+            delrp=delr,
+            delcp=delc,
+            topp=top,
+            botmp=botm,
+            idomainp=idomain,
+            ncpp=3,
+            ncppl=1,
+            xllp=0.0,
+            yllp=0.0,
+        )
 
     # Verify both methods produce the same results
     assert lgr_from_classmethod.get_shape() == lgr_traditional.get_shape()
@@ -274,3 +276,150 @@ def test_lgr_from_parent_grid():
 
     # Expected: 40 parent cells + 81 child cells = 121 total cells
     assert gridprops["ncpl"] == 121
+
+
+def test_lgr_deprecation_warnings():
+    """Test that deprecation warnings are raised for old API."""
+    from flopy.discretization import StructuredGrid
+
+    nlay, nrow, ncol = 1, 7, 7
+    delr = delc = 100.0 * np.ones(7)
+    top = np.zeros((nrow, ncol))
+    botm = -100.0 * np.ones((nlay, nrow, ncol))
+    refine_mask = np.ones((nlay, nrow, ncol))
+    refine_mask[:, 2:5, 2:5] = 0
+
+    # Test deprecated idomainp parameter
+    with pytest.warns(DeprecationWarning, match="idomainp.*deprecated.*refine_mask"):
+        lgr = Lgr(
+            nlayp=nlay,
+            nrowp=nrow,
+            ncolp=ncol,
+            delrp=delr,
+            delcp=delc,
+            topp=top,
+            botmp=botm,
+            idomainp=refine_mask,
+            ncpp=3,
+        )
+
+    # Test deprecated idomain attribute access
+    with pytest.warns(
+        DeprecationWarning, match="idomain.*attribute.*deprecated.*refine_mask"
+    ):
+        _ = lgr.idomain
+
+    # Verify new API works without warnings
+    import warnings
+
+    with warnings.catch_warnings(record=True) as warning_list:
+        warnings.simplefilter("always")
+        lgr_new = Lgr(
+            nlayp=nlay,
+            nrowp=nrow,
+            ncolp=ncol,
+            delrp=delr,
+            delcp=delc,
+            topp=top,
+            botmp=botm,
+            refine_mask=refine_mask,
+            ncpp=3,
+        )
+        # Access via new attribute should not warn
+        _ = lgr_new.refine_mask
+
+    # Check no deprecation warnings were raised
+    deprecation_warnings = [
+        w for w in warning_list if issubclass(w.category, DeprecationWarning)
+    ]
+    assert len(deprecation_warnings) == 0, (
+        "New API should not raise deprecation warnings"
+    )
+
+
+def test_lgr_nested_refinement_grandchild():
+    """Test nested refinement: parent -> child -> grandchild."""
+    from flopy.discretization import StructuredGrid
+
+    # Create parent grid (9x9)
+    nlay, nrow, ncol = 1, 9, 9
+    delr = delc = 100.0 * np.ones(9)
+    top = np.zeros((nrow, ncol))
+    botm = -100.0 * np.ones((nlay, nrow, ncol))
+
+    parent_grid = StructuredGrid(
+        delr=delr, delc=delc, top=top, botm=botm, idomain=np.ones((nlay, nrow, ncol))
+    )
+
+    # First refinement: refine center 3x3 cells of parent
+    parent_refine_mask = np.ones((nlay, nrow, ncol))
+    parent_refine_mask[:, 3:6, 3:6] = 0
+
+    lgr_child = Lgr.from_parent_grid(parent_grid, parent_refine_mask, ncpp=3)
+    assert lgr_child.get_shape() == (1, 9, 9)
+
+    # Get child grid as StructuredGrid
+    child_grid = lgr_child.child.modelgrid
+    assert isinstance(child_grid, StructuredGrid)
+    assert (child_grid.nlay, child_grid.nrow, child_grid.ncol) == (1, 9, 9)
+
+    # Second refinement: refine center 3x3 cells of child
+    child_refine_mask = np.ones((child_grid.nlay, child_grid.nrow, child_grid.ncol))
+    child_refine_mask[:, 3:6, 3:6] = 0
+
+    lgr_grandchild = Lgr.from_parent_grid(child_grid, child_refine_mask, ncpp=3)
+    assert lgr_grandchild.get_shape() == (1, 9, 9)
+
+    # Verify grandchild has finer resolution than child
+    assert np.allclose(lgr_grandchild.delr, lgr_child.delr / 3)
+    assert np.allclose(lgr_grandchild.delc, lgr_child.delc / 3)
+
+    # Verify we can generate gridprops for both
+    child_gridprops = lgr_child.to_disv_gridprops()
+    grandchild_gridprops = lgr_grandchild.to_disv_gridprops()
+    assert "ncpl" in child_gridprops
+    assert "ncpl" in grandchild_gridprops
+
+
+def test_lgr_multiple_child_regions():
+    """Test multiple separate refinement regions in one parent."""
+    from flopy.discretization import StructuredGrid
+
+    # Create parent grid (15x15) with two separate areas to refine
+    nlay, nrow, ncol = 1, 15, 15
+    delr = delc = 100.0 * np.ones(15)
+    top = np.zeros((nrow, ncol))
+    botm = -100.0 * np.ones((nlay, nrow, ncol))
+
+    parent_grid = StructuredGrid(
+        delr=delr, delc=delc, top=top, botm=botm, idomain=np.ones((nlay, nrow, ncol))
+    )
+
+    # Region 1: top-left (2:5, 2:5)
+    refine_mask_1 = np.ones((nlay, nrow, ncol))
+    refine_mask_1[:, 2:5, 2:5] = 0
+    lgr1 = Lgr.from_parent_grid(parent_grid, refine_mask_1, ncpp=3)
+
+    # Region 2: bottom-right (10:13, 10:13)
+    refine_mask_2 = np.ones((nlay, nrow, ncol))
+    refine_mask_2[:, 10:13, 10:13] = 0
+    lgr2 = Lgr.from_parent_grid(parent_grid, refine_mask_2, ncpp=3)
+
+    # Verify both children have correct shape (3x3 parent cells -> 9x9 child)
+    assert lgr1.get_shape() == (1, 9, 9)
+    assert lgr2.get_shape() == (1, 9, 9)
+
+    # Verify children are at different locations
+    assert lgr1.xll == 200.0  # Starts at column 2
+    assert lgr1.yll == 1000.0  # Starts at row 2 (from top)
+    assert lgr2.xll == 1000.0  # Starts at column 10
+    assert lgr2.yll == 200.0  # Starts at row 10
+
+    # Verify both have same resolution (refinement of parent)
+    assert np.allclose(lgr1.delr, lgr2.delr)
+    assert np.allclose(lgr1.delc, lgr2.delc)
+
+    # Verify we can generate gridprops for both
+    gridprops1 = lgr1.to_disv_gridprops()
+    gridprops2 = lgr2.to_disv_gridprops()
+    assert gridprops1["ncpl"] == gridprops2["ncpl"]

--- a/autotest/test_lgrutil.py
+++ b/autotest/test_lgrutil.py
@@ -1,10 +1,11 @@
 import numpy as np
 import pytest
 
-from flopy.utils.lgrutil import Lgr, LgrToDisv
+from flopy.discretization import StructuredGrid
+from flopy.utils.lgrutil import Lgr, LgrToDisv, SimpleRegularGrid
 
 
-def test_lgrutil():
+def test_lgr_connections():
     nlayp = 5
     nrowp = 5
     ncolp = 5
@@ -91,7 +92,7 @@ def test_lgrutil():
     ]
 
 
-def test_lgrutil2():
+def test_lgr_variable_rc_spacing():
     # Define parent grid information
     xoffp = 0.0
     yoffp = 0.0
@@ -146,7 +147,7 @@ def test_lgrutil2():
     assert np.allclose(lgr.delc, answer), f"{lgr.delc} /= {answer}"
 
 
-def test_lgrutil3():
+def test_lgr_hanging_vertices():
     # Define parent grid information
     xoffp = 0.0
     yoffp = 0.0
@@ -219,9 +220,6 @@ def test_lgrutil3():
 
 
 def test_lgr_from_parent_grid():
-    """Test the from_parent_grid classmethod convenience constructor."""
-    from flopy.discretization import StructuredGrid
-
     # Create a parent grid with center cells marked for refinement
     nlay, nrow, ncol = 1, 7, 7
     delr = delc = 100.0 * np.ones(7)
@@ -279,9 +277,6 @@ def test_lgr_from_parent_grid():
 
 
 def test_lgr_deprecation_warnings():
-    """Test that deprecation warnings are raised for old API."""
-    from flopy.discretization import StructuredGrid
-
     nlay, nrow, ncol = 1, 7, 7
     delr = delc = 100.0 * np.ones(7)
     top = np.zeros((nrow, ncol))
@@ -338,9 +333,6 @@ def test_lgr_deprecation_warnings():
 
 
 def test_lgr_nested_refinement_grandchild():
-    """Test nested refinement: parent -> child -> grandchild."""
-    from flopy.discretization import StructuredGrid
-
     # Create parent grid (9x9)
     nlay, nrow, ncol = 1, 9, 9
     delr = delc = 100.0 * np.ones(9)
@@ -382,9 +374,6 @@ def test_lgr_nested_refinement_grandchild():
 
 
 def test_lgr_multiple_child_regions():
-    """Test multiple separate refinement regions in one parent."""
-    from flopy.discretization import StructuredGrid
-
     # Create parent grid (15x15) with two separate areas to refine
     nlay, nrow, ncol = 1, 15, 15
     delr = delc = 100.0 * np.ones(15)
@@ -426,10 +415,6 @@ def test_lgr_multiple_child_regions():
 
 
 def test_simple_regular_grid_deprecation():
-    """Test that SimpleRegularGrid deprecation warnings are raised."""
-    from flopy.discretization import StructuredGrid
-    from flopy.utils.lgrutil import SimpleRegularGrid
-
     nlay, nrow, ncol = 1, 5, 5
     delr = delc = 100.0 * np.ones(5)
     top = np.zeros((nrow, ncol))

--- a/autotest/test_lgrutil.py
+++ b/autotest/test_lgrutil.py
@@ -215,3 +215,62 @@ def test_lgrutil3():
     b[1] = -2 * dz
     b[2] = -3 * dz
     assert np.allclose(gridprops["botm"], b)
+
+
+def test_lgr_from_parent_grid():
+    """Test the from_parent_grid classmethod convenience constructor."""
+    from flopy.discretization import StructuredGrid
+
+    # Create a parent grid with center cells marked for refinement
+    nlay, nrow, ncol = 1, 7, 7
+    delr = delc = 100.0 * np.ones(7)
+    top = np.zeros((nrow, ncol))
+    botm = -100.0 * np.ones((nlay, nrow, ncol))
+    idomain = np.ones((nlay, nrow, ncol), dtype=int)
+    idomain[:, 2:5, 2:5] = 0  # Mark center 3x3 cells for refinement
+
+    parent_grid = StructuredGrid(
+        delr=delr, delc=delc, top=top, botm=botm, idomain=idomain
+    )
+
+    # Create Lgr using the classmethod
+    lgr_from_classmethod = Lgr.from_parent_grid(parent_grid, idomain, ncpp=3, ncppl=1)
+
+    # Create Lgr using the traditional constructor
+    lgr_traditional = Lgr(
+        nlayp=nlay,
+        nrowp=nrow,
+        ncolp=ncol,
+        delrp=delr,
+        delcp=delc,
+        topp=top,
+        botmp=botm,
+        idomainp=idomain,
+        ncpp=3,
+        ncppl=1,
+        xllp=0.0,
+        yllp=0.0,
+    )
+
+    # Verify both methods produce the same results
+    assert lgr_from_classmethod.get_shape() == lgr_traditional.get_shape()
+    assert np.allclose(lgr_from_classmethod.delr, lgr_traditional.delr)
+    assert np.allclose(lgr_from_classmethod.delc, lgr_traditional.delc)
+    assert np.allclose(lgr_from_classmethod.top, lgr_traditional.top)
+    assert np.allclose(lgr_from_classmethod.botm, lgr_traditional.botm)
+
+    # Verify child grid has expected dimensions (3x3 parent cells refined to 9x9)
+    assert lgr_from_classmethod.get_shape() == (1, 9, 9)
+
+    # Verify gridprops can be generated
+    gridprops = lgr_from_classmethod.to_disv_gridprops()
+    assert "ncpl" in gridprops
+    assert "nvert" in gridprops
+    assert "vertices" in gridprops
+    assert "cell2d" in gridprops
+    assert "nlay" in gridprops
+    assert "top" in gridprops
+    assert "botm" in gridprops
+
+    # Expected: 40 parent cells + 81 child cells = 121 total cells
+    assert gridprops["ncpl"] == 121

--- a/flopy/utils/lgrutil.py
+++ b/flopy/utils/lgrutil.py
@@ -198,6 +198,51 @@ class Lgr:
         self.xll = xllp + float(self.delrp[0 : self.npcbeg].sum())
         self.yll = yllp + float(self.delcp[self.nprend + 1 :].sum())
 
+    @classmethod
+    def from_parent_grid(cls, parent_grid, refine_mask, ncpp=3, ncppl=1):
+        """
+        Create an Lgr instance from a parent StructuredGrid.
+
+        Parameters
+        ----------
+        parent_grid : StructuredGrid
+            The parent grid
+        refine_mask : ndarray
+            Array indicating which parent cells to refine (shape: nlay, nrow, ncol).
+            Cells with value 0 will be refined, with value 1 remain as parent cells.
+        ncpp : int
+            Number of child cells per parent cell face (default 3)
+        ncppl : int or list of ints
+            Number of child layers per parent layer (default 1)
+
+        Returns
+        -------
+        Lgr
+            Local grid refinement instance
+
+        Examples
+        --------
+        >>> # Create refinement mask - refine center 3x3 cells
+        >>> refine_mask = np.ones((nlay, nrow, ncol))
+        >>> refine_mask[:, 2:5, 2:5] = 0
+        >>> lgr = Lgr.from_parent_grid(parent_grid, refine_mask, ncpp=3)
+
+        """
+        return cls(
+            nlayp=parent_grid.nlay,
+            nrowp=parent_grid.nrow,
+            ncolp=parent_grid.ncol,
+            delrp=parent_grid.delr,
+            delcp=parent_grid.delc,
+            topp=parent_grid.top,
+            botmp=parent_grid.botm,
+            idomainp=refine_mask,
+            ncpp=ncpp,
+            ncppl=ncppl,
+            xllp=parent_grid.xoffset,
+            yllp=parent_grid.yoffset,
+        )
+
     def get_shape(self):
         """
         Return the shape of the child grid

--- a/flopy/utils/lgrutil.py
+++ b/flopy/utils/lgrutil.py
@@ -180,8 +180,8 @@ class Lgr:
             Array indicating which parent cells to refine (shape: nlay, nrow, ncol).
             Cells with value 0 will be refined, with value 1 remain as parent cells.
 
-            When a parent cell is marked to be refined, it will be deactived in the
-            parent model using the idomain functionality. Refined parent cells will
+            When a parent cell is marked to be refined, it will be deactivated in
+            the parent model using idomain functionality. Refined parent cells will
             become active cells in the child model.
 
             The child grid spans a rectangular bounding box around the cells marked
@@ -309,8 +309,8 @@ class Lgr:
             Array indicating which parent cells to refine (shape: nlay, nrow, ncol).
             Cells with value 0 will be refined, with value 1 remain as parent cells.
 
-            When a parent cell is marked to be refined, it will be deactived in the
-            parent model using the idomain functionality. Refined parent cells will
+            When a parent cell is marked to be refined, it will be deactivated in
+            the parent model using idomain functionality. Refined parent cells will
             become active cells in the child model.
 
             The child grid spans a rectangular bounding box around the cells marked

--- a/flopy/utils/lgrutil.py
+++ b/flopy/utils/lgrutil.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 
 from ..discretization import StructuredGrid
@@ -6,8 +8,14 @@ from .cvfdutil import get_disv_gridprops
 from .util_array import Util2d, Util3d
 
 
-class SimpleRegularGrid:
+class SimpleRegularGrid(StructuredGrid):
     """
+    Deprecated: Use StructuredGrid instead.
+
+    .. deprecated:: 3.9
+        SimpleRegularGrid is deprecated and will be removed in version 3.10.
+        Use :class:`flopy.discretization.StructuredGrid` instead.
+
     Simple object for representing regular MODFLOW grid information.
 
     Parameters
@@ -47,6 +55,13 @@ class SimpleRegularGrid:
         xorigin,
         yorigin,
     ):
+        warnings.warn(
+            "SimpleRegularGrid is deprecated and will be removed in version 3.10. "
+            "Use StructuredGrid instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         # enforce compliance
         assert delr.shape == (ncol,)
         assert delc.shape == (nrow,)
@@ -54,32 +69,62 @@ class SimpleRegularGrid:
         assert botm.shape == (nlay, nrow, ncol)
         assert idomain.shape == (nlay, nrow, ncol)
 
-        self.nlay = nlay
-        self.nrow = nrow
-        self.ncol = ncol
-        self.delr = delr
-        self.delc = delc
-        self.top = top
-        self.botm = botm
-        self.idomain = idomain
+        # Initialize parent StructuredGrid
+        super().__init__(
+            delc=delc,
+            delr=delr,
+            top=top,
+            botm=botm,
+            idomain=idomain,
+            xoff=xorigin,
+            yoff=yorigin,
+        )
+
+        # Store xorigin/yorigin for backward compatibility
+        # (StructuredGrid uses xoffset/yoffset internally)
         self.xorigin = xorigin
         self.yorigin = yorigin
-        return
 
     @property
     def modelgrid(self):
-        mg = StructuredGrid(
-            delc=self.delc,
-            delr=self.delr,
-            top=self.top,
-            botm=self.botm,
-            idomain=self.idomain,
-            xoff=self.xorigin,
-            yoff=self.yorigin,
+        """
+        Deprecated: SimpleRegularGrid now inherits from StructuredGrid.
+
+        .. deprecated:: 3.9
+            The modelgrid property is deprecated. SimpleRegularGrid now
+            inherits from StructuredGrid, so you can use the instance directly.
+
+        Returns
+        -------
+        StructuredGrid
+            Returns self (which is a StructuredGrid instance)
+        """
+        warnings.warn(
+            "The modelgrid property is deprecated. "
+            "SimpleRegularGrid now inherits from StructuredGrid, "
+            "so you can use the instance directly.",
+            DeprecationWarning,
+            stacklevel=2,
         )
-        return mg
+        return self
 
     def get_gridprops_dis6(self):
+        """
+        Get grid properties for MODFLOW 6 DIS package.
+
+        .. deprecated:: 3.9
+            get_gridprops_dis6 is deprecated and will be removed in version 3.10.
+
+        Returns
+        -------
+        dict
+            Dictionary of grid properties
+        """
+        warnings.warn(
+            "get_gridprops_dis6 is deprecated and will be removed in version 3.10.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         gridprops = {
             "xorigin": self.xorigin,
             "yorigin": self.yorigin,
@@ -718,8 +763,9 @@ class LgrToDisv:
 
         # store information
         self.lgr = lgr
-        self.pgrid = lgr.parent.modelgrid
-        self.cgrid = lgr.child.modelgrid
+        # SimpleRegularGrid now inherits from StructuredGrid, use directly
+        self.pgrid = lgr.parent
+        self.cgrid = lgr.child
 
         # count active parent and child cells
         self.ncpl_parent = np.count_nonzero(self.pgrid.idomain[0] > 0)

--- a/flopy/utils/lgrutil.py
+++ b/flopy/utils/lgrutil.py
@@ -134,7 +134,17 @@ class Lgr:
         refine_mask : ndarray
             Array indicating which parent cells to refine (shape: nlay, nrow, ncol).
             Cells with value 0 will be refined, with value 1 remain as parent cells.
-            The child grid domain will span a rectangular region covering the zeros.
+
+            When a parent cell is marked to be refined, it will be deactived in the
+            parent model using the idomain functionality. Refined parent cells will
+            become active cells in the child model.
+
+            The child grid spans a rectangular bounding box around the cells marked
+            for refinement in the parent. If the refinement region is not regularly
+            shaped (non-rectangular), some child cells will be marked inactive such
+            that no region is active in both the parent and child grid. In general,
+            child cells are active (1) in refined parent cells (refine_mask=0) and
+            inactive (0) where coinciding with active parent cells (refine_mask=1).
         ncpp : int
             number of child cells along the face of a parent cell
         ncppl : list of ints
@@ -253,7 +263,17 @@ class Lgr:
         refine_mask : ndarray
             Array indicating which parent cells to refine (shape: nlay, nrow, ncol).
             Cells with value 0 will be refined, with value 1 remain as parent cells.
-            The child grid domain will span a rectangular region covering the zeros.
+
+            When a parent cell is marked to be refined, it will be deactived in the
+            parent model using the idomain functionality. Refined parent cells will
+            become active cells in the child model.
+
+            The child grid spans a rectangular bounding box around the cells marked
+            for refinement in the parent. If the refinement region is not regularly
+            shaped (non-rectangular), some child cells will be marked inactive such
+            that no region is active in both the parent and child grid. In general,
+            child cells are active (1) in refined parent cells (refine_mask=0) and
+            inactive (0) where coinciding with active parent cells (refine_mask=1).
         ncpp : int
             Number of child cells per parent cell face (default 3)
         ncppl : int or list of ints
@@ -390,18 +410,17 @@ class Lgr:
         """
         Return the idomain array for the child model.
 
-        The child grid spans a rectangular bounding box around all cells marked
-        for refinement in the parent. If the refinement region is irregularly
-        shaped (non-rectangular), some child cells will fall outside the actual
-        refinement region and overlap with active parent cells. Those child cells
-        are marked as inactive (idomain=0) to avoid conflicts.
+        The child grid spans a rectangular bounding box around the cells marked
+        for refinement in the parent. If the refinement region is not regularly
+        shaped (non-rectangular), some child cells will be marked inactive such
+        that no region is active in both the parent and child grid. In general,
+        child cells are active (1) in refined parent cells (refine_mask=0) and
+        inactive (0) where coinciding with active parent cells (refine_mask=1).
 
         Returns
         -------
         idomain : ndarray
-            Child idomain array (shape: nlay, nrow, ncol). Cells are active (1)
-            where they correspond to parent cells marked for refinement (refine_mask=0),
-            and inactive (0) where they overlap active parent cells (refine_mask=1).
+            Child idomain array (shape: nlay, nrow, ncol)
 
         """
         idomain = np.ones((self.nlay, self.nrow, self.ncol), dtype=int)

--- a/flopy/utils/lgrutil.py
+++ b/flopy/utils/lgrutil.py
@@ -182,7 +182,7 @@ class Lgr:
 
             When a parent cell is marked to be refined, it will be deactivated in
             the parent model using idomain functionality. Refined parent cells will
-            become active cells in the child model.
+            correspond to active cells in the child model.
 
             The child grid spans a rectangular bounding box around the cells marked
             for refinement in the parent. If the refinement region is not regularly
@@ -311,7 +311,7 @@ class Lgr:
 
             When a parent cell is marked to be refined, it will be deactivated in
             the parent model using idomain functionality. Refined parent cells will
-            become active cells in the child model.
+            correspond to active cells in the child model.
 
             The child grid spans a rectangular bounding box around the cells marked
             for refinement in the parent. If the refinement region is not regularly

--- a/flopy/utils/lgrutil.py
+++ b/flopy/utils/lgrutil.py
@@ -105,11 +105,13 @@ class Lgr:
         delcp,
         topp,
         botmp,
-        idomainp,
+        refine_mask=None,
         ncpp=3,
         ncppl=1,
         xllp=0.0,
         yllp=0.0,
+        *,
+        idomainp=None,
     ):
         """
 
@@ -129,12 +131,10 @@ class Lgr:
             parent top array (nrowp, ncolp)
         botmp : ndarray
             parent botm array (nlayp, nrowp, ncolp)
-        idomainp : ndarray
-            parent idomain array used to create the child grid.  Ones indicate
-            a parent cell and zeros indicate a child cell.  The domain of the
-            child grid will span a rectangular region that spans all idomain
-            cells with a value of zero. idomain must be of shape
-            (nlayp, nrowp, ncolp)
+        refine_mask : ndarray
+            Array indicating which parent cells to refine (shape: nlay, nrow, ncol).
+            Cells with value 0 will be refined, with value 1 remain as parent cells.
+            The child grid domain will span a rectangular region covering the zeros.
         ncpp : int
             number of child cells along the face of a parent cell
         ncppl : list of ints
@@ -143,6 +143,12 @@ class Lgr:
             x location of parent grid lower left corner
         yllp : float
             y location of parent grid lower left corner
+        idomainp : ndarray, optional
+            parent idomain array used to create the child grid.  Ones indicate
+            a parent cell and zeros indicate a child cell.  The domain of the
+            child grid will span a rectangular region that spans all idomain
+            cells with a value of zero. idomain must be of shape
+            (nlayp, nrowp, ncolp). Deprecated/renamed, use refine_mask instead.
 
         """
 
@@ -157,11 +163,31 @@ class Lgr:
         self.topp = Util2d(m, (nrowp, ncolp), np.float32, topp, "topp").array
         self.botmp = Util3d(m, (nlayp, nrowp, ncolp), np.float32, botmp, "botmp").array
 
-        # idomain
-        assert idomainp.shape == (nlayp, nrowp, ncolp)
-        self.idomain = idomainp
-        idxl, idxr, idxc = np.asarray(idomainp == 0).nonzero()
-        assert idxl.shape[0] > 0, "no zero values found in idomain"
+        # refinement mask
+        if idomainp is not None:
+            import warnings
+
+            warnings.warn(
+                "The 'idomainp' parameter is deprecated and will be removed in "
+                "version 3.10. Use 'refine_mask' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if refine_mask is not None:
+                raise ValueError(
+                    "Provide either refine_mask or idomainp, not both. "
+                    "Prefer refine_mask as idomainp is deprecated."
+                )
+            refine_mask = idomainp
+        elif refine_mask is None:
+            raise ValueError(
+                "Need either refine_mask or idomainp. "
+                "Prefer refine_mask as idomainp is deprecated."
+            )
+        assert refine_mask.shape == (nlayp, nrowp, ncolp)
+        self.refine_mask = refine_mask
+        idxl, idxr, idxc = np.asarray(refine_mask == 0).nonzero()
+        assert idxl.shape[0] > 0, "no zero values found in refine_mask"
 
         # child cells per parent and child cells per parent layer
         self.ncpp = ncpp
@@ -198,6 +224,23 @@ class Lgr:
         self.xll = xllp + float(self.delrp[0 : self.npcbeg].sum())
         self.yll = yllp + float(self.delcp[self.nprend + 1 :].sum())
 
+    @property
+    def idomain(self):
+        """
+        .. deprecated:: 3.9
+            The `idomain` attribute is deprecated. Use `refine_mask` instead.
+            Will be removed in version 3.10.
+        """
+        import warnings
+
+        warnings.warn(
+            "The 'idomain' attribute is deprecated and will be removed in "
+            "version 3.10. Use 'refine_mask' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.refine_mask
+
     @classmethod
     def from_parent_grid(cls, parent_grid, refine_mask, ncpp=3, ncppl=1):
         """
@@ -210,6 +253,7 @@ class Lgr:
         refine_mask : ndarray
             Array indicating which parent cells to refine (shape: nlay, nrow, ncol).
             Cells with value 0 will be refined, with value 1 remain as parent cells.
+            The child grid domain will span a rectangular region covering the zeros.
         ncpp : int
             Number of child cells per parent cell face (default 3)
         ncppl : int or list of ints
@@ -236,7 +280,7 @@ class Lgr:
             delcp=parent_grid.delc,
             topp=parent_grid.top,
             botmp=parent_grid.botm,
-            idomainp=refine_mask,
+            refine_mask=refine_mask,
             ncpp=ncpp,
             ncppl=ncppl,
             xllp=parent_grid.xoffset,
@@ -344,15 +388,20 @@ class Lgr:
 
     def get_idomain(self):
         """
-        Return the idomain array for the child model.  This will normally
-        be all ones unless the idomain array for the parent model is
-        non-rectangular and irregularly shaped.  Then, parts of the child
-        model will have idomain zero cells.
+        Return the idomain array for the child model.
+
+        The child grid spans a rectangular bounding box around all cells marked
+        for refinement in the parent. If the refinement region is irregularly
+        shaped (non-rectangular), some child cells will fall outside the actual
+        refinement region and overlap with active parent cells. Those child cells
+        are marked as inactive (idomain=0) to avoid conflicts.
 
         Returns
         -------
         idomain : ndarray
-            idomain array for the child model
+            Child idomain array (shape: nlay, nrow, ncol). Cells are active (1)
+            where they correspond to parent cells marked for refinement (refine_mask=0),
+            and inactive (0) where they overlap active parent cells (refine_mask=1).
 
         """
         idomain = np.ones((self.nlay, self.nrow, self.ncol), dtype=int)
@@ -360,7 +409,7 @@ class Lgr:
             for ic in range(self.nrow):
                 for jc in range(self.ncol):
                     kp, ip, jp = self.get_parent_indices(kc, ic, jc)
-                    if self.idomain[kp, ip, jp] == 1:
+                    if self.refine_mask[kp, ip, jp] == 1:
                         idomain[kc, ic, jc] = 0
         return idomain
 
@@ -399,25 +448,25 @@ class Lgr:
         # parent cell to left
         if jc % self.ncpp == 0:
             if jp - 1 >= 0:
-                if self.idomain[kp, ip, jp - 1] != 0:
+                if self.refine_mask[kp, ip, jp - 1] != 0:
                     parentlist.append(((kp, ip, jp - 1), -1))
 
         # parent cell to right
         if (jc + 1) % self.ncpp == 0:
             if jp + 1 < self.ncolp:
-                if self.idomain[kp, ip, jp + 1] != 0:
+                if self.refine_mask[kp, ip, jp + 1] != 0:
                     parentlist.append(((kp, ip, jp + 1), 1))
 
         # parent cell to back
         if ic % self.ncpp == 0:
             if ip - 1 >= 0:
-                if self.idomain[kp, ip - 1, jp] != 0:
+                if self.refine_mask[kp, ip - 1, jp] != 0:
                     parentlist.append(((kp, ip - 1, jp), 2))
 
         # parent cell to front
         if (ic + 1) % self.ncpp == 0:
             if ip + 1 < self.nrowp:
-                if self.idomain[kp, ip + 1, jp] != 0:
+                if self.refine_mask[kp, ip + 1, jp] != 0:
                     parentlist.append(((kp, ip + 1, jp), -2))
 
         # parent cell to top is not possible
@@ -425,7 +474,7 @@ class Lgr:
         # parent cell to bottom
         if kc + 1 == self.ibcl[kp]:
             if kp + 1 < self.nlayp:
-                if self.idomain[kp + 1, ip, jp] != 0:
+                if self.refine_mask[kp + 1, ip, jp] != 0:
                     parentlist.append(((kp + 1, ip, jp), -3))
 
         return parentlist
@@ -575,7 +624,7 @@ class Lgr:
             self.delcp,
             self.topp,
             self.botmp,
-            self.idomain,
+            self.refine_mask,
             self.xllp,
             self.yllp,
         )


### PR DESCRIPTION
Factored out of #2667

It's a bit verbose to manually pass all the parent grid props into the Lgr grid initializer, this makes it easier. I named the refinement region parameter `refine_mask` as this seemed clearer than `idomainp` as in the initializer. If others agree maybe worth a deprecation/name change in the initializer too?

The original version in #2667 used the parent grid's idomain as the refinement mask, I was thinking because of the naming this might be justifiable, but decided it was better to keep them separate. Someone might want an inactive region to remain in the parent grid when the refinement is applied.