### PR TITLE
feat(mve): add support for gwe-gwe exchanges that include mve package

### DIFF
--- a/flopy/mf6/data/mfstructure.py
+++ b/flopy/mf6/data/mfstructure.py
@@ -35,6 +35,7 @@ class DfnType(Enum):
     mvr_file = 9
     utl = 10
     mvt_file = 11
+    mve_file = 12
     unknown = 999
 
 
@@ -106,6 +107,8 @@ class Dfn:
                 return DfnType.mvr_file, model_type
             elif file_name[3:6] == "mvt":
                 return DfnType.mvt_file, model_type
+            elif file_name[3:6] == "mve":
+                return DfnType.mve_file, model_type
             else:
                 return DfnType.model_file, model_type
 
@@ -1760,6 +1763,7 @@ class MFSimulationStructure:
             or dfn_file.dfn_type == DfnType.gnc_file
             or dfn_file.dfn_type == DfnType.mvr_file
             or dfn_file.dfn_type == DfnType.mvt_file
+            or dfn_file.dfn_type == DfnType.mve_file
         ):
             model_ver = f"{dfn_file.model_type}6"
             if model_ver not in self.mdl_spec:
@@ -1772,6 +1776,7 @@ class MFSimulationStructure:
                 dfn_file.dfn_type == DfnType.gnc_file
                 or dfn_file.dfn_type == DfnType.mvr_file
                 or dfn_file.dfn_type == DfnType.mvt_file
+                or dfn_file.dfn_type == DfnType.mve_file
             ):
                 # gnc and mvr files belong both on the simulation and model level
                 self.mdl_spec[model_ver].pkg_spec[dfn_file.package_type] = (

--- a/flopy/mf6/utils/codegen/component.py
+++ b/flopy/mf6/utils/codegen/component.py
@@ -30,6 +30,7 @@ def get_component_names(dfn: dict) -> list[tuple[str, str]]:
         ["gwf", "mvr"],
         ["gwf", "gnc"],
         ["gwt", "mvt"],
+        ["gwe", "mve"],
     ]:
         # TODO: deduplicate mfmvr.py/mfgwfmvr.py etc and remove special cases
         return [

--- a/flopy/mf6/utils/codegen/filters.py
+++ b/flopy/mf6/utils/codegen/filters.py
@@ -110,6 +110,8 @@ def dfn_file_name(component_name: tuple[str, str]) -> str:
         return f"gwf-{component_name[1]}.dfn"
     if tuple(component_name) in [(None, "mvt")]:
         return f"gwt-{component_name[1]}.dfn"
+    if tuple(component_name) in [(None, "mve")]:
+        return f"gwe-{component_name[1]}.dfn"
     return f"{component_name[0] or 'sim'}-{component_name[1]}.dfn"
 
 


### PR DESCRIPTION
model-level `MVE` package was previously supported by virtue of the dfn file.  However, simulation-level support for `MVE` was not supported.  A new autotest for MF6 confirms that these changes are sufficient.  

This missing functionality was discovered when attempting to support parallel energy mover (`MVE`) transport in MF6.  For example, if a stream was split across two flow and transport models and a transport mover was required to properly route solute from an SFT reach in one model to a connected SFT reach in a downstream model, MVT worked, but its complement in GWE, namely MVE, was not working prior to this PR.  