### PR TITLE
feat(lgr): add ghost node correction data for a GWF-GWF exchange

### DIFF
--- a/.docs/Notebooks/lgr_gnc_example.py
+++ b/.docs/Notebooks/lgr_gnc_example.py
@@ -1,0 +1,285 @@
+# ---
+# jupyter:
+#   jupytext:
+#     notebook_metadata_filter: all
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.14.5
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+#   metadata:
+#     section: mf6
+#     authors:
+#       - name: Joseph Hughes
+# ---
+
+# # Ghost Node Correction (GNC) Data for a GWF-GWF Exchange
+#
+# The control volume finite difference formulation used by MODFLOW 6 assumes that the line connecting two cell centers crosses the shared face at a right angle through the middle of the face. A local grid refinement violates that assumption on the exchange between the parent and the child model, because the face a child cell shares with a parent cell is offset from the center of the parent cell. The Ghost Node Correction (GNC) Package of the exchange corrects the resulting error by interpolating the head at a ghost node, which is the point in the parent cell that does lie on the perpendicular through the middle of the face.
+#
+# The `Lgr` utility builds the ghost node data along with the exchange data, and we use it here to correct a parent and child model. The same data can be built for any two models joined by a GWF-GWF exchange with `flopy.utils.get_gnc_exchange`.
+#
+# The problem is confined and homogeneous, with constant heads on the left and right edges of the parent model and no flow across the top and bottom edges. Head then varies linearly between the two constant head columns, which gives an exact solution to compare against.
+
+# +
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import numpy as np
+
+import flopy
+from flopy.utils import flopy_io
+from flopy.utils.lgrutil import Lgr
+
+print(sys.version)
+print(f"numpy version: {np.__version__}")
+print(f"matplotlib version: {mpl.__version__}")
+print(f"flopy version: {flopy.__version__}")
+# -
+
+# +
+temp_dir = TemporaryDirectory()
+workspace = Path(temp_dir.name)
+print(f"Model workspace is : {flopy_io.scrub_login(str(workspace))}")
+# -
+
+# ## Build the parent and child grids
+#
+# The parent grid is a single layer of 12 rows and 12 columns. The block of parent cells in the middle is made inactive and is replaced by a child model with three cells per parent cell in each direction.
+
+# +
+nlay, nrow, ncol = 1, 12, 12
+delr = delc = 1.0
+top = 1.0
+botm = [0.0]
+ncpp = 3
+
+refine_mask = np.ones((nlay, nrow, ncol), dtype=int)
+refine_mask[:, 4:8, 4:8] = 0
+
+lgr = Lgr(
+    nlay,
+    nrow,
+    ncol,
+    delr,
+    delc,
+    np.full((nrow, ncol), top),
+    np.zeros((nlay, nrow, ncol)),
+    refine_mask,
+    ncpp=ncpp,
+    ncppl=[1],
+)
+
+parent, child = lgr.parent, lgr.child
+print(f"Parent grid: {parent.nrow} rows, {parent.ncol} columns")
+print(f"Child grid : {child.nrow} rows, {child.ncol} columns")
+# -
+
+# ## Exchange and ghost node data
+#
+# `get_exchange_data()` returns the connections between the two models, and `get_gnc_data()` returns the ghost node data for those connections.
+
+# +
+exchangedata = lgr.get_exchange_data(angldegx=True, cdist=True)
+gnc_gridprops = lgr.get_gnc_data()
+
+print(f"Number of exchanges: {len(exchangedata)}")
+print(f"numgnc: {gnc_gridprops['numgnc']}")
+print(f"numalphaj: {gnc_gridprops['numalphaj']}")
+# -
+
+# MODFLOW 6 requires one ghost node record for every exchange record, in the same order, so `numgnc` always equals the number of exchanges. A connection that needs no correction is written with a cellid of zero and a contributing factor of zero, which MODFLOW 6 skips.
+#
+# With three child cells across the face of a parent cell, the middle one is centered on that face and needs no correction, so one connection in three is written that way.
+
+# +
+corrected = [rec for rec in gnc_gridprops["gncdata"] if rec[-1] != 0.0]
+skipped = [rec for rec in gnc_gridprops["gncdata"] if rec[-1] == 0.0]
+
+print(f"Connections with a ghost node: {len(corrected)}")
+print(f"Connections without one      : {len(skipped)}")
+print(f"first corrected record: {corrected[0]}")
+print(f"first skipped record  : {skipped[0]}")
+# -
+
+# The ghost node is in the parent cell, and so is the contributing cell whose head is interpolated with it. The contributing factor is the offset of the child cell from the center of the parent cell divided by the distance to the contributing cell.
+
+alpha = np.array([rec[-1] for rec in corrected])
+print(f"Contributing factors: {np.unique(np.round(alpha, 6))}")
+
+# ## Where the ghost nodes are
+#
+# Every ghost node lies on a connection between a parent cell and a child cell, so the ghost nodes trace the boundary of the child model.
+
+# +
+fig, ax = plt.subplots(figsize=(7, 7))
+ax.set_aspect("equal")
+pmv = flopy.plot.PlotMapView(modelgrid=parent, ax=ax)
+pmv.plot_grid(colors="0.5", lw=0.6)
+cmv = flopy.plot.PlotMapView(modelgrid=child, ax=ax)
+cmv.plot_grid(colors="0.5", lw=0.3)
+
+pxc, pyc = parent.xcellcenters, parent.ycellcenters
+cxc, cyc = child.xcellcenters, child.ycellcenters
+for cellidn, cellidm, cellidj, factor in corrected:
+    xn, yn = pxc[cellidn[1], cellidn[2]], pyc[cellidn[1], cellidn[2]]
+    xm, ym = cxc[cellidm[1], cellidm[2]], cyc[cellidm[1], cellidm[2]]
+    xj, yj = pxc[cellidj[1], cellidj[2]], pyc[cellidj[1], cellidj[2]]
+    ax.plot([xn, xm], [yn, ym], color="C3", lw=0.9, zorder=2)
+    ax.plot(xj, yj, "s", color="C0", ms=3.5, zorder=3)
+
+ax.plot([], [], color="C3", lw=0.9, label="ghost node connection")
+ax.plot([], [], "s", color="C0", ms=3.5, lw=0, label="contributing cell")
+ax.legend(loc="upper right", framealpha=1.0)
+ax.set_title("Ghost node connections on the exchange")
+# -
+
+# ## Build and run the models
+#
+# The same simulation is built with and without the GNC Package of the exchange. The correction is applied implicitly, so the BICGSTAB linear acceleration option is specified in the IMS Package.
+
+# +
+h_left, h_right = 1.0, 0.0
+
+
+def exact(grid):
+    x0, x1 = parent.xcellcenters[0, 0], parent.xcellcenters[0, -1]
+    return h_left + (h_right - h_left) * (grid.xcellcenters - x0) / (x1 - x0)
+
+
+def build_simulation(name, gnc=False):
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, sim_ws=str(workspace / name), exe_name="mf6"
+    )
+    flopy.mf6.ModflowTdis(sim)
+    flopy.mf6.ModflowIms(
+        sim,
+        linear_acceleration="bicgstab",
+        inner_maximum=1000,
+        inner_dvclose=1e-11,
+        outer_dvclose=1e-11,
+    )
+
+    gwfp = flopy.mf6.ModflowGwf(sim, modelname="parent", save_flows=True)
+    flopy.mf6.ModflowGwfdis(
+        gwfp,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=top,
+        botm=botm,
+        idomain=refine_mask,
+    )
+    flopy.mf6.ModflowGwfic(gwfp, strt=0.5)
+    flopy.mf6.ModflowGwfnpf(gwfp, icelltype=0, k=1.0)
+    flopy.mf6.ModflowGwfchd(
+        gwfp,
+        stress_period_data=[[(0, i, 0), h_left] for i in range(nrow)]
+        + [[(0, i, ncol - 1), h_right] for i in range(nrow)],
+    )
+    flopy.mf6.ModflowGwfoc(
+        gwfp, head_filerecord="parent.hds", saverecord=[("HEAD", "ALL")]
+    )
+
+    gwfc = flopy.mf6.ModflowGwf(sim, modelname="child", save_flows=True)
+    flopy.mf6.ModflowGwfdis(
+        gwfc,
+        nlay=child.nlay,
+        nrow=child.nrow,
+        ncol=child.ncol,
+        delr=child.delr,
+        delc=child.delc,
+        top=top,
+        botm=botm,
+        xorigin=child.xoffset,
+        yorigin=child.yoffset,
+    )
+    flopy.mf6.ModflowGwfic(gwfc, strt=0.5)
+    flopy.mf6.ModflowGwfnpf(gwfc, icelltype=0, k=1.0)
+    flopy.mf6.ModflowGwfoc(
+        gwfc, head_filerecord="child.hds", saverecord=[("HEAD", "ALL")]
+    )
+
+    exchange = flopy.mf6.ModflowGwfgwf(
+        sim,
+        exgtype="GWF6-GWF6",
+        nexg=len(exchangedata),
+        exgmnamea="parent",
+        exgmnameb="child",
+        exchangedata=exchangedata,
+        auxiliary=["angldegx", "cdist"],
+    )
+    if gnc:
+        exchange.gnc.initialize(filename=f"{name}.gnc", **gnc_gridprops)
+    return sim
+
+
+# +
+heads = {}
+for name, gnc in [("uncorrected", False), ("gnc", True)]:
+    sim = build_simulation(name, gnc=gnc)
+    sim.write_simulation(silent=True)
+    success, buff = sim.run_simulation(silent=True)
+    assert success, f"{name} did not converge"
+    ws = workspace / name
+    heads[name] = (
+        flopy.utils.HeadFile(ws / "parent.hds").get_data()[0],
+        flopy.utils.HeadFile(ws / "child.hds").get_data()[0],
+    )
+    print(f"{name} converged")
+# -
+
+# ## Effect of the correction
+#
+# The head varies linearly between the constant head columns, so the exact solution is known and the error of each model can be measured directly.
+
+# +
+active = refine_mask[0] > 0
+print(f"{'variant':14s}{'parent max error':>18s}{'child max error':>17s}")
+errors = {}
+for name in ("uncorrected", "gnc"):
+    head_parent, head_child = heads[name]
+    parent_error = np.abs(head_parent - exact(parent))[active].max()
+    child_error = np.abs(head_child - exact(child)).max()
+    errors[name] = max(parent_error, child_error)
+    print(f"{name:14s}{parent_error:18.3e}{child_error:17.3e}")
+# -
+
+# The correction removes the error the exchange introduces. What is left is at the level of the solver tolerance, so the linear head field is reproduced exactly once the ghost nodes are applied.
+
+assert errors["gnc"] < 1.0e-6
+
+# The error in the uncorrected model is largest along the boundary of the child model, which is where the ghost nodes are.
+
+# +
+error = np.abs(heads["uncorrected"][0] - exact(parent))
+error[~active] = np.nan
+vmax = np.nanmax(error)
+
+fig, axes = plt.subplots(1, 2, figsize=(11, 5), constrained_layout=True)
+for ax, name in zip(axes, ("uncorrected", "gnc")):
+    ax.set_aspect("equal")
+    err = np.abs(heads[name][0] - exact(parent))
+    err[~active] = np.nan
+    pmv = flopy.plot.PlotMapView(modelgrid=parent, ax=ax)
+    cb = pmv.plot_array(err, cmap="magma_r", vmin=0.0, vmax=vmax)
+    pmv.plot_grid(colors="0.5", lw=0.3, alpha=0.5)
+    ax.set_title(f"{name}, parent model")
+fig.colorbar(cb, ax=axes, shrink=0.7, label="absolute head error")
+# -
+
+# Clean up the temporary workspace.
+
+try:
+    temp_dir.cleanup()
+except (PermissionError, NotADirectoryError):
+    pass

