### PR TITLE
fix(CellBudgetFile): trap OSError when detecting precision

### DIFF
--- a/flopy/utils/binaryfile/__init__.py
+++ b/flopy/utils/binaryfile/__init__.py
@@ -2427,7 +2427,7 @@ class CellBudgetFile:
 
         try:
             self._build_index()
-        except (BudgetIndexError, EOFError) as e:
+        except (BudgetIndexError, EOFError, OSError) as e:
             success = False
             self.__reset()
 


### PR DESCRIPTION
Fix the precision detection issue mentioned in https://github.com/MODFLOW-ORG/modflow6/issues/2838#issuecomment-4722369441