### PR TITLE
fix(ModflowSfr2): support single reach models

### DIFF
--- a/autotest/test_sfr.py
+++ b/autotest/test_sfr.py
@@ -935,3 +935,26 @@ def test_mf2005(function_tmpdir, namfile):
             np.array_equal(str2.segment_data[0][name], m.str.segment_data[0][name])
             is True
         )
+
+
+def test_single_reach_sfr_pkg(function_tmpdir):
+    """Test for a single segment/reach SFR package"""
+    sfrfiletxt = (
+        "1 1 0 0 86400.00000000 0.00010000 0 0\n"
+        "1 5 1 1 1 100.0\n"
+        "1 0 0\n"
+        "1 1 0 0 100.0 0 0 0.3 0.025\n"
+        "1.0 1.0 87.5 10.0\n"
+        "1.0 1.0 86.5 10.0\n"
+    )
+    sfrfile = io.StringIO(sfrfiletxt)
+    m = Modflow("junk", model_ws=function_tmpdir)
+    sfr = ModflowSfr2.load(sfrfile, model=m)
+    assert len(sfr.segment_data[0]) == 1
+    assert len(sfr.reach_data) == 1
+
+    sfrfile2 = function_tmpdir / "junk.sfr"
+    sfr.write_file()
+    sfr = ModflowSfr2.load(sfrfile2, model=m)
+    assert len(sfr.segment_data[0]) == 1
+    assert len(sfr.reach_data) == 1

--- a/flopy/modflow/mfsfr2.py
+++ b/flopy/modflow/mfsfr2.py
@@ -458,10 +458,13 @@ class ModflowSfr2(Package):
                 self.reach_data[n] = reach_data[n]
 
         # assign node numbers if there are none (structured grid)
-        if np.diff(self.reach_data.node).max() == 0 and self.parent.has_package("DIS"):
-            # first make kij list
-            lrc = np.array(self.reach_data)[["k", "i", "j"]].tolist()
-            self.reach_data["node"] = self.parent.dis.get_node(lrc)
+        diff = np.diff(self.reach_data.node)
+        if len(diff) > 0:
+            if diff.max() == 0 and self.parent.has_package("DIS"):
+                # first make kij list
+                lrc = np.array(self.reach_data)[["k", "i", "j"]].tolist()
+                self.reach_data["node"] = self.parent.dis.get_node(lrc)
+
         # assign unique ID and outreach columns to each reach
         self.reach_data.sort(order=["iseg", "ireach"])
         new_cols = {
@@ -493,27 +496,30 @@ class ModflowSfr2(Package):
                 for n in segment_data[i].dtype.names:
                     self.segment_data[i][n] = segment_data[i][n]
         # compute outreaches if nseg and outseg columns have non-default values
-        if (
-            np.diff(self.reach_data.iseg).max() != 0
-            and np.max(list(set(self.graph.keys()))) != 0
-            and np.max(list(set(self.graph.values()))) != 0
-        ):
-            if len(self.graph) == 1:
-                self.segment_data[0]["nseg"] = 1
-                self.reach_data["iseg"] = 1
+        diff = np.diff(self.reach_data.iseg)
+        if len(diff) > 0:
+            if (
+                np.diff(diff).max() != 0
+                and np.max(list(set(self.graph.keys()))) != 0
+                and np.max(list(set(self.graph.values()))) != 0
+            ):
+                if len(self.graph) == 1:
+                    self.segment_data[0]["nseg"] = 1
+                    self.reach_data["iseg"] = 1
 
-            consistent_seg_numbers = (
-                len(set(self.reach_data.iseg).difference(set(self.graph.keys()))) == 0
-            )
-            if not consistent_seg_numbers:
-                warnings.warn(
-                    "Inconsistent segment numbers of reach_data and segment_data"
+                consistent_seg_numbers = (
+                    len(set(self.reach_data.iseg).difference(set(self.graph.keys())))
+                    == 0
                 )
+                if not consistent_seg_numbers:
+                    warnings.warn(
+                        "Inconsistent segment numbers of reach_data and segment_data"
+                    )
 
-            # first convert any not_a_segment_values to 0
-            for v in self.not_a_segment_values:
-                self.segment_data[0].outseg[self.segment_data[0].outseg == v] = 0
-            self.set_outreaches()
+                # first convert any not_a_segment_values to 0
+                for v in self.not_a_segment_values:
+                    self.segment_data[0].outseg[self.segment_data[0].outseg == v] = 0
+                self.set_outreaches()
         self.channel_geometry_data = channel_geometry_data
         self.channel_flow_data = channel_flow_data
 

--- a/flopy/modflow/mfsfr2.py
+++ b/flopy/modflow/mfsfr2.py
@@ -499,7 +499,7 @@ class ModflowSfr2(Package):
         diff = np.diff(self.reach_data.iseg)
         if len(diff) > 0:
             if (
-                np.diff(diff).max() != 0
+                diff.max() != 0
                 and np.max(list(set(self.graph.keys()))) != 0
                 and np.max(list(set(self.graph.values()))) != 0
             ):


### PR DESCRIPTION
* single reach models crashed due to np.diff(reach_data).max() > 0 comparison, fix for this issue breaks up this comparison by taking the diff first and evaluating if the diff returns an empty result prior to taking the max()