### PR TITLE
Fix(test_save_load_node_mapping_structured): 

### DIFF
--- a/autotest/test_model_splitter.py
+++ b/autotest/test_model_splitter.py
@@ -221,7 +221,6 @@ def test_metis_splitting_with_lak_sfr(function_tmpdir):
 @requires_exe("mf6")
 @requires_pkg("pymetis")
 @requires_pkg("h5py")
-@requires_pkg("scikit-learn", name_map={"scikit-learn": "sklearn"})
 def test_save_load_node_mapping_structured(function_tmpdir):
     import pymetis
 
@@ -245,19 +244,18 @@ def test_save_load_node_mapping_structured(function_tmpdir):
     new_sim.set_sim_path(new_sim_path)
     new_sim.write_simulation()
     new_sim.run_simulation()
-    original_node_map = mfsplit._node_map
+    original_node_map = mfsplit._node_map_arr
 
     mfsplit.save_node_mapping(hdf_file)
 
     new_sim2 = MFSimulation.load(sim_ws=new_sim_path)
 
     mfsplit2 = Mf6Splitter.load_node_mapping(hdf_file)
-    saved_node_map = mfsplit2._node_map
+    saved_node_map = mfsplit2._node_map_arr
 
-    for k, v1 in original_node_map.items():
-        v2 = saved_node_map[k]
-        if not v1 == v2:
-            raise AssertionError("Node map read/write not returning proper values")
+    np.testing.assert_allclose(
+        original_node_map, saved_node_map, err_msg="Node map read/write not returning proper values"
+    )
 
     array_dict = {}
     for model in range(nparts):
@@ -267,6 +265,7 @@ def test_save_load_node_mapping_structured(function_tmpdir):
 
     new_heads = mfsplit2.reconstruct_array(array_dict)
     err_msg = "Heads from original and split models do not match"
+    original_heads[sim.get_model().modelgrid.idomain == 0] = 0
     np.testing.assert_allclose(new_heads, original_heads, err_msg=err_msg)
 
 

--- a/autotest/test_model_splitter.py
+++ b/autotest/test_model_splitter.py
@@ -254,7 +254,9 @@ def test_save_load_node_mapping_structured(function_tmpdir):
     saved_node_map = mfsplit2._node_map_arr
 
     np.testing.assert_allclose(
-        original_node_map, saved_node_map, err_msg="Node map read/write not returning proper values"
+        original_node_map,
+        saved_node_map,
+        err_msg="Node map read/write not returning proper values",
     )
 
     array_dict = {}


### PR DESCRIPTION
* update `_node_map` to `_node_map_arr` to follow new convention

* remove `sklearn` requirement as test was getting skipped and now sklearn is not required 