### PR TITLE
chore: improve license metadata (PEP 639)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,11 @@ maintainers = [
     {name = "Joseph D. Hughes", email = "jdhughes@usgs.gov"},
 ]
 keywords = ["MODFLOW", "groundwater", "hydrogeology"]
-license = {text = "CC0"}
+license = "CC0-1.0"
+license-files = ["LICENSE.md"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
-    "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Improve license metadata, following [PEP 639](https://peps.python.org/pep-0639/), with these changes:

- Change licence from a deprecated table structure to a simpler text field using a valid identifier: [`CC0-1.0`](https://spdx.org/licenses/CC0-1.0.html)
- Specify the licence file
- Remove the licence classifier, which is deprecated