### PR TITLE
chore(dependencies): pin pandas<3

### DIFF
--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - python>=3.10
   - numpy>=1.20.3
   - matplotlib>=1.4.0
-  - pandas>=2.0.0
+  - pandas>=2.0.0,<3
 
   # codegen
   - boltons>=1.0


### PR DESCRIPTION
Until we can make sure we've accommodated [the changes](https://pandas.pydata.org/docs/whatsnew/v3.0.0.html). The `pyproject.toml` already has an upper bound