### PR TITLE
fix(grid): add vertices_coords init parameter

### DIFF
--- a/autotest/test_grid.py
+++ b/autotest/test_grid.py
@@ -1908,10 +1908,10 @@ def test_unstructured_grid_get_node():
     [
         ("default", 100.0, 200.0, 45.0, None),
         ("local", 100.0, 200.0, 45.0, "local"),
-        ("world", 100.0, 200.0, 45.0, "world"),
-        ("no_transform", 0.0, 0.0, 0.0, "world"),
+        ("global", 100.0, 200.0, 45.0, "global"),
+        ("no_transform", 0.0, 0.0, 0.0, "global"),
     ],
-    ids=["default", "local", "world", "no_transform"],
+    ids=["default", "local", "global", "no_transform"],
 )
 def test_vertices_coords_parameter(
     grid_type, grid_kwargs, scenario, xoff, yoff, angrot, vertices_coords
@@ -1932,8 +1932,8 @@ def test_vertices_coords_parameter(
         kwargs["vertices_coords"] = vertices_coords
 
     if (
-        scenario == "world"
-        and vertices_coords == "world"
+        scenario == "global"
+        and vertices_coords == "global"
         and grid_type != StructuredGrid
     ):
         # test #2388 scenario and verify that
@@ -1941,15 +1941,15 @@ def test_vertices_coords_parameter(
         default_kwargs = grid_kwargs.copy()
         default_kwargs.update({"xoff": xoff, "yoff": yoff, "angrot": angrot})
         grid_default = grid_type(**default_kwargs)
-        vertices_world = grid_default.verts.tolist()
-        vertices_world_indexed = [
-            [i, vertices_world[i][0], vertices_world[i][1]]
-            for i in range(len(vertices_world))
+        vertices_global = grid_default.verts.tolist()
+        vertices_global_indexed = [
+            [i, vertices_global[i][0], vertices_global[i][1]]
+            for i in range(len(vertices_global))
         ]
         kwargs = grid_kwargs.copy()
-        kwargs["vertices"] = vertices_world_indexed
+        kwargs["vertices"] = vertices_global_indexed
         kwargs.update(
-            {"xoff": xoff, "yoff": yoff, "angrot": angrot, "vertices_coords": "world"}
+            {"xoff": xoff, "yoff": yoff, "angrot": angrot, "vertices_coords": "global"}
         )
         grid = grid_type(**kwargs)
 

--- a/flopy/discretization/unstructuredgrid.py
+++ b/flopy/discretization/unstructuredgrid.py
@@ -78,9 +78,9 @@ class UnstructuredGrid(Grid):
         For each connection in the ja array: ihc = 0 indicates a vertical
         connection, ihc = 1 or 2 indicates a horizontal connection, with 2
         indicating that horizontal connections are vertically staggered.
-    vertices_coords : {'local', 'world'}, default 'local'
+    vertices_coords : {'local', 'global'}, default 'local'
         Coordinate system of input vertices. If 'local', vertices are in
-        model-local coordinates (as stored in DISU files). If 'world',
+        model-local coordinates (as stored in DISU files). If 'global',
         vertices are already georeferenced with rotation and offset applied.
     **kwargs : dict, optional
         Support deprecated keyword options.
@@ -165,8 +165,8 @@ class UnstructuredGrid(Grid):
             ycenters = np.array([i[2] for i in cell2d])
             iverts = [list(t)[4:] for t in cell2d]
 
-        if vertices is not None and vertices_coords == "world":
-            # Vertices are in world coordinates, need to transform to local
+        if vertices is not None and vertices_coords == "global":
+            # Vertices are in global coordinates, need to transform to local
             verts_array = np.array([list(v)[1:] for v in vertices], dtype=float).T
             angrot_rad = angrot * np.pi / 180.0
             x_local, y_local = transform(

--- a/flopy/discretization/vertexgrid.py
+++ b/flopy/discretization/vertexgrid.py
@@ -43,9 +43,9 @@ class VertexGrid(Grid):
         in the spatial reference coordinate system
     angrot : float
         rotation angle of model grid, as it is rotated around the origin point
-    vertices_coords : {'local', 'world'}, default 'local'
+    vertices_coords : {'local', 'global'}, default 'local'
         Coordinate system of input vertices. If 'local', vertices are in
-        model-local coordinates (as stored in DISV files). If 'world',
+        model-local coordinates (as stored in DISV files). If 'global',
         vertices are already georeferenced with rotation and offset applied.
     **kwargs : dict, optional
         Support deprecated keyword options.
@@ -104,8 +104,8 @@ class VertexGrid(Grid):
             **kwargs,
         )
 
-        if vertices is not None and vertices_coords == "world":
-            # Vertices are in world coordinates, need to transform to local
+        if vertices is not None and vertices_coords == "global":
+            # Vertices are in global coordinates, need to transform to local
             verts_array = np.array([list(v)[1:] for v in vertices], dtype=float).T
             angrot_rad = angrot * np.pi / 180.0
             x_local, y_local = transform(


### PR DESCRIPTION
Add a parameter `vertices_coords` to `VertexGrid` and `UnstructuredGrid` init methods, indicating whether vertices are in local or global coordinates. Default to `"local"`. This fixes #2388 by making it possible to avoid repeating the coordinate transformation. The parameter is not applicable to `StructuredGrid` because vertex coordinates are not provided to its init method.