### PR TITLE
test: add missing shapely requires_pkg markers

### DIFF
--- a/autotest/test_export.py
+++ b/autotest/test_export.py
@@ -241,7 +241,7 @@ def test_freyberg_export(function_tmpdir, example_data_path):
     assert m.drn.stress_period_data.mg.angrot == m.modelgrid.angrot
 
 
-@requires_pkg("pyshp", name_map={"pyshp": "shapefile"})
+@requires_pkg("pyshp", "shapely", name_map={"pyshp": "shapefile"})
 @pytest.mark.parametrize("missing_arrays", [True, False])
 @pytest.mark.slow
 def test_disu_export(function_tmpdir, missing_arrays):
@@ -623,7 +623,7 @@ def test_array3d_export_structured(function_tmpdir):
         ]
 
 
-@requires_pkg("pyshp", name_map={"pyshp": "shapefile"})
+@requires_pkg("pyshp", "shapely", name_map={"pyshp": "shapefile"})
 def test_array3d_export_unstructured(function_tmpdir):
     from shapefile import Reader
 

--- a/autotest/test_gridgen.py
+++ b/autotest/test_gridgen.py
@@ -59,7 +59,7 @@ def get_structured_grid():
 
 
 @requires_exe("gridgen")
-@requires_pkg("pyshp", name_map={"pyshp": "shapefile"})
+@requires_pkg("pyshp", "shapely", name_map={"pyshp": "shapefile"})
 @pytest.mark.parametrize("grid_type", ["vertex", "unstructured"])
 def test_add_active_domain(function_tmpdir, grid_type):
     bgrid = get_structured_grid()
@@ -95,7 +95,7 @@ def test_add_active_domain(function_tmpdir, grid_type):
 
 
 @requires_exe("gridgen")
-@requires_pkg("pyshp", name_map={"pyshp": "shapefile"})
+@requires_pkg("pyshp", "shapely", name_map={"pyshp": "shapefile"})
 @pytest.mark.parametrize("grid_type", ["vertex", "unstructured"])
 def test_add_refinement_feature(function_tmpdir, grid_type):
     bgrid = get_structured_grid()

--- a/autotest/test_model_splitter.py
+++ b/autotest/test_model_splitter.py
@@ -1031,7 +1031,7 @@ def test_unstructured_complex_disu(function_tmpdir):
 
 
 @requires_exe("mf6")
-@requires_pkg("pymetis", "scipy")
+@requires_pkg("pymetis", "scipy", "shapely")
 def test_multi_model(function_tmpdir):
     from scipy.spatial import KDTree
 

--- a/autotest/test_modeltime.py
+++ b/autotest/test_modeltime.py
@@ -3,7 +3,6 @@ import datetime
 import numpy as np
 import pandas as pd
 import pytest
-
 from modflow_devtools.markers import requires_pkg
 
 import flopy

--- a/autotest/test_modeltime.py
+++ b/autotest/test_modeltime.py
@@ -4,6 +4,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from modflow_devtools.markers import requires_pkg
+
 import flopy
 from flopy.discretization.modeltime import ModelTime
 from flopy.mf6.modflow.mfsimulation import MFSimulation
@@ -360,6 +362,7 @@ def test_from_headers_test005_advgw_tidal(example_data_path):
     assert np.allclose(mt.tsmult, tdis.perioddata.get_data()["tsmult"])
 
 
+@requires_pkg("pyshp", "shapely", name_map={"pyshp": "shapefile"})
 def test_from_headers_disu(function_tmpdir):
     from autotest.test_export import disu_sim as _disu_sim
 

--- a/autotest/test_particledata.py
+++ b/autotest/test_particledata.py
@@ -676,7 +676,7 @@ def test_nodeparticledata_to_prp_dis_1_per_face():
     assert len(rpts) == num_cells * 6
 
 
-@requires_pkg("pyshp", name_map={"pyshp": "shapefile"})
+@requires_pkg("pyshp", "shapely", name_map={"pyshp": "shapefile"})
 def test_nodeparticledata_prp_disv_big(function_tmpdir):
     Lx = 10000.0
     Ly = 10500.0


### PR DESCRIPTION
Some `requires_pkg` markers were missing, causing optional dependency CI testing to fail