### PR TITLE
fix(mfdataplist): accept DataFrame with tuple cellid

### DIFF
--- a/autotest/test_mf6.py
+++ b/autotest/test_mf6.py
@@ -1474,6 +1474,27 @@ def test_set_data_dataframe_column_mismatch_error(function_tmpdir):
         spd.set_data({0: df})
 
 
+def test_set_data_dataframe_tupled_cellid(function_tmpdir):
+    """DataFrame with a single tupled 'cellid' column is accepted, consistent with recarrays."""
+    sim = MFSimulation(sim_ws=str(function_tmpdir), exe_name="mf6")
+    ModflowTdis(sim, nper=1, perioddata=[(1.0, 1, 1.0)])
+    ModflowIms(sim)
+    gwf = ModflowGwf(sim, modelname="gwf")
+    ModflowGwfdis(gwf, nlay=1, nrow=10, ncol=10)
+    ModflowGwfic(gwf, strt=0.0)
+    ModflowGwfnpf(gwf)
+    ModflowGwfwel(gwf, stress_period_data={0: [[(0, 0, 0), -1.0]]})
+    spd = gwf.get_package("WEL").stress_period_data
+
+    df = pd.DataFrame({"cellid": [(0, 3, 4)], "q": [-500.0]})
+    spd.set_data({0: df})
+    result = spd.get_data(key=0)
+    assert result is not None
+    assert len(result) == 1
+    assert result[0]["cellid"] == (0, 3, 4)
+    assert result[0]["q"] == pytest.approx(-500.0)
+
+
 @requires_exe("mf6")
 def test_output(function_tmpdir, example_data_path):
     ex_name = "test001e_UZF_3lay"

--- a/autotest/test_mf6.py
+++ b/autotest/test_mf6.py
@@ -1475,7 +1475,7 @@ def test_set_data_dataframe_column_mismatch_error(function_tmpdir):
 
 
 def test_set_data_dataframe_tupled_cellid(function_tmpdir):
-    """DataFrame with a single tupled 'cellid' column is accepted, consistent with recarrays."""
+    """DataFrame with a tuple 'cellid' is accepted, consistent with recarrays."""
     sim = MFSimulation(sim_ws=str(function_tmpdir), exe_name="mf6")
     ModflowTdis(sim, nper=1, perioddata=[(1.0, 1, 1.0)])
     ModflowIms(sim)

--- a/flopy/mf6/data/mfdataplist.py
+++ b/flopy/mf6/data/mfdataplist.py
@@ -753,7 +753,16 @@ class MFPandasList(mfdata.MFMultiDimVar, DataListInterface):
                 # make sure columns are still in correct order
                 data = pandas.DataFrame(data, columns=self._header_names)
         elif isinstance(data, pandas.DataFrame):
-            if len(data.columns) != len(self._header_names):
+            if len(data.columns) == len(self._data_item_names) and len(
+                self._data_item_names
+            ) != len(self._header_names):
+                # data supplied with cellids as tuples (data_item_names format),
+                # consistent with how recarrays are handled above
+                if list(data.columns) != self._data_item_names:
+                    data = data.set_axis(self._data_item_names, axis=1)
+                data = self._untuple_cellids(data)[0]
+                data = pandas.DataFrame(data, columns=self._header_names)
+            elif len(data.columns) != len(self._header_names):
                 message = (
                     f"ERROR: Data list {self._data_name} supplied the "
                     f"wrong number of columns of data, expected "
@@ -775,8 +784,9 @@ class MFPandasList(mfdata.MFMultiDimVar, DataListInterface):
                     message,
                     self._simulation_data.debug,
                 )
-            # set correct data header names
-            data = data.set_axis(self._header_names, axis=1)
+            else:
+                # set correct data header names
+                data = data.set_axis(self._header_names, axis=1)
         else:
             message = (
                 f"ERROR: Data list {self._data_name} is an unsupported type: "


### PR DESCRIPTION
Fix an inconsistency mentioned in #2758. `pd.DataFrame` with a tuple `cellid` column was rejected by `.set_data()` while the equivalent recarray form was accepted. Accept tuple `cellid` for `DataFrame` too.