### PR TITLE
docs(examples): fix multiple example notebooks

### DIFF
--- a/.docs/Notebooks/feat_working_stack_examples.py
+++ b/.docs/Notebooks/feat_working_stack_examples.py
@@ -131,7 +131,7 @@ df_flux, df_vol = mfl.get_dataframes(start_datetime="10-21-2015")
 df_flux
 
 # +
-groups = df_flux.groupby(lambda x: x.split("_")[-1], axis=1).groups
+groups = df_flux.T.groupby(lambda x: x.split("_")[-1]).groups
 df_flux_in = df_flux.loc[:, groups["IN"]]
 df_flux_in.columns = df_flux_in.columns.map(lambda x: x.split("_")[0])
 

--- a/.docs/Notebooks/grid_intersection_example.py
+++ b/.docs/Notebooks/grid_intersection_example.py
@@ -1,4 +1,3 @@
-# %%
 # ---
 # jupyter:
 #   jupytext:

--- a/.docs/Notebooks/plot_cross_section_example.py
+++ b/.docs/Notebooks/plot_cross_section_example.py
@@ -89,7 +89,6 @@ modelpth = Path(tempdir.name)
 # ### Load and Run an Existing MODFLOW-2005 Model
 # A model called the "Freyberg Model" is located in the loadpth folder.  In the following code block, we load that model, then change into a new workspace (modelpth) where we recreate and run the model.  For this to work properly, the MODFLOW-2005 executable (mf2005) must be in the path.  We verify that it worked correctly by checking for the presence of freyberg.hds and freyberg.cbc.
 
-# +
 ml = flopy.modflow.Modflow.load(
     "freyberg.nam", model_ws=data_path / sim_name, exe_name=exe_name_2005, version=v2005
 )
@@ -495,7 +494,6 @@ for fname, fhash in file_names.items():
         known_hash=fhash,
     )
 
-# +
 # load the Freyberg model into mf6-flopy and run the simulation
 sim = flopy.mf6.MFSimulation.load(
     sim_name="mfsim.nam",

--- a/.docs/Notebooks/plot_map_view_example.py
+++ b/.docs/Notebooks/plot_map_view_example.py
@@ -24,7 +24,6 @@
 #
 
 
-# +
 import os
 import sys
 from pathlib import Path
@@ -92,7 +91,6 @@ for fname, fhash in file_names.items():
         known_hash=fhash,
     )
 
-# +
 ml = flopy.modflow.Modflow.load(
     "freyberg.nam", model_ws=data_path / sim_name, exe_name=exe_name_2005, version=v2005
 )
@@ -114,7 +112,6 @@ for f in files:
 #
 # The MODFLOW-2005 model created in the previous code block will be used to create a endpoint capture zone and pathline analysis for the pumping wells in the model.
 
-# +
 mp = flopy.modpath.Modpath6(
     "freybergmp", exe_name=exe_mp, modflowmodel=ml, model_ws=modelpth
 )


### PR DESCRIPTION
Close #2808 and fix some other example notebook failures

- `grid_intersection_example.py`: removed leading `# %%` before the YAML front-matter, which was causing jupytext to fail to parse and consequently fail to auto-detect a kernel
- `feat_working_stack_examples.py`: change `df_flux.groupby(lambda x: x.split("_")[-1], axis=1)` → `df_flux.T.groupby(lambda x: x.split("_")[-1])`, since pandas 3.0 removed the `axis` parameter from `DataFrame.groupby()`
- `plot_map_view_example.py` and `plot_cross_section_example.py`: these used to use PyCharm-style cell markers until #2414, but that PR missed a few `# +` lines that now have no matching closing markers. Jupytext's light-format parser swallows everything after these into one giant cell until it processes some markdown further down that superficially looks like another `# +` marker, which messes up the notebook's cell rendering.