### PR TITLE
refactor(grid): consistent API for get_cell_vertices

### DIFF
--- a/flopy/discretization/structuredgrid.py
+++ b/flopy/discretization/structuredgrid.py
@@ -1148,15 +1148,20 @@ class StructuredGrid(Grid):
 
         Parameters
         ----------
+        cellid : int or tuple, optional
+            Cell identifier. Can be:
+            - node number (int)
+            - (row, col) tuple
+            - (layer, row, col) tuple (layer is ignored, vertices are 2D)
         node : int, optional
-            Node index, mutually exclusive with i and j
+            Node index, mutually exclusive with cellid, i, and j
         i, j : int, optional
-            Row and column index, mutually exclusive with node
+            Row and column index, mutually exclusive with cellid and node
 
         Returns
         -------
         list
-            list of tuples with x,y coordinates to cell vertices
+            list of (x, y) cell vertex coordinates
 
         Examples
         --------
@@ -1168,26 +1173,63 @@ class StructuredGrid(Grid):
         [(0.0, 40.0), (10.0, 40.0), (10.0, 30.0), (0.0, 30.0)]
         >>> sg.get_cell_vertices(3, 0)
         [(0.0, 10.0), (10.0, 10.0), (10.0, 0.0), (0.0, 0.0)]
+        >>> sg.get_cell_vertices((3, 0))
+        [(0.0, 10.0), (10.0, 10.0), (10.0, 0.0), (0.0, 0.0)]
+        >>> sg.get_cell_vertices(cellid=(0, 3, 0))
+        [(0.0, 10.0), (10.0, 10.0), (10.0, 0.0), (0.0, 0.0)]
         """
         if kwargs:
             if args:
                 raise TypeError("mixed positional and keyword arguments not supported")
+            elif "cellid" in kwargs:
+                cellid = kwargs.pop("cellid")
+                # Handle cellid as int, tuple of 2, or tuple of 3
+                if isinstance(cellid, (tuple, list)):
+                    if len(cellid) == 2:
+                        i, j = cellid
+                    elif len(cellid) == 3:
+                        # (layer, row, col) - ignore layer
+                        _, i, j = cellid
+                    else:
+                        raise ValueError(
+                            f"cellid tuple must have 2 or 3 elements, got {len(cellid)}"
+                        )
+                else:
+                    # cellid is a node number
+                    _, i, j = self.get_lrc(cellid)[0]
             elif "node" in kwargs:
                 _, i, j = self.get_lrc(kwargs.pop("node"))[0]
             elif "i" in kwargs and "j" in kwargs:
                 i = kwargs.pop("i")
                 j = kwargs.pop("j")
+            else:
+                raise TypeError(
+                    "expected cellid, node, or i and j as keyword arguments"
+                )
             if kwargs:
                 unused = ", ".join(kwargs.keys())
                 raise TypeError(f"unused keyword arguments: {unused}")
         elif len(args) == 0:
             raise TypeError("expected one or more arguments")
-
-        if len(args) == 1:
-            _, i, j = self.get_lrc(args[0])[0]
+        elif len(args) == 1:
+            # Single arg could be node number or (row, col) or (layer, row, col) tuple
+            arg = args[0]
+            if isinstance(arg, (tuple, list)):
+                if len(arg) == 2:
+                    i, j = arg
+                elif len(arg) == 3:
+                    # (layer, row, col) - ignore layer
+                    _, i, j = arg
+                else:
+                    raise ValueError(
+                        f"cellid tuple must have 2 or 3 elements, got {len(arg)}"
+                    )
+            else:
+                # Node number
+                _, i, j = self.get_lrc(arg)[0]
         elif len(args) == 2:
             i, j = args
-        elif len(args) > 2:
+        else:
             raise TypeError("too many arguments")
 
         self._copy_cache = False

--- a/flopy/discretization/structuredgrid.py
+++ b/flopy/discretization/structuredgrid.py
@@ -1188,14 +1188,12 @@ class StructuredGrid(Grid):
                     if len(cellid) == 2:
                         i, j = cellid
                     elif len(cellid) == 3:
-                        # (layer, row, col) - ignore layer
-                        _, i, j = cellid
+                        _, i, j = cellid  # ignore layer
                     else:
                         raise ValueError(
                             f"cellid tuple must have 2 or 3 elements, got {len(cellid)}"
                         )
                 else:
-                    # cellid is a node number
                     _, i, j = self.get_lrc(cellid)[0]
             elif "node" in kwargs:
                 _, i, j = self.get_lrc(kwargs.pop("node"))[0]

--- a/flopy/discretization/unstructuredgrid.py
+++ b/flopy/discretization/unstructuredgrid.py
@@ -847,16 +847,60 @@ class UnstructuredGrid(Grid):
         new_botm = np.expand_dims(self._botm, 0)
         return np.concatenate((new_top, new_botm), axis=0)
 
-    def get_cell_vertices(self, cellid):
+    def get_cell_vertices(self, cellid=None, node=None):
         """
