### PR TITLE
feat(Mf6Splitter): weight horizontal flow barrier faces for metis

### DIFF
--- a/autotest/test_model_splitter.py
+++ b/autotest/test_model_splitter.py
@@ -220,6 +220,74 @@ def test_metis_splitting_with_lak_sfr(function_tmpdir):
 
 @requires_exe("mf6")
 @requires_pkg("pymetis")
+def test_metis_splitting_with_hfb(function_tmpdir):
+    import pymetis
+
+    nlay, nrow, ncol = 1, 20, 20
+
+    sim = flopy.mf6.MFSimulation(sim_name="hfb", sim_ws=function_tmpdir, exe_name="mf6")
+    flopy.mf6.ModflowTdis(sim)
+    flopy.mf6.ModflowIms(
+        sim, complexity="simple", outer_dvclose=1e-9, inner_dvclose=1e-10
+    )
+    gwf = flopy.mf6.ModflowGwf(sim, modelname="hfb", save_flows=True)
+    flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=100.0,
+        delc=100.0,
+        top=10.0,
+        botm=[0.0],
+    )
+    flopy.mf6.ModflowGwfnpf(gwf, k=1.0)
+    flopy.mf6.ModflowGwfic(gwf, strt=10.0)
+    chd = [[(0, i, 0), 10.0] for i in range(nrow)]
+    chd += [[(0, i, ncol - 1), 1.0] for i in range(nrow)]
+    flopy.mf6.ModflowGwfchd(gwf, stress_period_data=chd)
+
+    # two barriers that a partition would otherwise be free to cut
+    hfb = [[(0, i, 6), (0, i, 7), 1e-5] for i in range(nrow)]
+    hfb += [[(0, 9, j), (0, 10, j), 1e-5] for j in range(ncol)]
+    flopy.mf6.ModflowGwfhfb(gwf, stress_period_data={0: hfb})
+    flopy.mf6.ModflowGwfoc(gwf, head_filerecord="hfb.hds", saverecord=[("HEAD", "ALL")])
+    sim.write_simulation()
+    sim.run_simulation()
+
+    original_heads = gwf.output.head().get_alldata()[-1]
+
+    mfsplit = Mf6Splitter(sim)
+    array = mfsplit.optimize_splitting_mask(
+        nparts=4, options=pymetis.Options(seed=42, contig=1)
+    )
+
+    # a barrier must lie within one model, not on a model boundary
+    membership = array.ravel()
+    for recarray in gwf.get_package("hfb").stress_period_data.data.values():
+        _, nodes1 = mfsplit._cellid_to_layer_node(recarray.cellid1)
+        _, nodes2 = mfsplit._cellid_to_layer_node(recarray.cellid2)
+        if not np.array_equal(membership[nodes1], membership[nodes2]):
+            raise AssertionError("A horizontal flow barrier was split")
+
+    new_sim = mfsplit.split_model(array)
+    new_sim.set_sim_path(function_tmpdir / "split_model")
+    new_sim.write_simulation()
+    new_sim.run_simulation()
+
+    heads = {}
+    for mkey in np.unique(membership):
+        ml = new_sim.get_model(f"hfb_{mkey}")
+        heads[mkey] = ml.output.head().get_alldata()[-1]
+
+    new_heads = mfsplit.reconstruct_array(heads)
+
+    err_msg = "Heads from original and split models do not match"
+    np.testing.assert_allclose(new_heads, original_heads, atol=1e-6, err_msg=err_msg)
+
+
+@requires_exe("mf6")
+@requires_pkg("pymetis")
 @requires_pkg("h5py")
 @requires_pkg("scikit-learn", name_map={"scikit-learn": "sklearn"})
 def test_save_load_node_mapping_structured(function_tmpdir):

--- a/flopy/mf6/utils/model_splitter.py
+++ b/flopy/mf6/utils/model_splitter.py
@@ -123,6 +123,11 @@ OBS_ID2_LUT = {
 }
 
 
