### PR TITLE
chore(dependencies): require Python >=3.12 per SPEC 0

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ "3.11", "3.12", "3.13", "3.14" ]
+        python-version: [ "3.12", "3.13", "3.14" ]
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ "3.11", "3.11", "3.12", "3.13", "3.14" ]
+        python-version: [ "3.12", "3.13", "3.14" ]
         ref: ["develop", "master", "6.4.1", "6.4.0"]
     defaults:
       run:

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -71,7 +71,7 @@ jobs:
         shell: bash
     timeout-minutes: 10
     env:
-      PYTHON_VERSION: '3.11'
+      PYTHON_VERSION: '3.12'
 
     steps:
       - name: Checkout repo
@@ -115,7 +115,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ "3.11", "3.12", "3.13", "3.14" ]
+        python-version: [ "3.12", "3.13", "3.14" ]
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ "3.11", "3.12", "3.13", "3.14" ]
+        python-version: [ "3.12", "3.13", "3.14" ]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/optional.yml
+++ b/.github/workflows/optional.yml
@@ -15,7 +15,7 @@ jobs:
         shell: bash
     timeout-minutes: 10
     env:
-      PYTHON_VERSION: '3.11'
+      PYTHON_VERSION: '3.12'
     strategy:
       fail-fast: false
       matrix:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
   # todo: uncomment below if notebooks are to be executed in RTD build
   # instead of in CI as currently, requires runtime reduction <15 mins
   # jobs:

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -60,9 +60,9 @@ git config blame.ignoreRevsFile .git-blame-ignore-revs
 
 ### Python
 
-This project has historically aimed to support a wide range of [Python versions](https://devguide.python.org/versions/). In current and future development this window may narrow to follow [SPEC 0](https://scientific-python.org/specs/spec-0000/#support-window) instead.
+This project has historically aimed to support a wide range of [Python versions](https://devguide.python.org/versions/). Development now follows the [SPEC 0](https://scientific-python.org/specs/spec-0000/#support-window) support window instead.
 
-Install Python >=3.11 via [standalone download](https://www.python.org/downloads/), [uv](https://docs.astral.sh/uv/), or a conda-like distribution like [Anaconda](https://www.anaconda.com/products/individual), [miniconda](https://docs.conda.io/en/latest/miniconda.html) or [miniforge](https://github.com/conda-forge/miniforge) .
+Install Python >=3.12 via [standalone download](https://www.python.org/downloads/), [uv](https://docs.astral.sh/uv/), or a conda-like distribution like [Anaconda](https://www.anaconda.com/products/individual), [miniconda](https://docs.conda.io/en/latest/miniconda.html) or [miniforge](https://github.com/conda-forge/miniforge) .
 
 Then install FloPy and core dependencies from the project root path:
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Documentation
 Installation
 -----------------------------------------------
 
-FloPy requires **Python** 3.11+ with:
+FloPy requires **Python** 3.12+ with:
 
 ```
 numpy >=1.20.3

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - pip
 
   # required
-  - python>=3.11
+  - python>=3.12
   - numpy>=1.20.3
   - matplotlib>=1.4.0
   - pandas>=2.0.0,<3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,13 +18,12 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Hydrology",
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = [
     "numpy>=1.20.3,<3.0",
     "matplotlib >=1.4.0",


### PR DESCRIPTION
[SPEC 0](https://scientific-python.org/specs/spec-0000) recommends dropping Python 3.11 as of 2025 Q4. Bump the min to 3.12. Should probably merge just before the next minor release, so patch releases don't break any user environments.

CI should begin to pass after https://github.com/MODFLOW-ORG/modflow6/pull/2975 merges