### PR TITLE
chore(mf6-codegen): defensive devtools compatibility fix

### DIFF
--- a/flopy/mf6/utils/codegen/filters.py
+++ b/flopy/mf6/utils/codegen/filters.py
@@ -363,6 +363,7 @@ def attrs(
 
     legacy_dfn = dfn.get("legacy_dfn", {})
     legacy_meta = dfn.get("legacy_meta", [])
+    legacy_meta = [s.replace("#", "").replace("flopy", "").replace("mf6", "").strip() for s in legacy_meta]
     legacy_dfn = _dfn(legacy_dfn, _filter_metadata(legacy_meta))
     if component_base == "MFPackage":
         attrs.extend(


### PR DESCRIPTION
Compatibility fix anticipating some minor changes in devtools. Comment header lines will soon be returned verbatim, without stripping the leading `"# [flopy] [mf6]"`.