### PR TITLE
fix(rasters): accommodate rasterio>=1.5

### DIFF
--- a/flopy/utils/rasters.py
+++ b/flopy/utils/rasters.py
@@ -996,6 +996,11 @@ class Raster:
         import_optional_dependency("rasterio")
         from rasterio.plot import show
 
+        # rasterio >= 1.5 defaults to adjusting data to [0, 1], which
+        # can clash with user-supplied vmin/vmax. don't adjust unless
+        # the caller explicitly asks for it
+        kwargs.setdefault("adjust", False)
+
         if self._dataset is not None:
             ax = show(self._dataset, ax=ax, contour=contour, **kwargs)
 


### PR DESCRIPTION
Pass `adjust=False` to `rasterio.plot.show()` unless the caller sets it `True`. Accommodate the default switch in https://github.com/rasterio/rasterio/pull/3171. Looks like the default may be switched back https://github.com/rasterio/rasterio/issues/3549, but in any case this guarantees the right behavior by default, and a caller choosing to pass `adjust=True` can set `vmin`/`vmax` accordingly.

Close #2780