### PR TITLE
feat(lakpak_utils):  add support for VertexGrid embedded lakes

### DIFF
--- a/autotest/test_lake_connections.py
+++ b/autotest/test_lake_connections.py
@@ -4,12 +4,13 @@ import numpy as np
 import pytest
 from modflow_devtools.markers import requires_exe, requires_pkg
 
-from flopy.discretization import StructuredGrid
+from flopy.discretization import StructuredGrid, VertexGrid
 from flopy.mf6 import (
     MFSimulation,
     ModflowGwf,
     ModflowGwfchd,
     ModflowGwfdis,
+    ModflowGwfdisv,
     ModflowGwfevta,
     ModflowGwfic,
     ModflowGwflak,
@@ -623,3 +624,290 @@ def test_embedded_lak_prudic_mixed(example_data_path):
             assert bedleak == "none", f"bedleak for lake 0 is not 'none' ({bedleak})"
         else:
             assert bedleak == 1.0, f"bedleak for lake 1 is not 1.0 ({bedleak})"
+
+
+def build_simple_disv_grid(nlay=1, return_data=False):
+    vertices = [
+        (0, 0.0, 0.0),
+        (1, 1.0, 0.0),
+        (2, 2.0, 0.0),
+        (3, 3.0, 0.0),
+        (4, 0.0, 1.0),
+        (5, 1.0, 1.0),
+        (6, 2.0, 1.0),
+        (7, 3.0, 1.0),
+        (8, 0.0, 2.0),
+        (9, 1.0, 2.0),
+        (10, 2.0, 2.0),
+        (11, 3.0, 2.0),
+        (12, 1.0, 3.0),
+        (13, 2.0, 3.0),
+    ]
+
+    cell2d = [
+        (0, 1.5, 1.5, 4, 5, 6, 10, 9),
+        (1, 1.5, 2.5, 4, 9, 10, 13, 12),
+        (2, 0.5, 1.5, 4, 4, 5, 9, 8),
+        (3, 2.5, 1.5, 4, 6, 7, 11, 10),
+        (4, 1.5, 0.5, 4, 1, 2, 6, 5),
+    ]
+
+    ncpl = len(cell2d)
+
+    top = np.full(ncpl, 1.0)
+    botm = np.vstack(
+        [np.full(ncpl, -(k + 1), dtype=float) for k in range(nlay)]
+    )
+
+    idomain = np.ones((nlay, ncpl), dtype=int)
+
+    grid = VertexGrid(
+        vertices=vertices,
+        cell2d=cell2d,
+        top=top,
+        botm=botm,
+        idomain=idomain,
+        nlay=nlay,
+    )
+
+    if return_data:
+        return grid, vertices, cell2d
+
+    return grid
+
+
+def test_disv_horizontal_connections():
+    modelgrid = build_simple_disv_grid()
+
+    lake_map = np.full((1, modelgrid.ncpl), -1, dtype=int)
+    lake_map[0, 0] = 0
+    
+    idomain = np.ones((1, modelgrid.ncpl), dtype=int)
+
+    idomain_out, pakdata, connectiondata = get_lak_connections(
+        modelgrid,
+        lake_map,
+        idomain=idomain,
+        bedleak=1.0,
+    )
+
+    assert pakdata[0] == 4
+
+    expected = {
+        (0, 1),
+        (0, 2),
+        (0, 3),
+        (0, 4),
+    }
+
+    returned = {c[2] for c in connectiondata}
+
+    assert returned == expected
+
+    assert all(c[3] == "horizontal" for c in connectiondata)
+
+
+def test_disv_connection_widths():
+    modelgrid = build_simple_disv_grid()
+
+    lake_map = np.full((1, modelgrid.ncpl), -1, dtype=int)
+    lake_map[0, 0] = 0
+
+    _, _, connectiondata = get_lak_connections(
+        modelgrid,
+        lake_map,
+        bedleak=1.0,
+    )
+
+    horizontal = [c for c in connectiondata if c[3] == "horizontal"]
+
+    assert len(horizontal) == 4
+
+    widths = sorted(conn[8] for conn in horizontal)
+    assert widths == pytest.approx([1.0, 1.0, 1.0, 1.0])
+
+
+def test_disv_connection_lengths():
+    modelgrid = build_simple_disv_grid()
+
+    lake_map = np.full((1, modelgrid.ncpl), -1, dtype=int)
+    lake_map[0, 0] = 0
+
+    _, _, connectiondata = get_lak_connections(
+        modelgrid,
+        lake_map,
+        bedleak=1.0,
+    )
+
+    horizontal = [c for c in connectiondata if c[3] == "horizontal"]
+
+    assert len(horizontal) == 4
+
+    lengths = sorted(conn[7] for conn in horizontal)
+
+    assert lengths == pytest.approx([0.5, 0.5, 0.5, 0.5])
+
+
+def test_disv_vertical_connection():
+    modelgrid = build_simple_disv_grid(nlay=2)
+
+    lake_map = np.full((2, modelgrid.ncpl), -1, dtype=int)
+    lake_map[0, 0] = 0
+
+    _, pakdata, connectiondata = get_lak_connections(
+        modelgrid,
+        lake_map,
+        bedleak=1.0,
+    )
+
+    assert pakdata[0] == 5
+
+    horizontal = [c for c in connectiondata if c[3] == "horizontal"]
+    vertical = [c for c in connectiondata if c[3] == "vertical"]
+
+    assert len(horizontal) == 4
+    assert len(vertical) == 1
+
+    vconn = vertical[0]
+
+    assert vconn[2] == (1, 0)
+    assert vconn[5:] == [0.0, 0.0, 0.0, 0.0]
+
+
+def test_disv_inactive_neighbor():
+    modelgrid = build_simple_disv_grid()
+
+    lake_map = np.full((1, modelgrid.ncpl), -1, dtype=int)
+    lake_map[0, 0] = 0
+
+    idomain = np.ones((1, modelgrid.ncpl), dtype=int)
+
+    # Make the east neighbour inactive
+    idomain[0, 3] = 0
+
+    _, pakdata, connectiondata = get_lak_connections(
+        modelgrid,
+        lake_map,
+        idomain=idomain,
+        bedleak=1.0,
+    )
+
+    assert pakdata[0] == 3
+
+    expected = {
+        (0, 1),  # north
+        (0, 2),  # west
+        (0, 4),  # south
+    }
+
+    returned = {c[2] for c in connectiondata}
+
+    assert returned == expected
+    assert all(c[3] == "horizontal" for c in connectiondata)
+
+
+def test_disv_idomain_update():
+    modelgrid = build_simple_disv_grid()
+
+    lake_map = np.full((1, modelgrid.ncpl), -1, dtype=int)
+    lake_map[0, 0] = 0
+
+    idomain = np.ones((1, modelgrid.ncpl), dtype=int)
+
+    idomain_out, _, _ = get_lak_connections(
+        modelgrid,
+        lake_map,
+        idomain=idomain,
+        bedleak=1.0,
+    )
+
+    expected = np.ones((1, modelgrid.ncpl), dtype=int)
+    expected[0, 0] = 0
+
+    assert np.array_equal(idomain_out, expected)
+
+
+@requires_exe("mf6")
+def test_disv_lake_run(function_tmpdir):
+    modelgrid, vertices, cell2d = build_simple_disv_grid(
+        return_data=True
+    )
+
+    sim = MFSimulation(
+        sim_name="disv_lake_test",
+        sim_ws=function_tmpdir,
+        exe_name="mf6",
+    )
+
+    ModflowTdis(
+        sim,
+        nper=1,
+        perioddata=[(1.0, 1, 1.0)],
+    )
+
+    gwf = ModflowGwf(
+        sim,
+        modelname="disv_lake_test",
+        newtonoptions="newton under_relaxation",
+    )
+
+    ModflowGwfdisv(
+        gwf,
+        nlay=modelgrid.nlay,
+        ncpl=modelgrid.ncpl,
+        top=modelgrid.top,
+        botm=modelgrid.botm,
+        vertices=vertices,
+        cell2d=cell2d,
+    )
+
+    ModflowGwfic(
+        gwf,
+        strt=0.5,
+    )
+
+    ModflowGwfnpf(
+        gwf,
+        icelltype=1,
+        k=1.0,
+    )
+
+    lake_map = np.full((modelgrid.nlay, modelgrid.ncpl), -1, dtype=int)
+    lake_map[0, 0] = 0
+
+    idomain, pakdata_dict, connectiondata = get_lak_connections(
+        modelgrid,
+        lake_map,
+        bedleak=1.0,
+    )
+
+    assert pakdata_dict[0] == 4
+
+    lak_pak_data = []
+    for key, value in pakdata_dict.items():
+        lak_pak_data.append([key, 0.5, value])
+
+    ModflowGwflak(
+        gwf,
+        print_stage=True,
+        nlakes=1,
+        packagedata=lak_pak_data,
+        connectiondata=connectiondata,
+        perioddata={
+            0: [[0, "rainfall", 0.0]]
+        },
+        pname="LAK-1",
+    )
+
+    gwf.dis.idomain = idomain
+
+    ModflowGwfoc(
+        gwf,
+        printrecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+    )
+
+    sim.write_simulation()
+
+    success = sim.run_simulation(silent=False)
+
+    assert success, f"could not run {sim.name}"

--- a/autotest/test_lake_connections.py
+++ b/autotest/test_lake_connections.py
@@ -655,9 +655,7 @@ def build_simple_disv_grid(nlay=1, return_data=False):
     ncpl = len(cell2d)
 
     top = np.full(ncpl, 1.0)
-    botm = np.vstack(
-        [np.full(ncpl, -(k + 1), dtype=float) for k in range(nlay)]
-    )
+    botm = np.vstack([np.full(ncpl, -(k + 1), dtype=float) for k in range(nlay)])
 
     idomain = np.ones((nlay, ncpl), dtype=int)
 
@@ -676,12 +674,36 @@ def build_simple_disv_grid(nlay=1, return_data=False):
     return grid
 
 
+def build_asymmetric_disv_grid():
+    vertices = [
+        (0, 0.0, 0.0),
+        (1, 1.0, 0.0),
+        (2, 4.0, 0.0),
+        (3, 0.0, 1.0),
+        (4, 1.0, 1.0),
+        (5, 4.0, 1.0),
+    ]
+    cell2d = [
+        (0, 0.5, 0.5, 4, 0, 1, 4, 3),
+        (1, 2.5, 0.5, 4, 1, 2, 5, 4),
+    ]
+
+    return VertexGrid(
+        vertices=vertices,
+        cell2d=cell2d,
+        top=np.ones(2),
+        botm=-np.ones((1, 2)),
+        idomain=np.ones((1, 2), dtype=int),
+        nlay=1,
+    )
+
+
 def test_disv_horizontal_connections():
     modelgrid = build_simple_disv_grid()
 
     lake_map = np.full((1, modelgrid.ncpl), -1, dtype=int)
     lake_map[0, 0] = 0
-    
+
     idomain = np.ones((1, modelgrid.ncpl), dtype=int)
 
     idomain_out, pakdata, connectiondata = get_lak_connections(
@@ -748,6 +770,23 @@ def test_disv_connection_lengths():
     assert lengths == pytest.approx([0.5, 0.5, 0.5, 0.5])
 
 
+def test_disv_connection_length_uses_aquifer_cell_center():
+    modelgrid = build_asymmetric_disv_grid()
+
+    lake_map = np.full((1, modelgrid.ncpl), -1, dtype=int)
+    lake_map[0, 0] = 0
+
+    _, _, connectiondata = get_lak_connections(
+        modelgrid,
+        lake_map,
+        bedleak=1.0,
+    )
+
+    assert len(connectiondata) == 1
+    assert connectiondata[0][2] == (0, 1)
+    assert connectiondata[0][7] == pytest.approx(1.5)
+
+
 def test_disv_vertical_connection():
     modelgrid = build_simple_disv_grid(nlay=2)
 
@@ -772,6 +811,28 @@ def test_disv_vertical_connection():
 
     assert vconn[2] == (1, 0)
     assert vconn[5:] == [0.0, 0.0, 0.0, 0.0]
+
+
+def test_disv_horizontal_connections_in_nonzero_layer():
+    modelgrid = build_simple_disv_grid(nlay=2)
+
+    lake_map = np.full((2, modelgrid.ncpl), -1, dtype=int)
+    lake_map[1, 0] = 0
+
+    _, pakdata, connectiondata = get_lak_connections(
+        modelgrid,
+        lake_map,
+        bedleak=1.0,
+    )
+
+    assert pakdata[0] == 4
+    assert {conn[2] for conn in connectiondata} == {
+        (1, 1),
+        (1, 2),
+        (1, 3),
+        (1, 4),
+    }
+    assert all(conn[3] == "horizontal" for conn in connectiondata)
 
 
 def test_disv_inactive_neighbor():
@@ -829,9 +890,7 @@ def test_disv_idomain_update():
 
 @requires_exe("mf6")
 def test_disv_lake_run(function_tmpdir):
-    modelgrid, vertices, cell2d = build_simple_disv_grid(
-        return_data=True
-    )
+    modelgrid, vertices, cell2d = build_simple_disv_grid(return_data=True)
 
     sim = MFSimulation(
         sim_name="disv_lake_test",
@@ -893,9 +952,7 @@ def test_disv_lake_run(function_tmpdir):
         nlakes=1,
         packagedata=lak_pak_data,
         connectiondata=connectiondata,
-        perioddata={
-            0: [[0, "rainfall", 0.0]]
-        },
+        perioddata={0: [[0, "rainfall", 0.0]]},
         pname="LAK-1",
     )
 

--- a/autotest/test_lake_connections.py
+++ b/autotest/test_lake_connections.py
@@ -5,6 +5,7 @@ import pytest
 from modflow_devtools.markers import requires_exe, requires_pkg
 
 from flopy.discretization import StructuredGrid, VertexGrid
+from flopy.discretization.grid import Grid
 from flopy.mf6 import (
     MFSimulation,
     ModflowGwf,
@@ -706,7 +707,7 @@ def test_disv_horizontal_connections():
 
     idomain = np.ones((1, modelgrid.ncpl), dtype=int)
 
-    idomain_out, pakdata, connectiondata = get_lak_connections(
+    _, pakdata, connectiondata = get_lak_connections(
         modelgrid,
         lake_map,
         idomain=idomain,
@@ -897,8 +898,14 @@ def test_disv_grid_geometry_accessed_once(monkeypatch):
     # independently by Grid.neighbors().
     modelgrid.neighbors(method="rook")
 
-    properties = ("top_botm", "verts", "iverts", "xcellcenters", "ycellcenters")
-    originals = {name: getattr(VertexGrid, name) for name in properties}
+    properties = {
+        "top_botm": VertexGrid,
+        "verts": VertexGrid,
+        "iverts": VertexGrid,
+        "xcellcenters": Grid,
+        "ycellcenters": Grid,
+    }
+    originals = {name: getattr(owner, name) for name, owner in properties.items()}
     access_count = dict.fromkeys(properties, 0)
 
     def counted_property(name):
@@ -908,96 +915,340 @@ def test_disv_grid_geometry_accessed_once(monkeypatch):
 
         return property(getter)
 
-    for name in properties:
-        monkeypatch.setattr(VertexGrid, name, counted_property(name))
-
-    def unexpected_get_shared_edge(*args, **kwargs):
-        pytest.fail("get_shared_edge() called inside the neighbor loop")
-
-    monkeypatch.setattr(modelgrid, "get_shared_edge", unexpected_get_shared_edge)
+    for name, owner in properties.items():
+        monkeypatch.setattr(owner, name, counted_property(name))
 
     get_lak_connections(modelgrid, lake_map, bedleak=1.0)
 
-    assert access_count == dict.fromkeys(properties, 1)
+    assert all(count <= 1 for count in access_count.values())
 
 
-@requires_exe("mf6")
-def test_disv_lake_run(function_tmpdir):
-    modelgrid, vertices, cell2d = build_simple_disv_grid(return_data=True)
-
-    sim = MFSimulation(
-        sim_name="disv_lake_test",
-        sim_ws=function_tmpdir,
-        exe_name="mf6",
-    )
-
-    ModflowTdis(
-        sim,
-        nper=1,
-        perioddata=[(1.0, 1, 1.0)],
-    )
-
-    gwf = ModflowGwf(
-        sim,
-        modelname="disv_lake_test",
-        newtonoptions="newton under_relaxation",
-    )
-
-    ModflowGwfdisv(
-        gwf,
-        nlay=modelgrid.nlay,
-        ncpl=modelgrid.ncpl,
-        top=modelgrid.top,
-        botm=modelgrid.botm,
+def test_disv_shared_boundary_split_by_vertex():
+    # vertex 2 splits the common boundary into two shared edges
+    vertices = [
+        (0, 0.0, 0.0),
+        (1, 1.0, 0.0),
+        (2, 1.0, 1.0),
+        (3, 1.0, 2.0),
+        (4, 0.0, 2.0),
+        (5, 2.0, 0.0),
+        (6, 2.0, 2.0),
+    ]
+    cell2d = [
+        (0, 0.5, 1.0, 5, 0, 1, 2, 3, 4),
+        (1, 1.5, 1.0, 5, 1, 5, 6, 3, 2),
+    ]
+    modelgrid = VertexGrid(
         vertices=vertices,
         cell2d=cell2d,
+        top=np.ones(2),
+        botm=-np.ones((1, 2)),
+        idomain=np.ones((1, 2), dtype=int),
+        nlay=1,
     )
 
-    ModflowGwfic(
-        gwf,
-        strt=0.5,
-    )
-
-    ModflowGwfnpf(
-        gwf,
-        icelltype=1,
-        k=1.0,
-    )
-
-    lake_map = np.full((modelgrid.nlay, modelgrid.ncpl), -1, dtype=int)
-    lake_map[0, 0] = 0
-
-    idomain, pakdata_dict, connectiondata = get_lak_connections(
+    idomain, pakdata, connectiondata = get_lak_connections(
         modelgrid,
-        lake_map,
+        np.array([[0, -1]], dtype=int),
         bedleak=1.0,
     )
 
-    assert pakdata_dict[0] == 4
+    assert pakdata[0] == 1
+    assert len(connectiondata) == 1
+    conn = connectiondata[0]
+    assert conn[2] == (0, 1)
+    assert conn[3] == "horizontal"
+    assert conn[7] == pytest.approx(0.5)
+    assert conn[8] == pytest.approx(2.0)
+    assert np.array_equal(idomain, np.array([[0, 1]]))
 
-    lak_pak_data = []
-    for key, value in pakdata_dict.items():
-        lak_pak_data.append([key, 0.5, value])
 
-    ModflowGwflak(
-        gwf,
-        print_stage=True,
-        nlakes=1,
-        packagedata=lak_pak_data,
-        connectiondata=connectiondata,
-        perioddata={0: [[0, "rainfall", 0.0]]},
-        pname="LAK-1",
+def test_disv_lake_without_connections_warns():
+    # Only the lake cell carries the hanging vertex, so rook adjacency is absent.
+    vertices = [
+        (0, 0.0, 0.0),
+        (1, 1.0, 0.0),
+        (2, 1.0, 1.0),
+        (3, 1.0, 2.0),
+        (4, 0.0, 2.0),
+        (5, 2.0, 0.0),
+        (6, 2.0, 2.0),
+    ]
+    cell2d = [
+        (0, 0.5, 1.0, 5, 0, 1, 2, 3, 4),
+        (1, 1.5, 1.0, 4, 1, 5, 6, 3),
+    ]
+    modelgrid = VertexGrid(
+        vertices=vertices,
+        cell2d=cell2d,
+        top=np.ones(2),
+        botm=-np.ones((1, 2)),
+        idomain=np.ones((1, 2), dtype=int),
+        nlay=1,
     )
 
-    gwf.dis.idomain = idomain
+    with pytest.warns(UserWarning, match="Embedded lake 0 has no connections"):
+        idomain, pakdata, connectiondata = get_lak_connections(
+            modelgrid,
+            np.array([[0, -1]], dtype=int),
+            bedleak=1.0,
+        )
 
-    ModflowGwfoc(
-        gwf,
-        printrecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+    assert pakdata[0] == 0
+    assert connectiondata == []
+    assert np.array_equal(idomain, np.ones((1, 2), dtype=int))
+
+
+@pytest.mark.parametrize("closed", (False, True))
+def test_disv_nonrectangular_cells(closed):
+    vertices = [
+        (0, 0.0, 0.0),
+        (1, 1.0, 0.0),
+        (2, 1.0, 1.0),
+        (3, 2.0, 0.0),
+    ]
+    if closed:
+        cell2d = [
+            (0, 2.0 / 3.0, 1.0 / 3.0, 4, 0, 1, 2, 0),
+            (1, 4.0 / 3.0, 1.0 / 3.0, 4, 1, 3, 2, 1),
+        ]
+    else:
+        cell2d = [
+            (0, 2.0 / 3.0, 1.0 / 3.0, 3, 0, 1, 2),
+            (1, 4.0 / 3.0, 1.0 / 3.0, 3, 1, 3, 2),
+        ]
+    modelgrid = VertexGrid(
+        vertices=vertices,
+        cell2d=cell2d,
+        top=np.ones(2),
+        botm=-np.ones((1, 2)),
+        idomain=np.ones((1, 2), dtype=int),
+        nlay=1,
     )
 
-    sim.write_simulation()
+    _, pakdata, connectiondata = get_lak_connections(
+        modelgrid,
+        np.array([[0, -1]], dtype=int),
+        bedleak=1.0,
+    )
 
-    success = sim.run_simulation(silent=False)
+    assert pakdata[0] == 1
+    assert connectiondata[0][7] == pytest.approx(1.0 / 3.0)
+    assert connectiondata[0][8] == pytest.approx(1.0)
 
-    assert success, f"could not run {sim.name}"
+
+def build_dis_and_equivalent_disv(nlay, nrow, ncol, delr, delc, top, botm):
+    structured = StructuredGrid(
+        delr=delr,
+        delc=delc,
+        top=top,
+        botm=botm,
+        idomain=np.ones((nlay, nrow, ncol), dtype=int),
+        nlay=nlay,
+    )
+
+    xv = np.concatenate(([0.0], np.cumsum(delr)))
+    yv = delc.sum() - np.concatenate(([0.0], np.cumsum(delc)))
+    vertices = []
+    ivert = {}
+    for i in range(nrow + 1):
+        for j in range(ncol + 1):
+            ivert[(i, j)] = len(vertices)
+            vertices.append((len(vertices), float(xv[j]), float(yv[i])))
+
+    cell2d = []
+    for i in range(nrow):
+        for j in range(ncol):
+            cell2d.append(
+                (
+                    i * ncol + j,
+                    0.5 * (xv[j] + xv[j + 1]),
+                    0.5 * (yv[i] + yv[i + 1]),
+                    4,
+                    ivert[(i, j)],
+                    ivert[(i, j + 1)],
+                    ivert[(i + 1, j + 1)],
+                    ivert[(i + 1, j)],
+                )
+            )
+
+    ncpl = nrow * ncol
+    vertex = VertexGrid(
+        vertices=vertices,
+        cell2d=cell2d,
+        top=top.flatten(),
+        botm=botm.reshape(nlay, ncpl),
+        idomain=np.ones((nlay, ncpl), dtype=int),
+        nlay=nlay,
+    )
+    return structured, vertex, vertices, cell2d
+
+
+@pytest.mark.parametrize(
+    "lakes, inactive",
+    (
+        ([[(0, 2, 2)]], []),
+        ([[(0, 1, 1), (0, 1, 2), (0, 2, 1), (0, 2, 2)]], []),
+        ([[(0, 0, 0)]], []),
+        ([[(0, 0, 2)]], []),
+        ([[(1, 2, 2)]], []),
+        ([[(0, 2, 2), (1, 2, 2)]], []),
+        ([[(0, 2, 2)]], [(0, 2, 3)]),
+        ([[(0, 2, 1)], [(0, 2, 2)]], []),
+        ([[(0, 1, 1)], [(0, 3, 3)]], []),
+        ([[(0, 2, 2), (0, 2, 3)]], [(0, 2, 2)]),
+    ),
+)
+def test_disv_matches_dis_embedded_lake(lakes, inactive):
+    nlay, nrow, ncol = 2, 5, 5
+    delr = np.array([10.0, 20.0, 30.0, 20.0, 10.0])
+    delc = np.array([5.0, 15.0, 25.0, 15.0, 5.0])
+    top = np.full((nrow, ncol), 10.0)
+    botm = np.array([np.zeros((nrow, ncol)), np.full((nrow, ncol), -10.0)])
+    ncpl = nrow * ncol
+    structured, vertex, _, _ = build_dis_and_equivalent_disv(
+        nlay, nrow, ncol, delr, delc, top, botm
+    )
+
+    lake_map = np.full((nlay, nrow, ncol), -1, dtype=int)
+    for lake_number, cells in enumerate(lakes):
+        for cell in cells:
+            lake_map[cell] = lake_number
+    idomain = np.ones((nlay, nrow, ncol), dtype=int)
+    for cell in inactive:
+        idomain[cell] = 0
+
+    dis_idomain, dis_pakdata, dis_conn = get_lak_connections(
+        structured, lake_map.copy(), idomain=idomain.copy(), bedleak=1.0
+    )
+    disv_idomain, disv_pakdata, disv_conn = get_lak_connections(
+        vertex,
+        lake_map.reshape(nlay, ncpl).copy(),
+        idomain=idomain.reshape(nlay, ncpl).copy(),
+        bedleak=1.0,
+    )
+
+    def normalize(conn):
+        lake_number, _, cellid, claktype, _, _, _, connlen, connwidth = conn
+        if len(cellid) == 3:
+            k, i, j = cellid
+            cellid = (k, i * ncol + j)
+        return (
+            lake_number,
+            *cellid,
+            claktype,
+            round(connlen, 6),
+            round(connwidth, 6),
+        )
+
+    assert dis_pakdata == disv_pakdata
+    assert sorted(map(normalize, dis_conn)) == sorted(map(normalize, disv_conn))
+    assert np.array_equal(dis_idomain.reshape(nlay, ncpl), disv_idomain)
+
+
+@requires_exe("mf6")
+def test_disv_lake_matches_dis_run(function_tmpdir):
+    nlay, nrow, ncol = 1, 3, 3
+    delr = np.array([1.0, 1.5, 2.0])
+    delc = np.array([2.0, 1.5, 1.0])
+    top = np.ones((nrow, ncol))
+    botm = np.zeros((nlay, nrow, ncol))
+    structured, vertex, vertices, cell2d = build_dis_and_equivalent_disv(
+        nlay, nrow, ncol, delr, delc, top, botm
+    )
+
+    def build_and_run(grid_type):
+        name = f"{grid_type}_lake_test"
+        modelgrid = structured if grid_type == "dis" else vertex
+        lake_map = np.full(modelgrid.shape, -1, dtype=int)
+        lake_map[(0, 1, 1) if grid_type == "dis" else (0, 4)] = 0
+        idomain, pakdata_dict, connectiondata = get_lak_connections(
+            modelgrid,
+            lake_map,
+            bedleak=1.0,
+        )
+        assert pakdata_dict[0] == 4
+
+        sim = MFSimulation(
+            sim_name=name,
+            sim_ws=function_tmpdir / grid_type,
+            exe_name="mf6",
+        )
+        ModflowTdis(sim, nper=1, perioddata=[(1.0, 1, 1.0)])
+        ModflowIms(
+            sim,
+            print_option="summary",
+            linear_acceleration="BICGSTAB",
+            outer_dvclose=1e-9,
+            inner_dvclose=1e-10,
+        )
+        gwf = ModflowGwf(
+            sim,
+            modelname=name,
+            newtonoptions="newton under_relaxation",
+            save_flows=True,
+        )
+        if grid_type == "dis":
+            ModflowGwfdis(
+                gwf,
+                nlay=nlay,
+                nrow=nrow,
+                ncol=ncol,
+                delr=delr,
+                delc=delc,
+                top=top,
+                botm=botm,
+                idomain=idomain,
+            )
+        else:
+            ModflowGwfdisv(
+                gwf,
+                nlay=nlay,
+                ncpl=nrow * ncol,
+                top=top.flatten(),
+                botm=botm.reshape(nlay, nrow * ncol),
+                vertices=vertices,
+                cell2d=cell2d,
+                idomain=idomain,
+            )
+        ModflowGwfic(gwf, strt=0.5)
+        ModflowGwfnpf(gwf, icelltype=1, k=1.0)
+
+        chd_spd = []
+        for i in range(nrow):
+            if grid_type == "dis":
+                chd_spd.extend([((0, i, 0), 0.75), ((0, i, 2), 0.25)])
+            else:
+                chd_spd.extend([((0, i * ncol), 0.75), ((0, i * ncol + 2), 0.25)])
+        ModflowGwfchd(gwf, stress_period_data=chd_spd)
+
+        lak = ModflowGwflak(
+            gwf,
+            print_stage=True,
+            stage_filerecord=f"{name}.lak.stage.bin",
+            nlakes=1,
+            packagedata=[[0, 0.5, pakdata_dict[0]]],
+            connectiondata=connectiondata,
+            perioddata={0: [[0, "rainfall", 0.01]]},
+            pname="LAK-1",
+        )
+        ModflowGwfoc(
+            gwf,
+            head_filerecord=f"{name}.hds",
+            saverecord=[("HEAD", "ALL")],
+            printrecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+        )
+
+        sim.write_simulation()
+        success, _ = sim.run_simulation(silent=False)
+        assert success, f"could not run {sim.name}"
+
+        heads = gwf.output.head().get_data().reshape(nlay, nrow, ncol)
+        stage = lak.output.stage().get_data()
+        return heads, stage
+
+    dis_heads, dis_stage = build_and_run("dis")
+    disv_heads, disv_stage = build_and_run("disv")
+
+    assert np.allclose(dis_heads, disv_heads, rtol=1e-6, atol=1e-6)
+    assert np.allclose(dis_stage, disv_stage, rtol=1e-6, atol=1e-6)

--- a/autotest/test_lake_connections.py
+++ b/autotest/test_lake_connections.py
@@ -888,6 +888,39 @@ def test_disv_idomain_update():
     assert np.array_equal(idomain_out, expected)
 
 
+def test_disv_grid_geometry_accessed_once(monkeypatch):
+    modelgrid = build_simple_disv_grid(nlay=2)
+    lake_map = np.full((2, modelgrid.ncpl), -1, dtype=int)
+    lake_map[0, :2] = 0
+
+    # Build neighbor topology before counting geometry accesses. This is cached
+    # independently by Grid.neighbors().
+    modelgrid.neighbors(method="rook")
+
+    properties = ("top_botm", "verts", "iverts", "xcellcenters", "ycellcenters")
+    originals = {name: getattr(VertexGrid, name) for name in properties}
+    access_count = dict.fromkeys(properties, 0)
+
+    def counted_property(name):
+        def getter(grid):
+            access_count[name] += 1
+            return originals[name].fget(grid)
+
+        return property(getter)
+
+    for name in properties:
+        monkeypatch.setattr(VertexGrid, name, counted_property(name))
+
+    def unexpected_get_shared_edge(*args, **kwargs):
+        pytest.fail("get_shared_edge() called inside the neighbor loop")
+
+    monkeypatch.setattr(modelgrid, "get_shared_edge", unexpected_get_shared_edge)
+
+    get_lak_connections(modelgrid, lake_map, bedleak=1.0)
+
+    assert access_count == dict.fromkeys(properties, 1)
+
+
 @requires_exe("mf6")
 def test_disv_lake_run(function_tmpdir):
     modelgrid, vertices, cell2d = build_simple_disv_grid(return_data=True)

--- a/autotest/test_lake_connections.py
+++ b/autotest/test_lake_connections.py
@@ -987,7 +987,7 @@ def test_disv_lake_without_connections_warns():
         nlay=1,
     )
 
-    with pytest.warns(UserWarning, match="Embedded lake 0 has no connections"):
+    with pytest.warns(UserWarning, match="embedded lake 0 has no connections"):
         idomain, pakdata, connectiondata = get_lak_connections(
             modelgrid,
             np.array([[0, -1]], dtype=int),

--- a/flopy/mf6/utils/lakpak_utils.py
+++ b/flopy/mf6/utils/lakpak_utils.py
@@ -303,10 +303,6 @@ def __vertex_lake_connections(
     node = k * ncpl + icpl
     neighbors = modelgrid.neighbors(node=node, method="rook")
 
-    cx = modelgrid.xcellcenters[node]
-    cy = modelgrid.ycellcenters[node]
-    centre = (cx, cy)
-
     elevations = modelgrid.top_botm
 
     for neighbor in neighbors:
@@ -319,7 +315,7 @@ def __vertex_lake_connections(
         if not (np.ma.is_masked(lake_map[ci]) and idomain[ci] > 0):
             continue
 
-        shared = modelgrid.get_shared_edge(node, neighbor)
+        shared = modelgrid.get_shared_edge(icpl, nicpl)
 
         if shared is None or len(shared) != 2:
             continue
@@ -329,6 +325,9 @@ def __vertex_lake_connections(
         p1 = modelgrid.verts[v1]
         connwidth = np.linalg.norm(p1 - p0)
 
+        cx = modelgrid.xcellcenters[nicpl]
+        cy = modelgrid.ycellcenters[nicpl]
+        centre = (cx, cy)
         connlen = __distance_to_segment(centre, p0, p1)
 
         cellids.append(ci)

--- a/flopy/mf6/utils/lakpak_utils.py
+++ b/flopy/mf6/utils/lakpak_utils.py
@@ -220,7 +220,7 @@ def get_lak_connections(modelgrid, lake_map, idomain=None, bedleak=None):
 
         if embedded and iconn == 0:
             warnings.warn(
-                f"Embedded lake {lake_number} has no connections to active "
+                f"embedded lake {lake_number} has no connections to active "
                 "model cells.",
                 UserWarning,
                 stacklevel=2,

--- a/flopy/mf6/utils/lakpak_utils.py
+++ b/flopy/mf6/utils/lakpak_utils.py
@@ -48,9 +48,7 @@ def get_lak_connections(modelgrid, lake_map, idomain=None, bedleak=None):
     """
 
     if modelgrid.grid_type in ("unstructured",):
-        raise ValueError(
-            "unstructured grids not supported in get_lak_connections()"
-        )
+        raise ValueError("unstructured grids not supported in get_lak_connections()")
 
     embedded = True
     shape3d = modelgrid.shape
@@ -60,9 +58,7 @@ def get_lak_connections(modelgrid, lake_map, idomain=None, bedleak=None):
     if isinstance(lake_map, (list, tuple)):
         lake_map = np.array(lake_map, dtype=np.int32)
     elif isinstance(lake_map, (int, float)):
-        raise TypeError(
-            "lake_map must be a Masked Array, ndarray, list, or tuple"
-        )
+        raise TypeError("lake_map must be a Masked Array, ndarray, list, or tuple")
 
     # evaluate lake_map shape
     shape_map = lake_map.shape
@@ -85,9 +81,7 @@ def get_lak_connections(modelgrid, lake_map, idomain=None, bedleak=None):
 
     # check dimensions of idomain
     if idomain.shape != shape3d:
-        raise ValueError(
-            f"shape of idomain ({idomain.shape}) not equal to {shape3d}"
-        )
+        raise ValueError(f"shape of idomain ({idomain.shape}) not equal to {shape3d}")
 
     # convert bedleak to numpy array if necessary
     if bedleak is None:
@@ -100,9 +94,7 @@ def get_lak_connections(modelgrid, lake_map, idomain=None, bedleak=None):
 
     # check the dimensions of the bedleak array
     if bedleak.shape != shape2d:
-        raise ValueError(
-            f"shape of bedleak ({bedleak.shape}) not equal to {shape2d}"
-        )
+        raise ValueError(f"shape of bedleak ({bedleak.shape}) not equal to {shape2d}")
 
     # get the model grid elevations and reset lake_map using idomain
     # if lake is embedded and in an inactive cell
@@ -127,6 +119,8 @@ def get_lak_connections(modelgrid, lake_map, idomain=None, bedleak=None):
     unique = unique[idx]
 
     dx, dy = None, None
+    vertices, iverts = None, None
+    xcenters, ycenters = None, None
 
     # embedded lakes
     for lake_number in unique:
@@ -152,6 +146,11 @@ def get_lak_connections(modelgrid, lake_map, idomain=None, bedleak=None):
                         lake_map, idomain, cell_index, dx, dy, elevations
                     )
                 elif modelgrid.grid_type == "vertex":
+                    if vertices is None:
+                        vertices = modelgrid.verts
+                        iverts = modelgrid.iverts
+                        xcenters = modelgrid.xcellcenters
+                        ycenters = modelgrid.ycellcenters
                     (
                         cellids,
                         claktypes,
@@ -160,7 +159,15 @@ def get_lak_connections(modelgrid, lake_map, idomain=None, bedleak=None):
                         connlens,
                         connwidths,
                     ) = __vertex_lake_connections(
-                        lake_map, idomain, cell_index, modelgrid
+                        lake_map,
+                        idomain,
+                        cell_index,
+                        modelgrid,
+                        elevations,
+                        vertices,
+                        iverts,
+                        xcenters,
+                        ycenters,
                     )
             else:
                 cellid = (0,) + cell_index
@@ -204,17 +211,13 @@ def get_lak_connections(modelgrid, lake_map, idomain=None, bedleak=None):
 
         # reset idomain for lake
         if iconn > 0:
-            idx = np.asarray(
-                (lake_map == lake_number) & (idomain > 0)
-            ).nonzero()
+            idx = np.asarray((lake_map == lake_number) & (idomain > 0)).nonzero()
             idomain[idx] = 0
 
     return idomain, connection_dict, connectiondata
 
 
-def __structured_lake_connections(
-    lake_map, idomain, cell_index, dx, dy, elevations
-):
+def __structured_lake_connections(lake_map, idomain, cell_index, dx, dy, elevations):
     nlay, nrow, ncol = lake_map.shape
     cellids = []
     claktypes = []
@@ -289,7 +292,15 @@ def __structured_lake_connections(
 
 
 def __vertex_lake_connections(
-    lake_map, idomain, cell_index, modelgrid
+    lake_map,
+    idomain,
+    cell_index,
+    modelgrid,
+    elevations,
+    vertices,
+    iverts,
+    xcenters,
+    ycenters,
 ):
     nlay, ncpl = lake_map.shape
     cellids = []
@@ -302,11 +313,9 @@ def __vertex_lake_connections(
     k, icpl = cell_index
     node = k * ncpl + icpl
     neighbors = modelgrid.neighbors(node=node, method="rook")
-
-    elevations = modelgrid.top_botm
+    cell_iverts = set(iverts[icpl])
 
     for neighbor in neighbors:
-
         # Convert global node number to (layer, cell-per-layer)
         nk = neighbor // ncpl
         nicpl = neighbor % ncpl
@@ -315,18 +324,18 @@ def __vertex_lake_connections(
         if not (np.ma.is_masked(lake_map[ci]) and idomain[ci] > 0):
             continue
 
-        shared = modelgrid.get_shared_edge(icpl, nicpl)
+        shared = tuple(cell_iverts & set(iverts[nicpl]))
 
         if shared is None or len(shared) != 2:
             continue
 
         v0, v1 = shared
-        p0 = modelgrid.verts[v0]
-        p1 = modelgrid.verts[v1]
+        p0 = vertices[v0]
+        p1 = vertices[v1]
         connwidth = np.linalg.norm(p1 - p0)
 
-        cx = modelgrid.xcellcenters[nicpl]
-        cy = modelgrid.ycellcenters[nicpl]
+        cx = xcenters[nicpl]
+        cy = ycenters[nicpl]
         centre = (cx, cy)
         connlen = __distance_to_segment(centre, p0, p1)
 
@@ -339,11 +348,9 @@ def __vertex_lake_connections(
 
     # vertical connection
     if k < nlay - 1:
-
         cell_below = (k + 1, icpl)
 
         if np.ma.is_masked(lake_map[cell_below]) and idomain[cell_below] > 0:
-
             cellids.append(cell_below)
             claktypes.append("vertical")
             belevs.append(0.0)

--- a/flopy/mf6/utils/lakpak_utils.py
+++ b/flopy/mf6/utils/lakpak_utils.py
@@ -9,8 +9,6 @@ def get_lak_connections(modelgrid, lake_map, idomain=None, bedleak=None):
     and are vertically connected to cells at the top of the model. Otherwise
     the lakes are embedded in the grid.
 
-    TODO: implement embedded lakes for VertexGrid
-
     TODO: add support for UnstructuredGrid
 
     Parameters
@@ -154,8 +152,15 @@ def get_lak_connections(modelgrid, lake_map, idomain=None, bedleak=None):
                         lake_map, idomain, cell_index, dx, dy, elevations
                     )
                 elif modelgrid.grid_type == "vertex":
-                    raise NotImplementedError(
-                        "embedded lakes have not been implemented"
+                    (
+                        cellids,
+                        claktypes,
+                        belevs,
+                        televs,
+                        connlens,
+                        connwidths,
+                    ) = __vertex_lake_connections(
+                        lake_map, idomain, cell_index, modelgrid
                     )
             else:
                 cellid = (0,) + cell_index
@@ -281,3 +286,96 @@ def __structured_lake_connections(
                 connwidths.append(0.0)
 
     return cellids, claktypes, belevs, televs, connlens, connwidths
+
+
+def __vertex_lake_connections(
+    lake_map, idomain, cell_index, modelgrid
+):
+    nlay, ncpl = lake_map.shape
+    cellids = []
+    claktypes = []
+    belevs = []
+    televs = []
+    connlens = []
+    connwidths = []
+
+    k, icpl = cell_index
+    node = k * ncpl + icpl
+    neighbors = modelgrid.neighbors(node=node, method="rook")
+
+    cx = modelgrid.xcellcenters[node]
+    cy = modelgrid.ycellcenters[node]
+    centre = (cx, cy)
+
+    elevations = modelgrid.top_botm
+
+    for neighbor in neighbors:
+
+        # Convert global node number to (layer, cell-per-layer)
+        nk = neighbor // ncpl
+        nicpl = neighbor % ncpl
+        ci = (nk, nicpl)
+
+        if not (np.ma.is_masked(lake_map[ci]) and idomain[ci] > 0):
+            continue
+
+        shared = modelgrid.get_shared_edge(node, neighbor)
+
+        if shared is None or len(shared) != 2:
+            continue
+
+        v0, v1 = shared
+        p0 = modelgrid.verts[v0]
+        p1 = modelgrid.verts[v1]
+        connwidth = np.linalg.norm(p1 - p0)
+
+        connlen = __distance_to_segment(centre, p0, p1)
+
+        cellids.append(ci)
+        claktypes.append("horizontal")
+        belevs.append(elevations[nk + 1, nicpl])
+        televs.append(elevations[nk, nicpl])
+        connlens.append(connlen)
+        connwidths.append(connwidth)
+
+    # vertical connection
+    if k < nlay - 1:
+
+        cell_below = (k + 1, icpl)
+
+        if np.ma.is_masked(lake_map[cell_below]) and idomain[cell_below] > 0:
+
+            cellids.append(cell_below)
+            claktypes.append("vertical")
+            belevs.append(0.0)
+            televs.append(0.0)
+            connlens.append(0.0)
+            connwidths.append(0.0)
+
+    return cellids, claktypes, belevs, televs, connlens, connwidths
+
+
+def __distance_to_segment(cell_centre, p0, p1):
+    """
+    Perpendicular distance from a point to a line segment.
+    """
+
+    P = np.asarray(cell_centre, dtype=float)
+    A = np.asarray(p0, dtype=float)
+    B = np.asarray(p1, dtype=float)
+
+    AB = B - A
+    AP = P - A
+
+    denom = np.dot(AB, AB)
+
+    # clamp projections that fall outside the edge
+    if denom == 0:
+        return np.linalg.norm(P - A)
+
+    t = np.dot(AP, AB) / denom
+    t = np.clip(t, 0.0, 1.0)
+
+    C = A + t * AB
+
+    return np.linalg.norm(P - C)

--- a/flopy/mf6/utils/lakpak_utils.py
+++ b/flopy/mf6/utils/lakpak_utils.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 
 
@@ -44,6 +46,11 @@ def get_lak_connections(modelgrid, lake_map, idomain=None, bedleak=None):
         connections in a lake values
     connectiondata : list of lists
         connectiondata block for the lake package
+
+    Warns
+    -----
+    UserWarning
+        If an embedded lake has no connections to active model cells.
 
     """
 
@@ -119,7 +126,7 @@ def get_lak_connections(modelgrid, lake_map, idomain=None, bedleak=None):
     unique = unique[idx]
 
     dx, dy = None, None
-    vertices, iverts = None, None
+    vertices, cell_edges = None, None
     xcenters, ycenters = None, None
 
     # embedded lakes
@@ -148,7 +155,9 @@ def get_lak_connections(modelgrid, lake_map, idomain=None, bedleak=None):
                 elif modelgrid.grid_type == "vertex":
                     if vertices is None:
                         vertices = modelgrid.verts
-                        iverts = modelgrid.iverts
+                        cell_edges = tuple(
+                            __cell_edges(poly) for poly in modelgrid.iverts
+                        )
                         xcenters = modelgrid.xcellcenters
                         ycenters = modelgrid.ycellcenters
                     (
@@ -165,7 +174,7 @@ def get_lak_connections(modelgrid, lake_map, idomain=None, bedleak=None):
                         modelgrid,
                         elevations,
                         vertices,
-                        iverts,
+                        cell_edges,
                         xcenters,
                         ycenters,
                     )
@@ -208,6 +217,14 @@ def get_lak_connections(modelgrid, lake_map, idomain=None, bedleak=None):
 
         # set number of connections for lake
         connection_dict[lake_number] = iconn
+
+        if embedded and iconn == 0:
+            warnings.warn(
+                f"Embedded lake {lake_number} has no connections to active "
+                "model cells.",
+                UserWarning,
+                stacklevel=2,
+            )
 
         # reset idomain for lake
         if iconn > 0:
@@ -298,7 +315,7 @@ def __vertex_lake_connections(
     modelgrid,
     elevations,
     vertices,
-    iverts,
+    cell_edges,
     xcenters,
     ycenters,
 ):
@@ -311,59 +328,69 @@ def __vertex_lake_connections(
     connwidths = []
 
     k, icpl = cell_index
-    node = k * ncpl + icpl
-    neighbors = modelgrid.neighbors(node=node, method="rook")
-    cell_iverts = set(iverts[icpl])
+    if idomain[cell_index] > 0:
+        node = k * ncpl + icpl
+        neighbors = modelgrid.neighbors(node=node, method="rook")
 
-    for neighbor in neighbors:
-        # Convert global node number to (layer, cell-per-layer)
-        nk = neighbor // ncpl
-        nicpl = neighbor % ncpl
-        ci = (nk, nicpl)
+        for neighbor in neighbors:
+            # neighbors() returns 2D adjacency offset to the requested layer
+            nicpl = neighbor % ncpl
+            ci = (k, nicpl)
 
-        if not (np.ma.is_masked(lake_map[ci]) and idomain[ci] > 0):
-            continue
+            if not (np.ma.is_masked(lake_map[ci]) and idomain[ci] > 0):
+                continue
 
-        shared = tuple(cell_iverts & set(iverts[nicpl]))
+            # A face can contain multiple edges when split by hanging vertices.
+            shared = cell_edges[icpl] & cell_edges[nicpl]
+            if not shared:
+                continue
 
-        if shared is None or len(shared) != 2:
-            continue
+            centre = (xcenters[nicpl], ycenters[nicpl])
+            connwidth = 0.0
+            connlen = None
+            for v0, v1 in shared:
+                p0 = vertices[v0]
+                p1 = vertices[v1]
+                connwidth += np.linalg.norm(p1 - p0)
+                distance = __distance_to_segment(centre, p0, p1)
+                if connlen is None or distance < connlen:
+                    connlen = distance
 
-        v0, v1 = shared
-        p0 = vertices[v0]
-        p1 = vertices[v1]
-        connwidth = np.linalg.norm(p1 - p0)
+            cellids.append(ci)
+            claktypes.append("horizontal")
+            belevs.append(elevations[k + 1, nicpl])
+            televs.append(elevations[k, nicpl])
+            connlens.append(connlen)
+            connwidths.append(connwidth)
 
-        cx = xcenters[nicpl]
-        cy = ycenters[nicpl]
-        centre = (cx, cy)
-        connlen = __distance_to_segment(centre, p0, p1)
+        # vertical connection
+        if k < nlay - 1:
+            cell_below = (k + 1, icpl)
 
-        cellids.append(ci)
-        claktypes.append("horizontal")
-        belevs.append(elevations[nk + 1, nicpl])
-        televs.append(elevations[nk, nicpl])
-        connlens.append(connlen)
-        connwidths.append(connwidth)
-
-    # vertical connection
-    if k < nlay - 1:
-        cell_below = (k + 1, icpl)
-
-        if np.ma.is_masked(lake_map[cell_below]) and idomain[cell_below] > 0:
-            cellids.append(cell_below)
-            claktypes.append("vertical")
-            belevs.append(0.0)
-            televs.append(0.0)
-            connlens.append(0.0)
-            connwidths.append(0.0)
+            if np.ma.is_masked(lake_map[cell_below]) and idomain[cell_below] > 0:
+                cellids.append(cell_below)
+                claktypes.append("vertical")
+                belevs.append(0.0)
+                televs.append(0.0)
+                connlens.append(0.0)
+                connwidths.append(0.0)
 
     return cellids, claktypes, belevs, televs, connlens, connwidths
 
 
+def __cell_edges(poly):
+    """Return normalized vertex pairs defining a cell's edges."""
+    if poly[0] == poly[-1]:
+        poly = poly[:-1]
+
+    return {tuple(sorted((poly[v - 1], poly[v]))) for v in range(len(poly))}
+
+
 def __distance_to_segment(cell_centre, p0, p1):
     """
-    Perpendicular distance from a point to a line segment.
+    Shortest distance from a point to a line segment.
+
+    Projections beyond the segment are clamped to the nearest endpoint.
     """
 
     P = np.asarray(cell_centre, dtype=float)


### PR DESCRIPTION
## Summary

- add embedded lake connection generation for VertexGrids
- calculate horizontal connection widths and lengths from shared edges
- support horizontal and vertical lake connections across multiple layers
- respect inactive neighbouring cells and update `idomain`
- add unit and MODFLOW 6 integration tests
- cover asymmetric cells and lakes below the top layer
- reformat lakpak_utils.py to pass ruff format --check

## Testing

- `pytest -q autotest/test_lake_connections.py`
- `cd autotest; pytest -v -n auto` 
- `ruff check autotest/test_lake_connections.py flopy/mf6/utils/lakpak_utils.py`
- `ruff format --check autotest/test_lake_connections.py`