### PR TITLE
chore(dependencies): exclude modflow-devtools 1.9.0

### DIFF
--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   # codegen
   - boltons>=1.0
   - Jinja2>=3.0
-  - modflow-devtools>=1.7.0
+  - modflow-devtools>=1.7.0,!=1.9.0,<2
   - tomli
   - tomli-w
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dev = ["flopy[codegen,lint,test,optional,doc]", "tach"]
 codegen = [
     "Jinja2>=3.0",
     "boltons",
-    "modflow-devtools>=1.7.0",
+    "modflow-devtools>=1.7.0,!=1.9.0,<2",
     "tomli",
     "tomli-w"
 ]
@@ -51,7 +51,7 @@ test = [
     "jupyter",
     "jupyter_client >=8.4.0", # avoid datetime.utcnow() deprecation warning
     "jupytext",
-    "modflow-devtools>=1.7.0",
+    "modflow-devtools>=1.7.0,!=1.9.0,<2",
     "pytest !=8.1.0",
     "pytest-benchmark",
     "pytest-cov",


### PR DESCRIPTION
I borked devtools 1.9.0 https://github.com/MODFLOW-ORG/modflow-devtools/pull/299, make sure we don't use it. Also add an upper bound.