### PR TITLE
test(postprocessing): check signed magnitudes in 1-D faceflow cases

### DIFF
--- a/autotest/test_postprocessing.py
+++ b/autotest/test_postprocessing.py
@@ -149,6 +149,16 @@ def test_get_structured_faceflows(function_tmpdir, nlay, nrow, ncol):
     assert np.any(fff) == (nrow > 1)
     assert np.any(flf) == (nlay > 1)
 
+    if nlay * nrow * ncol == 3:
+        # The 1-D cases have unit K and cell dimensions, with all heads
+        # prescribed as 11, 12, 13. Darcy flow is -1 toward increasing
+        # column, row, or layer number; the final face has no neighbor.
+        expected = np.array([-1.0, -1.0, 0.0]).reshape(nlay, nrow, ncol)
+        for flow, size in zip((frf, fff, flf), (ncol, nrow, nlay)):
+            if size == 3:
+                np.testing.assert_allclose(flow, expected, rtol=0.0, atol=1e-8)
+                assert flow.flat[-1] == 0.0
+
 
 @pytest.mark.mf6
 @requires_exe("mf6")


### PR DESCRIPTION
The existing one-dimensional `get_structured_faceflows` cases check whether the active-direction array contains nonzero values. Add an independent physical reference: unit conductivity and cell dimensions with prescribed heads 11, 12 and 13 imply face flows `[-1, -1, 0]` toward increasing column, row or layer number. Check the absent terminal face is exactly zero.

This adds ten lines and preserves all seven existing parameterizations, model inputs, simulation calls and dependencies. It is a test improvement; no existing implementation defect is claimed.

Validation on base `18dc192cac9ed731dc84f40bc898e0f4d9f87e20`:

- All seven targeted cases passed on Windows with zero skips using Python 3.12.13, NumPy 2.3.5, pytest 8.4.2 and the official MODFLOW 6.8.0 Windows release asset, which reports `6.8.0+8680167.dirty`.
- Observed execution confirmed both new assertions ran for all three one-dimensional cases; active-face outputs were exactly `[-1, -1, 0]`.
- Ruff 0.16.6 lint and format checks passed for the changed file.

The full FloPy test suite and project-wide release checks were not run locally. This PR is ready for review and has received maintainer approval on commit `c08bb9d93db82635bd63eb0a063d2042a53710cd`. As of September 9, 2026, eleven of twelve main CI test jobs passed, along with build, lint, MODFLOW integration tests and documentation notebook checks. The remaining job, labeled Ubuntu/Python 3.12, failed in `test_get_modflow.py::test_python_api[modflow6-MODFLOW-ORG]` because the expected executable destination was empty after the download attempt; all seven modified face-flow cases passed in that same job. The download failure appears separate from this assertion change, but its cause remains unconfirmed and CI is not fully green. See the [failed job](https://github.com/modflowpy/flopy/actions/runs/34295109393/job/102452209857).

Related PR #2746 adds broader conversion/round-trip coverage and leaves this existing assertion block unchanged at the head inspected. This patch is limited to the existing physical 1-D cases.

AI assistance: OpenAI Codex using GPT-6 Astra assisted with the assessment, patch and local validation.
