### PR TITLE
chore(dependencies): support pandas 3

### DIFF
--- a/flopy/export/metadata.py
+++ b/flopy/export/metadata.py
@@ -188,7 +188,7 @@ class acdd:
             mlen = self.model_time.perlen.sum()
             tunits = self.model_time.time_units
             tc["duration"] = f"{mlen} {tunits}"
-            end = strt + pd.Timedelta(mlen, unit="d")
+            end = strt + pd.Timedelta(mlen, unit="D")
             tc["end"] = str(end)
         return tc
 

--- a/flopy/mf6/data/mfdataplist.py
+++ b/flopy/mf6/data/mfdataplist.py
@@ -676,9 +676,11 @@ class MFPandasList(mfdata.MFMultiDimVar, DataListInterface):
                 if len(data[0]) == len(self._data_item_names):
                     # data most likely being stored with cellids as tuples,
                     # create a dataframe and untuple the cellids
-                    data = pandas.DataFrame(
-                        data, columns=self._data_item_names
-                    )
+                    # In pandas 3+, DataFrame() with recarray requires columns to match
+                    # field names, so create without columns param then rename if needed
+                    data = pandas.DataFrame(data)
+                    if list(data.columns) != self._data_item_names:
+                        data.columns = self._data_item_names
                     data = self._untuple_cellids(data)[0]
                     # make sure columns are still in correct order
                     data = pandas.DataFrame(data, columns=self._header_names)
@@ -691,19 +693,21 @@ class MFPandasList(mfdata.MFMultiDimVar, DataListInterface):
             else:
                 # data size matches the expected header names, create a pandas
                 # dataframe from the data
-                data_new = pandas.DataFrame(data, columns=self._header_names)
+                # In pandas 3+, DataFrame() with recarray requires columns to match
+                # field names, so create without columns param then rename if needed
+                data_new = pandas.DataFrame(data)
+                if list(data_new.columns) != self._header_names:
+                    data_new.columns = self._header_names
                 if not self._dataframe_check(data_new):
                     data_list = self._untuple_recarray(data)
-                    data = pandas.DataFrame(
-                        data_list, columns=self._header_names
-                    )
+                    data = pandas.DataFrame(data_list)
+                    if list(data.columns) != self._header_names:
+                        data.columns = self._header_names
                 else:
                     data, count = self._untuple_cellids(data_new)
                     if count > 0:
                         # make sure columns are still in correct order
-                        data = pandas.DataFrame(
-                            data, columns=self._header_names
-                        )
+                        data = pandas.DataFrame(data, columns=self._header_names)
         elif isinstance(data, list) or isinstance(data, tuple):
             if not (isinstance(data[0], list) or isinstance(data[0], tuple)):
                 # get data in the format of a tuple of lists (or tuples)

--- a/flopy/utils/mtlistfile.py
+++ b/flopy/utils/mtlistfile.py
@@ -51,7 +51,7 @@ class MtListBudget:
 
         return
 
-    def parse(self, forgive=True, diff=True, start_datetime=None, time_unit="d"):
+    def parse(self, forgive=True, diff=True, start_datetime=None, time_unit="D"):
         """
         Main entry point for parsing the list file.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ requires-python = ">=3.10"
 dependencies = [
     "numpy>=1.20.3,<3.0",
     "matplotlib >=1.4.0",
-    "pandas >=2.0.0,<3.0",
+    "pandas >=2.0.0",
 ]
 dynamic = ["version", "readme"]
 


### PR DESCRIPTION
Recently [pandas 3 was released](https://pandas.pydata.org/community/blog/pandas-3.0.html).

Only minimal changes needed from us, namely

- switching timedelta units from deprecated "d" to "D"
- a fix in the model splitter where columns that were previously renamed automatically on dataframe construction must now be renamed manually due to stricter dataframe init method requirements

There are two other potentially relevant changes

1. String dtype

Pandas 3 will infer string columns as str dtype instead of object. Code checking `dtype == 'object'` for strings will break. I think we are safe as internal dtype checks are generally on numpy arrays, not pandas DataFrames. We kind of luck out for having not migrated everything over to pandas.

When we do `pd.DataFrame.from_records(recarray)`, numpy string fields will get converted to str dtype instead of object. But I don't think we need to care, indexing, selection, etc should all work as before.

  2. Copy-on-Write (CoW)

As far as I can tell we use `.loc` internally, no chained assignments, so we should be good.
