### PR TITLE
ci(optional): stop uv run from reinstalling the removed dependencies

### DIFF
--- a/.github/workflows/optional.yml
+++ b/.github/workflows/optional.yml
@@ -5,6 +5,7 @@ name: Optional dependency testing
 on:
   schedule:
     - cron: '0 8 * * *' # run at 8 AM UTC (12 am PST)
+  workflow_dispatch:
 jobs:
   test:
     name: Test
@@ -62,7 +63,7 @@ jobs:
 
       - name: Smoke test (${{ matrix.optdeps }})
         working-directory: autotest
-        run: uv run pytest -v -n=auto -m "not regression and not example" --cov=flopy --cov-report=xml --durations=0 --keep-failed=.failed
+        run: uv run --no-sync pytest -v -n=auto -m "not regression and not example" --cov=flopy --cov-report=xml --durations=0 --keep-failed=.failed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
`uv run` re-syncs the project before running the command, which undoes both the
`uv sync --only-group test` install and the random `uv pip uninstall` that precede it. Both
matrix variants therefore run the full suite with every optional dependency present, so the
workflow has not been testing the absence of any of them.

Evidence from the 22 Aug run ([32562777097](https://github.com/modflowpy/flopy/actions/runs/32562777097)):
the `no optional dependencies` job logs `optional packages: affine-3.0.0, ..., h5py-3.16.0, ...,
pymetis-2025.2.2, ...` and passes `test_model_splitter.py::test_multi_model`, which requires pymetis.

* run pytest with `--no-sync` so the environment the preceding steps built is the one used
* add a `workflow_dispatch` trigger so the workflow can be run on demand

Opened as a draft: once the constraint is actually enforced this may surface tests that do not
degrade gracefully, which is the point of the workflow, but I cannot exercise it from a branch —
`workflow_dispatch` only appears once the trigger is on the default branch.