+# cost of cutting a cell face that a horizontal flow barrier crosses,
+# relative to the cost of one for every other face
+HFB_EDGE_WEIGHT = 1000
+
+
 class Mf6Splitter:
     """
     A class for splitting a single model into a multi-model simulation
@@ -717,10 +722,43 @@ class Mf6Splitter:
         weights = [np.count_nonzero(idomain[:, nn]) + adv_pkg_weights[nn] for nn in neighbors.keys()]
         graph = [np.array(neigh, dtype=int) for neigh in neighbors.values()]
 
+        eweights = None
+        if hfbs:
+            if verbose:
+                print("Weighting horizontal flow barrier faces")
+            # metis cannot be told that a barrier must not be cut, but making
+            # the faces it crosses expensive to cut steers the partition around
+            # it. Barriers that are still cut are moved after the partition is
+            # built.
+            gnode = {node: ix for ix, node in enumerate(neighbors.keys())}
+            hfb_faces = set()
+            for hfb in hfbs:
+                for recarray in hfb.stress_period_data.data.values():
+                    _, nodes1 = self._cellid_to_layer_node(recarray.cellid1)
+                    _, nodes2 = self._cellid_to_layer_node(recarray.cellid2)
+                    for node1, node2 in zip(nodes1, nodes2):
+                        if node1 not in gnode or node2 not in gnode:
+                            continue
+
+                        hfb_faces.add((gnode[node1], gnode[node2]))
+                        hfb_faces.add((gnode[node2], gnode[node1]))
+
+            eweights = []
+            for node, conns in enumerate(graph):
+                for conn in conns:
+                    if (node, int(conn)) in hfb_faces:
+                        eweights.append(HFB_EDGE_WEIGHT)
+                    else:
+                        eweights.append(1)
+
         if verbose:
             print("Running Metis")
         n_cuts, membership = pymetis.part_graph(
-            nparts, adjacency=graph, vweights=weights, options=options
+            nparts,
+            adjacency=graph,
+            vweights=weights,
+            eweights=eweights,
+            options=options,
         )
         membership = np.array(membership, dtype=int)
 
@@ -761,6 +799,7 @@ class Mf6Splitter:
                     _, nodes1 = self._cellid_to_layer_node(cellids1)
                     _, nodes2 = self._cellid_to_layer_node(cellids2)
                     cnt = 0
+                    moved = 0
                     while cnt < len(nodes1):
                         mnums1 = membership[nodes1]
                         mnums2 = membership[nodes2]
@@ -771,12 +810,19 @@ class Mf6Splitter:
                         mnum_to = mnums1[idx]
                         adj_nodes = np.array(nodes2)[idx]
                         membership[adj_nodes] = mnum_to
+                        moved += len(adj_nodes)
                         cnt += 1
 
                     if cnt == len(nodes1):
                         raise AssertionError(
-                            "Cannot uniquely spilt around HFB boundaries, try another "
+                            "Cannot uniquely split around HFB boundaries, try another "
                             "value for nparts"
+                        )
+
+                    if verbose and moved:
+                        print(
+                            f"Moved {moved} cell(s) to keep horizontal flow "
+                            f"barriers within a model"
                         )
 
         return membership.reshape(shape)


### PR DESCRIPTION
`optimize_splitting_mask()` built the adjacency graph without telling metis where the barriers
are, so a partition was free to cut one. The barriers were then put back together by moving
cells between models *after* the partition was built, which undoes the balance metis produced
and can break contiguity even when `contig=1` was passed.

* pass `eweights` that make a face a barrier crosses expensive to cut, so metis routes the
  partition around it
* keep the check after the partition is built for any barrier that is still split
* report the cells that check moves when `verbose` is set, and correct the spelling of split
  in the error message

Worst imbalance (largest part / mean part) on a 40 by 40 model with three barriers, over seeds
42, 7, and 1234:

| parts | before | after |
| --- | --- | --- |
| 4 | 1.015 | 1.000 |
| 6 | 1.027 | 1.001 |
| 8 | 1.030 | 1.005 |

This is a partition quality change, not a correctness fix: the check after the partition is
built already produced usable partitions, and neither version failed on any configuration I
tried, up to 32 parts. The new test covers what the splitter guarantees — a barrier stays
within one model and the heads reconstruct — and passes with or without the weights, so it
guards the contract rather than the weighting.
