### PR TITLE
ci: drop discontinued vtk-osmesa headless workaround

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -30,12 +30,9 @@ jobs:
       - name: Install FloPy
         run: uv sync --all-extras
 
-      - name: OpenGL workaround on Linux
+      - name: Set up headless display on Linux
         if: runner.os == 'Linux'
-        run: |
-          # referenced from https://github.com/pyvista/pyvista/blob/main/.github/workflows/vtk-pre-test.yml#L53
-          uv pip uninstall vtk
-          uv pip install --extra-index-url https://wheels.vtk.org trame vtk-osmesa
+        uses: pyvista/setup-headless-display-action@v5
 
       - name: Install OpenGL on Windows
         if: runner.os == 'Windows'

--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -98,14 +98,6 @@ jobs:
           pixi run -e rtd install
           pixi run -e rtd pip install "../flopy[optional]"
 
-      - name: Workaround OpenGL issue on Linux
-        if: runner.os == 'Linux'
-        working-directory: modflow6
-        run: |
-          # referenced from https://github.com/pyvista/pyvista/blob/main/.github/workflows/vtk-pre-test.yml#L53
-          pixi run -e rtd pip uninstall vtk
-          pixi run -e rtd pip install --extra-index-url https://wheels.vtk.org trame vtk-osmesa
-
       - name: Install fonts on Linux
         if: runner.os == 'Linux'
         run: |


### PR DESCRIPTION
use `pyvista/setup-headless-display-action` everywhere and drop the old osmesa workaround