### PR TITLE
fix(binarygrid_util): restore top assignment dropped with reshape

### DIFF
--- a/flopy/mf6/utils/binarygrid_util.py
+++ b/flopy/mf6/utils/binarygrid_util.py
@@ -258,7 +258,7 @@ class MfGrdFile(FlopyBinaryData):
                 )
                 delr, delc = self.delr, self.delc
 
-                top.reshape((nrow, ncol))
+                top = top.reshape((nrow, ncol))
                 botm = botm.reshape((nlay, nrow, ncol))
                 modelgrid = StructuredGrid(
                     delc,


### PR DESCRIPTION
Fix #2831. #2794 switched several places where `.shape` was set directly to `.reshape()` calls instead, but dropped an assignment on [one of them](https://github.com/modflowpy/flopy/pull/2794/changes#diff-0ee677be802c843687e526a76492588f842e0ff89b9b8b79b3e895985ae21cb6R261).