### PR TITLE
feat(arrays): add model.free_format_npl to control values-per-line in free-format array output   

### DIFF
--- a/flopy/mbase.py
+++ b/flopy/mbase.py
@@ -375,6 +375,12 @@ class BaseModel(ModelInterface):
         Specify if model grid is structured (default) or unstructured.
     verbose : bool, default False
         Print additional information to the screen.
+    free_format_npl : int, optional
+        Number of values per line when writing free-format arrays. When set
+        (e.g., ``free_format_npl=10``), arrays are written with that many
+        values per line instead of all values on a single line. This produces
+        block-format output, improving readability for large models.
+        Default is None (all values on one line).
     **kwargs : dict, optional
         Used to define: ``xll``/``yll`` for the x- and y-coordinates of
         the lower-left corner of the grid, ``xul``/``yul`` for the
@@ -393,6 +399,7 @@ class BaseModel(ModelInterface):
         model_ws: Union[str, PathLike] = curdir,
         structured=True,
         verbose=False,
+        free_format_npl=None,
         **kwargs,
     ):
         """Initialize BaseModel."""
@@ -453,6 +460,7 @@ class BaseModel(ModelInterface):
         # external option stuff
         self.array_free_format = True
         self.free_format_input = True
+        self.free_format_npl = free_format_npl
         self.parameter_load = False
         self.array_format = None
         self.external_fnames = []

--- a/flopy/mfusg/mfusg.py
+++ b/flopy/mfusg/mfusg.py
@@ -34,7 +34,12 @@ class MfUsg(Modflow):
         Location for external files.
     verbose : bool, default False
         Print additional information to the screen.
-
+    free_format_npl : int, optional
+        Number of values per line when writing free-format arrays. When set
+        (e.g., ``free_format_npl=10``), arrays are written with that many
+        values per line instead of all values on a single line. This produces
+        block-format output, improving readability for large models.
+        Default is None (all values on one line).
 
     Attributes
     ----------
@@ -65,6 +70,7 @@ class MfUsg(Modflow):
         model_ws: Union[str, PathLike] = curdir,
         external_path=None,
         verbose=False,
+        free_format_npl=None,
         **kwargs,
     ):
         super().__init__(
@@ -77,6 +83,7 @@ class MfUsg(Modflow):
             model_ws=model_ws,
             external_path=external_path,
             verbose=verbose,
+            free_format_npl=free_format_npl,
             **kwargs,
         )
 

--- a/flopy/modflow/mf.py
+++ b/flopy/modflow/mf.py
@@ -85,6 +85,12 @@ class Modflow(BaseModel):
     extra_pkgs : dict, optional
         Add custom packages classes to mfnam_packages. Allows for loading models
         with custom packages not contained in the standard flopy distribution.
+    free_format_npl : int, optional
+        Number of values per line when writing free-format arrays. When set
+        (e.g., ``free_format_npl=10``), arrays are written with that many
+        values per line instead of all values on a single line. This produces
+        block-format output, improving readability for large models.
+        Default is None (all values on one line).
 
     Attributes
     ----------
@@ -117,6 +123,7 @@ class Modflow(BaseModel):
         external_path: Union[str, PathLike, None] = None,
         verbose=False,
         extra_pkgs: Optional[dict] = None,
+        free_format_npl=None,
         **kwargs,
     ):
         super().__init__(
@@ -126,6 +133,7 @@ class Modflow(BaseModel):
             model_ws,
             structured=structured,
             verbose=verbose,
+            free_format_npl=free_format_npl,
             **kwargs,
         )
         self.version_types = {

--- a/flopy/utils/util_array.py
+++ b/flopy/utils/util_array.py
@@ -2475,11 +2475,23 @@ class Util2d(DataInterface):
                         self.shape, self.python_file_path, self._array, bintype="head"
                     )
                 else:
+                    # Override npl for free format if model specifies free_format_npl
+                    python_format = None
+                    if (
+                        self.format.free
+                        and self._model is not None
+                        and getattr(self._model, "free_format_npl", None) is not None
+                    ):
+                        python_format = (
+                            self._model.free_format_npl,
+                            self.format.py[1],
+                        )
                     self.write_txt(
                         self.shape,
                         self.python_file_path,
                         self._array,
                         fortran_format=self.format.fortran,
+                        python_format=python_format,
                     )
 
             elif self.__value != self.python_file_path:
@@ -2536,8 +2548,16 @@ class Util2d(DataInterface):
 
         """
         # convert array to string with specified format
+        python_format = self.format.py
+        # Override npl for free format if model specifies free_format_npl
+        if (
+            self.format.free
+            and self._model is not None
+            and getattr(self._model, "free_format_npl", None) is not None
+        ):
+            python_format = (self._model.free_format_npl, python_format[1])
         a_string = self.array2string(
-            self.shape, self._array, python_format=self.format.py
+            self.shape, self._array, python_format=python_format
         )
         return a_string
 


### PR DESCRIPTION
When FloPy writes free-format arrays for unstructured MODFLOW-USG models,                                                                                                     
  all values are written on a single line (e.g., 65,448 values on one line for                                                                                                  
  a large model). This makes files unreadable and difficult to diff or inspect.                                                                                                 
                                                                                                                                                                                
  Groundwater Vistas and other preprocessors write these same arrays with                                                                                                       
  10 values per line in block format, which is equally valid for MODFLOW but                                                                                                    
  far more readable.                                                                                                                                                            
                                                                                                                                                                                
  This PR adds a `model.free_format_npl` property (values per line) that                                                                                                        
  controls line wrapping when writing free-format arrays.                                                                                                                       
                                                                                                                                                                                
  ### Usage                                                                                                                                                                     
  ```python                                                                                                                                                                     
  m = flopy.mfusg.MfUsg.load('model.nam', model_ws='path')                                                                                                                      
  m.free_format_npl = 10  # 10 values per line                                                                                                                                  
  m.write_input()                                                                                                                                                               
                                                                                                                                                                                
  Before (default, free_format_npl=None)                                                                                                                                        
                                                                                                                                                                                
  INTERNAL 1 (FREE) -1                                                                                                                                                          
  0.000000E+00  2.562436E-05  2.562436E-05  2.562436E-05  ...  (65,448 values on one line)                                                                                      
                                                                                                                                                                                
  After (free_format_npl=10)                                                                                                                                                    
                                                                                                                                                                                
  INTERNAL 1 (FREE) -1                                                                                                                                                          
  0.000000E+00  2.562436E-05  2.562436E-05  2.562436E-05  2.562436E-05  2.562436E-05  2.562436E-05  2.562436E-05  2.562436E-05  2.562436E-05                                    
  2.562436E-05  2.562436E-05  2.562436E-05  2.562436E-05  2.562436E-05  2.562436E-05  2.562436E-05  2.562436E-05  2.562436E-05  2.562436E-05                                    
  ...                                                                                                                                                                           
                                                                                                                                                                                
  Changes                                                                                                                                                                       
                                                                                                                                                                                
  - mbase.py: add free_format_npl property (default None, no change in behavior)                                                                                                
  - util_array.py: override npl in Util2d.string (INTERNAL arrays) and                                                                                                          
  Util2d.get_file_entry (EXTERNAL/OPENCLOSE arrays) when property is set