### PR TITLE
fix(mfpackage): clear timeseries files on ts initialize

### DIFF
--- a/autotest/test_mf6.py
+++ b/autotest/test_mf6.py
@@ -2605,3 +2605,191 @@ def test_evt_auxiliary_variables(function_tmpdir):
             aux_name_lower = aux_name.lower()
             assert aux_name_lower in spd_load.dtype.names
             assert spd_load[0][aux_name_lower] == float(i + 1)
+
+
+def _make_gwf_sim(function_tmpdir):
+    """Minimal single-layer GWF simulation used by the ts tests below."""
+    sim = MFSimulation(
+        sim_name="test", version="mf6", exe_name="mf6", sim_ws=str(function_tmpdir)
+    )
+    ModflowTdis(sim, time_units="DAYS", nper=2, perioddata=[(1.0, 1, 1.0)] * 2)
+    ModflowIms(sim)
+    gwf = ModflowGwf(sim, modelname="gwf")
+    ModflowGwfdis(gwf, nlay=1, nrow=3, ncol=3, delr=1.0, delc=1.0, top=10.0, botm=0.0)
+    ModflowGwfic(gwf, strt=5.0)
+    ModflowGwfnpf(gwf, k=1.0)
+    return sim, gwf
+
+
+def test_multi_ts_files_written(function_tmpdir):
+    """
+    Test that multiple time series files are all written to disk when
+    using initialize() followed by append_package(), and that the file
+    record only contains the current set of filenames.
+
+    Regression test for https://github.com/modflowpy/flopy/issues/2748.
+    """
+    sim, gwf = _make_gwf_sim(function_tmpdir)
+
+    ghb_spd = {0: [((0, 0, 0), "tide1", 100.0), ((0, 1, 0), "tide2", 100.0)]}
+    ghb = ModflowGwfghb(gwf, maxbound=2, stress_period_data=ghb_spd)
+
+    ts_data1 = [(0.0, 1.0), (1.0, 2.0)]
+    ts_data2 = [(0.0, 3.0), (1.0, 4.0)]
+
+    ghb.ts.initialize(
+        filename="tides1.ts",
+        timeseries=ts_data1,
+        time_series_namerecord="tide1",
+        interpolation_methodrecord="linearend",
+    )
+    ghb.ts.append_package(
+        filename="tides2.ts",
+        timeseries=ts_data2,
+        time_series_namerecord="tide2",
+        interpolation_methodrecord="linearend",
+    )
+
+    assert [p.filename for p in ghb.ts._packages] == ["tides1.ts", "tides2.ts"]
+    fr = ghb._ts_filerecord.get_data()
+    assert len(fr) == 2
+    assert fr[0][0] == "tides1.ts"
+    assert fr[1][0] == "tides2.ts"
+
+    sim.write_simulation()
+
+    assert (function_tmpdir / "tides1.ts").exists(), "tides1.ts not written"
+    assert (function_tmpdir / "tides2.ts").exists(), "tides2.ts not written"
+
+
+def test_initialize_ts_replaces_filerecord(function_tmpdir):
+    """
+    Test that calling initialize() a second time properly replaces the first
+    ts package — including clearing the stale filename from the file record.
+
+    Before the fix for https://github.com/modflowpy/flopy/issues/2748,
+    the first filename remained in the file record even after the first
+    package was removed from the model's package list, causing MF6 to
+    expect a file that was never written.
+    """
+    sim, gwf = _make_gwf_sim(function_tmpdir)
+
+    ghb_spd = {0: [((0, 0, 0), "tide2", 100.0)]}
+    ghb = ModflowGwfghb(gwf, maxbound=1, stress_period_data=ghb_spd)
+
+    ts_data1 = [(0.0, 1.0), (1.0, 2.0)]
+    ts_data2 = [(0.0, 3.0), (1.0, 4.0)]
+
+    # First initialize sets up ts package
+    ghb.ts.initialize(
+        filename="tides1.ts",
+        timeseries=ts_data1,
+        time_series_namerecord="tide1",
+        interpolation_methodrecord="linearend",
+    )
+    # Second initialize replaces the first — filerecord must be updated too
+    ghb.ts.initialize(
+        filename="tides2.ts",
+        timeseries=ts_data2,
+        time_series_namerecord="tide2",
+        interpolation_methodrecord="linearend",
+    )
+
+    assert [p.filename for p in ghb.ts._packages] == ["tides2.ts"]
+    fr = ghb._ts_filerecord.get_data()
+    assert len(fr) == 1, (
+        f"filerecord should have 1 entry after replace, got {len(fr)}: {fr}"
+    )
+    assert fr[0][0] == "tides2.ts"
+
+    sim.write_simulation()
+
+    # Only tides2.ts should exist; tides1.ts was replaced and must not appear
+    assert not (function_tmpdir / "tides1.ts").exists(), (
+        "tides1.ts should not be written after being replaced"
+    )
+    assert (function_tmpdir / "tides2.ts").exists(), "tides2.ts not written"
+
+
+def test_ts_kwarg_and_append_package(function_tmpdir):
+    """
+    Test that passing timeseries= during package construction (which internally
+    calls build_child_package) followed by append_package() correctly writes
+    both ts files.
+
+    Regression test for https://github.com/modflowpy/flopy/issues/2748.
+    """
+    sim, gwf = _make_gwf_sim(function_tmpdir)
+
+    ts_data1 = [(0.0, 1.0), (1.0, 2.0)]
+    ts_data2 = [(0.0, 3.0), (1.0, 4.0)]
+
+    ghb_spd = {0: [((0, 0, 0), "tide1", 100.0), ((0, 1, 0), "tide2", 100.0)]}
+    ghb = ModflowGwfghb(
+        gwf,
+        maxbound=2,
+        stress_period_data=ghb_spd,
+        timeseries={
+            "filename": "tides1.ts",
+            "timeseries": ts_data1,
+            "time_series_namerecord": "tide1",
+            "interpolation_methodrecord": "linearend",
+        },
+    )
+    ghb.ts.append_package(
+        filename="tides2.ts",
+        timeseries=ts_data2,
+        time_series_namerecord="tide2",
+        interpolation_methodrecord="linearend",
+    )
+
+    assert [p.filename for p in ghb.ts._packages] == ["tides1.ts", "tides2.ts"]
+    fr = ghb._ts_filerecord.get_data()
+    assert len(fr) == 2
+    assert fr[0][0] == "tides1.ts"
+    assert fr[1][0] == "tides2.ts"
+
+    sim.write_simulation()
+
+    assert (function_tmpdir / "tides1.ts").exists(), "tides1.ts not written"
+    assert (function_tmpdir / "tides2.ts").exists(), "tides2.ts not written"
+
+
+def test_ts_write_load_roundtrip(function_tmpdir):
+    """
+    Test that multiple ts files survive a write/load round-trip: both packages
+    are present in the loaded model and both files exist on disk.
+
+    Regression test for https://github.com/modflowpy/flopy/issues/2748.
+    """
+    sim, gwf = _make_gwf_sim(function_tmpdir)
+
+    ts_data1 = [(0.0, 1.0), (1.0, 2.0)]
+    ts_data2 = [(0.0, 3.0), (1.0, 4.0)]
+
+    ghb_spd = {0: [((0, 0, 0), "tide1", 100.0), ((0, 1, 0), "tide2", 100.0)]}
+    ghb = ModflowGwfghb(gwf, maxbound=2, stress_period_data=ghb_spd)
+    ghb.ts.initialize(
+        filename="tides1.ts",
+        timeseries=ts_data1,
+        time_series_namerecord="tide1",
+        interpolation_methodrecord="linearend",
+    )
+    ghb.ts.append_package(
+        filename="tides2.ts",
+        timeseries=ts_data2,
+        time_series_namerecord="tide2",
+        interpolation_methodrecord="linearend",
+    )
+
+    sim.write_simulation()
+
+    sim2 = MFSimulation.load("mfsim.nam", sim_ws=str(function_tmpdir))
+    ghb2 = sim2.get_model("gwf").get_package("ghb")
+
+    assert len(ghb2.ts._packages) == 2
+    fr2 = ghb2._ts_filerecord.get_data()
+    assert len(fr2) == 2
+    fnames = {row[0] for row in fr2}
+    assert "tides1.ts" in fnames
+    assert "tides2.ts" in fnames

