### PR TITLE
test(get-modflow): remove mac.zip from expected assets

### DIFF
--- a/autotest/test_get_modflow.py
+++ b/autotest/test_get_modflow.py
@@ -115,7 +115,7 @@ def test_get_release(repo):
     tag = "latest"
     release = get_release(repo=repo, tag=tag)
     assets = release["assets"]
-    expected_assets = ["linux.zip", "mac.zip", "macarm.zip", "win64.zip"]
+    expected_assets = ["linux.zip", "macarm.zip", "win64.zip"]
     expected_ostags = [a.replace(".zip", "") for a in expected_assets]
     actual_assets = [asset["name"] for asset in assets]
 


### PR DESCRIPTION
With MF6.8.0 there is no longer a distribution for Intel macOS