--- a/autotest/test_gnc.py
+++ b/autotest/test_gnc.py
@@ -13,9 +13,11 @@ import pytest
 from modflow_devtools.markers import requires_exe, requires_pkg
 
 import flopy
-from flopy.discretization import UnstructuredGrid, VertexGrid
+from flopy.discretization import StructuredGrid, UnstructuredGrid, VertexGrid
 from flopy.utils.gnc import (
+    _as_cellid,
     _check_gnc,
+    _node_to_cellid,
     get_gnc,
     get_gnc_dtype,
     get_gnc_exchange,
@@ -724,3 +726,36 @@ def test_lgr_get_gnc_data_numalphaj_too_small():
     lgr = lgr_pair()
     with pytest.raises(ValueError, match="more than numalphaj"):
         get_gnc_exchange(lgr.parent, lgr.child, lgr.get_exchange_data(), numalphaj=0)
+
+
+def test_cellid_conversion_by_grid_type():
+    """Cellids are built for the grid type, not only for a structured grid"""
+    structured = StructuredGrid(
+        delr=np.ones(3),
+        delc=np.ones(2),
+        top=np.ones((2, 3)),
+        botm=np.zeros((2, 2, 3)),
+    )
+    vertex = VertexGrid(
+        vertices=[[0, 0.0, 0.0], [1, 1.0, 0.0], [2, 1.0, 1.0], [3, 0.0, 1.0]],
+        cell2d=[[i, 0.5, 0.5, 4, 0, 1, 2, 3] for i in range(4)],
+        nlay=2,
+        top=np.ones(4),
+        botm=np.zeros((2, 4)),
+    )
+    unstructured, _ = synthetic_grid()
+
+    assert _node_to_cellid(structured, 4) == (0, 1, 1)
+    assert _node_to_cellid(vertex, 4) == (1, 0)
+    assert _node_to_cellid(unstructured, 4) == (4,)
+
+    # every cellid must map back to the node it came from
+    for grid in (structured, vertex, unstructured):
+        for node in range(grid.nnodes):
+            cellid = _node_to_cellid(grid, node)
+            assert int(grid.get_node([cellid])[0]) == node
+
+    # a cellid may be given as a bare node number
+    assert _as_cellid(5) == (5,)
+    assert _as_cellid((0, 1, 2)) == (0, 1, 2)
+    assert _as_cellid(np.array([0, 1, 2])) == (0, 1, 2)

--- a/autotest/test_gnc.py
+++ b/autotest/test_gnc.py
@@ -18,6 +18,7 @@ from flopy.utils.gnc import (
     _check_gnc,
     get_gnc,
     get_gnc_dtype,
+    get_gnc_exchange,
     get_gridprops_gnc5,
     get_gridprops_gnc6,
     get_numalphaj,
@@ -690,3 +691,36 @@ def test_lgr_gnc_exchange(function_tmpdir):
     # the linear head field is exact once the correction is applied
     assert errors["gnc"] < 1.0e-6
     assert errors["gnc"] < errors["uncorrected"] / 1000.0
+
+
+def test_lgr_get_gnc_data_without_idomain():
+    """The idomain is taken from the grid when it is not supplied"""
+    lgr = lgr_pair()
+    supplied = lgr.get_gnc_data()
+    from_grid = get_gnc_exchange(lgr.parent, lgr.child, lgr.get_exchange_data())
+    assert from_grid["numgnc"] == supplied["numgnc"]
+    assert from_grid["gncdata"] == supplied["gncdata"]
+
+
+def test_lgr_get_gnc_data_no_contributing_cells():
+    """A record is still written when no contributing cell is active"""
+    lgr = lgr_pair()
+    gridprops = get_gnc_exchange(
+        lgr.parent,
+        lgr.child,
+        lgr.get_exchange_data(),
+        idomain1=np.zeros_like(lgr.refine_mask),
+    )
+
+    # MODFLOW 6 needs one record per exchange and at least one contributing
+    # cell per record, even when none of them is used
+    assert gridprops["numgnc"] == len(lgr.get_exchange_data())
+    assert gridprops["numalphaj"] == 1
+    assert all(rec[2] == (-1, -1, -1) for rec in gridprops["gncdata"])
+    assert all(rec[-1] == 0.0 for rec in gridprops["gncdata"])
+
+
+def test_lgr_get_gnc_data_numalphaj_too_small():
+    lgr = lgr_pair()
+    with pytest.raises(ValueError, match="more than numalphaj"):
+        get_gnc_exchange(lgr.parent, lgr.child, lgr.get_exchange_data(), numalphaj=0)

--- a/autotest/test_gnc.py
+++ b/autotest/test_gnc.py
@@ -530,3 +530,163 @@ def test_fmt_string_separates_free_format_fields():
         buff = io.StringIO()
         np.savetxt(buff, record, fmt=fmt_string(record, free=False), delimiter="")
         assert len(buff.getvalue().split()) < len(dtype.names), name
+
+
+def lgr_pair(ncpp=3, nrowp=12, ncolp=12):
+    """A parent grid with a refined block in the middle"""
+    from flopy.utils.lgrutil import Lgr
+
+    idomain = np.ones((1, nrowp, ncolp), dtype=int)
+    idomain[:, 4:8, 4:8] = 0
+    return Lgr(
+        1,
+        nrowp,
+        ncolp,
+        1.0,
+        1.0,
+        np.ones((nrowp, ncolp)),
+        np.zeros((1, nrowp, ncolp)),
+        idomain,
+        ncpp=ncpp,
+        ncppl=[1],
+    )
+
+
+def test_lgr_get_gnc_data():
+    lgr = lgr_pair()
+    exchangedata = lgr.get_exchange_data()
+    gridprops = lgr.get_gnc_data()
+
+    # MODFLOW 6 requires one ghost node record for every exchange record
+    assert gridprops["numgnc"] == len(exchangedata)
+    assert gridprops["numalphaj"] == 1
+
+    corrected = [rec for rec in gridprops["gncdata"] if rec[-1] != 0.0]
+    skipped = [rec for rec in gridprops["gncdata"] if rec[-1] == 0.0]
+
+    # with three child cells per parent cell the middle one is centered on the
+    # face of the parent cell and needs no correction
+    assert len(corrected) == 2 * len(skipped)
+    assert np.allclose([rec[-1] for rec in corrected], 1.0 / 3.0)
+
+    # a skipped record carries a cellid of zero, written by flopy as 0 0 0
+    assert all(rec[2] == (-1, -1, -1) for rec in skipped)
+
+    # the ghost node and the contributing cell are both in the parent model,
+    # and the connected cell is in the child model
+    for cellidn, cellidm, cellidj, _ in corrected:
+        assert cellidn != cellidj
+        assert lgr.refine_mask[cellidn] > 0
+        assert lgr.refine_mask[cellidj] > 0
+
+    # the records follow the exchange records, cell for cell
+    for exchange, gnc in zip(exchangedata, gridprops["gncdata"]):
+        assert tuple(exchange[0]) == gnc[0]
+        assert tuple(exchange[1]) == gnc[1]
+
+
+def test_lgr_get_gnc_data_even_refinement():
+    """With an even refinement every child cell is offset from the parent"""
+    gridprops = lgr_pair(ncpp=2).get_gnc_data()
+    assert all(rec[-1] != 0.0 for rec in gridprops["gncdata"])
+    assert np.allclose([rec[-1] for rec in gridprops["gncdata"]], 0.25)
+
+
+@pytest.mark.slow
+@requires_exe("mf6")
+def test_lgr_gnc_exchange(function_tmpdir):
+    """The correction must remove the error on an exact linear head field"""
+    lgr = lgr_pair()
+    exchangedata = lgr.get_exchange_data(angldegx=True, cdist=True)
+    gnc_gridprops = lgr.get_gnc_data()
+    parent, child = lgr.parent, lgr.child
+    h_left, h_right = 1.0, 0.0
+
+    def exact(grid):
+        x = grid.xcellcenters
+        x0, x1 = parent.xcellcenters[0, 0], parent.xcellcenters[0, -1]
+        return h_left + (h_right - h_left) * (x - x0) / (x1 - x0)
+
+    def run(name, gnc=False):
+        ws = function_tmpdir / name
+        sim = flopy.mf6.MFSimulation(sim_name="s", sim_ws=str(ws), exe_name="mf6")
+        flopy.mf6.ModflowTdis(sim)
+        flopy.mf6.ModflowIms(
+            sim,
+            linear_acceleration="bicgstab",
+            inner_maximum=1000,
+            inner_dvclose=1e-11,
+            outer_dvclose=1e-11,
+        )
+        p = flopy.mf6.ModflowGwf(sim, modelname="parent")
+        flopy.mf6.ModflowGwfdis(
+            p,
+            nlay=1,
+            nrow=parent.nrow,
+            ncol=parent.ncol,
+            delr=1.0,
+            delc=1.0,
+            top=1.0,
+            botm=[0.0],
+            idomain=lgr.refine_mask,
+        )
+        flopy.mf6.ModflowGwfic(p, strt=0.5)
+        flopy.mf6.ModflowGwfnpf(p, icelltype=0, k=1.0)
+        flopy.mf6.ModflowGwfchd(
+            p,
+            stress_period_data=[[(0, i, 0), h_left] for i in range(parent.nrow)]
+            + [[(0, i, parent.ncol - 1), h_right] for i in range(parent.nrow)],
+        )
+        flopy.mf6.ModflowGwfoc(
+            p, head_filerecord="parent.hds", saverecord=[("HEAD", "ALL")]
+        )
+        c = flopy.mf6.ModflowGwf(sim, modelname="child")
+        flopy.mf6.ModflowGwfdis(
+            c,
+            nlay=child.nlay,
+            nrow=child.nrow,
+            ncol=child.ncol,
+            delr=child.delr,
+            delc=child.delc,
+            top=1.0,
+            botm=[0.0],
+            xorigin=child.xoffset,
+            yorigin=child.yoffset,
+        )
+        flopy.mf6.ModflowGwfic(c, strt=0.5)
+        flopy.mf6.ModflowGwfnpf(c, icelltype=0, k=1.0)
+        flopy.mf6.ModflowGwfoc(
+            c, head_filerecord="child.hds", saverecord=[("HEAD", "ALL")]
+        )
+        exchange = flopy.mf6.ModflowGwfgwf(
+            sim,
+            exgtype="GWF6-GWF6",
+            nexg=len(exchangedata),
+            exgmnamea="parent",
+            exgmnameb="child",
+            exchangedata=exchangedata,
+            auxiliary=["angldegx", "cdist"],
+        )
+        if gnc:
+            exchange.gnc.initialize(filename="s.gnc", **gnc_gridprops)
+        sim.write_simulation()
+        success, buff = sim.run_simulation(silent=True)
+        assert success, "\n".join(buff[-20:])
+        return (
+            flopy.utils.HeadFile(ws / "parent.hds").get_data()[0],
+            flopy.utils.HeadFile(ws / "child.hds").get_data()[0],
+        )
+
+    active = lgr.refine_mask[0] > 0
+    errors = {}
+    for name, gnc in [("uncorrected", False), ("gnc", True)]:
+        head_parent, head_child = run(name, gnc=gnc)
+        errors[name] = max(
+            np.abs(head_parent - exact(parent))[active].max(),
+            np.abs(head_child - exact(child)).max(),
+        )
+        print(f"{name} max error {errors[name]:.3e}")
+
+    # the linear head field is exact once the correction is applied
+    assert errors["gnc"] < 1.0e-6
+    assert errors["gnc"] < errors["uncorrected"] / 1000.0

--- a/flopy/utils/__init__.py
+++ b/flopy/utils/__init__.py
@@ -29,7 +29,12 @@ from .flopy_io import read_fixed_var, write_fixed_var
 from .formattedfile import FormattedHeadFile
 
 get_modflow = get_modflow_module.run_main
-from .gnc import get_gnc, get_gridprops_gnc5, get_gridprops_gnc6
+from .gnc import (
+    get_gnc,
+    get_gnc_exchange,
+    get_gridprops_gnc5,
+    get_gridprops_gnc6,
+)
 from .gridintersect import GridIntersect
 from .hfb_util import make_hfb_array
 from .mflistfile import (

--- a/flopy/utils/gnc.py
+++ b/flopy/utils/gnc.py
@@ -481,3 +481,129 @@ def get_gridprops_gnc5(gnc, i2kn=0, isymgncn=0, ia=None, ja=None, iac=None, chec
         "iflalphan": iflalphan,
         "gncdata": gncdata,
     }
+
+
+def get_gnc_exchange(
+    modelgrid1,
+    modelgrid2,
+    exchangedata,
+    idomain1=None,
+    numalphaj=None,
+    rtol=1.0e-6,
+):
+    """
+    Compute ghost node correction data for a GWF-GWF exchange
+
+    A ghost node is added in the cell of model 1 for every horizontal exchange
+    connection to a finer cell of model 2 whose center is offset transverse to
+    the connection.  The head at the ghost node is interpolated between the
+    cell of model 1 and its own neighbors, so model 1 must be the coarser of
+    the two models.
+
+    Parameters
+    ----------
+    modelgrid1 : flopy.discretization.Grid
+        Grid of the first model of the exchange, which holds the ghost nodes
+        and the contributing cells
+    modelgrid2 : flopy.discretization.Grid
+        Grid of the second model of the exchange
+    exchangedata : list
+        Exchange records, each starting with cellidm1, cellidm2, and ihc, as
+        returned by :meth:`flopy.utils.lgrutil.Lgr.get_exchange_data`
+    idomain1 : array_like
+        Idomain of the first model, used to skip inactive contributing cells.
+        Taken from modelgrid1 if None.
+    numalphaj : int
+        Number of contributing cells written per ghost node.  The largest
+        number found is used if None.
+    rtol : float
+        Relative tolerance used to decide whether the center of the cell of
+        model 2 is offset from the center of the cell of model 1 (default is
+        1.0e-6).
+
+    Returns
+    -------
+    gridprops : dict
+        Dictionary with numgnc, numalphaj, and gncdata, which can be unpacked
+        into the gnc package of a ModflowGwfgwf exchange.
+
+    Notes
+    -----
+    MODFLOW 6 requires one ghost node record for every exchange record, in the
+    same order, so connections that need no correction are written with a
+    cellid of zero and a contributing factor of zero.  Only horizontal
+    corrections are computed.
+
+    """
+    if idomain1 is None:
+        idomain1 = getattr(modelgrid1, "idomain", None)
+
+    xc1, yc1 = _node_centers(modelgrid1)
+    xc2, yc2 = _node_centers(modelgrid2)
+    area1, area2 = _cell_areas(modelgrid1), _cell_areas(modelgrid2)
+    active1 = None if idomain1 is None else np.asarray(idomain1).ravel() > 0
+    neighbors = modelgrid1.neighbors(method="rook")
+
+    # the contributing cells of a cell are the same for every exchange record
+    # that uses it, so the offsets to its neighbors are built once
+    cache = {}
+
+    def offsets(node):
+        if node not in cache:
+            conn = np.array(sorted(neighbors.get(node, [])), dtype=int)
+            if active1 is not None and conn.size:
+                conn = conn[active1[conn]]
+            if conn.size == 0:
+                cache[node] = (conn, None, None)
+            else:
+                dn = np.column_stack((xc1[conn] - xc1[node], yc1[conn] - yc1[node]))
+                cache[node] = (conn, dn, np.argmax(np.abs(dn), axis=1))
+        return cache[node]
+
+    records = []
+    for rec in exchangedata:
+        cellidn, cellidm, ihc = rec[0], rec[1], rec[2]
+        n = modelgrid1.get_node([tuple(cellidn)])[0]
+        m = modelgrid2.get_node([tuple(cellidm)])[0]
+
+        js, alpha = np.array([], dtype=int), 0.0
+        if ihc != 0 and area2[m] < area1[n]:
+            conn, dn, naxis = offsets(n)
+            if dn is not None:
+                d_nm = np.array([xc2[m] - xc1[n], yc2[m] - yc1[n]])
+                sel, total = _contributing_cells(dn, naxis, d_nm, rtol)
+                if sel is not None:
+                    js, alpha = conn[sel], total / sel.sum()
+        records.append((cellidn, cellidm, js, alpha))
+
+    if numalphaj is None:
+        numalphaj = max((len(rec[2]) for rec in records), default=1)
+
+    ndim1 = len(records[0][0]) if records else 3
+    none_cellid = tuple([-1] * ndim1)  # written as a cellid of zero
+
+    gncdata = []
+    for irec, (cellidn, cellidm, js, alpha) in enumerate(records):
+        if len(js) > numalphaj:
+            raise ValueError(
+                f"gnc record {irec}: cell {cellidn} has {len(js)} contributing "
+                f"cells, which is more than numalphaj of {numalphaj}"
+            )
+        cellids = [tuple(int(v) for v in modelgrid1.get_lrc([int(j)])[0]) for j in js]
+        alphas = [float(alpha)] * len(js)
+        # pad with a cellid of zero, which MODFLOW 6 skips
+        cellids += [none_cellid] * (numalphaj - len(js))
+        alphas += [0.0] * (numalphaj - len(js))
+        gncdata.append(
+            tuple(
+                [tuple(int(v) for v in cellidn), tuple(int(v) for v in cellidm)]
+                + cellids
+                + alphas
+            )
+        )
+
+    return {
+        "numgnc": len(gncdata),
+        "numalphaj": numalphaj,
+        "gncdata": gncdata,
+    }

--- a/flopy/utils/gnc.py
+++ b/flopy/utils/gnc.py
@@ -577,7 +577,10 @@ def get_gnc_exchange(
         records.append((cellidn, cellidm, js, alpha))
 
     if numalphaj is None:
-        numalphaj = max((len(rec[2]) for rec in records), default=1)
+        # every exchange gets a record, so a connection that needs no
+        # correction contributes a length of zero; MODFLOW 6 still needs at
+        # least one contributing cell per record
+        numalphaj = max(max((len(rec[2]) for rec in records), default=1), 1)
 
     ndim1 = len(records[0][0]) if records else 3
     none_cellid = tuple([-1] * ndim1)  # written as a cellid of zero

--- a/flopy/utils/gnc.py
+++ b/flopy/utils/gnc.py
@@ -483,6 +483,27 @@ def get_gridprops_gnc5(gnc, i2kn=0, isymgncn=0, ia=None, ja=None, iac=None, chec
     }
 
 
+def _as_cellid(cellid):
+    """Return a cellid as a tuple, accepting a bare node number"""
+    if np.isscalar(cellid):
+        return (int(cellid),)
+    return tuple(int(v) for v in cellid)
+
+
+def _node_to_cellid(modelgrid, node):
+    """Return the cellid of a node number for any grid type"""
+    node = int(node)
+    if hasattr(modelgrid, "get_lrc"):
+        # a structured grid addresses a cell by layer, row, and column
+        return tuple(int(v) for v in modelgrid.get_lrc([node])[0])
+    ncpl = modelgrid.ncpl
+    if np.isscalar(ncpl):
+        # a vertex grid addresses a cell by layer and cell2d number
+        return (node // int(ncpl), node % int(ncpl))
+    # an unstructured grid addresses a cell by node number
+    return (node,)
+
+
 def get_gnc_exchange(
     modelgrid1,
     modelgrid2,
@@ -563,8 +584,8 @@ def get_gnc_exchange(
     records = []
     for rec in exchangedata:
         cellidn, cellidm, ihc = rec[0], rec[1], rec[2]
-        n = modelgrid1.get_node([tuple(cellidn)])[0]
-        m = modelgrid2.get_node([tuple(cellidm)])[0]
+        n = int(modelgrid1.get_node([_as_cellid(cellidn)])[0])
+        m = int(modelgrid2.get_node([_as_cellid(cellidm)])[0])
 
         js, alpha = np.array([], dtype=int), 0.0
         if ihc != 0 and area2[m] < area1[n]:
@@ -582,8 +603,8 @@ def get_gnc_exchange(
         # least one contributing cell per record
         numalphaj = max(max((len(rec[2]) for rec in records), default=1), 1)
 
-    ndim1 = len(records[0][0]) if records else 3
-    none_cellid = tuple([-1] * ndim1)  # written as a cellid of zero
+    # a cellid of -1 in every dimension is written as a cellid of zero
+    none_cellid = tuple([-1] * len(_node_to_cellid(modelgrid1, 0)))
 
     gncdata = []
     for irec, (cellidn, cellidm, js, alpha) in enumerate(records):
@@ -592,17 +613,13 @@ def get_gnc_exchange(
                 f"gnc record {irec}: cell {cellidn} has {len(js)} contributing "
                 f"cells, which is more than numalphaj of {numalphaj}"
             )
-        cellids = [tuple(int(v) for v in modelgrid1.get_lrc([int(j)])[0]) for j in js]
+        cellids = [_node_to_cellid(modelgrid1, j) for j in js]
         alphas = [float(alpha)] * len(js)
         # pad with a cellid of zero, which MODFLOW 6 skips
         cellids += [none_cellid] * (numalphaj - len(js))
         alphas += [0.0] * (numalphaj - len(js))
         gncdata.append(
-            tuple(
-                [tuple(int(v) for v in cellidn), tuple(int(v) for v in cellidm)]
-                + cellids
-                + alphas
-            )
+            tuple([_as_cellid(cellidn), _as_cellid(cellidm)] + cellids + alphas)
         )
 
     return {

--- a/flopy/utils/lgrutil.py
+++ b/flopy/utils/lgrutil.py
@@ -5,6 +5,7 @@ import numpy as np
 from ..discretization import StructuredGrid
 from ..modflow import Modflow
 from .cvfdutil import get_disv_gridprops, gridlist_to_verts
+from .gnc import get_gnc_exchange
 from .util_array import Util2d, Util3d
 
 
@@ -719,6 +720,40 @@ class Lgr:
             nlayc, nrowc, ncolc, delrc, delcc, topc, botmc, idomainc, xorigin, yorigin
         )
         return simple_regular_grid
+
+    def get_gnc_data(self, numalphaj=None):
+        """
+        Get a dictionary of information needed to create the GNC package of
+        the GWF-GWF exchange between the parent and child models.  The
+        returned dictionary can be unpacked directly into the gnc package of
+        the exchange.
+
+        Parameters
+        ----------
+        numalphaj : int
+            Number of contributing cells written per ghost node.  The largest
+            number found is used if None.
+
+        Returns
+        -------
+        gridprops : dict
+
+        Notes
+        -----
+        The ghost nodes are in the parent model, which must be the first model
+        of the exchange.  MODFLOW 6 requires one record for every exchange
+        record, so connections that need no correction, such as a child cell
+        centered on the face of a parent cell, are written with a cellid of
+        zero and a contributing factor of zero.
+
+        """
+        return get_gnc_exchange(
+            self.parent,
+            self.child,
+            self.get_exchange_data(),
+            idomain1=self.refine_mask,
+            numalphaj=numalphaj,
+        )
 
     def to_disv_gridprops(self):
         """


### PR DESCRIPTION
- Added `get_gnc_exchange` to compute ghost node correction data for the connections between two models joined by a GWF-GWF exchange
- Added `Lgr.get_gnc_data` to return it for a parent and child model
- MODFLOW 6 requires one record for every exchange record in the same order, so a connection that needs no correction is written with a cellid of zero and a contributing factor of zero