### PR TITLE
Fix condition for richards laytyp check in mfusglpf.py

### DIFF
--- a/flopy/mfusg/mfusglpf.py
+++ b/flopy/mfusg/mfusglpf.py
@@ -335,7 +335,7 @@ class MfUsgLpf(ModflowLpf):
                 model, (njag,), np.float32, ksat, "ksat", locat=self.unit_number[0]
             )
 
-        if self.laytyp == 5:
+        if (self.laytyp.array == 5).any():
             self.richards = True
             bas = model.get_package("BAS6")
             if not hasattr(bas, "richards") or not bas.richards:


### PR DESCRIPTION
This check (`self.laytyp==5`) always defaults to False as `self.laytyp` is a `MFArray` due to the `super().__init__`. Therefore, if laytyp=5 parsed to the MfUsgLpf.__init__, `self.richards` will always be False and unsaturated flow won't be simulated. 