### PR TITLE
fix(model_splitter): fix spurious ssm creation

### DIFF
--- a/autotest/test_model_splitter.py
+++ b/autotest/test_model_splitter.py
@@ -578,6 +578,53 @@ def test_empty_packages(function_tmpdir):
     )
 
 
+def test_empty_ssm(function_tmpdir):
+    nlay, nrow, ncol = 1, 1, 10
+    gwfname = "gwf"
+    gwtname = "gwt"
+
+    sim = flopy.mf6.MFSimulation(sim_ws=function_tmpdir)
+    flopy.mf6.ModflowIms(sim)
+    flopy.mf6.ModflowTdis(sim)
+
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=gwfname)
+    flopy.mf6.ModflowGwfdis(gwf, nlay=nlay, nrow=nrow, ncol=ncol)
+    flopy.mf6.ModflowGwfnpf(gwf)
+    flopy.mf6.ModflowGwfic(gwf, strt=1.0)
+    flopy.mf6.ModflowGwfchd(
+        gwf, stress_period_data=[((0, 0, 0), 1.0), ((0, 0, ncol - 1), 0.0)]
+    )
+    flopy.mf6.ModflowGwfwel(
+        gwf,
+        auxiliary=["CONCENTRATION"],
+        stress_period_data=[((0, 0, 2), -1.0, 0.0)],
+    )
+
+    gwt = flopy.mf6.ModflowGwt(sim, modelname=gwtname)
+    flopy.mf6.ModflowGwtdis(gwt, nlay=nlay, nrow=nrow, ncol=ncol)
+    flopy.mf6.ModflowGwtic(gwt, strt=0.0)
+    flopy.mf6.ModflowGwtmst(gwt, porosity=0.3)
+    flopy.mf6.ModflowGwtssm(gwt, sources=[("wel", "AUX", "CONCENTRATION")])
+
+    flopy.mf6.ModflowGwfgwt(
+        sim, exgtype="GWF6-GWT6", exgmnamea=gwfname, exgmnameb=gwtname
+    )
+
+    # Split: partition 0 = cols 0-4 (contains WEL at col 2)
+    #        partition 1 = cols 5-9 (no WEL)
+    array = np.zeros((nrow, ncol), dtype=int)
+    array[0, 5:] = 1
+
+    mfs = Mf6Splitter(sim)
+    new_sim = mfs.split_multi_model(array)
+
+    gwt0 = new_sim.get_model(f"{gwtname}_0")
+    gwt1 = new_sim.get_model(f"{gwtname}_1")
+
+    assert gwt0.get_package("ssm") is not None
+    assert gwt1.get_package("ssm") is None
+
+
 @requires_exe("mf6")
 def test_transient_array(function_tmpdir):
     name = "tarr"

--- a/flopy/mf6/utils/model_splitter.py
+++ b/flopy/mf6/utils/model_splitter.py
@@ -2648,8 +2648,6 @@ class Mf6Splitter:
 
                     if records:
                         mapped_data[mkey]["sources"] = records
-                    else:
-                        mapped_data[mkey]["sources"] = None
 
         return mapped_data
 


### PR DESCRIPTION
The model splitter generated empty SSM package files for partitions containing no boundary conditions, causing MODFLOW 6 to fail.

The `_remap_ssm()` method set a dict entry to `None` to indicate a partition had no boundary flows. Later the dict is checked in an `if` statement and considered "truthy" since it contains an entry whose value is `None`

Instead, indicate no boundary flows by not adding an entry to the dict. The conditional works, no SSM package is created, no file written, MF6 is happy.

Fix #2715