--- a/flopy/mf6/mfpackage.py
+++ b/flopy/mf6/mfpackage.py
@@ -3669,8 +3669,9 @@ class MFChildPackages:
 
     def init_package(self, package, fname, remove_packages=True):
         if remove_packages:
-            # clear out existing packages
+            # clear out existing packages and reset file record
             self._remove_packages()
+            self._filerecord.set_data(None)
         elif fname is not None:
             self._remove_packages(fname)
         if fname is None:


### PR DESCRIPTION
Fix #2748.

Semantics primer:

  - `package.ts.initialize()` removes all existing TS packages and starts fresh with a new one. Each call is a replacement.                                                                   
  - `append_package()` preserves existing TS packages and registers a new one. This is the way to register multiple TS files.
  - `timeseries=...` package kwarg is equivalent to a single `initialize()`, creating exactly one ts package.

Before now, `MFChildPackages.init_package`, called internally by `package.ts.initialize()`, correctly removed existing packages from the package list, but left their filenames. This meant that calling `initialize()` multiple times, or calling it after constructing a package with `timeseries=`, would accumulate TS filenames in the OPTIONS block's TS6 FILEIN entries, without corresponding TS packages. MODFLOW 6 would then fail at runtime trying to open TS files that don't exist. Reset the file record in `init_package` when `remove_packages=True`, so it stays consistent with the package list.