### PR TITLE
fix(mfdataarray): use integer indexed filenames

### DIFF
--- a/autotest/test_mf6_tas.py
+++ b/autotest/test_mf6_tas.py
@@ -134,6 +134,10 @@ def test_tas_set_all_data_external(function_tmpdir):
         content = f.read()
         assert "OPEN/CLOSE" in content
         assert "INTERNAL" not in content
+        assert "tas_array_1.txt" in content
+        assert "tas_array_2.txt" in content
 
-    external_files = list(sim_ws.glob("*.txt"))
-    assert len(external_files) >= 2
+    external_files = sorted(sim_ws.glob("*tas_array_*.txt"))
+    assert len(external_files) == 2
+    assert external_files[0].name.endswith("tas_array_1.txt")
+    assert external_files[1].name.endswith("tas_array_2.txt")

--- a/flopy/mf6/data/mfdataarray.py
+++ b/flopy/mf6/data/mfdataarray.py
@@ -1790,7 +1790,7 @@ class MFTransientArray(MFArray, MFTransient):
 
         """
         # store each stress period in separate file(s)
-        for sp in self._data_storage.keys():
+        for idx, sp in enumerate(sorted(self._data_storage.keys()), start=1):
             self._current_key = sp
             layer_storage = self._get_storage_obj().layer_storage
             if (
@@ -1799,10 +1799,7 @@ class MFTransientArray(MFArray, MFTransient):
                 != DataStorageType.external_file
             ):
                 fname, ext = os.path.splitext(external_file_path)
-                if DatumUtil.is_int(sp):
-                    full_name = f"{fname}_{sp + 1}{ext}"
-                else:
-                    full_name = f"{fname}_{sp}{ext}"
+                full_name = f"{fname}_{idx}{ext}"
                 super().store_as_external_file(
                     full_name,
                     layer,


### PR DESCRIPTION
As suggested in https://github.com/modflowpy/flopy/issues/2702#issuecomment-3849829097. Numbering is 1-based as elsewhere