### PR TITLE
fix: wipe toml dfn dir before regenerating mf6 module

### DIFF
--- a/flopy/mf6/utils/generate_classes.py
+++ b/flopy/mf6/utils/generate_classes.py
@@ -89,7 +89,8 @@ def generate_classes(
         print()
 
         tomlpath = dfnpath / "toml"
-        tomlpath.mkdir(exist_ok=True)
+        shutil.rmtree(tomlpath, ignore_errors=True)
+        tomlpath.mkdir()
         dfn2toml(dfnpath, tomlpath)
 
         shutil.rmtree(_MF6_AUTOGEN_PATH)


### PR DESCRIPTION
Delete all the TOMLs before recreating them from DFNs otherwise unwanted TOML components can remain