-        Method to get a set of cell vertices for a single cell
-            used in the Shapefile export utilities
-        :param cellid: (int) cellid number
+        Get a set of cell vertices for a single cell.
+
+        Parameters
+        ----------
+        cellid : int or tuple, optional
+            Cell identifier. Can be:
+            - node number (int)
+            - (node,) single-element tuple
+        node : int, optional
+            Node number, mutually exclusive with cellid
+
         Returns
-        ------- list of x,y cell vertices
+        -------
+        list
+            list of (x, y) cell vertex coordinates
+
+        Examples
+        --------
+        >>> import flopy
+        >>> from flopy.utils.gridutil import get_disu_kwargs
+        >>> disu_props = get_disu_kwargs(1, 10, 10, 1.0, 1.0, 1.0, [0.0])
+        >>> ug = flopy.discretization.UnstructuredGrid(**disu_props)
+        >>> ug.get_cell_vertices(5)  # node number
+        >>> ug.get_cell_vertices((5,))  # (node,) tuple
+        >>> ug.get_cell_vertices(node=5)  # explicit node kwarg
+        >>> ug.get_cell_vertices(cellid=5)  # explicit cellid kwarg
         """
+        # Handle arguments
+        if cellid is not None and node is not None:
+            raise ValueError("cellid and node are mutually exclusive")
+
+        if cellid is None and node is None:
+            raise TypeError("expected cellid or node argument")
+
+        # Use cellid if provided, otherwise use node
+        if node is not None:
+            node_idx = node
+        else:
+            node_idx = cellid
+
+        # Handle tuple form
+        if isinstance(node_idx, (tuple, list)):
+            if len(node_idx) == 1:
+                node_idx = node_idx[0]
+            else:
+                raise ValueError(
+                    f"cellid tuple must have 1 element for "
+                    f"unstructured grids, got {len(node_idx)}"
+                )
+
         self._copy_cache = False
-        cell_vert = list(zip(self.xvertices[cellid], self.yvertices[cellid]))
+        cell_vert = list(zip(self.xvertices[node_idx], self.yvertices[node_idx]))
         self._copy_cache = True
         return cell_vert
 

--- a/flopy/discretization/unstructuredgrid.py
+++ b/flopy/discretization/unstructuredgrid.py
@@ -876,31 +876,25 @@ class UnstructuredGrid(Grid):
         >>> ug.get_cell_vertices(node=5)  # explicit node kwarg
         >>> ug.get_cell_vertices(cellid=5)  # explicit cellid kwarg
         """
-        # Handle arguments
+
         if cellid is not None and node is not None:
             raise ValueError("cellid and node are mutually exclusive")
 
         if cellid is None and node is None:
             raise TypeError("expected cellid or node argument")
 
-        # Use cellid if provided, otherwise use node
-        if node is not None:
-            node_idx = node
-        else:
-            node_idx = cellid
-
-        # Handle tuple form
-        if isinstance(node_idx, (tuple, list)):
-            if len(node_idx) == 1:
-                node_idx = node_idx[0]
+        idx = node if node is not None else cellid
+        if isinstance(idx, (tuple, list)):
+            if len(idx) == 1:
+                idx = idx[0]
             else:
                 raise ValueError(
                     f"cellid tuple must have 1 element for "
-                    f"unstructured grids, got {len(node_idx)}"
+                    f"unstructured grids, got {len(idx)}"
                 )
 
         self._copy_cache = False
-        cell_vert = list(zip(self.xvertices[node_idx], self.yvertices[node_idx]))
+        cell_vert = list(zip(self.xvertices[idx], self.yvertices[idx]))
         self._copy_cache = True
         return cell_vert
 

--- a/flopy/discretization/vertexgrid.py
+++ b/flopy/discretization/vertexgrid.py
@@ -514,31 +514,33 @@ class VertexGrid(Grid):
 
         # Use cellid if provided, otherwise use node
         if node is not None:
-            cell2d = node
+            idx = node
         else:
-            cell2d = cellid
+            idx = cellid
 
         # Handle tuple forms
-        if isinstance(cell2d, (tuple, list)):
-            if len(cell2d) == 1:
+        if isinstance(idx, (tuple, list)):
+            if len(idx) == 1:
                 # (cell2d,) or (node,)
-                cell2d = cell2d[0]
-            elif len(cell2d) == 2:
+                idx = idx[0]
+            elif len(idx) == 2:
                 # (layer, cell2d) - ignore layer since vertices are 2D
-                _, cell2d = cell2d
+                _, idx = idx
             else:
                 raise ValueError(
-                    f"cellid tuple must have 1 or 2 elements, got {len(cell2d)}"
+                    f"cellid tuple must have 1 or 2 elements, got {len(idx)}"
                 )
 
         # Convert node to cell2d if necessary
