### PR TITLE
chore(dependencies): bump minimum numpy and pandas per SPEC 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Installation
 FloPy requires **Python** 3.11+ with:
 
 ```
-numpy >=1.20.3
+numpy >=2.2.0
 matplotlib >=1.4.0
 pandas >=2.0.0
 ```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ FloPy requires **Python** 3.11+ with:
 ```
 numpy >=2.2.0
 matplotlib >=1.4.0
-pandas >=2.0.0
+pandas >=2.2.0
 ```
 
 Dependencies for optional features are summarized [here](https://flopy.readthedocs.io/en/latest/md/optional_dependencies.html).

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - python>=3.11
   - numpy>=2.2.0
   - matplotlib>=1.4.0
-  - pandas>=2.0.0,<3
+  - pandas>=2.2.0,<3
 
   # codegen
   - boltons>=1.0

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 
   # required
   - python>=3.11
-  - numpy>=1.20.3
+  - numpy>=2.2.0
   - matplotlib>=1.4.0
   - pandas>=2.0.0,<3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "numpy>=1.20.3,<3.0",
+    "numpy>=2.2.0,<3.0",
     "matplotlib >=1.4.0",
     "pandas >=2.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ requires-python = ">=3.11"
 dependencies = [
     "numpy>=2.2.0,<3.0",
     "matplotlib >=1.4.0",
-    "pandas >=2.0.0",
+    "pandas >=2.2.0",
 ]
 dynamic = ["version", "readme"]
 


### PR DESCRIPTION
[SPEC 0](https://scientific-python.org/specs/spec-0000) recommends dropping numpy <=2.1.0 (as of 2026 Q3) and pandas <=2.2.0 (as of 2026 Q1), leaving numpy 2.2.0 and pandas 2.3.0 as the minimum supported versions.

Should probably merge just before the next minor release, so patch releases don't break any user environments