### PR TITLE
ci: drop setup-micromamba

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -15,35 +15,27 @@ jobs:
         python-version: [ "3.10", "3.11", "3.12" ]
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash
     timeout-minutes: 90
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
 
-      - name: Setup Micromamba
-        uses: mamba-org/setup-micromamba@v3
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: astral-sh/setup-uv@v7
         with:
-          environment-file: etc/environment.yml
-          cache-environment: true
-          cache-downloads: true
-          create-args: >-
-            python=${{ matrix.python-version }}
-          init-shell: >-
-            bash
-            powershell
+          python-version: ${{ matrix.python-version }}
+          cache-dependency-glob: "**/pyproject.toml"
 
       - name: Install FloPy
-        run: |
-          pip install .
-          pip install ".[codegen]"
+        run: uv sync --all-extras
 
       - name: OpenGL workaround on Linux
         if: runner.os == 'Linux'
         run: |
           # referenced from https://github.com/pyvista/pyvista/blob/main/.github/workflows/vtk-pre-test.yml#L53
-          pip uninstall -y vtk
-          pip install --extra-index-url https://wheels.vtk.org trame vtk-osmesa
+          uv pip uninstall vtk
+          uv pip install --extra-index-url https://wheels.vtk.org trame vtk-osmesa
 
       - name: Install OpenGL on Windows
         if: runner.os == 'Windows'
@@ -71,11 +63,11 @@ jobs:
           subset: triangle
 
       - name: Update FloPy packages
-        run: python -m flopy.mf6.utils.generate_classes --ref develop
+        run: uv run python -m flopy.mf6.utils.generate_classes --ref develop
 
       - name: Run example tests
         working-directory: autotest
-        run: pytest -v test_example_notebooks.py -n=auto -s --durations=0 --keep-failed=.failed
+        run: uv run pytest -v test_example_notebooks.py -n=auto -s --durations=0 --keep-failed=.failed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -86,31 +86,25 @@ jobs:
           echo $GITHUB_REF
           echo $GITHUB_EVENT_NAME
 
-      - name: Setup Micromamba
-        uses: mamba-org/setup-micromamba@v3
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@v0.9.5
         with:
-          environment-file: flopy/etc/environment.yml
-          cache-environment: true
-          cache-downloads: true
-          create-args: >-
-            python=3.12
-          init-shell: >-
-            bash
-            powershell
+          pixi-version: v0.41.4
+          manifest-path: modflow6/pixi.toml
 
       - name: Install Python dependencies
-        working-directory: flopy
+        working-directory: modflow6
         run: |
-          pip install --upgrade pip
-          pip install .
-          pip install meson ninja
+          pixi run install
+          pixi run pip install "../flopy[optional,test]"
 
       - name: Workaround OpenGL issue on Linux
         if: runner.os == 'Linux'
+        working-directory: modflow6
         run: |
           # referenced from https://github.com/pyvista/pyvista/blob/main/.github/workflows/vtk-pre-test.yml#L53
-          pip uninstall -y vtk
-          pip install --extra-index-url https://wheels.vtk.org trame vtk-osmesa
+          pixi run pip uninstall vtk
+          pixi run pip install --extra-index-url https://wheels.vtk.org trame vtk-osmesa
 
       - name: Install fonts on Linux
         if: runner.os == 'Linux'
@@ -142,14 +136,14 @@ jobs:
       - name: Build MODFLOW 6
         working-directory: modflow6
         run: |
-          meson setup builddir --buildtype=debugoptimized --prefix=$(pwd) --libdir=bin
-          meson install -C builddir
-          meson test --verbose --no-rebuild -C builddir
+          pixi run meson setup builddir --buildtype=debugoptimized --prefix=$(pwd) --libdir=bin
+          pixi run meson install -C builddir
+          pixi run meson test --verbose --no-rebuild -C builddir
           echo "$(pwd)/bin" >> $GITHUB_PATH
 
       - name: Run tutorial and example notebooks
         working-directory: flopy/autotest
-        run: pytest -v -n auto test_example_notebooks.py
+        run: pixi run --manifest-path=../../modflow6/pixi.toml pytest -v -n auto test_example_notebooks.py
 
       - name: Upload notebooks artifact for ReadtheDocs
         if: |

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -95,16 +95,16 @@ jobs:
       - name: Install Python dependencies
         working-directory: modflow6
         run: |
-          pixi run install
-          pixi run pip install "../flopy[optional,test]"
+          pixi run -e rtd install
+          pixi run -e rtd pip install "../flopy[optional,test]"
 
       - name: Workaround OpenGL issue on Linux
         if: runner.os == 'Linux'
         working-directory: modflow6
         run: |
           # referenced from https://github.com/pyvista/pyvista/blob/main/.github/workflows/vtk-pre-test.yml#L53
-          pixi run pip uninstall vtk
-          pixi run pip install --extra-index-url https://wheels.vtk.org trame vtk-osmesa
+          pixi run -e rtd pip uninstall vtk
+          pixi run -e rtd pip install --extra-index-url https://wheels.vtk.org trame vtk-osmesa
 
       - name: Install fonts on Linux
         if: runner.os == 'Linux'
@@ -136,14 +136,14 @@ jobs:
       - name: Build MODFLOW 6
         working-directory: modflow6
         run: |
-          pixi run meson setup builddir --buildtype=debugoptimized --prefix=$(pwd) --libdir=bin
-          pixi run meson install -C builddir
-          pixi run meson test --verbose --no-rebuild -C builddir
+          pixi run -e rtd meson setup builddir --buildtype=debugoptimized --prefix=$(pwd) --libdir=bin
+          pixi run -e rtd meson install -C builddir
+          pixi run -e rtd meson test --verbose --no-rebuild -C builddir
           echo "$(pwd)/bin" >> $GITHUB_PATH
 
       - name: Run tutorial and example notebooks
         working-directory: flopy/autotest
-        run: pixi run --manifest-path=../../modflow6/pixi.toml pytest -v -n auto test_example_notebooks.py
+        run: pixi run --manifest-path=../../modflow6/pixi.toml -e rtd pytest -v -n auto test_example_notebooks.py
 
       - name: Upload notebooks artifact for ReadtheDocs
         if: |

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -98,10 +98,6 @@ jobs:
           pixi run -e rtd install
           pixi run -e rtd pip install "../flopy[optional,test]"
 
-      - name: Install pymetis (Windows)
-        working-directory: modflow6
-        run: pixi add pymetis
-
       - name: Workaround OpenGL issue on Linux
         if: runner.os == 'Linux'
         working-directory: modflow6

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -98,6 +98,10 @@ jobs:
           pixi run -e rtd install
           pixi run -e rtd pip install "../flopy[optional,test]"
 
+      - name: Install pymetis (Windows)
+        working-directory: modflow6
+        run: pixi add pymetis
+
       - name: Workaround OpenGL issue on Linux
         if: runner.os == 'Linux'
         working-directory: modflow6


### PR DESCRIPTION
732a55b5 introduced `setup-uv` and switched most jobs off `setup-micromamba`. Some were not changed because dependencies were only available from conda-forge, not PyPI 

- windows pymetis
- arm mac vtk >=9.4.0

VTK is available from PyPI, and we can use the MF6 pixi `rtd` environment with `setup-pixi` where `setup-micromamba` is otherwise used, dropping `setup-micromamba`.