### PR TITLE
ci(commit): add optional dependencies to the pixi environment

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -159,7 +159,12 @@ jobs:
         working-directory: modflow6
         run: |
           pixi run install
-          pixi run pip install coverage pytest-cov netcdf4 h5py
+          pixi run pip install coverage pytest-cov netcdf4
+          # the h5py and netcdf4 wheels bundle different HDF5 libraries and
+          # Windows loads the wrong one, which breaks the h5py import
+          if [[ "${{ runner.os }}" != "Windows" ]]; then
+            pixi run pip install h5py
+          fi
 
       - name: Install FloPy
         working-directory: flopy

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -159,8 +159,9 @@ jobs:
         working-directory: modflow6
         run: |
           # optional dependencies of FloPy come from conda so they are
-          # consistent with the libraries already in the environment
-          pixi add h5py pymetis scikit-learn
+          # consistent with the libraries already in the environment. pymetis
+          # is held back until the metis tests pass on macOS
+          pixi add h5py scikit-learn
           pixi run install
           pixi run pip install coverage pytest-cov netcdf4
 

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -158,13 +158,11 @@ jobs:
       - name: Install dependencies
         working-directory: modflow6
         run: |
+          # optional dependencies of FloPy come from conda so they are
+          # consistent with the libraries already in the environment
+          pixi add h5py pymetis scikit-learn
           pixi run install
           pixi run pip install coverage pytest-cov netcdf4
-          # the h5py and netcdf4 wheels bundle different HDF5 libraries and
-          # Windows loads the wrong one, which breaks the h5py import
-          if [[ "${{ runner.os }}" != "Windows" ]]; then
-            pixi run pip install h5py
-          fi
 
       - name: Install FloPy
         working-directory: flopy

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -159,7 +159,7 @@ jobs:
         working-directory: modflow6
         run: |
           pixi run install
-          pixi run pip install coverage pytest-cov netcdf4
+          pixi run pip install coverage pytest-cov netcdf4 h5py
 
       - name: Install FloPy
         working-directory: flopy


### PR DESCRIPTION
The `Test` job runs in the MODFLOW 6 pixi environment and installs FloPy with `--no-deps`,
so none of the `optional` extras are present and every test guarded by `requires_pkg()` for
them is skipped on a pull request.

* add h5py and scikit-learn to the pixi environment rather than installing them from pypi, so
  they are consistent with the libraries already there
* h5py gates the node mapping save and load tests, none of which have run on a pull request
* pymetis is held back until #2828 is resolved. Adding it ran the metis splitting tests for
  the first time on a pull request and `test_multi_model` fails on macOS, which was not
  visible before because pymetis has never been installed in this job
