### PR TITLE
fix(vtk): transpose before numpy_to_vtk in add_vector

### DIFF
--- a/flopy/export/vtk.py
+++ b/flopy/export/vtk.py
@@ -897,7 +897,7 @@ class Vtk:
             else:
                 raise AssertionError("Size of vector must be 3 * nnodes or 3 * ncpl")
         else:
-            vector = np.reshape(vector, (3, self.nnodes))
+            vector = np.reshape(vector, (3, self.nnodes)).T
 
         if self.point_scalars:
             tmp = []


### PR DESCRIPTION
`add_vector()` assigns a vector to each grid cell. The method takes an array of shape `(3, nnodes)` and passes it to `numpy_support.numpy_to_vtk()`, which due to the order of indices flattens it in column-major order, but VTK expects row-major order.

So where cell `i` should get

`(x[i], y[i], z[i])`

it instead gets

`(x[3i], x[3i+1], x[3i+2])`

Fixed by transposing the array passed to `numpy_to_vtk()` so it is `(nnodes, 3)` and is flattened/interpreted correctly
