### PR TITLE
feat(mfusg): add TVM and TIB packages

### DIFF
--- a/autotest/test_mfusg_tvm_tib.py
+++ b/autotest/test_mfusg_tvm_tib.py
@@ -1,0 +1,383 @@
+"""
+Tests for MODFLOW-USG TVM (Time-Varying Materials) and TIB (Transient IBOUND) packages.
+
+These tests verify the functionality of the MfUsgTvm and MfUsgTib classes
+for creating and writing MODFLOW-USG input files.
+"""
+
+import os
+from unittest.mock import MagicMock, PropertyMock
+
+import pytest
+
+import flopy
+from flopy.mfusg import MfUsg, MfUsgTib, MfUsgTvm
+
+
+@pytest.fixture
+def temp_model_ws(tmp_path):
+    """Create temporary directory for model workspace."""
+    return tmp_path
+
+
+@pytest.fixture
+def mock_mfusg_model(temp_model_ws):
+    """
+    Create a mock MODFLOW-USG model for testing.
+
+    This avoids the complexity of setting up a full DISU package.
+    """
+    m = MfUsg(modelname="test_model", model_ws=str(temp_model_ws))
+
+    # Mock nper property to return 5
+    type(m).nper = PropertyMock(return_value=5)
+
+    return m
+
+
+class TestMfUsgTvm:
+    """Tests for Time-Varying Materials (TVM) package."""
+
+    def test_tvm_import(self):
+        """Test that MfUsgTvm can be imported."""
+        from flopy.mfusg import MfUsgTvm
+
+        assert MfUsgTvm is not None
+
+    def test_tvm_ftype(self):
+        """Test that TVM file type is correct."""
+        assert MfUsgTvm._ftype() == "TVM"
+
+    def test_tvm_defaultunit(self):
+        """Test that TVM default unit number is set."""
+        assert MfUsgTvm._defaultunit() == 71
+
+    def test_tvm_init_basic(self, mock_mfusg_model):
+        """Test basic TVM initialization."""
+        m = mock_mfusg_model
+
+        tvm = MfUsgTvm(m)
+
+        assert tvm.itvmprint == 0
+        assert tvm.tvmlogbasehk == 0.0
+        assert tvm.stress_period_data == {}
+        assert "TVM" in m.get_package_list()
+
+    def test_tvm_init_with_parameters(self, mock_mfusg_model):
+        """Test TVM initialization with custom parameters."""
+        m = mock_mfusg_model
+
+        tvm = MfUsgTvm(
+            m,
+            itvmprint=2,
+            tvmlogbasehk=10.0,
+            tvmlogbasevka=-1.0,  # step function
+            tvmlogbasess=0.0,
+        )
+
+        assert tvm.itvmprint == 2
+        assert tvm.tvmlogbasehk == 10.0
+        assert tvm.tvmlogbasevka == -1.0
+
+    def test_tvm_init_with_stress_period_data(self, mock_mfusg_model):
+        """Test TVM initialization with stress period data."""
+        m = mock_mfusg_model
+
+        spd = {
+            0: {"hk": [(1, 1e-4), (2, 1e-4)]},
+            3: {"hk": [(1, 1e-6)], "ss": [(1, 1e-5)]},
+        }
+
+        tvm = MfUsgTvm(m, stress_period_data=spd)
+
+        assert len(tvm.stress_period_data) == 2
+        assert 0 in tvm.stress_period_data
+        assert 3 in tvm.stress_period_data
+        assert len(tvm.stress_period_data[0]["hk"]) == 2
+
+    def test_tvm_write_file(self, mock_mfusg_model):
+        """Test TVM write_file creates output."""
+        m = mock_mfusg_model
+
+        spd = {
+            0: {"hk": [(1, 1e-4), (2, 1e-4)]},
+            2: {"hk": [(1, 1e-5)]},
+        }
+
+        tvm = MfUsgTvm(
+            m,
+            itvmprint=1,
+            tvmlogbasehk=10.0,
+            stress_period_data=spd,
+        )
+
+        tvm.write_file()
+
+        # Check file exists
+        tvm_path = os.path.join(m.model_ws, f"{m.name}.tvm")
+        assert os.path.exists(tvm_path)
+
+        # Check file content
+        with open(tvm_path) as f:
+            content = f.read()
+
+        # Verify header line with interpolation options
+        assert "1" in content  # itvmprint
+        assert "10.000" in content  # tvmlogbasehk
+
+        # Verify HK values are written
+        assert "1.000000E-04" in content
+        assert "1.000000E-05" in content
+
+    def test_tvm_write_all_properties(self, mock_mfusg_model):
+        """Test TVM write_file with all property types."""
+        m = mock_mfusg_model
+
+        spd = {
+            0: {
+                "hk": [(1, 1e-4)],
+                "vka": [(1, 1e-5)],
+                "ss": [(1, 1e-6)],
+                "sy": [(1, 0.2)],
+            },
+        }
+
+        tvm = MfUsgTvm(m, stress_period_data=spd)
+        tvm.write_file()
+
+        tvm_path = os.path.join(m.model_ws, f"{m.name}.tvm")
+        with open(tvm_path) as f:
+            content = f.read()
+
+        # All values should be present
+        assert "1.000000E-04" in content  # HK
+        assert "1.000000E-05" in content  # VKA
+        assert "1.000000E-06" in content  # SS
+        assert "2.000000E-01" in content  # SY
+
+    def test_tvm_model_type_validation(self, temp_model_ws):
+        """Test that TVM requires MfUsg model type."""
+        # Create a regular MODFLOW model (not USG)
+        m = flopy.modflow.Modflow(modelname="test", model_ws=str(temp_model_ws))
+
+        with pytest.raises(AssertionError, match="MfUsg"):
+            MfUsgTvm(m)
+
+    def test_tvm_load_not_implemented(self, mock_mfusg_model):
+        """Test that TVM load raises NotImplementedError."""
+        m = mock_mfusg_model
+
+        with pytest.raises(NotImplementedError):
+            MfUsgTvm.load("dummy.tvm", m)
+
+
+class TestMfUsgTib:
+    """Tests for Transient IBOUND (TIB) package."""
+
+    def test_tib_import(self):
+        """Test that MfUsgTib can be imported."""
+        from flopy.mfusg import MfUsgTib
+
+        assert MfUsgTib is not None
+
+    def test_tib_ftype(self):
+        """Test that TIB file type is correct."""
+        assert MfUsgTib._ftype() == "TIB"
+
+    def test_tib_defaultunit(self):
+        """Test that TIB default unit number is set."""
+        assert MfUsgTib._defaultunit() == 72
+
+    def test_tib_init_basic(self, mock_mfusg_model):
+        """Test basic TIB initialization."""
+        m = mock_mfusg_model
+
+        tib = MfUsgTib(m)
+
+        assert tib.stress_period_data == {}
+        assert "TIB" in m.get_package_list()
+
+    def test_tib_init_with_ib0(self, mock_mfusg_model):
+        """Test TIB with nodes to deactivate (IBOUND=0)."""
+        m = mock_mfusg_model
+
+        spd = {
+            0: {"ib0": [5, 6, 7]},
+        }
+
+        tib = MfUsgTib(m, stress_period_data=spd)
+
+        assert len(tib.stress_period_data[0]["ib0"]) == 3
+
+    def test_tib_init_with_ib1(self, mock_mfusg_model):
+        """Test TIB with nodes to activate (IBOUND=1)."""
+        m = mock_mfusg_model
+
+        spd = {
+            2: {
+                "ib1": [
+                    {"node": 1, "head": 50.0},
+                    {"node": 2, "avhead": True},
+                ],
+            },
+        }
+
+        tib = MfUsgTib(m, stress_period_data=spd)
+
+        assert len(tib.stress_period_data[2]["ib1"]) == 2
+
+    def test_tib_init_with_ibm1(self, mock_mfusg_model):
+        """Test TIB with nodes to set as constant head (IBOUND=-1)."""
+        m = mock_mfusg_model
+
+        spd = {
+            1: {
+                "ibm1": [
+                    {"node": 3, "head": 75.0},
+                    {"node": 4, "head": 75.0},
+                ],
+            },
+        }
+
+        tib = MfUsgTib(m, stress_period_data=spd)
+
+        assert len(tib.stress_period_data[1]["ibm1"]) == 2
+
+    def test_tib_write_file(self, mock_mfusg_model):
+        """Test TIB write_file creates output."""
+        m = mock_mfusg_model
+
+        spd = {
+            0: {"ib0": [5, 6]},
+            2: {"ibm1": [{"node": 1, "head": 50.0}]},
+        }
+
+        tib = MfUsgTib(m, stress_period_data=spd)
+        tib.write_file()
+
+        # Check file exists
+        tib_path = os.path.join(m.model_ws, f"{m.name}.tib")
+        assert os.path.exists(tib_path)
+
+        # Check file content
+        with open(tib_path) as f:
+            content = f.read()
+
+        # Verify deactivated nodes
+        assert "5" in content
+        assert "6" in content
+
+        # Verify constant head
+        assert "HEAD" in content
+        assert "5.000000E+01" in content
+
+    def test_tib_write_avhead_option(self, mock_mfusg_model):
+        """Test TIB write_file with AVHEAD option."""
+        m = mock_mfusg_model
+
+        spd = {
+            1: {
+                "ib1": [{"node": 3, "avhead": True}],
+            },
+        }
+
+        tib = MfUsgTib(m, stress_period_data=spd)
+        tib.write_file()
+
+        tib_path = os.path.join(m.model_ws, f"{m.name}.tib")
+        with open(tib_path) as f:
+            content = f.read()
+
+        assert "AVHEAD" in content
+
+    def test_tib_ibm1_requires_head_option(self, mock_mfusg_model):
+        """Test that IBM1 nodes require head or avhead option."""
+        m = mock_mfusg_model
+
+        # IBM1 without head option should raise error on write
+        spd = {
+            0: {
+                "ibm1": [{"node": 1}],  # Missing head or avhead
+            },
+        }
+
+        tib = MfUsgTib(m, stress_period_data=spd)
+
+        with pytest.raises(ValueError, match="head"):
+            tib.write_file()
+
+    def test_tib_model_type_validation(self, temp_model_ws):
+        """Test that TIB requires MfUsg model type."""
+        m = flopy.modflow.Modflow(modelname="test", model_ws=str(temp_model_ws))
+
+        with pytest.raises(AssertionError, match="MfUsg"):
+            MfUsgTib(m)
+
+    def test_tib_load_not_implemented(self, mock_mfusg_model):
+        """Test that TIB load raises NotImplementedError."""
+        m = mock_mfusg_model
+
+        with pytest.raises(NotImplementedError):
+            MfUsgTib.load("dummy.tib", m)
+
+    def test_tib_multiple_stress_periods(self, mock_mfusg_model):
+        """Test TIB with changes across multiple stress periods."""
+        m = mock_mfusg_model
+
+        spd = {
+            0: {"ib0": [8, 9, 10]},  # Deactivate initially
+            2: {"ibm1": [{"node": 1, "head": 90.0}]},  # Add lake
+            4: {"ib1": [{"node": 1, "avhead": True}]},  # Remove lake
+        }
+
+        tib = MfUsgTib(m, stress_period_data=spd)
+        tib.write_file()
+
+        tib_path = os.path.join(m.model_ws, f"{m.name}.tib")
+        assert os.path.exists(tib_path)
+
+        with open(tib_path) as f:
+            lines = f.readlines()
+
+        # Should have data for all 5 stress periods
+        # Count lines with data (excluding header comment)
+        data_lines = [line for line in lines if not line.startswith("#")]
+        assert len(data_lines) >= 5  # At least one line per SP
+
+
+class TestTvmTibIntegration:
+    """Integration tests for TVM and TIB packages together."""
+
+    def test_tvm_and_tib_together(self, mock_mfusg_model):
+        """Test using both TVM and TIB in the same model."""
+        m = mock_mfusg_model
+
+        # Add TVM
+        tvm_spd = {
+            0: {"hk": [(1, 1e-4)]},
+            2: {"hk": [(1, 1e-5)]},
+        }
+        tvm = MfUsgTvm(m, stress_period_data=tvm_spd)
+
+        # Add TIB
+        tib_spd = {
+            1: {"ibm1": [{"node": 5, "head": 50.0}]},
+        }
+        tib = MfUsgTib(m, stress_period_data=tib_spd)
+
+        # Both packages should be in model
+        pkg_list = m.get_package_list()
+        assert "TVM" in pkg_list
+        assert "TIB" in pkg_list
+
+        # Write both files
+        tvm.write_file()
+        tib.write_file()
+
+        # Both files should exist
+        assert os.path.exists(os.path.join(m.model_ws, f"{m.name}.tvm"))
+        assert os.path.exists(os.path.join(m.model_ws, f"{m.name}.tib"))
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/flopy/mfusg/__init__.py
+++ b/flopy/mfusg/__init__.py
@@ -20,6 +20,8 @@ from .mfusgoc import MfUsgOc
 from .mfusgpcb import MfUsgPcb
 from .mfusgrch import MfUsgRch
 from .mfusgsms import MfUsgSms
