### PR TITLE
fix(mp7): fix input file writing

### DIFF
--- a/autotest/test_particlegroup.py
+++ b/autotest/test_particlegroup.py
@@ -88,7 +88,8 @@ def test_pgroup_write_with_release_timing():
             releasedata=[nripg2, 0.0, ripg2],
         )
 
-        # Test releaseoption 3 (explicit list of times) - this triggers Util2d with None model
+        # Test releaseoption 3 (explicit list of times).
+        # this triggers Util2d with None model
         nripg3 = 7
         pgrd3 = ParticleGroup(
             particlegroupname="PG3",

--- a/autotest/test_particlegroup.py
+++ b/autotest/test_particlegroup.py
@@ -1,3 +1,6 @@
+import tempfile
+from pathlib import Path
+
 import numpy as np
 
 from flopy.modpath import ParticleData, ParticleGroup
@@ -51,3 +54,56 @@ def test_pgroup_release_data():
         f"mp7: pgroup with releaseoption 3 returned "
         f"len(releasetimes)={len(pgrd3.releasetimes)}. Should be {nripg3}"
     )
+
+
+def test_pgroup_write_with_release_timing():
+    """Test that particle groups can be written to files with all release options."""
+    # create particles
+    partlocs = []
+    partids = []
+    nrow = 21
+    for i in range(nrow):
+        partlocs.append((0, i, 2))
+        partids.append(i)
+    pdata = ParticleData(partlocs, structured=True, particleids=partids)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+
+        # Test releaseoption 1 (single release time)
+        pgrd1 = ParticleGroup(
+            particlegroupname="PG1",
+            particledata=pdata,
+            filename=None,  # Write internally to test that path
+            releasedata=0.0,
+        )
+
+        # Test releaseoption 2 (time range with interval)
+        nripg2 = 10
+        ripg2 = 1.0
+        pgrd2 = ParticleGroup(
+            particlegroupname="PG2",
+            particledata=pdata,
+            filename=None,
+            releasedata=[nripg2, 0.0, ripg2],
+        )
+
+        # Test releaseoption 3 (explicit list of times) - this triggers Util2d with None model
+        nripg3 = 7
+        pgrd3 = ParticleGroup(
+            particlegroupname="PG3",
+            particledata=pdata,
+            filename=None,
+            releasedata=[nripg3, np.array([0.0, 1.0, 1.2, 1.4, 1.6, 1.8, 2.0])],
+        )
+
+        # Write each particle group to test all release options
+        for pg in [pgrd1, pgrd2, pgrd3]:
+            sim_file = tmpdir / f"{pg.particlegroupname}_test.sim"
+            with open(sim_file, "w") as f:
+                # This should not raise an AttributeError
+                pg.write(f, ws=str(tmpdir))
+
+            # Verify file was created and has content
+            assert sim_file.exists()
+            assert sim_file.stat().st_size > 0

--- a/flopy/modpath/mp7particlegroup.py
+++ b/flopy/modpath/mp7particlegroup.py
@@ -149,7 +149,7 @@ class _Modpath7ParticleGroup:
             fp.write(f"{self.releasetimecount}\n")
             # item 31
             tp = self.releasetimes
-            v = Util2d(self, (tp.shape[0],), np.float32, tp, name="temp", locat=0)
+            v = Util2d(None, (tp.shape[0],), np.float32, tp, name="temp", locat=0)
             fp.write(v.string)
 
         # item 32

--- a/flopy/utils/util_array.py
+++ b/flopy/utils/util_array.py
@@ -1871,7 +1871,9 @@ class Util2d(DataInterface):
         if self.vtype in [np.int32, np.float32]:
             self._how = "constant"
         # if a filename was passed in or external path was set
-        elif (self._model is not None and self._model.external_path is not None) or self.vtype == str:
+        elif (
+            self._model is not None and self._model.external_path is not None
+        ) or self.vtype == str:
             if self.format.array_free_format:
                 self._how = "openclose"
             else:

--- a/flopy/utils/util_array.py
+++ b/flopy/utils/util_array.py
@@ -2710,7 +2710,7 @@ class Util2d(DataInterface):
             if len(value.shape) == 3 and value.shape[0] == 1:
                 value = value[0]
 
-            if self.model.version == "mfusg":
+            if self.model is not None and self.model.version == "mfusg":
                 if self.shape != value.shape:
                     value = np.array([np.squeeze(value)])
 

--- a/flopy/utils/util_array.py
+++ b/flopy/utils/util_array.py
@@ -89,8 +89,11 @@ class ArrayFormat:
         self._decimal = None
         if array_free_format is not None:
             self._freeformat_model = bool(array_free_format)
-        else:
+        elif u2d.model is not None:
             self._freeformat_model = bool(u2d.model.array_free_format)
+        else:
+            # Default to free format when no model is available
+            self._freeformat_model = True
 
         self.default_float_width = 15
         self.default_int_width = 10
@@ -1868,7 +1871,7 @@ class Util2d(DataInterface):
         if self.vtype in [np.int32, np.float32]:
             self._how = "constant"
         # if a filename was passed in or external path was set
-        elif self._model.external_path is not None or self.vtype == str:
+        elif (self._model is not None and self._model.external_path is not None) or self.vtype == str:
             if self.format.array_free_format:
                 self._how = "openclose"
             else:


### PR DESCRIPTION
`Util2d` assumes its first argument is a model, but a `ParticleGroup` was being passed. This caused an error when writing MP7 input files with certain release configurations. Don't pass `ParticleGroup` to `Util2d` as it's not needed, and only check `self.model` in `Util2d` if it's not `None`. Likewise in the `ArrayFormat` class.