### PR TITLE
fix(zonebudget_example): index the budget values by position

### DIFF
--- a/.docs/Notebooks/zonebudget_example.py
+++ b/.docs/Notebooks/zonebudget_example.py
@@ -267,6 +267,11 @@ def volumetric_budget_bar_plot(values_in, values_out, labels, **kwargs):
     else:
         ax = plt.gca()
 
+    # the values are indexed by position below, and a series passed in is
+    # indexed by zone name, so the values are taken out of the series
+    values_in = np.asarray(values_in)
+    values_out = np.asarray(values_out)
+
     x_pos = np.arange(len(values_in))
     rects_in = ax.bar(x_pos, values_in, align="center", alpha=0.5)
 


### PR DESCRIPTION
`volumetric_budget_bar_plot` labels each bar by indexing the values with the position of the bar, but the values are passed in as a series indexed by zone name, so the label lookup raised `KeyError: 0`. Pandas used to fall back to positional indexing for a series that is not indexed by integers and no longer does. The values are now taken out of the series before they are indexed.

This is one of the notebooks failing in the nightly example workflow. The notebook runs to completion with this change and raises the `KeyError` without it.