-        while cell2d >= self.ncpl:
-            if cell2d > self.nnodes:
-                raise IndexError(f"cellid {cell2d} out of index for size {self.nnodes}")
-            cell2d -= self.ncpl
+        while idx >= self.ncpl:
+            if idx > self.nnodes:
+                raise IndexError(
+                    f"node number {idx} exceeds grid node count {self.nnodes}"
+                )
+            idx -= self.ncpl
 
         self._copy_cache = False
-        cell_verts = list(zip(self.xvertices[cell2d], self.yvertices[cell2d]))
+        cell_verts = list(zip(self.xvertices[idx], self.yvertices[idx]))
         self._copy_cache = True
         return cell_verts
 

--- a/flopy/discretization/vertexgrid.py
+++ b/flopy/discretization/vertexgrid.py
@@ -474,23 +474,71 @@ class VertexGrid(Grid):
                     results.astype(int) if np.all(valid_mask) else results,
                 )
 
-    def get_cell_vertices(self, cellid):
+    def get_cell_vertices(self, cellid=None, node=None):
         """
-        Method to get a set of cell vertices for a single cell
-            used in the Shapefile export utilities
-        :param cellid: (int) cellid number
-        Returns
-        ------- list of x,y cell vertices
-        """
-        while cellid >= self.ncpl:
-            if cellid > self.nnodes:
-                err = f"cellid {cellid} out of index for size {self.nnodes}"
-                raise IndexError(err)
+        Get a set of cell vertices for a single cell.
 
-            cellid -= self.ncpl
+        Parameters
+        ----------
+        cellid : int or tuple, optional
+            Cell identifier. Can be:
+            - cell2d index (int, 0 to ncpl-1)
+            - node number (int, >= ncpl) - will be converted to cell2d
+            - (cell2d,) single-element tuple
+            - (layer, cell2d) tuple (layer is ignored, vertices are 2D)
+        node : int, optional
+            Node number, mutually exclusive with cellid
+
+        Returns
+        -------
+        list
+            list of (x, y) cell vertex coordinates
+
+        Examples
+        --------
+        >>> import flopy
+        >>> from flopy.utils.gridutil import get_disv_kwargs
+        >>> disv_props = get_disv_kwargs(1, 10, 10, 1.0, 1.0, 1.0, [0.0])
+        >>> vg = flopy.discretization.VertexGrid(**disv_props)
+        >>> vg.get_cell_vertices(5)  # cell2d index
+        >>> vg.get_cell_vertices((0, 5))  # (layer, cell2d) tuple
+        >>> vg.get_cell_vertices(node=105)  # node number
+        >>> vg.get_cell_vertices(cellid=(1, 5))  # explicit cellid kwarg
+        """
+        # Handle arguments
+        if cellid is not None and node is not None:
+            raise ValueError("cellid and node are mutually exclusive")
+
+        if cellid is None and node is None:
+            raise TypeError("expected cellid or node argument")
+
+        # Use cellid if provided, otherwise use node
+        if node is not None:
+            cell2d = node
+        else:
+            cell2d = cellid
+
+        # Handle tuple forms
+        if isinstance(cell2d, (tuple, list)):
+            if len(cell2d) == 1:
+                # (cell2d,) or (node,)
+                cell2d = cell2d[0]
+            elif len(cell2d) == 2:
+                # (layer, cell2d) - ignore layer since vertices are 2D
+                _, cell2d = cell2d
+            else:
+                raise ValueError(
+                    f"cellid tuple must have 1 or 2 elements, got {len(cell2d)}"
+                )
+
+        # Convert node to cell2d if necessary
+        while cell2d >= self.ncpl:
+            if cell2d > self.nnodes:
+                raise IndexError(f"cellid {cell2d} out of index for size {self.nnodes}")
+            cell2d -= self.ncpl
 
         self._copy_cache = False
-        cell_verts = list(zip(self.xvertices[cellid], self.yvertices[cellid]))
+        cell_verts = list(zip(self.xvertices[cell2d], self.yvertices[cell2d]))
         self._copy_cache = True
         return cell_verts
 


### PR DESCRIPTION
Previously the `Grid.get_cell_vertices()` method looked/worked different depending on the grid type. Make it consistent across all three grid types by supporting both `cellid` and `node` keyword arguments and being lenient about what's passed to `cellid` i.e. accept a node number, a fully-sized tuple, or an "abbreviated" tuple lacking layer index. Cell ID and node number are conceptually distinct but til now `VertexGrid` and `UnstructuredGrid` methods had a single parameter `cellid` supporting (for vertex) or expecting (for unstructured) a node number, which we don't want to break.  And continue also supporting `i` and `j` for `StructuredGrid`.

Noticed these inconsistencies when working on #2677