### PR TITLE
fix(evt): fix optional field handling at write time

### DIFF
--- a/flopy/mf6/data/mfdatalist.py
+++ b/flopy/mf6/data/mfdatalist.py
@@ -1026,6 +1026,13 @@ class MFList(mfdata.MFMultiDimVar, DataListInterface):
                         indent,
                     )
                 elif (
+                    storage._dependent_opt(data_item)
+                    and storage._optional_nval(data_item) == 0
+                ):
+                    # Skip EVT-specific optional fields (pxdp, petm, petm0)
+                    # that are not present in the data structure
+                    pass
+                elif (
                     not data_item.is_boundname
                     or data_dim.package_dim.boundnames()
                 ) and (

--- a/flopy/mf6/data/mfdatalist.py
+++ b/flopy/mf6/data/mfdatalist.py
@@ -1029,8 +1029,7 @@ class MFList(mfdata.MFMultiDimVar, DataListInterface):
                     storage._dependent_opt(data_item)
                     and storage._optional_nval(data_item) == 0
                 ):
-                    # Skip EVT-specific optional fields (pxdp, petm, petm0)
-                    # that are not present in the data structure
+                    # Skip optional fields that are not present
                     pass
                 elif (
                     not data_item.is_boundname


### PR DESCRIPTION
EVT packages with `nseg > 1`, and auxiliary variables, failed on file write with:

```
  IndexError: invalid index (7)
  MFDataException: An error occurred while processing auxiliary variables in the "_get_file_entry_record" method.
```

When `nseg > 1`, the EVT package has optional fields `pxdp`, `petm`, `petm0` that may or may not be present in the structured array depending on `nseg` and `surf_rate_specified` values. #2496 added `_dependent_opt()` and `_optional_nval()` methods to handle these fields when reading, but `_get_file_entry_record()` in `mfdatalist.py` still iterated through all DFN-defined fields when writing. The index then advanced past the array bounds before reaching auxiliary variables.

At write time, skip EVT-specific optional fields that aren't present in the structured array, using the same methods #2496 added for reading.

Close #2683