+from .mfusgtib import MfUsgTib
+from .mfusgtvm import MfUsgTvm
 from .mfusgwel import MfUsgWel
 
 __all__ = [
@@ -44,5 +46,7 @@ __all__ = [
     "MfUsgPcb",
     "MfUsgRch",
     "MfUsgSms",
+    "MfUsgTib",
+    "MfUsgTvm",
     "MfUsgWel",
 ]

--- a/flopy/mfusg/mfusgtib.py
+++ b/flopy/mfusg/mfusgtib.py
@@ -1,0 +1,348 @@
+"""
+mfusgtib module.
+
+Contains the MfUsgTib class. Note that the user can access
+the MfUsgTib class as `flopy.mfusg.MfUsgTib`.
+
+Transient IBOUND (TIB) Package for MODFLOW-USG.
+"""
+
+import numpy as np
+
+from ..pakbase import Package
+from .mfusg import MfUsg
+
+
+class MfUsgTib(Package):
+    """
+    MODFLOW-USG Transient IBOUND Package Class.
+
+    The TIB package allows the IBOUND array to change during a simulation.
+    Cells can be activated, deactivated, or converted to constant head.
+    This is useful for simulating:
+    - Excavation or reclamation
+    - Well drilling or plugging
+    - Lake/reservoir filling or draining
+    - Mining operations
+
+    Parameters
+    ----------
+    model : MfUsg
+        Model object (must be of type flopy.mfusg.MfUsg)
+    stress_period_data : dict
+        Dictionary keyed by stress period number (0-based).
+        Each value is a dict with optional keys:
+
+        - 'ib0': list of int
+            Node numbers to deactivate (set IBOUND=0)
+        - 'ib1': list of dict
+            Nodes to activate (set IBOUND=1). Each dict has:
+            - 'node': int (required) - node number
+            - 'head': float (optional) - initial head value
+            - 'avhead': bool (optional) - use average head of neighbors
+        - 'ibm1': list of dict
+            Nodes to set as constant head (IBOUND=-1). Each dict has:
+            - 'node': int (required) - node number
+            - 'head': float (optional) - prescribed head value
+            - 'avhead': bool (optional) - use average head of neighbors
+
+        For transport simulations, additional keys are available:
+        - 'icb0': list of int - deactivate ICBUND
+        - 'icb1': list of dict - activate ICBUND
+        - 'icbm1': list of dict - set prescribed concentration
+
+        Example::
+
+            stress_period_data = {
+                0: {
+                    'ib0': [100, 101, 102],  # Deactivate nodes
+                },
+                5: {
+                    'ibm1': [
+                        {'node': 200, 'head': 2900.0},
+                        {'node': 201, 'head': 2900.0},
+                    ],
+                },
+                10: {
+                    'ib1': [
+                        {'node': 200, 'avhead': True},  # Use avg head
+                    ],
+                },
+            }
+
+    extension : str
+        Filename extension (default 'tib')
+    unitnumber : int
+        File unit number (default None)
+    filenames : str or list of str
+        Filenames to use for the package (default None)
+    add_package : bool
+        Flag to add the package to the model (default True)
+
+    Attributes
+    ----------
+    heading : str
+        Package heading
+
+    Methods
+    -------
+    write_file()
+        Write the package file
+
+    See Also
+    --------
+    flopy.mfusg.MfUsgBas : Basic package with initial IBOUND
+
+    Notes
+    -----
+    The TIB package provides flexibility to change the IBOUND array
+    during the simulation. This is particularly useful for:
+
+    - Simulating excavation/reclamation by activating/deactivating cells
+    - Simulating well drilling/plugging
+    - Simulating filling/draining of lakes or reservoirs
+    - Mining operations where voids are created or filled
+
+    When activating a cell (IBOUND=1 or -1), you must provide either:
+    - A specific head value using the 'head' option
+    - The 'avhead' option to use average head of connected active cells
+
+    If the cell was inactive in the previous stress period and no head
+    option is provided, the simulation will abort with an error.
+
+    Examples
+    --------
+    >>> import flopy
+    >>> m = flopy.mfusg.MfUsg(modelname='test', model_ws='.', nper=10)
+    >>> # Simulate lake filling: convert cells to constant head in SP 3
+    >>> spd = {
+    ...     3: {
+    ...         'ibm1': [
+    ...             {'node': 100, 'head': 2900.0},
+    ...             {'node': 101, 'head': 2900.0},
+    ...             {'node': 102, 'head': 2900.0},
+    ...         ]
+    ...     },
+    ...     # Simulate lake draining: reactivate cells in SP 8
+    ...     8: {
+    ...         'ib1': [
+    ...             {'node': 100, 'avhead': True},
+    ...             {'node': 101, 'avhead': True},
+    ...             {'node': 102, 'avhead': True},
+    ...         ]
+    ...     }
+    ... }
+    >>> tib = flopy.mfusg.MfUsgTib(m, stress_period_data=spd)
+
+    """
+
+    def __init__(
+        self,
+        model,
+        stress_period_data=None,
+        extension="tib",
+        unitnumber=None,
+        filenames=None,
+        add_package=True,
+    ):
+        """Package constructor."""
+        # Validate model type
+        msg = (
+            "Model object must be of type flopy.mfusg.MfUsg\n"
+            f"but received type: {type(model)}."
+        )
+        assert isinstance(model, MfUsg), msg
+
+        # Set default unit number
+        if unitnumber is None:
+            unitnumber = MfUsgTib._defaultunit()
+
+        # Prepare filenames
+        filenames = MfUsgTib._prepare_filenames(filenames)
+
+        # Call parent constructor
+        super().__init__(
+            model,
+            extension=extension,
+            name=MfUsgTib._ftype(),
+            unit_number=unitnumber,
+            filenames=filenames,
+        )
+
+        self._generate_heading()
+
+        # Store parameters
+        self.stress_period_data = stress_period_data if stress_period_data else {}
+
+        # Add package to model
+        if add_package:
+            self.parent.add_package(self)
+
+    @staticmethod
+    def _prepare_filenames(filenames):
+        """Prepare filenames for the package."""
+        if filenames is None:
+            filenames = [None]
+        elif isinstance(filenames, str):
+            filenames = [filenames]
+        return filenames
+
+    def write_file(self):
+        """
+        Write the TIB package file.
+
+        Returns
+        -------
+        None
+        """
+        # Open file
+        f_tib = open(self.fn_path, "w")
+
+        # Write header comment
+        f_tib.write(f"# {self.heading}\n")
+
+        # Get number of stress periods
+        nper = self.parent.nper
+
+        # Write data for each stress period
+        for iper in range(nper):
+            spd = self.stress_period_data.get(iper, {})
+
+            # Get data for each IBOUND type
+            ib0_data = spd.get("ib0", [])  # Deactivate (IBOUND=0)
+            ib1_data = spd.get("ib1", [])  # Activate (IBOUND=1)
+            ibm1_data = spd.get("ibm1", [])  # Constant head (IBOUND=-1)
+
+            # For transport (ICBUND)
+            icb0_data = spd.get("icb0", [])
+            icb1_data = spd.get("icb1", [])
+            icbm1_data = spd.get("icbm1", [])
+
+            # Line 1: NIB0 NIB1 NIBM1 NICB0 NICB1 NICBM1
+            f_tib.write(
+                f"{len(ib0_data):10d}"
+                f"{len(ib1_data):10d}"
+                f"{len(ibm1_data):10d}"
+                f"{len(icb0_data):10d}"
+                f"{len(icb1_data):10d}"
+                f"{len(icbm1_data):10d}\n"
+            )
+
+            # Write IB0 data (nodes to deactivate) - as array
+            if len(ib0_data) > 0:
+                # Write nodes, 10 per line
+                for i, node in enumerate(ib0_data):
+                    f_tib.write(f"{node:10d}")
+                    if (i + 1) % 10 == 0:
+                        f_tib.write("\n")
+                if len(ib0_data) % 10 != 0:
+                    f_tib.write("\n")
+
+            # Write IB1 data (nodes to activate)
+            for item in ib1_data:
+                node = item["node"]
+                line = f"{node:10d}"
+                if "head" in item:
+                    line += f" HEAD {item['head']:15.6E}"
+                elif item.get("avhead", False):
+                    line += " AVHEAD"
+                f_tib.write(line + "\n")
+
+            # Write IBM1 data (nodes to set as constant head)
+            for item in ibm1_data:
+                node = item["node"]
+                line = f"{node:10d}"
+                if "head" in item:
+                    line += f" HEAD {item['head']:15.6E}"
+                elif item.get("avhead", False):
+                    line += " AVHEAD"
+                else:
+                    raise ValueError(
+                        f"Node {node} in IBM1 requires either 'head' value "
+                        "or 'avhead': True option"
+                    )
+                f_tib.write(line + "\n")
+
+            # Write ICB0 data (transport - deactivate ICBUND)
+            if len(icb0_data) > 0:
+                for i, node in enumerate(icb0_data):
+                    f_tib.write(f"{node:10d}")
+                    if (i + 1) % 10 == 0:
+                        f_tib.write("\n")
+                if len(icb0_data) % 10 != 0:
+                    f_tib.write("\n")
+
+            # Write ICB1 data (transport - activate ICBUND)
+            for item in icb1_data:
+                node = item["node"]
+                line = f"{node:10d}"
+                if "conc" in item:
+                    # conc can be a single value or list for multiple species
+                    conc = item["conc"]
+                    if isinstance(conc, (list, tuple)):
+                        conc_str = " ".join(f"{c:15.6E}" for c in conc)
+                    else:
+                        conc_str = f"{conc:15.6E}"
+                    line += f" CONC {conc_str}"
+                elif item.get("avconc", False):
+                    line += " AVCONC"
+                f_tib.write(line + "\n")
+
+            # Write ICBM1 data (transport - prescribed concentration)
+            for item in icbm1_data:
+                node = item["node"]
+                line = f"{node:10d}"
+                if "conc" in item:
+                    conc = item["conc"]
+                    if isinstance(conc, (list, tuple)):
+                        conc_str = " ".join(f"{c:15.6E}" for c in conc)
+                    else:
+                        conc_str = f"{conc:15.6E}"
+                    line += f" CONC {conc_str}"
+                elif item.get("avconc", False):
+                    line += " AVCONC"
+                else:
+                    raise ValueError(
+                        f"Node {node} in ICBM1 requires either 'conc' value "
+                        "or 'avconc': True option"
+                    )
+                f_tib.write(line + "\n")
+
+        f_tib.close()
+
+    @staticmethod
+    def _ftype():
+        return "TIB"
+
+    @staticmethod
+    def _defaultunit():
+        return 72
+
+    @classmethod
+    def load(cls, f, model, ext_unit_dict=None):
+        """
+        Load an existing TIB package from a file.
+
+        Parameters
+        ----------
+        f : str or file-like object
+            Filename or file handle
+        model : MfUsg
+            Model object
+        ext_unit_dict : dict, optional
+            External unit dictionary
+
+        Returns
+        -------
+        tib : MfUsgTib
+            MfUsgTib object
+
+        Examples
+        --------
+        >>> tib = MfUsgTib.load('model.tib', model)
+
+        """
+        raise NotImplementedError(
+            "TIB load method not yet implemented. "
+            "Contributions welcome at https://github.com/modflowpy/flopy"
+        )

--- a/flopy/mfusg/mfusgtvm.py
+++ b/flopy/mfusg/mfusgtvm.py
@@ -1,0 +1,297 @@
+"""
+mfusgtvm module.
+
+Contains the MfUsgTvm class. Note that the user can access
+the MfUsgTvm class as `flopy.mfusg.MfUsgTvm`.
+
+Time-Varying Materials (TVM) Package for MODFLOW-USG.
+"""
+
+import numpy as np
+
+from ..pakbase import Package
+from .mfusg import MfUsg
+
+
+class MfUsgTvm(Package):
+    """
+    MODFLOW-USG Time-Varying Materials Package Class.
+
+    The TVM package allows hydraulic properties (HK, VKA, SS, SY, DDFTR, POR)
+    to vary during a simulation. Properties are interpolated between stress
+    period boundaries.
+
+    Parameters
+    ----------
+    model : MfUsg
+        Model object (must be of type flopy.mfusg.MfUsg)
+    itvmprint : int
+        Print flag. 0=no output, 1=summary, 2=detailed (default 0)
+    tvmlogbasehk : float
+        Interpolation type for HK.
+        0 = linear interpolation
+        > 0 = logarithmic interpolation with this base
+        < 0 = step function (default 0)
+    tvmlogbasevka : float
+        Interpolation type for VKA. Same options as tvmlogbasehk (default 0)
+    tvmlogbasess : float
+        Interpolation type for SS. 0=linear, >0=log base.
+        Note: step function not supported for SS (default 0)
+    tvmlogbasesy : float
+        Interpolation type for SY. 0=linear, >0=log base.
+        Note: step function not supported for SY (default 0)
+    tvmddftr : float
+        Interpolation type for DDFTR (dual domain flow transfer rate).
+        Same options as tvmlogbasehk (default 0)
+    tvmlogbasepor : float
+        Interpolation type for porosity. 0=linear, >0=log base.
+        Note: step function not supported for porosity (default 0)
+    stress_period_data : dict
+        Dictionary keyed by stress period boundary index.
+        Boundary 0 = start of stress period 1
+        Boundary 1 = end of stress period 1 (= start of SP2)
+        Boundary N = end of stress period N
+
+        Each value is a dict with optional keys:
+        'hk', 'vka', 'ss', 'sy', 'ddftr', 'por'
+
+        Each property is a list of tuples: [(node, value), ...]
+
+        Example::
+
+            stress_period_data = {
+                0: {'hk': [(100, 1e-5), (101, 1e-5)]},  # Start SP1
+                1: {'hk': [(100, 1e-6), (101, 1e-6)]},  # End SP1
+                5: {'hk': [(100, 1e-7)]},               # End SP5
+            }
+
+    extension : str
+        Filename extension (default 'tvm')
+    unitnumber : int
+        File unit number (default None)
+    filenames : str or list of str
+        Filenames to use for the package (default None)
+    add_package : bool
+        Flag to add the package to the model (default True)
+
+    Attributes
+    ----------
+    heading : str
+        Package heading
+
+    Methods
+    -------
+    write_file()
+        Write the package file
+
+    See Also
+    --------
+    flopy.mfusg.MfUsgLpf : Layer Property Flow package
+    flopy.mfusg.MfUsgBcf : Block Centered Flow package
+
+    Notes
+    -----
+    The TVM package was developed by Damian Merrick (HydroAlgorithmics)
+    and Vivek Bedekar for MODFLOW-USG.
+
+    Properties change at stress period boundaries and are interpolated
+    during time steps within each stress period.
+
+    Interpolation options:
+    - Linear (0): Value changes linearly between boundaries
+    - Logarithmic (>0): Value changes logarithmically with specified base
+    - Step (<0): Value maintains start value until end of stress period
+
+    Examples
+    --------
+    >>> import flopy
+    >>> m = flopy.mfusg.MfUsg(modelname='test', model_ws='.')
+    >>> # Change HK for nodes 100-102 gradually from SP1 to SP5
+    >>> spd = {
+    ...     0: {'hk': [(100, 1e-4), (101, 1e-4), (102, 1e-4)]},
+    ...     5: {'hk': [(100, 1e-6), (101, 1e-6), (102, 1e-6)]},
+    ... }
+    >>> tvm = flopy.mfusg.MfUsgTvm(m, stress_period_data=spd)
+
+    """
+
+    def __init__(
+        self,
+        model,
+        itvmprint=0,
+        tvmlogbasehk=0.0,
+        tvmlogbasevka=0.0,
+        tvmlogbasess=0.0,
+        tvmlogbasesy=0.0,
+        tvmddftr=0.0,
+        tvmlogbasepor=0.0,
+        stress_period_data=None,
+        extension="tvm",
+        unitnumber=None,
+        filenames=None,
+        add_package=True,
+    ):
+        """Package constructor."""
+        # Validate model type
+        msg = (
+            "Model object must be of type flopy.mfusg.MfUsg\n"
+            f"but received type: {type(model)}."
+        )
+        assert isinstance(model, MfUsg), msg
+
+        # Set default unit number
+        if unitnumber is None:
+            unitnumber = MfUsgTvm._defaultunit()
+
+        # Prepare filenames
+        filenames = MfUsgTvm._prepare_filenames(filenames)
+
+        # Call parent constructor
+        super().__init__(
+            model,
+            extension=extension,
+            name=MfUsgTvm._ftype(),
+            unit_number=unitnumber,
+            filenames=filenames,
+        )
+
+        self._generate_heading()
+
+        # Store parameters
+        self.itvmprint = int(itvmprint)
+        self.tvmlogbasehk = float(tvmlogbasehk)
+        self.tvmlogbasevka = float(tvmlogbasevka)
+        self.tvmlogbasess = float(tvmlogbasess)
+        self.tvmlogbasesy = float(tvmlogbasesy)
+        self.tvmddftr = float(tvmddftr)
+        self.tvmlogbasepor = float(tvmlogbasepor)
+        self.stress_period_data = stress_period_data if stress_period_data else {}
+
+        # Add package to model
+        if add_package:
+            self.parent.add_package(self)
+
+    @staticmethod
+    def _prepare_filenames(filenames):
+        """Prepare filenames for the package."""
+        if filenames is None:
+            filenames = [None]
+        elif isinstance(filenames, str):
+            filenames = [filenames]
+        return filenames
+
+    def write_file(self):
+        """
+        Write the TVM package file.
+
+        Returns
+        -------
+        None
+        """
+        # Open file
+        f_tvm = open(self.fn_path, "w")
+
+        # Write header comment
+        f_tvm.write(f"# {self.heading}\n")
+
+        # Line 1: Interpolation options
+        # ITVMPRINT TVMLOGBASEHK TVMLOGBASEVKA TVMLOGBASESS ...
+        f_tvm.write(
+            f"{self.itvmprint:10d}"
+            f"{self.tvmlogbasehk:10.3f}"
+            f"{self.tvmlogbasevka:10.3f}"
+            f"{self.tvmlogbasess:10.3f}"
+            f"{self.tvmlogbasesy:10.3f}"
+            f"{self.tvmddftr:10.3f}"
+            f"{self.tvmlogbasepor:10.3f}\n"
+        )
+
+        # Get number of stress periods
+        nper = self.parent.nper
+
+        # Write data for each stress period boundary
+        # Boundary 0 = start of SP1, Boundary 1 = end of SP1, etc.
+        for iper in range(nper + 1):
+            spd = self.stress_period_data.get(iper, {})
+
+            # Get data for each property
+            hk_data = spd.get("hk", [])
+            vka_data = spd.get("vka", [])
+            ss_data = spd.get("ss", [])
+            sy_data = spd.get("sy", [])
+            ddftr_data = spd.get("ddftr", [])
+            por_data = spd.get("por", [])
+
+            # Line 2: Counts for each property
+            # NTVMHK NTVMVKA NTVMSS NTVMSY NTVMDDFTR NTVMPOR
+            f_tvm.write(
+                f"{len(hk_data):10d}"
+                f"{len(vka_data):10d}"
+                f"{len(ss_data):10d}"
+                f"{len(sy_data):10d}"
+                f"{len(ddftr_data):10d}"
+                f"{len(por_data):10d}\n"
+            )
+
+            # Write HK data (ITVMHK HKNEW)
+            for node, value in hk_data:
+                f_tvm.write(f"{node:10d} {value:15.6E}\n")
+
+            # Write VKA data (ITVMVKA VKANEW)
+            for node, value in vka_data:
+                f_tvm.write(f"{node:10d} {value:15.6E}\n")
+
+            # Write SS data (ITVMSS SSNEW)
+            for node, value in ss_data:
+                f_tvm.write(f"{node:10d} {value:15.6E}\n")
+
+            # Write SY data (ITVMSY SYNEW)
+            for node, value in sy_data:
+                f_tvm.write(f"{node:10d} {value:15.6E}\n")
+
+            # Write DDFTR data (ITVMDDFTR DDFTRNEW)
+            for node, value in ddftr_data:
+                f_tvm.write(f"{node:10d} {value:15.6E}\n")
+
+            # Write POR data (ITVMPOR PORNEW)
+            for node, value in por_data:
+                f_tvm.write(f"{node:10d} {value:15.6E}\n")
+
+        f_tvm.close()
+
+    @staticmethod
+    def _ftype():
+        return "TVM"
+
+    @staticmethod
+    def _defaultunit():
+        return 71
+
+    @classmethod
+    def load(cls, f, model, ext_unit_dict=None):
+        """
+        Load an existing TVM package from a file.
+
+        Parameters
+        ----------
+        f : str or file-like object
+            Filename or file handle
+        model : MfUsg
+            Model object
+        ext_unit_dict : dict, optional
+            External unit dictionary
+
+        Returns
+        -------
+        tvm : MfUsgTvm
+            MfUsgTvm object
+
+        Examples
+        --------
+        >>> tvm = MfUsgTvm.load('model.tvm', model)
+
+        """
+        raise NotImplementedError(
+            "TVM load method not yet implemented. "
+            "Contributions welcome at https://github.com/modflowpy/flopy"
+        )


### PR DESCRIPTION
## Summary

- Add **MfUsgTvm** (Time-Varying Materials) package for MODFLOW-USG
- Add **MfUsgTib** (Transient IBOUND) package for MODFLOW-USG
- Include comprehensive unit tests (24 tests)

## Description

### TVM Package (MfUsgTvm)

The TVM package allows hydraulic properties to vary during a simulation:

- **Supported properties**: HK, VKA, SS, SY, DDFTR, POR
- **Interpolation methods**: Linear, logarithmic (with configurable base), step function
- Properties are interpolated between stress period boundaries

Example usage:
```python
spd = {
    0: {'hk': [(100, 1e-4), (101, 1e-4)]},  # Start SP1
    5: {'hk': [(100, 1e-6), (101, 1e-6)]},  # End SP5
}
tvm = flopy.mfusg.MfUsgTvm(model, stress_period_data=spd)
```

### TIB Package (MfUsgTib)

The TIB package allows the IBOUND array to change during simulation:

- **IB0**: Deactivate cells (IBOUND=0)
- **IB1**: Activate cells (IBOUND=1) with HEAD or AVHEAD option
- **IBM1**: Set constant head (IBOUND=-1) with HEAD or AVHEAD option
- Also supports transport ICBUND modifications

Use cases: excavation, reclamation, well drilling/plugging, reservoir filling/draining

Example usage:
```python
spd = {
    0: {'ib0': [100, 101, 102]},  # Deactivate
    5: {'ibm1': [{'node': 200, 'head': 2900.0}]},  # Set constant head
}
tib = flopy.mfusg.MfUsgTib(model, stress_period_data=spd)
```

## Test plan

- [x] Unit tests for TVM package initialization
- [x] Unit tests for TVM write_file() with all property types
- [x] Unit tests for TIB package initialization (ib0, ib1, ibm1)
- [x] Unit tests for TIB write_file() with HEAD and AVHEAD options
- [x] Integration test using both TVM and TIB together
- [x] Model type validation tests (require MfUsg)
- [x] All 24 tests passing with ruff checks

## Notes

- The `load()` method raises `NotImplementedError` - contributions welcome
- Based on MODFLOW-USG documentation for TVM and TIB input files

🤖 Generated with [Claude Code](https://claude.ai/code)