### PR TITLE
test(markers): fix the scikit-learn requires_pkg marker

### DIFF
--- a/autotest/test_model_splitter.py
+++ b/autotest/test_model_splitter.py
@@ -221,7 +221,7 @@ def test_metis_splitting_with_lak_sfr(function_tmpdir):
 @requires_exe("mf6")
 @requires_pkg("pymetis")
 @requires_pkg("h5py")
-@requires_pkg("sklearn")
+@requires_pkg("scikit-learn", name_map={"scikit-learn": "sklearn"})
 def test_save_load_node_mapping_structured(function_tmpdir):
     import pymetis
 


### PR DESCRIPTION
`requires_pkg()` resolves a distribution name *and* imports the matching module, so
scikit-learn matches neither name on its own — the distribution is `scikit-learn` and the
module is `sklearn`. `test_save_load_node_mapping_structured` was skipped everywhere as a
result, including the nightly optional dependency build, and had never run.

* map the distribution to its module with `name_map`, as `requires_pkg()` documents for this case
* the test passes once it runs
