### PR TITLE
fix(GeoSpatialUtil): accommodate stricter pyshp API

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Setup pixi
         uses: prefix-dev/setup-pixi@v0.9.6
         with:
-          pixi-version: v0.41.4
+          pixi-version: v0.70.1
           manifest-path: modflow6/pixi.toml
 
       - name: Install dependencies

--- a/.github/workflows/mf6.yml
+++ b/.github/workflows/mf6.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Setup pixi
       uses: prefix-dev/setup-pixi@v0.9.6
       with:
-        pixi-version: v0.41.4
+        pixi-version: v0.70.1
         manifest-path: modflow6/pixi.toml
 
     - name: Install dependencies
@@ -124,7 +124,7 @@ jobs:
     - name: Setup pixi
       uses: prefix-dev/setup-pixi@v0.9.6
       with:
-        pixi-version: v0.41.4
+        pixi-version: v0.70.1
         manifest-path: modflow6/pixi.toml
 
     - name: Install dependencies

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Setup pixi
         uses: prefix-dev/setup-pixi@v0.9.6
         with:
-          pixi-version: v0.41.4
+          pixi-version: v0.70.1
           manifest-path: modflow6/pixi.toml
 
       - name: Install Python dependencies

--- a/flopy/utils/geospatial_utils.py
+++ b/flopy/utils/geospatial_utils.py
@@ -210,7 +210,16 @@ class GeoSpatialUtil:
         """
         if self.__shapefile is not None:
             if self._shape is None:
-                self._shape = self.__shapefile.Shape._from_geojson(self.__geo_interface)
+                geo_iface = self.__geo_interface
+                # pyshp >= 3.0.11 requires list (not tuple) for Point coordinates
+                if geo_iface.get("type") == "Point" and isinstance(
+                    geo_iface.get("coordinates"), tuple
+                ):
+                    geo_iface = {
+                        **geo_iface,
+                        "coordinates": list(geo_iface["coordinates"]),
+                    }
+                self._shape = self.__shapefile.Shape._from_geojson(geo_iface)
             return self._shape
 
     @property


### PR DESCRIPTION
`pyshp` 3.0.11 got stricter about its arguments: https://github.com/GeospatialPython/pyshp#3011