### PR TITLE
fix(vtk): transpose the vector after the point scalar expansion

### DIFF
--- a/autotest/test_export.py
+++ b/autotest/test_export.py
@@ -1481,6 +1481,40 @@ def test_vtk_vector(function_tmpdir, example_data_path):
 
 
 @requires_pkg("vtk")
+@pytest.mark.parametrize("point_scalars", [False, True])
+@pytest.mark.parametrize("size", ["nnodes", "ncpl"])
+def test_vtk_add_vector_components(size, point_scalars):
+    """Cell i must get (x[i], y[i], z[i]) for either input size"""
+    from vtk.util import numpy_support
+
+    nlay, nrow, ncol = 2, 3, 4
+    grid = StructuredGrid(
+        delr=np.full(ncol, 10.0),
+        delc=np.full(nrow, 10.0),
+        top=np.full((nrow, ncol), 10.0),
+        botm=np.array([np.full((nrow, ncol), 0.0), np.full((nrow, ncol), -10.0)]),
+        nlay=nlay,
+    )
+    n = nlay * nrow * ncol if size == "nnodes" else nrow * ncol
+
+    # a constant field is used because inverse distance weighting of a
+    # constant returns the constant, so the point and the cell case have the
+    # same expected value
+    vector = np.array([np.full(n, 1.0), np.full(n, 2.0), np.full(n, 3.0)])
+    vtk = Vtk(modelgrid=grid, point_scalars=point_scalars)
+    vtk.add_vector(vector, "v")
+
+    data = vtk.vtk_grid.GetPointData() if point_scalars else vtk.vtk_grid.GetCellData()
+    arr = numpy_support.vtk_to_numpy(data.GetVectors())
+    assert arr.shape[1] == 3
+
+    # cells that the ncpl sized vector does not reach are filled with nan
+    finite = arr[np.isfinite(arr).all(axis=1)]
+    assert len(finite) > 0
+    assert np.allclose(finite, [1.0, 2.0, 3.0])
+
+
+@requires_pkg("vtk")
 def test_vtk_unstructured(function_tmpdir, unstructured_grid):
     from vtkmodules.util.numpy_support import vtk_to_numpy
     from vtkmodules.vtkIOLegacy import vtkUnstructuredGridReader

--- a/autotest/test_export.py
+++ b/autotest/test_export.py
@@ -1417,7 +1417,6 @@ def test_vtk_cbc(function_tmpdir, example_data_path):
 
 
 @requires_pkg("vtk")
-@pytest.mark.slow
 def test_vtk_vector(function_tmpdir, example_data_path):
     # test mf 2005 freyberg
     mpth = example_data_path / "freyberg_multilayer_transient"

--- a/flopy/export/vtk.py
+++ b/flopy/export/vtk.py
@@ -897,7 +897,7 @@ class Vtk:
             else:
                 raise AssertionError("Size of vector must be 3 * nnodes or 3 * ncpl")
         else:
-            vector = np.reshape(vector, (3, self.nnodes)).T
+            vector = np.reshape(vector, (3, self.nnodes))
 
         if self.point_scalars:
             tmp = []
@@ -907,8 +907,11 @@ class Vtk:
 
         vector = self._mask_values(vector, masked_values)
 
+        # a row per component is built above, but numpy_to_vtk flattens in
+        # row-major order and vtk reads each row as one tuple, so the array
+        # is transposed to give a row per cell or point
         vtk_arr = numpy_support.numpy_to_vtk(
-            num_array=vector, array_type=self.__vtk.VTK_FLOAT
+            num_array=vector.T, array_type=self.__vtk.VTK_FLOAT
         )
         vtk_arr.SetName(name)
         vtk_arr.SetNumberOfComponents(3)


### PR DESCRIPTION
`add_vector` builds a row per component and `numpy_to_vtk` flattens in row-major order, so the array has to be transposed to give a row per cell or point. The transpose was applied to the vector sized `3 * nnodes` before the point scalar expansion, which left three of the four paths through the method wrong:

| vector size | `point_scalars` | before | after |
|---|---|---|---|
| `3 * nnodes` | False | correct | correct |
| `3 * nnodes` | True | `IndexError` | correct |
| `3 * ncpl` | False | first component written to all three | correct |
| `3 * ncpl` | True | first component written to all three | correct |

The transpose is now applied once, after the expansion. The two `3 * ncpl` cases wrote the wrong data without raising.

`test_vtk_vector` covers only the `3 * nnodes` point scalar path, and the smoke test used by the test matrix skips the tests marked slow, so it only ran in the nightly optional dependency workflow. A test covering all four paths has been added; it fails on three of the four before this change. The slow mark has also been dropped from `test_vtk_vector`, which loads a model and exports it but does not run one, and takes about half a second.