### PR TITLE
fix(autotest): skip export tests that need geopandas

### DIFF
--- a/autotest/test_export.py
+++ b/autotest/test_export.py
@@ -160,7 +160,7 @@ def unstructured_grid(example_data_path):
     )
 
 
-@requires_pkg("pyshp", name_map={"pyshp": "shapefile"})
+@requires_pkg("pyshp", "geopandas", name_map={"pyshp": "shapefile"})
 @pytest.mark.parametrize("pathlike", (True, False))
 def test_output_helper_shapefile_export(pathlike, function_tmpdir, example_data_path):
     ml = Modflow.load(
@@ -179,7 +179,7 @@ def test_output_helper_shapefile_export(pathlike, function_tmpdir, example_data_
     )
 
 
-@requires_pkg("pyshp", name_map={"pyshp": "shapefile"})
+@requires_pkg("pyshp", "geopandas", name_map={"pyshp": "shapefile"})
 @pytest.mark.slow
 def test_freyberg_export(function_tmpdir, example_data_path):
     # steady state
@@ -323,7 +323,7 @@ def test_write_gridlines_shapefile(function_tmpdir):
         assert len(sf) == 22
 
 
-@requires_pkg("pyshp", name_map={"pyshp": "shapefile"})
+@requires_pkg("pyshp", "geopandas", name_map={"pyshp": "shapefile"})
 def test_export_shapefile_polygon_closed(function_tmpdir):
     from shapefile import Reader
 
@@ -442,7 +442,7 @@ def test_netcdf_classmethods(function_tmpdir, example_data_path):
     new_f.nc.close()
 
 
-@requires_pkg("pyshp", name_map={"pyshp": "shapefile"})
+@requires_pkg("pyshp", "geopandas", name_map={"pyshp": "shapefile"})
 def test_shapefile_ibound(function_tmpdir, example_data_path):
     from shapefile import Reader
 
@@ -465,7 +465,7 @@ def test_shapefile_ibound(function_tmpdir, example_data_path):
     shape.close()
 
 
-@requires_pkg("pyshp", name_map={"pyshp": "shapefile"})
+@requires_pkg("pyshp", "geopandas", name_map={"pyshp": "shapefile"})
 @pytest.mark.slow
 @pytest.mark.parametrize("namfile", namfiles())
 def test_shapefile(function_tmpdir, namfile):
@@ -555,7 +555,7 @@ def test_export_netcdf(function_tmpdir, namfile):
     nc.close()
 
 
-@requires_pkg("pyshp", name_map={"pyshp": "shapefile"})
+@requires_pkg("pyshp", "geopandas", name_map={"pyshp": "shapefile"})
 def test_export_array2(function_tmpdir):
     nrow = 7
     ncol = 11
@@ -586,7 +586,7 @@ def test_export_array2(function_tmpdir):
 
 
 @pytest.mark.mf6
-@requires_pkg("pyshp", name_map={"pyshp": "shapefile"})
+@requires_pkg("pyshp", "geopandas", name_map={"pyshp": "shapefile"})
 def test_array3d_export_structured(function_tmpdir):
     from shapefile import Reader
 
@@ -2127,7 +2127,7 @@ def test_to_shapefile_raises_attributeerror():
 
 
 @pytest.mark.mf6
-@requires_pkg("pyshp", name_map={"pyshp": "shapefile"})
+@requires_pkg("pyshp", "geopandas", name_map={"pyshp": "shapefile"})
 @pytest.mark.parametrize("use_pandas", [True])  # TODO: test non-pandas
 @pytest.mark.parametrize("sparse", [True, False])
 def test_mf6_chd_shapefile_export_structured(function_tmpdir, use_pandas, sparse):

--- a/autotest/test_model_splitter.py
+++ b/autotest/test_model_splitter.py
@@ -221,7 +221,7 @@ def test_metis_splitting_with_lak_sfr(function_tmpdir):
 @requires_exe("mf6")
 @requires_pkg("pymetis")
 @requires_pkg("h5py")
-# @requires_pkg("sklearn")
+@requires_pkg("sklearn")
 def test_save_load_node_mapping_structured(function_tmpdir):
     import pymetis
 


### PR DESCRIPTION
The nightly optional dependency job installs the optional dependencies and then removes three of them chosen by the date, so it reaches combinations the job that installs none of them does not. Shapefile export goes through geopandas, but the export tests were marked as needing only pyshp and failed with an `ImportError` rather than being skipped on the night geopandas was removed. The two export tests that do not go through geopandas keep their existing mark.

The mark for sklearn on `test_save_load_node_mapping_structured` was added commented out and never took effect, so that test failed the same way when scikit-learn was removed.

Reproducing the 2026-08-07 run of that job locally (shapely, fiona and scikit-learn removed) takes it from 37 dependency failures to none. The one failure left in that configuration is `test_vtk_vector`, which is a separate defect fixed in #2799.