### PR TITLE
fix(get_transmissivities): handle single r/c

### DIFF
--- a/autotest/test_postprocessing.py
+++ b/autotest/test_postprocessing.py
@@ -531,9 +531,18 @@ def test_get_transmissivities_mf6_structured(function_tmpdir):
     T = get_transmissivities(heads, gwf, r=r, c=c)
     assert (T - TRANSMISSIVITIES_DATA["expected_no_intervals"]).sum() < 1e-3
 
-    # test specific point
+    # test specific point with x/y coordinates
     T = get_transmissivities(dis.botm.array, gwf, x=[0.5], y=[0.5])
     assert T.shape == (nl, 1)
+
+    # test specific point with r/c indices (single values, not arrays)
+    T_single = get_transmissivities(dis.botm.array, gwf, r=0, c=0)
+    assert T_single.shape == (nl, 1)
+
+    # test specific point with r/c indices (as arrays)
+    T_array = get_transmissivities(dis.botm.array, gwf, r=[0], c=[0])
+    assert T_array.shape == (nl, 1)
+    assert np.array_equal(T_single, T_array)
 
     # test all cell centers
     Tcoords = get_transmissivities(

--- a/flopy/utils/postprocessing.py
+++ b/flopy/utils/postprocessing.py
@@ -264,7 +264,7 @@ def get_transmissivities(
     if r is not None and c is not None:
         if grid_type != "structured":
             raise ValueError("r, c parameters only valid for structured grids")
-        indices = (r, c)
+        indices = (np.atleast_1d(r), np.atleast_1d(c))
     elif x is not None and y is not None:
         points = zip(np.atleast_1d(x), np.atleast_1d(y))
         if grid_type == "structured":


### PR DESCRIPTION
Apply `np.atleast_1d()` to r and c for consistency with x and y. Previously, passing single values for r and c resulted in `IndexError`.